### PR TITLE
Allowing Renderer's to accept a pre-made canvas/view

### DIFF
--- a/src/pixi/renderers/CanvasRenderer.js
+++ b/src/pixi/renderers/CanvasRenderer.js
@@ -8,8 +8,9 @@
  * @class CanvasRenderer
  * @param width {Number} the width of the canvas view
  * @param height {Number} the height of the canvas view
+ * @param view {Canvas} the canvas to use as a view, optional
  */
-PIXI.CanvasRenderer = function(width, height)
+PIXI.CanvasRenderer = function(width, height, view)
 {
 	/**
 	 * The width of the canvas view
@@ -33,7 +34,7 @@ PIXI.CanvasRenderer = function(width, height)
 	 * @property view
 	 * @type Canvas
 	 */
-	this.view = document.createElement( 'canvas' ); 
+	this.view = view ? view : document.createElement( 'canvas' ); 
 	
 	// hack to enable some hardware acceleration!
 	//this.view.style["transform"] = "translatez(0)";

--- a/src/pixi/renderers/WebGLRenderer.js
+++ b/src/pixi/renderers/WebGLRenderer.js
@@ -13,13 +13,14 @@ PIXI._defaultFrame = new PIXI.Rectangle(0,0,1,1);
  * @default 0
  * @param height {Number} the height of the canvas view
  * @default 0
+ * @param view {Canvas} the canvas to use as a view, optional
  */
-PIXI.WebGLRenderer = function(width, height)
+PIXI.WebGLRenderer = function(width, height, view)
 {
 	this.width = width ? width : 800;
 	this.height = height ? height : 600;
 	
-	this.view = document.createElement( 'canvas' ); 
+	this.view = view ? view : document.createElement( 'canvas' ); 
     this.view.width = this.width;
 	this.view.height = this.height;  
 	this.view.background = "#FF0000";

--- a/src/pixi/utils/Detector.js
+++ b/src/pixi/utils/Detector.js
@@ -9,8 +9,9 @@
  * @static
  * @param width {Number} the width of the renderers view
  * @param height {Number} the height of the renderers view
+ * @param view {Canvas} the canvas to use as a view, optional
  */
-PIXI.autoDetectRenderer = function(width, height)
+PIXI.autoDetectRenderer = function(width, height, view)
 {
 	if(!width)width = 800;
 	if(!height)height = 600;
@@ -21,10 +22,10 @@ PIXI.autoDetectRenderer = function(width, height)
 	//console.log(webgl);
 	if( webgl )
 	{
-		return new PIXI.WebGLRenderer(width, height) 
+		return new PIXI.WebGLRenderer(width, height, view) 
 	}
 	
-	return	new PIXI.CanvasRenderer(width, height);
+	return	new PIXI.CanvasRenderer(width, height, view);
 }
 
 


### PR DESCRIPTION
The reason for this commit is to allow support for previously created
canvases to be specified as views.

The major usecase here is Ejecta, who's primary screen canvas is always
obtained through document.getElementById('canvas'); Thus, creating a
canvas using document.createElement('canvas') would only make an
offscreen canvas which wouldn't be visible.

This commit maintains backwards compatibility since specifying a canvas
is completely optional, and if none is specified, it falls back to
previous behaviour.

Please note: There is a major bug with Ejecta currently that I have [reported](https://github.com/phoboslab/Ejecta/issues/142) that doesn't allow assets to be loaded properly. Once it is sorted, Pixi.js should work fine within Ejecta as long as you specify the view on Renderer instantiation.
