### PR TITLE
Add mime type override to json request

### DIFF
--- a/src/pixi/loaders/SpriteSheetLoader.js
+++ b/src/pixi/loaders/SpriteSheetLoader.js
@@ -46,7 +46,7 @@ PIXI.SpriteSheetLoader.prototype.load = function()
 	}
 		
 	this.ajaxRequest.open("GET", this.url, true)
-	this.ajaxRequest.overrideMimeType("application/json");
+	if (this.ajaxRequest.overrideMimeType) this.ajaxRequest.overrideMimeType("application/json");
 	this.ajaxRequest.send(null)
 }
 


### PR DESCRIPTION
This makes loading spritesheets work when developing locally. Will also help if the server fails to set the correct mimetype.
