### PR TITLE
Added Cross Origin Resource Sharing support.

### DIFF
--- a/src/pixi/loaders/AssetLoader.js
+++ b/src/pixi/loaders/AssetLoader.js
@@ -23,6 +23,8 @@ PIXI.AssetLoader = function(assetURLs)
 	this.assetURLs = assetURLs;
 	
 	this.assets = [];
+
+	this.crossorigin = false;
 }
 
 /**
@@ -79,7 +81,7 @@ PIXI.AssetLoader.prototype.load = function()
 		if(type == "img")
 		{
 			
-			var texture = PIXI.Texture.fromImage(filename);
+			var texture = PIXI.Texture.fromImage(filename, this.crossorigin);
 			if(!texture.hasLoaded)
 			{
 				
@@ -102,6 +104,7 @@ PIXI.AssetLoader.prototype.load = function()
 		else if(type == "atlas")
 		{
 			var spriteSheetLoader = new PIXI.SpriteSheetLoader(filename);
+			spriteSheetLoader.crossorigin = this.crossorigin;
 			this.assets.push(spriteSheetLoader);
 			
 			var scope = this;

--- a/src/pixi/loaders/SpriteSheetLoader.js
+++ b/src/pixi/loaders/SpriteSheetLoader.js
@@ -27,7 +27,8 @@ PIXI.SpriteSheetLoader = function(url)
 	this.url = url;
 	this.baseUrl = url.replace(/[^\/]*$/, '');
 	this.texture;
-	this.frames = {};	
+	this.frames = {};
+	this.crossorigin = false;
 }
 
 // constructor
@@ -60,7 +61,7 @@ PIXI.SpriteSheetLoader.prototype.onLoaded = function()
 			
 			var textureUrl = this.baseUrl + jsondata.meta.image;
 			
-			this.texture = PIXI.Texture.fromImage(textureUrl).baseTexture;
+			this.texture = PIXI.Texture.fromImage(textureUrl, this.crossorigin).baseTexture;
 			
 		//	if(!this.texture)this.texture = new PIXI.Texture(textureUrl);
 			

--- a/src/pixi/textures/Texture.js
+++ b/src/pixi/textures/Texture.js
@@ -94,7 +94,7 @@ PIXI.Texture.prototype.setFrame = function(frame)
  * @param imageUrl {String} The image url of the texture
  * @return Texture
  */
-PIXI.Texture.fromImage = function(imageUrl)
+PIXI.Texture.fromImage = function(imageUrl, crossorigin)
 {
 	var texture = PIXI.TextureCache[imageUrl];
 	
@@ -104,6 +104,10 @@ PIXI.Texture.fromImage = function(imageUrl)
 		if(!baseTexture) 
 		{
 			var image = new Image();//new Image();
+			if (crossorigin)
+			{
+				image.crossOrigin = '';
+			}
 			image.src = imageUrl;
 			
 			baseTexture = new PIXI.BaseTexture(image);


### PR DESCRIPTION
In production, I host JS/CSS/IMG on a CDN (Amazon S3 in my case) Without this patch Pixi.js will not let me load images on another domain/server as textures. With this code, you can use the following example to load your assets from another Server/Domain as long as that Server is CORS-enabled.

``` javascript
    loader = new PIXI.AssetLoader(asset_list);
    loader.onComplete = onAssetsLoaded;
    loader.crossorigin = true;
    // Other pre-load things you might need to do.
    loader.load();
```

This works for me, am I missing any other key places modification would be necessary?
