### PR TITLE
Add on/off/trigger syntax

### DIFF
--- a/src/pixi/utils/EventTarget.js
+++ b/src/pixi/utils/EventTarget.js
@@ -23,7 +23,7 @@ PIXI.EventTarget = function () {
 
 	};
 
-	this.dispatchEvent = this.trigger = function ( event ) {
+	this.dispatchEvent = this.emit = function ( event ) {
 		
 		for ( var listener in listeners[ event.type ] ) {
 


### PR DESCRIPTION
I prefer to use `.on()`, `.off()` and `.trigger()` syntax with events. So I added those in as aliases for their longer counterparts.

I will be making use of this mixin for more than just the loader, so might as well make it friendly :smiley: 
