### PR TITLE
PIXI now wrapped in an anonymous function, with exports for CommonJS.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,6 +9,7 @@ module.exports = function(grunt) {
     var root = 'src/pixi/',
         debug = 'bin/pixi.dev.js',
         srcFiles = [
+            '<%= dirs.src %>/Intro.js',
             '<%= dirs.src %>/Pixi.js',
             '<%= dirs.src %>/Point.js',
             '<%= dirs.src %>/Rectangle.js',
@@ -31,7 +32,8 @@ module.exports = function(grunt) {
             '<%= dirs.src %>/textures/BaseTexture.js',
             '<%= dirs.src %>/textures/Texture.js',
             '<%= dirs.src %>/loaders/SpriteSheetLoader.js',
-            '<%= dirs.src %>/loaders/AssetLoader.js'
+            '<%= dirs.src %>/loaders/AssetLoader.js',
+            '<%= dirs.src %>/Outro.js',
         ], banner = [
             '/**',
             ' * @license',

--- a/src/pixi/Intro.js
+++ b/src/pixi/Intro.js
@@ -1,0 +1,7 @@
+/**
+ * @author Mat Groves http://matgroves.com/ @Doormat23
+ */
+
+(function(){
+
+	var root = this;

--- a/src/pixi/Outro.js
+++ b/src/pixi/Outro.js
@@ -1,0 +1,15 @@
+/**
+ * @author Mat Groves http://matgroves.com/ @Doormat23
+ */
+
+ if (typeof exports !== 'undefined') {
+    if (typeof module !== 'undefined' && module.exports) {
+      exports = module.exports = PIXI;
+    }
+    exports.PIXI = PIXI;
+  } else {
+    root.PIXI = PIXI;
+  }
+
+
+}).call(this);


### PR DESCRIPTION
It'd be great if PIXI could be used as a [Component](https://github.com/component/component) so that it can be added to projects with the Component tooling with `component install GoodBoyDigital/pixi.js` and then used with `require('pixi')` At the moment I'm having to manually convert it into a CommonJS module and maintain it that way.

This pull request makes PIXI CommonJS friendly. It adds a tiny Intro and Outro file so that the whole of PIXI is wrapped in an anonymous function. There's also code to export PIXI as a module (for Component or other CommonJS implementations), or add PIXI to the global scope (which is what PIXI currently does).

I'll add the component.json file (to make it an installable component) as a separate pull request if this one is merged :). We'll probably need to update the built versions of the files in the repo soon, as Components work by downloading a specific file directly from Github.
