### PR TITLE
Sanity check frame object before adding to TextureCache

### DIFF
--- a/src/pixi/loaders/SpriteSheetLoader.js
+++ b/src/pixi/loaders/SpriteSheetLoader.js
@@ -69,16 +69,19 @@ PIXI.SpriteSheetLoader.prototype.onLoaded = function()
 			for (var i in frameData) 
 			{
 				var rect = frameData[i].frame;
-				PIXI.TextureCache[i] = new PIXI.Texture(this.texture, {x:rect.x, y:rect.y, width:rect.w, height:rect.h});
-				
-				if(frameData[i].trimmed)
+				if (rect)
 				{
-					//var realSize = frameData[i].spriteSourceSize;
-					PIXI.TextureCache[i].realSize = frameData[i].spriteSourceSize;
-					PIXI.TextureCache[i].trim.x = 0// (realSize.x / rect.w)
-					// calculate the offset!
+					PIXI.TextureCache[i] = new PIXI.Texture(this.texture, {x:rect.x, y:rect.y, width:rect.w, height:rect.h});
+					
+					if(frameData[i].trimmed)
+					{
+						//var realSize = frameData[i].spriteSourceSize;
+						PIXI.TextureCache[i].realSize = frameData[i].spriteSourceSize;
+						PIXI.TextureCache[i].trim.x = 0// (realSize.x / rect.w)
+						// calculate the offset!
+					}
+	//				this.frames[i] = ;
 				}
-//				this.frames[i] = ;
    			}
 			
 			if(this.texture.hasLoaded)


### PR DESCRIPTION
For texturepacker compatibility, make sure 'frame' property exists before attempting to use it.

I will concede that the patch name here is a little misleading. This may be an error specific to the project I am working on presently, and perhaps not attributed directly to the output of TexturePacker. But whatever the cause it seems ok to just be a little safer by sanity-checking the frame object before attempting to do something with it.

It seems that in some cases, the for in loop here encounters an `extend` property which of course doesn't contain a `frame` property, so the following error throws during the caching flow:

`Uncaught TypeError: Cannot read property 'x' of undefined`
