### PR TITLE
Coffeescript compatibility fix.

### DIFF
--- a/src/pixi/Sprite.js
+++ b/src/pixi/Sprite.js
@@ -140,8 +140,8 @@ PIXI.Sprite = function(texture)
 }
 
 // constructor
-PIXI.Sprite.constructor = PIXI.Sprite;
 PIXI.Sprite.prototype = Object.create( PIXI.DisplayObjectContainer.prototype );
+PIXI.Sprite.prototype.constructor = PIXI.Sprite;
 
 /**
 @method setTexture


### PR DESCRIPTION
Allows sprite properties to be properly accessed when PIXI.Sprite is
extended by a coffeescript class.
