### PR TITLE
WebGLRender should cleanup previous stage.

### DIFF
--- a/src/pixi/renderers/WebGLRenderer.js
+++ b/src/pixi/renderers/WebGLRenderer.js
@@ -166,6 +166,14 @@ PIXI.WebGLRenderer.prototype.render = function(stage)
 {
 	if(this.contextLost)return;
 	
+	//clear objects left behind by the previous stage
+	if(!this.__stage) this.__stage = stage
+	if(this.__stage && this.__stage !== stage)
+	{
+		this.checkVisibility(this.__stage, false)
+		this.__stage = stage
+	}
+	
 	// update children if need be
 	// best to remove first!
 	for (var i=0; i < stage.__childrenRemoved.length; i++)


### PR DESCRIPTION
Add cleanup logic to WebGLRender to so if the stage is changed, sprites from the previous stage are not left behind.
