### PR TITLE
Add Stage.getMousePosition()

### DIFF
--- a/src/pixi/Stage.js
+++ b/src/pixi/Stage.js
@@ -68,6 +68,16 @@ PIXI.Stage.prototype.setBackgroundColor = function(backgroundColor)
 	this.backgroundColorString =  "#" + this.backgroundColor.toString(16);
 }
 
+/**
+ * This will return the point containing global coords of the mouse.
+ * @method getMousePosition
+ * @return {Point} The point containing the coords of the global InteractionData position.
+ */
+PIXI.Stage.prototype.getMousePosition = function()
+{
+	return this.interactionManager.mouse.global;
+}
+
 PIXI.Stage.prototype.__addChild = function(child)
 {
 	if(child.interactive)this.dirty = true;


### PR DESCRIPTION
Adds a function to PIXI.Stage that directly returns a more sane path to the
Stage.interactionManager.mouse.global point object.

Can either be called every time the mouse is needed, or since it returns the original mouse object and not a copy, it can be used to set a local pointer to the original.
