### PR TITLE
BitmapText docs update and new line character

### DIFF
--- a/src/pixi/text/BitmapText.js
+++ b/src/pixi/text/BitmapText.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * A Text Object will create a line(s) of text using bitmap font 
+ * A Text Object will create a line(s) of text using bitmap font. To split a line you can use "\n", "\r" or "\r\n"
  * You can generate the fnt files using 
  * http://www.angelcode.com/products/bmfont/ for windows or
  * http://www.bmglyph.com/ for mac.
@@ -32,7 +32,7 @@ PIXI.BitmapText.prototype = Object.create(PIXI.DisplayObjectContainer.prototype)
 
 /**
  * Set the copy for the text object
- * @methos setText
+ * @method setText
  * @param {String} text The copy that you would like the text to display
  */
 PIXI.BitmapText.prototype.setText = function(text)
@@ -78,7 +78,7 @@ PIXI.BitmapText.prototype.updateText = function()
     for(var i = 0; i < this.text.length; i++)
     {
         var charCode = this.text.charCodeAt(i);
-        if(charCode == "\n".charCodeAt(0))
+        if(/(?:\r\n|\r|\n)/.test(this.text.charAt(i)))
         {
             lineWidths.push(pos.x);
             maxLineWidth = Math.max(maxLineWidth, pos.x);

--- a/src/pixi/text/Text.js
+++ b/src/pixi/text/Text.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * A Text Object will create a line(s) of text to split a line you can use "\n"
+ * A Text Object will create a line(s) of text. To split a line you can use "\n", "\r" or "\r\n"
  * @class Text
  * @extends Sprite
  * @constructor
@@ -54,7 +54,7 @@ PIXI.Text.prototype.setStyle = function(style)
 
 /**
  * Set the copy for the text object. To split a line you can use "\n"
- * @methos setText
+ * @method setText
  * @param {String} text The copy that you would like the text to display
  */
 PIXI.Sprite.prototype.setText = function(text)
@@ -72,7 +72,7 @@ PIXI.Text.prototype.updateText = function()
 	this.context.font = this.style.font;
 
 	//split text into lines
-	var lines = this.text.split("\n");
+	var lines = this.text.split(/(?:\r\n|\r|\n)/);
 
 	//calculate text width
 	var lineWidths = [];
@@ -154,9 +154,10 @@ PIXI.Text.prototype.updateTransform = function()
 	PIXI.Sprite.prototype.updateTransform.call(this);
 };
 
-/*
+/**
  * http://stackoverflow.com/users/34441/ellisbben
  * great solution to the problem!
+ * @private
  */
 PIXI.Text.prototype.determineFontHeight = function(fontStyle) 
 {


### PR DESCRIPTION
Style parameter is not optional for BitmapText (it requires at least font name). Alignment is optional.
Also different operating systems uses different new line characters. Now PIXI supports all of them.

> \n is used as an end-of-line terminator in Unix text files
> \r is used as an end-of-line terminator in Mac text files
> \r\n (ie both) are used to terminate lines in Windows and DOS text files.
