### PR TITLE
Make AjaxRequest public to enable _YourType_Loader creation

### DIFF
--- a/src/pixi/utils/Utils.js
+++ b/src/pixi/utils/Utils.js
@@ -42,7 +42,7 @@ if (typeof Function.prototype.bind != 'function') {
   })();
 }
 
-var AjaxRequest = function()
+var AjaxRequest = PIXI.AjaxRequest = function()
 {
 	var activexmodes = ["Msxml2.XMLHTTP", "Microsoft.XMLHTTP"] //activeX versions to check for in IE
 	


### PR DESCRIPTION
Good day everyone! I working on extension of `AssetLoader` that provides possibility to load bare Json, so I needed somekind of `JsonLoader` (like `SpriteSheetLoader`), but it uses `AjaxRequest` which is private (due `into.js` and `outro.js`). Can it be public?

P.s. I know, that, maybe, it easier to write my own, but it's already there.
