### PR TITLE
support custom display objects in CanvasRenderer

### DIFF
--- a/src/pixi/renderers/CanvasRenderer.js
+++ b/src/pixi/renderers/CanvasRenderer.js
@@ -190,6 +190,11 @@ PIXI.CanvasRenderer.prototype.renderDisplayObject = function(displayObject)
 		context.setTransform(transform[0], transform[3], transform[1], transform[4], transform[2], transform[5])
 		this.renderTilingSprite(displayObject);
 	}
+	else if(displayObject.renderCanvas)
+	{
+		// custom canvas renderer display object
+		displayObject.renderCanvas(context, transform);
+	}
 	
 	// render!
 	for (var i=0; i < displayObject.children.length; i++) 


### PR DESCRIPTION
Sometimes customer rendering must be done at specific point in time during render, for example to add dynamic lighting on top of static background but below moving sprites.

This simple change checks to see if `DisplayObject` has a function named `renderCanvas` and if so call it with Canvas context and transform.

If accepted, similar change should be made on WebGLRenderer for function named something like `renderWebGL`.
