### PR TITLE
Typo in WebGLRenderGroup?

### DIFF
--- a/src/pixi/renderers/WebGLRenderGroup.js
+++ b/src/pixi/renderers/WebGLRenderGroup.js
@@ -781,7 +781,7 @@ PIXI.WebGLRenderGroup.prototype.renderTilingSprite = function(sprite, projection
 /**
  * @private
  */
-PIXI.WebGLRenderer.prototype.initStrip = function(strip)
+PIXI.WebGLRenderGroup.prototype.initStrip = function(strip)
 {
 	// build the strip!
 	var gl = this.gl;


### PR DESCRIPTION
`PIXI.WebGLRenderer.initStrip` should be `PIXI.WebGLRenderGroup.initStrip`, unless I'm missing something about how `WebGLRenderGroup` is implemented (which is not unlikely).

By the way, what's the purpose of `WebGLRenderGroup`, in brief terms? I don't remember seeing this in previous versions, and it's a pretty substantial addition!
