### PR TITLE
Fix update textures in handleContextRestored

### DIFF
--- a/src/pixi/renderers/WebGLRenderer.js
+++ b/src/pixi/renderers/WebGLRenderer.js
@@ -325,9 +325,11 @@ PIXI.WebGLRenderer.prototype.handleContextRestored = function(event)
         
 	this.initShaders();	
 	
-	for (var i=0; i < PIXI.TextureCache.length; i++) 
+	for(var key in PIXI.TextureCache) 
 	{
-		this.updateTexture(PIXI.TextureCache[i]);
+        	var texture = PIXI.TextureCache[key].baseTexture;
+        	texture._glTexture = null;
+        	PIXI.WebGLRenderer.updateTexture(texture);
 	};
 	
 	for (var i=0; i <  this.batchs.length; i++) 


### PR DESCRIPTION
- org code try to iterate on PIXI.TextureCache as Array but it's Object;
- PIXI.WebGLRenderer.updateTexture deals with base texture, so we need to get such a field;
- need to texture._glTexture = null, because PIXI.WebGLRenderer.updateTexture only deal with texture without _glTexture;
- and also run as static method PIXI.WebGLRenderer.updateTexture(...);
