### PR TITLE
Fix for Chrome error when loading texture created with new Image()

### DIFF
--- a/src/pixi/textures/BaseTexture.js
+++ b/src/pixi/textures/BaseTexture.js
@@ -114,7 +114,9 @@ PIXI.BaseTexture.fromImage = function(imageUrl, crossorigin)
 	var baseTexture = PIXI.BaseTextureCache[imageUrl];
 	if(!baseTexture)
 	{
-		var image = new Image();
+		// new Image() breaks tex loading in Chrome.
+		// See https://code.google.com/p/chromium/issues/detail?id=115668
+		var image = document.createElement('img'); 
 		if (crossorigin)
 		{
 			image.crossOrigin = '';


### PR DESCRIPTION
See https://code.google.com/p/chromium/issues/detail?id=238071
