### PR TITLE
Fix issue with CanvasRenderer trying to render DisplayObject children

### DIFF
--- a/src/pixi/renderers/CanvasRenderer.js
+++ b/src/pixi/renderers/CanvasRenderer.js
@@ -199,7 +199,8 @@ PIXI.CanvasRenderer.prototype.renderDisplayObject = function(displayObject)
 	}
 	
 	// render!
-	if(displayObject.children) {
+	if(displayObject.children)
+	{
 		for (var i=0; i < displayObject.children.length; i++) 
 		{
 			this.renderDisplayObject(displayObject.children[i]);


### PR DESCRIPTION
This is a fix for a problem found in #166 where the canvas renderer will try to render DisplayObject children, which they do not have.
