### PR TITLE
Fix for iOS Safari not rendering some stage background colors

### DIFF
--- a/src/pixi/Stage.js
+++ b/src/pixi/Stage.js
@@ -68,7 +68,9 @@ PIXI.Stage.prototype.setBackgroundColor = function(backgroundColor)
 {
 	this.backgroundColor = backgroundColor || 0x000000;
 	this.backgroundColorSplit = HEXtoRGB(this.backgroundColor);
-	this.backgroundColorString =  "#" + this.backgroundColor.toString(16);
+	var hex = this.backgroundColor.toString(16);
+	hex = "000000".substr(0, 6 - hex.length) + hex;
+	this.backgroundColorString = "#" + hex;
 }
 
 /**


### PR DESCRIPTION
PIXI.Stage.prototype.setBackgroundColor converts color numbers to hex strings without padding (e.g., 0x00ff00 becomes "#ff00"). Safari iOS does not handle colors specified this way correctly:

![0x00ff00](https://f.cloud.github.com/assets/249571/651835/33fa1674-d484-11e2-94bc-aa0b9dfdfd91.png)

This fix pads the representation with leading "0" characters (e.g., 0x00ff00 becomes "#00ff00").
