### PR TITLE
not all DisplayObject has children

### DIFF
--- a/src/pixi/renderers/CanvasRenderer.js
+++ b/src/pixi/renderers/CanvasRenderer.js
@@ -198,10 +198,13 @@ PIXI.CanvasRenderer.prototype.renderDisplayObject = function(displayObject)
 		displayObject.renderCanvas(this);
 	}
 	
-	// render!
-	for (var i=0; i < displayObject.children.length; i++) 
+	// render children if any
+	if(displayObject.children)
 	{
-		this.renderDisplayObject(displayObject.children[i]);
+		for (var i=0; i < displayObject.children.length; i++) 
+		{
+			this.renderDisplayObject(displayObject.children[i]);
+		}
 	}
 	
 	this.context.setTransform(1,0,0,1,0,0); 


### PR DESCRIPTION
reference to `displayObject.children.length` was failing because `children` property exists only in `DisplayObjectContainer`.
