### PR TITLE
Filter out prototype properties

### DIFF
--- a/src/pixi/utils/EventTarget.js
+++ b/src/pixi/utils/EventTarget.js
@@ -24,10 +24,16 @@ PIXI.EventTarget = function () {
 	};
 
 	this.dispatchEvent = this.emit = function ( event ) {
-		
-		for ( var listener in listeners[ event.type ] ) {
 
-			listeners[ event.type ][ listener ]( event );
+		if ( typeof listeners[ event.type ] !== 'function' ) {
+
+			return;
+			
+		}
+		
+		for(var i = 0, l = listeners[ event.type ].length; i < l; i++) {
+
+			listeners[ event.type ][ i ]( event );
 			
 		}
 


### PR DESCRIPTION
Make sure to filter out properties from the prototype. Currently pixi.js doesn't work with ember.js due to this.
