### PR TITLE
Add constructor property to prototype for coffeescript

### DIFF
--- a/src/pixi/InteractionManager.js
+++ b/src/pixi/InteractionManager.js
@@ -53,7 +53,7 @@ PIXI.InteractionManager = function(stage)
 }
 
 // constructor
-PIXI.InteractionManager.constructor = PIXI.InteractionManager;
+PIXI.InteractionManager.constructor = PIXI.InteractionManager.prototype.constructor = PIXI.InteractionManager;
 
 /**
  * Collects an interactive sprite recursively to have their interactions managed
@@ -618,4 +618,4 @@ PIXI.InteractionData.prototype.getLocalPosition = function(displayObject)
 }
 
 // constructor
-PIXI.InteractionData.constructor = PIXI.InteractionData;
+PIXI.InteractionData.constructor = PIXI.InteractionData.prototype.constructor = PIXI.InteractionData;

--- a/src/pixi/core/Circle.js
+++ b/src/pixi/core/Circle.js
@@ -69,5 +69,5 @@ PIXI.Circle.prototype.contains = function(x, y)
     return (dx + dy <= r2);
 }
 
-PIXI.Circle.constructor = PIXI.Circle;
+PIXI.Circle.constructor = PIXI.Circle.prototype.constructor = PIXI.Circle;
 

--- a/src/pixi/core/Ellipse.js
+++ b/src/pixi/core/Ellipse.js
@@ -83,5 +83,5 @@ PIXI.Ellipse.getBounds = function()
     return new PIXI.Rectangle(this.x, this.y, this.width, this.height);
 }
 
-PIXI.Ellipse.constructor = PIXI.Ellipse;
+PIXI.Ellipse.constructor = PIXI.Ellipse.prototype.constructor = PIXI.Ellipse;
 

--- a/src/pixi/core/Point.js
+++ b/src/pixi/core/Point.js
@@ -39,5 +39,5 @@ PIXI.Point.prototype.clone = function()
 }
 
 // constructor
-PIXI.Point.constructor = PIXI.Point;
+PIXI.Point.constructor = PIXI.Point.prototype.constructor = PIXI.Point;
 

--- a/src/pixi/core/Polygon.js
+++ b/src/pixi/core/Polygon.js
@@ -73,5 +73,5 @@ PIXI.Polygon.prototype.contains = function(x, y)
     return inside;
 }
 
-PIXI.Polygon.constructor = PIXI.Polygon;
+PIXI.Polygon.constructor = PIXI.Polygon.prototype.constructor = PIXI.Polygon;
 

--- a/src/pixi/core/Rectangle.js
+++ b/src/pixi/core/Rectangle.js
@@ -82,5 +82,5 @@ PIXI.Rectangle.prototype.contains = function(x, y)
 }
 
 // constructor
-PIXI.Rectangle.constructor = PIXI.Rectangle;
+PIXI.Rectangle.constructor = PIXI.Rectangle.prototype.constructor = PIXI.Rectangle;
 

--- a/src/pixi/display/DisplayObject.js
+++ b/src/pixi/display/DisplayObject.js
@@ -258,7 +258,7 @@ PIXI.DisplayObject = function()
 }
 
 // constructor
-PIXI.DisplayObject.constructor = PIXI.DisplayObject;
+PIXI.DisplayObject.constructor = PIXI.DisplayObject.prototype.constructor = PIXI.DisplayObject;
 
 //TODO make visible a getter setter
 /*

--- a/src/pixi/display/DisplayObjectContainer.js
+++ b/src/pixi/display/DisplayObjectContainer.js
@@ -26,8 +26,8 @@ PIXI.DisplayObjectContainer = function()
 }
 
 // constructor
-PIXI.DisplayObjectContainer.constructor = PIXI.DisplayObjectContainer;
 PIXI.DisplayObjectContainer.prototype = Object.create( PIXI.DisplayObject.prototype );
+PIXI.DisplayObjectContainer.constructor = PIXI.DisplayObjectContainer.prototype.constructor = PIXI.DisplayObjectContainer;
 
 //TODO make visible a getter setter
 /*

--- a/src/pixi/display/MovieClip.js
+++ b/src/pixi/display/MovieClip.js
@@ -69,8 +69,8 @@ PIXI.MovieClip = function(textures)
 }
 
 // constructor
-PIXI.MovieClip.constructor = PIXI.MovieClip;
 PIXI.MovieClip.prototype = Object.create( PIXI.Sprite.prototype );
+PIXI.MovieClip.constructor = PIXI.MovieClip.prototype.constructor = PIXI.MovieClip;
 
 /**
  * Stops the MovieClip

--- a/src/pixi/display/Sprite.js
+++ b/src/pixi/display/Sprite.js
@@ -80,8 +80,8 @@ PIXI.Sprite = function(texture)
 }
 
 // constructor
-PIXI.Sprite.constructor = PIXI.Sprite;
 PIXI.Sprite.prototype = Object.create( PIXI.DisplayObjectContainer.prototype );
+PIXI.Sprite.constructor = PIXI.Sprite.prototype.constructor = PIXI.Sprite;
 
 /**
  * The width of the sprite, setting this will actually modify the scale to acheive the value set

--- a/src/pixi/display/Stage.js
+++ b/src/pixi/display/Stage.js
@@ -65,8 +65,8 @@ PIXI.Stage = function(backgroundColor, interactive)
 }
 
 // constructor
-PIXI.Stage.constructor = PIXI.Stage;
 PIXI.Stage.prototype = Object.create( PIXI.DisplayObjectContainer.prototype );
+PIXI.Stage.constructor = PIXI.Stage.prototype.constructor = PIXI.Stage;
 
 /*
  * Updates the object transform for rendering

--- a/src/pixi/extras/CustomRenderable.js
+++ b/src/pixi/extras/CustomRenderable.js
@@ -17,8 +17,8 @@ PIXI.CustomRenderable = function()
 }
 
 // constructor
-PIXI.CustomRenderable.constructor = PIXI.CustomRenderable;
 PIXI.CustomRenderable.prototype = Object.create( PIXI.DisplayObject.prototype );
+PIXI.CustomRenderable.constructor = PIXI.CustomRenderable.prototype.constructor = PIXI.CustomRenderable;
 
 /**
  * If this object is being rendered by a CanvasRenderer it will call this callback

--- a/src/pixi/extras/Rope.js
+++ b/src/pixi/extras/Rope.js
@@ -29,8 +29,8 @@ PIXI.Rope = function(texture, points)
 
 
 // constructor
-PIXI.Rope.constructor = PIXI.Rope;
 PIXI.Rope.prototype = Object.create( PIXI.Strip.prototype );
+PIXI.Rope.constructor = PIXI.Rope.prototype.constructor = PIXI.Rope;
 
 PIXI.Rope.prototype.refresh = function()
 {

--- a/src/pixi/extras/Spine.js
+++ b/src/pixi/extras/Spine.js
@@ -58,8 +58,8 @@ PIXI.Spine = function(url)
 	};
 }
 
-PIXI.Spine.constructor = PIXI.Spine;
 PIXI.Spine.prototype = Object.create( PIXI.DisplayObjectContainer.prototype );
+PIXI.Spine.constructor = PIXI.Spine.prototype.constructor = PIXI.Spine;
 
 /*
  * Updates the object transform for rendering

--- a/src/pixi/extras/Strip.js
+++ b/src/pixi/extras/Strip.js
@@ -66,8 +66,8 @@ PIXI.Strip = function(texture, width, height)
 }
 
 // constructor
-PIXI.Strip.constructor = PIXI.Strip;
 PIXI.Strip.prototype = Object.create( PIXI.DisplayObjectContainer.prototype );
+PIXI.Strip.constructor = PIXI.Strip.prototype.constructor = PIXI.Strip;
 
 PIXI.Strip.prototype.setTexture = function(texture)
 {

--- a/src/pixi/extras/TilingSprite.js
+++ b/src/pixi/extras/TilingSprite.js
@@ -62,8 +62,8 @@ PIXI.TilingSprite = function(texture, width, height)
 }
 
 // constructor
-PIXI.TilingSprite.constructor = PIXI.TilingSprite;
 PIXI.TilingSprite.prototype = Object.create( PIXI.DisplayObjectContainer.prototype );
+PIXI.TilingSprite.constructor = PIXI.TilingSprite.prototype.constructor = PIXI.TilingSprite;
 
 /**
  * Sets the texture of the tiling sprite

--- a/src/pixi/loaders/AssetLoader.js
+++ b/src/pixi/loaders/AssetLoader.js
@@ -69,7 +69,7 @@ PIXI.AssetLoader = function(assetURLs, crossorigin)
  */
 
 // constructor
-PIXI.AssetLoader.constructor = PIXI.AssetLoader;
+PIXI.AssetLoader.constructor = PIXI.AssetLoader.prototype.constructor = PIXI.AssetLoader;
 
 /**
  * Starts loading the assets sequentially

--- a/src/pixi/loaders/BitmapFontLoader.js
+++ b/src/pixi/loaders/BitmapFontLoader.js
@@ -58,7 +58,7 @@ PIXI.BitmapFontLoader = function(url, crossorigin)
 };
 
 // constructor
-PIXI.BitmapFontLoader.constructor = PIXI.BitmapFontLoader;
+PIXI.BitmapFontLoader.constructor = PIXI.BitmapFontLoader.prototype.constructor = PIXI.BitmapFontLoader;
 
 /**
  * Loads the XML font data

--- a/src/pixi/loaders/ImageLoader.js
+++ b/src/pixi/loaders/ImageLoader.js
@@ -27,7 +27,7 @@ PIXI.ImageLoader = function(url, crossorigin)
 };
 
 // constructor
-PIXI.ImageLoader.constructor = PIXI.ImageLoader;
+PIXI.ImageLoader.constructor = PIXI.ImageLoader.prototype.constructor = PIXI.ImageLoader;
 
 /**
  * Loads image or takes it from cache

--- a/src/pixi/loaders/JsonLoader.js
+++ b/src/pixi/loaders/JsonLoader.js
@@ -53,7 +53,7 @@ PIXI.JsonLoader = function (url, crossorigin) {
 };
 
 // constructor
-PIXI.JsonLoader.constructor = PIXI.JsonLoader;
+PIXI.JsonLoader.constructor = PIXI.JsonLoader.prototype.constructor = PIXI.JsonLoader;
 
 /**
  * Loads the JSON data

--- a/src/pixi/loaders/SpineLoader.js
+++ b/src/pixi/loaders/SpineLoader.js
@@ -51,7 +51,7 @@ PIXI.SpineLoader = function(url, crossorigin)
 	this.loaded = false;
 }
 
-PIXI.SpineLoader.constructor = PIXI.SpineLoader;
+PIXI.SpineLoader.constructor = PIXI.SpineLoader.prototype.constructor = PIXI.SpineLoader;
 
 /**
  * Loads the JSON data

--- a/src/pixi/loaders/SpriteSheetLoader.js
+++ b/src/pixi/loaders/SpriteSheetLoader.js
@@ -69,7 +69,7 @@ PIXI.SpriteSheetLoader = function (url, crossorigin) {
 };
 
 // constructor
-PIXI.SpriteSheetLoader.constructor = PIXI.SpriteSheetLoader;
+PIXI.SpriteSheetLoader.constructor = PIXI.SpriteSheetLoader.prototype.constructor = PIXI.SpriteSheetLoader;
 
 /**
  * This will begin loading the JSON file

--- a/src/pixi/primitives/Graphics.js
+++ b/src/pixi/primitives/Graphics.js
@@ -62,8 +62,8 @@ PIXI.Graphics = function()
 }
 
 // constructor
-PIXI.Graphics.constructor = PIXI.Graphics;
 PIXI.Graphics.prototype = Object.create( PIXI.DisplayObjectContainer.prototype );
+PIXI.Graphics.constructor = PIXI.Graphics.prototype.constructor = PIXI.Graphics;
 
 /**
  * Specifies a line style used for subsequent calls to Graphics methods such as the lineTo() method or the drawCircle() method.

--- a/src/pixi/renderers/canvas/CanvasRenderer.js
+++ b/src/pixi/renderers/canvas/CanvasRenderer.js
@@ -61,7 +61,7 @@ PIXI.CanvasRenderer = function(width, height, view, transparent)
 }
 
 // constructor
-PIXI.CanvasRenderer.constructor = PIXI.CanvasRenderer;
+PIXI.CanvasRenderer.constructor = PIXI.CanvasRenderer.prototype.constructor = PIXI.CanvasRenderer;
 
 /**
  * Renders the stage to its canvas view

--- a/src/pixi/renderers/webgl/WebGLBatch.js
+++ b/src/pixi/renderers/webgl/WebGLBatch.js
@@ -66,7 +66,7 @@ PIXI.WebGLBatch = function(gl)
 }
 
 // constructor
-PIXI.WebGLBatch.constructor = PIXI.WebGLBatch;
+PIXI.WebGLBatch.constructor = PIXI.WebGLBatch.prototype.constructor = PIXI.WebGLBatch;
 
 /**
  * Cleans the batch so that is can be returned to an object pool and reused

--- a/src/pixi/renderers/webgl/WebGLRenderGroup.js
+++ b/src/pixi/renderers/webgl/WebGLRenderGroup.js
@@ -26,7 +26,7 @@ PIXI.WebGLRenderGroup = function(gl)
 }
 
 // constructor
-PIXI.WebGLRenderGroup.constructor = PIXI.WebGLRenderGroup;
+PIXI.WebGLRenderGroup.constructor = PIXI.WebGLRenderGroup.prototype.constructor = PIXI.WebGLRenderGroup;
 
 /**
  * Add a display object to the webgl renderer

--- a/src/pixi/renderers/webgl/WebGLRenderer.js
+++ b/src/pixi/renderers/webgl/WebGLRenderer.js
@@ -81,7 +81,7 @@ PIXI.WebGLRenderer = function(width, height, view, transparent)
 }
 
 // constructor
-PIXI.WebGLRenderer.constructor = PIXI.WebGLRenderer;
+PIXI.WebGLRenderer.constructor = PIXI.WebGLRenderer.prototype.constructor = PIXI.WebGLRenderer;
 
 /**
  * Gets a new WebGLBatch from the pool

--- a/src/pixi/text/BitmapText.js
+++ b/src/pixi/text/BitmapText.js
@@ -28,8 +28,8 @@ PIXI.BitmapText = function(text, style)
 };
 
 // constructor
-PIXI.BitmapText.constructor = PIXI.BitmapText;
 PIXI.BitmapText.prototype = Object.create(PIXI.DisplayObjectContainer.prototype);
+PIXI.BitmapText.constructor = PIXI.BitmapText.prototype.constructor = PIXI.BitmapText;
 
 /**
  * Set the copy for the text object

--- a/src/pixi/text/Text.js
+++ b/src/pixi/text/Text.js
@@ -32,8 +32,8 @@ PIXI.Text = function(text, style)
 };
 
 // constructor
-PIXI.Text.constructor = PIXI.Text;
 PIXI.Text.prototype = Object.create(PIXI.Sprite.prototype);
+PIXI.Text.constructor = PIXI.Text.prototype.constructor = PIXI.Text;
 
 /**
  * Set the style of the text

--- a/src/pixi/textures/BaseTexture.js
+++ b/src/pixi/textures/BaseTexture.js
@@ -94,7 +94,7 @@ PIXI.BaseTexture = function(source)
 	this._powerOf2 = false;
 }
 
-PIXI.BaseTexture.constructor = PIXI.BaseTexture;
+PIXI.BaseTexture.constructor = PIXI.BaseTexture.prototype.constructor = PIXI.BaseTexture;
 
 /**
  * Destroys this base texture

--- a/src/pixi/textures/RenderTexture.js
+++ b/src/pixi/textures/RenderTexture.js
@@ -51,8 +51,8 @@ PIXI.RenderTexture = function(width, height)
 	}
 }
 
-PIXI.RenderTexture.constructor = PIXI.RenderTexture;
 PIXI.RenderTexture.prototype = Object.create( PIXI.Texture.prototype );
+PIXI.RenderTexture.constructor = PIXI.RenderTexture.prototype.constructor = PIXI.RenderTexture;
 
 /**
  * Initializes the webgl data for this texture

--- a/src/pixi/textures/Texture.js
+++ b/src/pixi/textures/Texture.js
@@ -68,7 +68,7 @@ PIXI.Texture = function(baseTexture, frame)
 	}
 }
 
-PIXI.Texture.constructor = PIXI.Texture;
+PIXI.Texture.constructor = PIXI.Texture.prototype.constructor = PIXI.Texture;
 
 /**
  * Called when the base texture is loaded


### PR DESCRIPTION
This is to fix #189, by adding the `constructor` property to the prototype. Placing here for some peer review.
