### PR TITLE
fixed typo in PIXI.Text.prototype.setText

### DIFF
--- a/src/pixi/text/Text.js
+++ b/src/pixi/text/Text.js
@@ -68,7 +68,7 @@ PIXI.Text.prototype.setStyle = function(style)
  * @methos setText
  * @param {String} text The copy that you would like the text to display
  */
-PIXI.Sprite.prototype.setText = function(text)
+PIXI.Text.prototype.setText = function(text)
 {
     this.text = text.toString() || " ";
     this.dirty = true;


### PR DESCRIPTION
Fix for a typo in PIXI.Text.prototype.setType (https://github.com/GoodBoyDigital/pixi.js/commit/ae98487b164ed661a451cfa9a7f4bf3d1ffd2182#commitcomment-3678832). 
Thanks, @namuol :+1: 
