### PR TITLE
fixes issue with interaction not working on displayObjects which were invisible when InteractionManager was last marked dirty

### DIFF
--- a/src/pixi/InteractionManager.js
+++ b/src/pixi/InteractionManager.js
@@ -73,24 +73,22 @@ PIXI.InteractionManager.prototype.collectInteractiveSprite = function(displayObj
 	{
 		var child = children[i];
 		
-		if(child.visible) {
-			// push all interactive bits
-			if(child.interactive)
-			{
-				iParent.interactiveChildren = true;
-				this.interactiveItems.push(child);
+		// push all interactive bits
+		if(child.interactive)
+		{
+			iParent.interactiveChildren = true;
+			this.interactiveItems.push(child);
 
-				if(child.children.length > 0)
-				{
-					this.collectInteractiveSprite(child, child);
-				}
-			}
-			else
+			if(child.children.length > 0)
 			{
-				if(child.children.length > 0)
-				{
-					this.collectInteractiveSprite(child, iParent);
-				}
+				this.collectInteractiveSprite(child, child);
+			}
+		}
+		else
+		{
+			if(child.children.length > 0)
+			{
+				this.collectInteractiveSprite(child, iParent);
 			}
 		}
 	}
@@ -235,7 +233,8 @@ PIXI.InteractionManager.prototype.onMouseMove = function(event)
 	for (var i = 0; i < length; i++)
 	{
 		var item = this.interactiveItems[i];
-		
+		if(!item.visible)continue;
+
 		if(item.mousemove)
 		{
 			//call the function!
@@ -271,7 +270,8 @@ PIXI.InteractionManager.prototype.onMouseDown = function(event)
 	for (var i = 0; i < length; i++)
 	{
 		var item = this.interactiveItems[i];
-		
+		if(!item.visible)continue;
+
 		if(item.mousedown || item.click)
 		{
 			item.__mouseIsDown = true;
@@ -310,6 +310,7 @@ PIXI.InteractionManager.prototype.onMouseUp = function(event)
 	for (var i = 0; i < length; i++)
 	{
 		var item = this.interactiveItems[i];
+		if(!item.visible)continue;
 		
 		if(item.mouseup || item.mouseupoutside || item.click)
 		{


### PR DESCRIPTION
this fix has InteractionManager track displayObjects regardless of visibility, then bail out of processing events on invisible displayObjects as they occur.

this fixes #209 and also covers #124
