### PR TITLE
Add "main" entry to package.json for external dependency usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
         "url": "https://github.com/GoodBoyDigital/pixi.js.git"
     },
 
+    "main": "bin/pixi.js",
+
     "dependencies": {},
     "devDependencies": {
         "grunt": "~0.4.x",


### PR DESCRIPTION
Very small change, added the "main" entry to package.json so that pixi.js can be used as a dependency in a node project, e.g.

dependencies {
 "pixi.js": "git://github.com/GoodBoyDigital/pixi.js.git"
}
