### PR TITLE
Fixed destroy of texture.

### DIFF
--- a/src/pixi/renderers/WebGLRenderGroup.js
+++ b/src/pixi/renderers/WebGLRenderGroup.js
@@ -43,10 +43,10 @@ PIXI.WebGLRenderGroup.prototype.setRenderable = function(displayObject)
 	//displayObject
 }
 
-PIXI.WebGLRenderGroup.prototype.render = function(projectionMatrix)
+PIXI.WebGLRenderGroup.prototype.render = function(projectionMatrix, renderer)
 {
 	
-	PIXI.WebGLRenderer.updateTextures();
+	renderer.updateTextures();
 	
 	var gl = this.gl;
 	
@@ -79,9 +79,9 @@ PIXI.WebGLRenderGroup.prototype.render = function(projectionMatrix)
 	
 }
 
-PIXI.WebGLRenderGroup.prototype.renderSpecific = function(displayObject, projectionMatrix)
+PIXI.WebGLRenderGroup.prototype.renderSpecific = function(displayObject, projectionMatrix, renderer)
 {
-	PIXI.WebGLRenderer.updateTextures();
+	renderer.updateTextures();
 	
 	var gl = this.gl;
 	this.checkVisibility(displayObject, displayObject.visible);

--- a/src/pixi/renderers/WebGLRenderer.js
+++ b/src/pixi/renderers/WebGLRenderer.js
@@ -172,7 +172,7 @@ PIXI.WebGLRenderer.prototype.render = function(stage)
 	}*/
 
 	// update any textures	
-	PIXI.WebGLRenderer.updateTextures();
+	this.updateTextures();
 		
 	// recursivly loop through all items!
 	//this.checkVisibility(stage, true);
@@ -196,7 +196,7 @@ PIXI.WebGLRenderer.prototype.render = function(stage)
 
 
 	this.stageRenderGroup.backgroundColor = stage.backgroundColorSplit;
-	this.stageRenderGroup.render(this.projectionMatrix);
+	this.stageRenderGroup.render(this.projectionMatrix, this);
 	
 	// interaction
 	// run interaction!
@@ -226,7 +226,7 @@ PIXI.WebGLRenderer.prototype.render = function(stage)
  * @private
  */
 
-PIXI.WebGLRenderer.updateTextures = function()
+PIXI.WebGLRenderer.prototype.updateTextures = function()
 {
 	for (var i=0; i < PIXI.texturesToUpdate.length; i++) this.updateTexture(PIXI.texturesToUpdate[i]);
 	for (var i=0; i < PIXI.texturesToDestroy.length; i++) this.destroyTexture(PIXI.texturesToDestroy[i]);
@@ -234,7 +234,7 @@ PIXI.WebGLRenderer.updateTextures = function()
 	PIXI.texturesToDestroy = [];
 }
 
-PIXI.WebGLRenderer.updateTexture = function(texture)
+PIXI.WebGLRenderer.prototype.updateTexture = function(texture)
 {
 	var gl = PIXI.gl;
 	
@@ -270,7 +270,7 @@ PIXI.WebGLRenderer.updateTexture = function(texture)
 	
 }
 
-PIXI.WebGLRenderer.destroyTexture = function(texture)
+PIXI.WebGLRenderer.prototype.destroyTexture = function(texture)
 {
 	var gl = this.gl;
 	


### PR DESCRIPTION
When destroying a (render)texture i noticed pixi threw an error.
I think the PIXI.WebGLRenderer.prototype.destroyTexture must be PIXI.WebGLRenderer.destroyTexture (otherwise PIXI.WebGLRenderer.updateTexture cannot call it).
Also the destroy is wrongly implemented.
