### PR TITLE
Fixes #284 masking issue when stage background is transparent

### DIFF
--- a/src/pixi/renderers/webgl/WebGLRenderGroup.js
+++ b/src/pixi/renderers/webgl/WebGLRenderGroup.js
@@ -109,7 +109,7 @@ PIXI.WebGLRenderGroup.prototype.render = function(projection)
   
 				PIXI.WebGLGraphics.renderGraphics(renderable.mask, projection);
   					
-				gl.colorMask(true, true, true, false);
+				gl.colorMask(true, true, true, true);
 				gl.stencilFunc(gl.NOTEQUAL,0,0xff);
 				gl.stencilOp(gl.KEEP,gl.KEEP,gl.KEEP);
 			}


### PR DESCRIPTION
Fixes #284 

This appears to fix the problem that occurs when attempting to add a mask to a displayobject that is added to a stage with a transparent background. 
