### PR TITLE
Added loadFramedSpriteSheet to ImageLoader, this method allows loading uniform sprite sheets that don't need a texture packer description file .

### DIFF
--- a/src/pixi/loaders/ImageLoader.js
+++ b/src/pixi/loaders/ImageLoader.js
@@ -58,7 +58,6 @@ PIXI.ImageLoader.prototype.load = function()
 };
 
 
-
 /**
  * Loads image and split it to uniform sized frames
  * 


### PR DESCRIPTION
This will allow loading frame sprite sheets and give access to each frame.
the method also allow caching of each frame

usage example

``` javascript
var image = new PIXI.ImageLoader('tileset.png');
image.addEventListener("loaded", function (event) { 
    var frames = event.content.frames;  //image frames are stored here

    var terrain = new PIXI.Sprite(frames[8]);  
    //var terrain = PIXI.Sprite.fromFrame('terrain-8');  //we can use this syntax too if a frame name is provided (here the frame name is 'terrain' the frame order is 8

    terrain.position.x = 0;
    terrain.position.y = 0;
    stage.addChild(terrain);

    document.body.appendChild(canvas);

    renderer.render(stage);

});
image.loadFramedSpriteSheet(92, 46);

//image.loadFramedSpriteSheet(92, 46, 'terrain'); //if a frame name is provided (here = 'terrain') then the frames will be added to PIXI.TextureCache

```
