### PR TITLE
Added totalframes to MovieClip

### DIFF
--- a/src/pixi/display/MovieClip.js
+++ b/src/pixi/display/MovieClip.js
@@ -73,6 +73,23 @@ PIXI.MovieClip.prototype = Object.create( PIXI.Sprite.prototype );
 PIXI.MovieClip.prototype.constructor = PIXI.MovieClip;
 
 /**
+* [read-only] totalFrames is the total number of frames in the MovieClip. This is the same as number of textures
+* assigned to the MovieClip.
+*
+* @property totalFrames
+* @type Number
+* @default 0
+* @readOnly
+*/
+Object.defineProperty( PIXI.MovieClip.prototype, 'totalFrames', {
+	get: function() {
+
+		return this.textures.length;
+	}
+});
+
+
+/**
  * Stops the MovieClip
  *
  * @method stop


### PR DESCRIPTION
Currently the only way you can find out the total number of frames in a MovieClip is by checking the length of the textures array.

Just added a getter called totalFrames to help with this. Since a lot of the PIXI library mimics the AS3 figured it doesn't hurt to add in totalFrames. Actually I was immediately looking for it since we have currentframe.
