### PR TITLE
Add Anchor Point to SpriteSheet + setTextures for MovieClip

### DIFF
--- a/src/pixi/display/MovieClip.js
+++ b/src/pixi/display/MovieClip.js
@@ -83,6 +83,16 @@ PIXI.MovieClip.prototype.stop = function()
 }
 
 /**
+ * Change Textures of MovieClip
+ *
+ * @method setTextures
+ */
+PIXI.MovieClip.prototype.setTextures = function(textures)
+{
+	this.textures = textures;
+}
+
+/**
  * Plays the MovieClip
  *
  * @method play

--- a/src/pixi/display/Sprite.js
+++ b/src/pixi/display/Sprite.js
@@ -75,7 +75,11 @@ PIXI.Sprite = function(texture)
 		this.onTextureUpdateBind = this.onTextureUpdate.bind(this);
 		this.texture.addEventListener( 'update', this.onTextureUpdateBind );
 	}
-
+	//Set Anchor Point of Texture to Anchor Point of Sprite
+	if(texture.anchor) {
+		this.anchor.x = texture.anchor.x;
+		this.anchor.y = texture.anchor.y;
+	}
 	this.renderable = true;
 }
 
@@ -129,6 +133,12 @@ PIXI.Sprite.prototype.setTexture = function(texture)
 		this.textureChange = true;	
 		this.texture = texture;
 		
+		//Set Anchor Point of Texture to Anchor Point of Sprite
+		if(texture.anchor) {
+			this.anchor.x = texture.anchor.x;
+			this.anchor.y = texture.anchor.y;
+		}
+
 		if(this.__renderGroup)
 		{
 			this.__renderGroup.updateTexture(this);
@@ -137,6 +147,12 @@ PIXI.Sprite.prototype.setTexture = function(texture)
 	else
 	{
 		this.texture = texture;
+		
+		//Set Anchor Point of Texture to Anchor Point of Sprite
+		if(texture.anchor) {
+			this.anchor.x = texture.anchor.x;
+			this.anchor.y = texture.anchor.y;
+		}
 	}
 	
 	this.updateFrame = true;

--- a/src/pixi/loaders/JsonLoader.js
+++ b/src/pixi/loaders/JsonLoader.js
@@ -112,6 +112,10 @@ PIXI.JsonLoader.prototype.onJSONLoaded = function () {
 							// calculate the offset!
 						}
 					}
+					//Get the custom Anchor Point
+					if (frameData[i].AnchorPoint) {
+						PIXI.TextureCache[i].anchor = new PIXI.Point(frameData[i].AnchorPoint.x, frameData[i].AnchorPoint.y);
+					}
 				}
 			
 				image.load();

--- a/src/pixi/loaders/SpriteSheetLoader.js
+++ b/src/pixi/loaders/SpriteSheetLoader.js
@@ -118,6 +118,10 @@ PIXI.SpriteSheetLoader.prototype.onJSONLoaded = function () {
 				PIXI.TextureCache[i].trim.x = 0; // (realSize.x / rect.w)
 				// calculate the offset!
 			}
+			//Get the custom Anchor Point
+			if (frameData[i].AnchorPoint) {
+				PIXI.TextureCache[i].anchor = new PIXI.Point(frameData[i].AnchorPoint.x, frameData[i].AnchorPoint.y);
+			}
 		}
 	}
 


### PR DESCRIPTION
I have add the ability to set Anchor Point of a Texture with in the Texture Sheet.

I have done so to save space on the images and allow creates to line up Sprites Texture how they want.

Here is a link to a Node-Webkit App i quickly put together with the add script.
https://github.com/ProjectEnder/pixi_anchorTool

as i continuing on with a project of mine, i noticed that i could not set the Texture of the MovieClip and found that there was not function or way other then to delete and re add the sprite to set texture of the MovieClip so i also added setTextures() to MovieClip to allow quick changes of Textures.

the AnchorTool is very rough but works. also i found http://renderhjs.net/shoebox/, and have asked the programer to add PIXI to his list of exports, this is a free option to TexturePacker, that i have been using.
