### PR TITLE
Enable per-texture scale filtering

### DIFF
--- a/src/pixi/renderers/canvas/CanvasRenderer.js
+++ b/src/pixi/renderers/canvas/CanvasRenderer.js
@@ -51,11 +51,25 @@ PIXI.CanvasRenderer = function(width, height, view, transparent)
 	 */
 	this.context = this.view.getContext("2d");
 
+	//some filter variables
+	this.smoothProperty = null;
+
+	if('imageSmoothingEnabled' in this.context)
+		this.smoothProperty = 'imageSmoothingEnabled';
+	else if('webkitImageSmoothingEnabled' in this.context)
+		this.smoothProperty = 'webkitImageSmoothingEnabled';
+	else if('mozImageSmoothingEnabled' in this.context)
+		this.smoothProperty = 'mozImageSmoothingEnabled';
+	else if('oImageSmoothingEnabled' in this.context)
+		this.smoothProperty = 'oImageSmoothingEnabled';
+
+	this.scaleMode = null;
+
 	this.refresh = true;
 	// hack to enable some hardware acceleration!
 	//this.view.style["transform"] = "translatez(0)";
 	
-    this.view.width = this.width;
+	this.view.width = this.width;
 	this.view.height = this.height;  
 	this.count = 0;
 }
@@ -171,8 +185,14 @@ PIXI.CanvasRenderer.prototype.renderDisplayObject = function(displayObject)
 				context.globalAlpha = displayObject.worldAlpha;
 				
 				context.setTransform(transform[0], transform[3], transform[1], transform[4], transform[2], transform[5]);
+
+				//if smoothingEnabled is supported and we need to change the smoothing property for this texture
+				if(this.smoothProperty && this.scaleMode !== displayObject.texture.baseTexture.scaleMode) {
+					this.scaleMode = displayObject.texture.baseTexture.scaleMode;
+					context[this.smoothProperty] = (this.scaleMode === PIXI.BaseTexture.SCALE_MODE.LINEAR);
+				}
 					
-				context.drawImage(displayObject.texture.baseTexture.source, 
+				context.drawImage(displayObject.texture.baseTexture.source,
 								   frame.x,
 								   frame.y,
 								   frame.width,

--- a/src/pixi/renderers/webgl/WebGLRenderer.js
+++ b/src/pixi/renderers/webgl/WebGLRenderer.js
@@ -244,8 +244,8 @@ PIXI.WebGLRenderer.updateTexture = function(texture)
 	 	gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, true);
 
 		gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, texture.source);
-		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
-		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, texture.scaleMode === PIXI.BaseTexture.SCALE_MODE.LINEAR ? gl.LINEAR : gl.NEAREST);
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, texture.scaleMode === PIXI.BaseTexture.SCALE_MODE.LINEAR ? gl.LINEAR : gl.NEAREST);
 
 		// reguler...
 

--- a/src/pixi/textures/BaseTexture.js
+++ b/src/pixi/textures/BaseTexture.js
@@ -14,7 +14,7 @@ PIXI.texturesToDestroy = [];
  * @constructor
  * @param source {String} the source object (image or canvas)
  */
-PIXI.BaseTexture = function(source)
+PIXI.BaseTexture = function(source, scaleMode)
 {
 	PIXI.EventTarget.call( this );
 
@@ -35,6 +35,14 @@ PIXI.BaseTexture = function(source)
 	 * @readOnly
 	 */
 	this.height = 100;
+
+	/**
+	 * The scale mode to apply when scaling this texture
+	 * @property scaleMode
+	 * @type PIXI.BaseTexture.SCALE_MODE
+	 * @default PIXI.BaseTexture.SCALE_MODE.LINEAR
+	 */
+	this.scaleMode = scaleMode || PIXI.BaseTexture.SCALE_MODE.DEFAULT;
 
 	/**
 	 * [read-only] Describes if the base texture has loaded or not
@@ -120,7 +128,7 @@ PIXI.BaseTexture.prototype.destroy = function()
  * @param imageUrl {String} The image url of the texture
  * @return BaseTexture
  */
-PIXI.BaseTexture.fromImage = function(imageUrl, crossorigin)
+PIXI.BaseTexture.fromImage = function(imageUrl, crossorigin, scaleMode)
 {
 	var baseTexture = PIXI.BaseTextureCache[imageUrl];
 	if(!baseTexture)
@@ -133,9 +141,15 @@ PIXI.BaseTexture.fromImage = function(imageUrl, crossorigin)
 			image.crossOrigin = '';
 		}
 		image.src = imageUrl;
-		baseTexture = new PIXI.BaseTexture(image);
+		baseTexture = new PIXI.BaseTexture(image, scaleMode);
 		PIXI.BaseTextureCache[imageUrl] = baseTexture;
 	}
 
 	return baseTexture;
 }
+
+PIXI.BaseTexture.SCALE_MODE = {
+	DEFAULT: 0, //default to LINEAR
+	LINEAR: 0,
+	NEAREST: 1
+};

--- a/src/pixi/textures/Texture.js
+++ b/src/pixi/textures/Texture.js
@@ -134,13 +134,13 @@ PIXI.Texture.prototype.setFrame = function(frame)
  * @param crossorigin {Boolean} Whether requests should be treated as crossorigin
  * @return Texture
  */
-PIXI.Texture.fromImage = function(imageUrl, crossorigin)
+PIXI.Texture.fromImage = function(imageUrl, crossorigin, scaleMode)
 {
 	var texture = PIXI.TextureCache[imageUrl];
 
 	if(!texture)
 	{
-		texture = new PIXI.Texture(PIXI.BaseTexture.fromImage(imageUrl, crossorigin));
+		texture = new PIXI.Texture(PIXI.BaseTexture.fromImage(imageUrl, crossorigin, scaleMode));
 		PIXI.TextureCache[imageUrl] = texture;
 	}
 
@@ -172,9 +172,9 @@ PIXI.Texture.fromFrame = function(frameId)
  * @param canvas {Canvas} The canvas element source of the texture
  * @return Texture
  */
-PIXI.Texture.fromCanvas = function(canvas)
+PIXI.Texture.fromCanvas = function(canvas, scaleMode)
 {
-	var	baseTexture = new PIXI.BaseTexture(canvas);
+	var	baseTexture = new PIXI.BaseTexture(canvas, scaleMode);
 	return new PIXI.Texture(baseTexture);
 }
 
@@ -210,3 +210,4 @@ PIXI.Texture.removeTextureFromCache = function(id)
 // this is more for webGL.. it contains updated frames..
 PIXI.Texture.frameUpdates = [];
 
+PIXI.Texture.SCALE_MODE = PIXI.BaseTexture.SCALE_MODE;


### PR DESCRIPTION
Bringing this back up, I figure if we cache the last smoothing value we can make it switch smoothing only when necessary. Since it is likely that many applications will only use one scale mode (either nearest or linear) you can set the default mode to use:

``` js
PIXI.Texture.SCALE_MODE.DEFAULT = PIXI.Texture.SCALE_MODE.NEAREST;
```

This will make all textures created _after this value is set_ have the `NEAREST` scale mode enabled. This works because the `.scaleMode` property of textures is set to `PIXI.Texture.SCALE_MODE.DEFAULT` when the object is created.

If only Nearest or only Linear is used for all textures there is no performance degradation; if multiple are used the swapping is negligible. Note that any performance concern only exist for the CanvasRenderer, webgl performance is not effected at all.

This will close #201
