### PR TITLE
Update AssetLoader.js

### DIFF
--- a/src/pixi/loaders/AssetLoader.js
+++ b/src/pixi/loaders/AssetLoader.js
@@ -85,7 +85,7 @@ PIXI.AssetLoader.prototype.load = function()
     for (var i=0; i < this.assetURLs.length; i++)
 	{
 		var fileName = this.assetURLs[i];
-		var fileType = fileName.split(".").pop().toLowerCase();
+		var fileType = fileName.split("?").shift().toLowerCase().split(".").pop();
 
         var loaderClass = this.loadersByType[fileType];
         if(!loaderClass)


### PR DESCRIPTION
Allow arguments on JSON Url - Example: spritesheet.json?version=1.0
