### PR TITLE
Cleaning up BaseTexture Destroy

### DIFF
--- a/src/pixi/renderers/canvas/CanvasRenderer.js
+++ b/src/pixi/renderers/canvas/CanvasRenderer.js
@@ -163,10 +163,11 @@ PIXI.CanvasRenderer.prototype.renderDisplayObject = function(displayObject)
 		
 		if(displayObject instanceof PIXI.Sprite)
 		{
-				
-			var frame = displayObject.texture.frame;
-			
-			if(frame && frame.width && frame.height)
+
+		var frame = displayObject.texture.frame;
+
+			//ignore null sources
+			if(frame && frame.width && frame.height && displayObject.texture.baseTexture.source)
 			{
 				context.globalAlpha = displayObject.worldAlpha;
 				

--- a/src/pixi/textures/BaseTexture.js
+++ b/src/pixi/textures/BaseTexture.js
@@ -91,6 +91,7 @@ PIXI.BaseTexture = function(source)
 		PIXI.texturesToUpdate.push(this);
 	}
 
+	this.imageUrl = null;
 	this._powerOf2 = false;
 }
 
@@ -103,11 +104,11 @@ PIXI.BaseTexture.prototype.constructor = PIXI.BaseTexture;
  */
 PIXI.BaseTexture.prototype.destroy = function()
 {
-	if(this.source instanceof Image)
+	if(this.source && this.source instanceof Image)
 	{
-		// removeFrom Cache
-		PIXI.BaseTextureCache[this.source.src] = null;
-
+		if (this.imageUrl in PIXI.BaseTextureCache) 
+			delete PIXI.BaseTextureCache[this.imageUrl];
+		this.imageUrl = null;
 		this.source.src = null;
 	}
 	this.source = null;
@@ -139,6 +140,7 @@ PIXI.BaseTexture.fromImage = function(imageUrl, crossorigin)
 		}
 		image.src = imageUrl;
 		baseTexture = new PIXI.BaseTexture(image);
+		baseTexture.imageUrl = imageUrl;
 		PIXI.BaseTextureCache[imageUrl] = baseTexture;
 	}
 

--- a/src/pixi/utils/EventTarget.js
+++ b/src/pixi/utils/EventTarget.js
@@ -63,4 +63,9 @@ PIXI.EventTarget = function () {
 
 	};
 
+	this.removeAllEventListeners = function( type ) {
+		var a = listeners[type];
+		if (a)
+			a.length = 0;
+	};
 };


### PR DESCRIPTION
Just noticed that we are now [removing the Image reference](https://github.com/GoodBoyDigital/pixi.js/blob/dev_simple_batch/src/pixi/textures/BaseTexture.js#L109) from the base texture cache on destroy. This is good (we use this in our own fork, and it caused a big boost on mobile performance). But in my testing I've noticed that the "src" attribute of Image will not always return the exact string you set it earlier. For example, it may get appended with the domain (i.e. "http://localhost/"). This leads to a problem where the BaseTexture is still not deleted correctly. 

This pull request adds three things:
- It fixes this issue by storing the imageURL string for later deletion.
- It does not call drawImage if the baseTexture's source is null.
- It adds removeAllEventListeners to EventTarget. This was useful in our game where we are loading and unloading textures on the fly, and relying on AssetLoader's "onComplete" event.

We are not unloading textures when WebGL is active, so that path may need some further testing. 

P.S. What is with "dev_simple_batch" branch? Is this the new dev branch going forward?
