### PR TITLE
adding base64 support to AssetLoader

### DIFF
--- a/src/pixi/loaders/AssetLoader.js
+++ b/src/pixi/loaders/AssetLoader.js
@@ -71,6 +71,33 @@ PIXI.AssetLoader = function(assetURLs, crossorigin)
 // constructor
 PIXI.AssetLoader.prototype.constructor = PIXI.AssetLoader;
 
+
+PIXI.AssetLoader.prototype._getDataType = function(str) 
+{
+    var test = "data:";
+    //starts with 'data:'
+    var start = str.slice(0, test.length).toLowerCase();
+    if (start == test) {
+        var data = str.slice(test.length);
+        
+        var sepIdx = data.indexOf(',');
+        if (sepIdx === -1) //malformed data URI scheme
+            return null;
+
+        //e.g. "image/gif;base64" => "image/gif"
+        var info = data.slice(0, sepIdx).split(';')[0];
+
+        //We might need to handle some special cases here...
+        //standardize text/plain to "txt" file extension
+        if (!info || info.toLowerCase() == "text/plain")
+            return "txt"
+
+        //User specified mime type, try splitting it by '/'
+        return info.split('/').pop().toLowerCase();
+    }
+    return null;
+}
+
 /**
  * Starts loading the assets sequentially
  *
@@ -85,7 +112,13 @@ PIXI.AssetLoader.prototype.load = function()
     for (var i=0; i < this.assetURLs.length; i++)
 	{
 		var fileName = this.assetURLs[i];
-		var fileType = fileName.split(".").pop().toLowerCase();
+
+        //first see if we have a data URI scheme..
+        var fileType = this._getDataType(fileName);
+
+        //if not, assume it's a file URI
+        if (!fileType)
+            fileType = fileName.split(".").pop().toLowerCase();
 
         var loaderClass = this.loadersByType[fileType];
         if(!loaderClass)


### PR DESCRIPTION
#411

Attempts to extract the file-type from the mime-type for base64-encoded URIs. The "text/plain" type looks for "txt" file extension. 

This brings up another topic. To reference the image you would need to use the same huge string. Not sure how desirable that is. Another approach would be to decouple the AssetLoader key and URI, so that you can grab a Texture (or whatever) by a short key name which has nothing to do with its URI. 
