### PR TITLE
Fix setText documentation attribute

### DIFF
--- a/src/pixi/text/Text.js
+++ b/src/pixi/text/Text.js
@@ -68,7 +68,7 @@ PIXI.Text.prototype.setStyle = function(style)
  * @method setText
  * @param {String} text The copy that you would like the text to display
  */
-PIXI.Sprite.prototype.setText = function(text)
+PIXI.Text.prototype.setText = function(text)
 {
     this.text = text.toString() || " ";
     this.dirty = true;


### PR DESCRIPTION
Text.setText does not appear in PIXI's documentation due to a typo in its documentation attribute
