### PR TITLE
Fixed declaration for docs

### DIFF
--- a/src/pixi/text/Text.js
+++ b/src/pixi/text/Text.js
@@ -65,7 +65,7 @@ PIXI.Text.prototype.setStyle = function(style)
 /**
  * Set the copy for the text object. To split a line you can use "\n"
  *
- * @methos setText
+ * @method setText
  * @param {String} text The copy that you would like the text to display
  */
 PIXI.Sprite.prototype.setText = function(text)


### PR DESCRIPTION
Just a typo, the decoration of setText was "methos" instead of "method", hence it didn't show up in the docs.
