### PR TITLE
Fixed IE11 check. IE11 no longer has MSIE in the userAgent, you need to ...

### DIFF
--- a/src/pixi/utils/Detector.js
+++ b/src/pixi/utils/Detector.js
@@ -27,7 +27,7 @@ PIXI.autoDetectRenderer = function(width, height, view, transparent, antialias)
 
 	if(webgl)
 	{
-		var ie =  (navigator.userAgent.toLowerCase().indexOf('msie') != -1);
+		var ie =  (navigator.userAgent.toLowerCase().indexOf('trident') != -1);
 		 webgl = !ie;
 	}
 	


### PR DESCRIPTION
...check for Trident/7.0 instead.
