### PR TITLE
Check for webserved files by looking at the protocol

### DIFF
--- a/src/pixi/loaders/BitmapFontLoader.js
+++ b/src/pixi/loaders/BitmapFontLoader.js
@@ -89,7 +89,7 @@ PIXI.BitmapFontLoader.prototype.onXMLLoaded = function()
 {
     if (this.ajaxRequest.readyState == 4)
     {
-        if (this.ajaxRequest.status == 200 || window.location.href.indexOf("http") == -1)
+        if (this.ajaxRequest.status == 200 || window.location.protocol.indexOf("http") == -1)
         {
             var textureUrl = this.baseUrl + this.ajaxRequest.responseXML.getElementsByTagName("page")[0].attributes.getNamedItem("file").nodeValue;
             var image = new PIXI.ImageLoader(textureUrl, this.crossorigin);

--- a/src/pixi/loaders/JsonLoader.js
+++ b/src/pixi/loaders/JsonLoader.js
@@ -80,7 +80,7 @@ PIXI.JsonLoader.prototype.load = function () {
  */
 PIXI.JsonLoader.prototype.onJSONLoaded = function () {
 	if (this.ajaxRequest.readyState == 4) {
-		if (this.ajaxRequest.status == 200 || window.location.href.indexOf("http") == -1) {
+		if (this.ajaxRequest.status == 200 || window.location.protocol.indexOf("http") == -1) {
 			this.json = JSON.parse(this.ajaxRequest.responseText);
 			
 			if(this.json.frames)


### PR DESCRIPTION
Previously it would assume a file is being served from the web as long as href happened to include the string 'http' anywhere - not just at the beginning.

This caused problems in our project where files are being loaded locally but the document has "http" somewhere in the URL.

Another way to fix this would be to change the check to `window.location.href.indexOf("http") != 0`.
