### PR TITLE
Fix for addChild when parent is null

### DIFF
--- a/src/pixi/display/DisplayObjectContainer.js
+++ b/src/pixi/display/DisplayObjectContainer.js
@@ -37,9 +37,8 @@ PIXI.DisplayObjectContainer.prototype.constructor = PIXI.DisplayObjectContainer;
  */
 PIXI.DisplayObjectContainer.prototype.addChild = function(child)
 {
-    if(child.parent !== undefined)
+    if(child.parent && child.parent !== this)
     {
-
         //// COULD BE THIS???
         child.parent.removeChild(child);
     //  return;


### PR DESCRIPTION
Previously addChild was checking this: `if(child.parent != undefined)` but testing just for 'undefined' isn't enough, as the parent is set to 'null' in DisplayObject.js, so this condition fails and throws an error as it tries to removeChild from null.
