### PR TITLE
Remove redundant code, fix trimmed sprite sheets

### DIFF
--- a/src/pixi/loaders/SpineLoader.js
+++ b/src/pixi/loaders/SpineLoader.js
@@ -64,24 +64,9 @@ PIXI.SpineLoader.prototype.load = function () {
     var jsonLoader = new PIXI.JsonLoader(this.url, this.crossorigin);
     jsonLoader.addEventListener("loaded", function (event) {
         scope.json = event.content.json;
-        scope.onJSONLoaded();
+        scope.onLoaded();
     });
     jsonLoader.load();
-};
-
-/**
- * Invoke when JSON file is loaded
- *
- * @method onJSONLoaded
- * @private
- */
-PIXI.SpineLoader.prototype.onJSONLoaded = function () {
-    var spineJsonParser = new spine.SkeletonJson();
-    var skeletonData = spineJsonParser.readSkeletonData(this.json);
-
-    PIXI.AnimCache[this.url] = skeletonData;
-
-    this.onLoaded();
 };
 
 /**

--- a/src/pixi/loaders/SpriteSheetLoader.js
+++ b/src/pixi/loaders/SpriteSheetLoader.js
@@ -80,47 +80,9 @@ PIXI.SpriteSheetLoader.prototype.load = function () {
     var jsonLoader = new PIXI.JsonLoader(this.url, this.crossorigin);
     jsonLoader.addEventListener('loaded', function (event) {
         scope.json = event.content.json;
-        scope.onJSONLoaded();
-    });
-    jsonLoader.load();
-};
-
-/**
- * Invoke when JSON file is loaded
- *
- * @method onJSONLoaded
- * @private
- */
-PIXI.SpriteSheetLoader.prototype.onJSONLoaded = function () {
-    var scope = this;
-    var textureUrl = this.baseUrl + this.json.meta.image;
-    var image = new PIXI.ImageLoader(textureUrl, this.crossorigin);
-    var frameData = this.json.frames;
-
-    this.texture = image.texture.baseTexture;
-    image.addEventListener('loaded', function () {
         scope.onLoaded();
     });
-
-    for (var i in frameData) {
-        var rect = frameData[i].frame;
-        if (rect) {
-            PIXI.TextureCache[i] = new PIXI.Texture(this.texture, {
-                x: rect.x,
-                y: rect.y,
-                width: rect.w,
-                height: rect.h
-            });
-            if (frameData[i].trimmed) {
-                //var realSize = frameData[i].spriteSourceSize;
-                PIXI.TextureCache[i].realSize = frameData[i].spriteSourceSize;
-                PIXI.TextureCache[i].trim.x = 0; // (realSize.x / rect.w)
-                // calculate the offset!
-            }
-        }
-    }
-
-    image.load();
+    jsonLoader.load();
 };
 
 /**


### PR DESCRIPTION
This code is duplicated in jsonLoader. Fixes trimmed sprite sheets as the duped code overwrites the correct trimmed handling.
