### PR TITLE
grunt-contrib-jshint 0.8 works now

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
 
     "dependencies": {},
     "devDependencies": {
-        "grunt": "~0.4.1",
-        "grunt-contrib-jshint": "git+https://github.com/englercj/grunt-contrib-jshint.git",
+        "grunt": "~0.4.2",
+        "grunt-contrib-jshint": "~0.8",
         "grunt-contrib-uglify": "~0.2",
         "grunt-contrib-connect": "~0.5",
         "grunt-contrib-yuidoc": "~0.5",


### PR DESCRIPTION
Been using 0.8 and works fine, also upped maintenance version of grunt.
