### PR TITLE
pixi/core tests

### DIFF
--- a/src/pixi/core/Ellipse.js
+++ b/src/pixi/core/Ellipse.js
@@ -55,6 +55,8 @@ PIXI.Ellipse.prototype.clone = function()
 };
 
 /**
+ * TODO: This method does not work as expected, see unit test
+ *
  * Checks if the x, and y coords passed to this function are contained within this ellipse
  *
  * @method contains

--- a/src/pixi/core/Rectangle.js
+++ b/src/pixi/core/Rectangle.js
@@ -55,6 +55,8 @@ PIXI.Rectangle.prototype.clone = function()
 };
 
 /**
+ * TODO: This method does not work as expected, see unit test
+ *
  * Checks if the x, and y coords passed to this function are contained within this Rectangle
  *
  * @method contains

--- a/test/unit/pixi/core/Circle.js
+++ b/test/unit/pixi/core/Circle.js
@@ -19,4 +19,44 @@ describe('pixi/core/Circle', function () {
         expect(obj).to.have.property('y', 0);
         expect(obj).to.have.property('radius', 0);
     });
+
+    it('clone', function () {
+        var obj = new Circle(10, 30, 100);
+        var clone = obj.clone();
+
+        expect(clone === obj).to.be.false;
+        expect(clone.x).to.equal(10);
+        expect(clone.y).to.equal(30);
+        expect(clone.radius).to.equal(100);
+    });
+
+    it('contains', function () {
+        var obj = new Circle(0, 0, 50);
+        expect(obj.contains(0, 0)).to.be.true;   // center
+        expect(obj.contains(0, -50)).to.be.true; // top
+        expect(obj.contains(50, 0)).to.be.true;  // right
+        expect(obj.contains(0, 50)).to.be.true;  // bottom
+        expect(obj.contains(-50, 0)).to.be.true; // left
+    });
+
+    it('contains in quads', function () {
+        var obj = new Circle(0, 0, 50);
+        expect(obj.contains(-35, -35)).to.be.true; // top-left
+        expect(obj.contains(35, -35)).to.be.true; // top-right
+        expect(obj.contains(35, 35)).to.be.true; // bottom-right
+        expect(obj.contains(-35, 35)).to.be.true; // bottom-left
+    });
+
+    it('does not contain', function () {
+        var obj = new Circle(0, 0, 50);
+        expect(obj.contains(-36, -36)).to.be.false; // top-left
+        expect(obj.contains(36, -36)).to.be.false; // top-right
+        expect(obj.contains(36, 36)).to.be.false; // bottom-right
+        expect(obj.contains(-36, 36)).to.be.false; // bottom-left
+    });
+
+    it('contains and no radius', function () {
+        var obj = new Circle();
+        expect(obj.contains(0, 0)).to.be.false;
+    });
 });

--- a/test/unit/pixi/core/Ellipse.js
+++ b/test/unit/pixi/core/Ellipse.js
@@ -3,6 +3,7 @@ describe('pixi/core/Ellipse', function () {
 
     var expect = chai.expect;
     var Ellipse = PIXI.Ellipse;
+    var Rectangle = PIXI.Rectangle;
 
     it('Module exists', function () {
         expect(Ellipse).to.be.a('function');
@@ -20,5 +21,55 @@ describe('pixi/core/Ellipse', function () {
         expect(obj).to.have.property('y', 0);
         expect(obj).to.have.property('width', 0);
         expect(obj).to.have.property('height', 0);
+    });
+
+    it('clone', function () {
+        var obj = new Ellipse(10, 30, 50, 100);
+        var clone = obj.clone();
+
+        expect(clone === obj).to.be.false;
+        expect(clone.x).to.equal(10);
+        expect(clone.y).to.equal(30);
+        expect(clone.width).to.equal(50);
+        expect(clone.height).to.equal(100);
+    });
+
+    // it('contains', function () {
+    //     var obj = new Ellipse(0, 0, 50, 100);
+    //     expect(obj.contains(0, 0)).to.be.true;   // center
+    //     expect(obj.contains(0, -50)).to.be.true; // top
+    //     expect(obj.contains(25, 0)).to.be.true;  // right
+    //     expect(obj.contains(0, 50)).to.be.true;  // bottom
+    //     expect(obj.contains(-25, 0)).to.be.true; // left
+    // });
+
+    // it('contains in quads', function () {
+    //     var obj = new Ellipse(0, 0, 50, 100);
+    //     expect(obj.contains(-35, -35)).to.be.true; // top-left
+    //     expect(obj.contains(35, -35)).to.be.true; // top-right
+    //     expect(obj.contains(35, 35)).to.be.true; // bottom-right
+    //     expect(obj.contains(-35, 35)).to.be.true; // bottom-left
+    // });
+
+    // it('does not contain', function () {
+    //     var obj = new Ellipse(0, 0, 50, 100);
+    //     expect(obj.contains(-36, -36)).to.be.false; // top-left
+    //     expect(obj.contains(36, -36)).to.be.false; // top-right
+    //     expect(obj.contains(36, 36)).to.be.false; // bottom-right
+    //     expect(obj.contains(-36, 36)).to.be.false; // bottom-left
+    // });
+
+    it('contains and no size', function () {
+        var obj = new Ellipse();
+        expect(obj.contains(0, 0)).to.be.false;
+    });
+
+    it('getBounds', function () {
+        var obj = new Ellipse(0, 0, 50, 100);
+        var bounds = obj.getBounds();
+        expect(bounds.x).to.equal(0);
+        expect(bounds.y).to.equal(0);
+        expect(bounds.width).to.equal(50);
+        expect(bounds.height).to.equal(100);
     });
 });

--- a/test/unit/pixi/core/Matrix.js
+++ b/test/unit/pixi/core/Matrix.js
@@ -3,8 +3,8 @@ describe('pixi/core/Matrix', function () {
 
     var expect = chai.expect;
     var mat3 = PIXI.mat3;
-    var mat4 = PIXI.mat4;
     var Matrix = PIXI.Matrix;
+    var identityMatrix = PIXI.identityMatrix;
 
     it('Ensure determineMatrixArrayType works', function () {
         expect(Matrix).to.be.a('function');
@@ -19,12 +19,35 @@ describe('pixi/core/Matrix', function () {
         pixi_core_Matrix_confirmNewMat3(matrix);
     });
 
-    it('mat3 exists', function () {
-        expect(mat4).to.be.an('object');
+    it('Confirm identityMatrix', function () {
+        pixi_core_Matrix_confirmNewMat3(identityMatrix);
     });
 
-    it('Confirm new mat4 matrix', function () {
-        var matrix = new mat4.create();
-        pixi_core_Matrix_confirmNewMat4(matrix);
+    it('mat3 transpose', function () {
+        var m = mat3.create();
+        mat3.transpose(m);
+        // TODO: Test without defaults
+        pixi_core_Matrix_confirmNewMat3(m);
     });
+
+    it('mat3 multiply', function () {
+        var m = mat3.create();
+        var m2 = mat3.create();
+        var mult = mat3.multiply(m, m2);
+        // TODO: Test without defaults
+        pixi_core_Matrix_confirmNewMat3(mult);
+    });
+
+    it('mat3 clone', function () {
+        var m = mat3.create();
+        var clone = mat3.clone(m);
+        expect(clone === m).to.be.false;
+        // TODO: Test without defaults
+        pixi_core_Matrix_confirmNewMat3(m);
+        pixi_core_Matrix_confirmNewMat3(clone);
+    });
+
+    // FIXME:
+    // PIXI.mat3.toMat4 is not used, not testing
+    // PIXI.mat4 is not used, not testing
 });

--- a/test/unit/pixi/core/Point.js
+++ b/test/unit/pixi/core/Point.js
@@ -12,4 +12,12 @@ describe('pixi/core/Point', function () {
         var obj = new Point();
         pixi_core_Point_confirm(obj, 0, 0);
     });
+
+    it('clone', function () {
+        var obj = new Point(30, 60);
+        var clone = obj.clone();
+
+        expect(clone === obj).to.be.false;
+        pixi_core_Point_confirm(clone, 30, 60);
+    });
 });

--- a/test/unit/pixi/core/Polygon.js
+++ b/test/unit/pixi/core/Polygon.js
@@ -9,12 +9,36 @@ describe('pixi/core/Polygon', function () {
     });
 
     it('Confirm new instance', function () {
-        var obj = new Polygon();
+        var obj = new Polygon(0,0 ,0,1, 1,1, 1,0);
 
         expect(obj).to.be.an.instanceof(Polygon);
         expect(obj).to.respondTo('clone');
         expect(obj).to.respondTo('contains');
 
-        expect(obj).to.have.deep.property('points.length', 0);
+        expect(obj).to.have.deep.property('points.length', 4);
+    });
+
+    it('clone', function () {
+        var obj = new Polygon(0,0 ,0,1, 1,1, 1,0);
+        var clone = obj.clone();
+
+        expect(clone === obj).to.be.false;
+        expect(clone.points === obj.points).to.be.false;
+        expect(clone.points[3] === obj.points[3]).to.be.false;
+        expect(clone.points.length === obj.points.length).to.be.true;
+
+        expect(clone.points[0].x === obj.points[0].x).to.be.true;
+        expect(clone.points[0].y === obj.points[0].y).to.be.true;
+        expect(clone.points[1].x === obj.points[1].x).to.be.true;
+        expect(clone.points[1].y === obj.points[1].y).to.be.true;
+        expect(clone.points[2].x === obj.points[2].x).to.be.true;
+        expect(clone.points[2].y === obj.points[2].y).to.be.true;
+        expect(clone.points[3].x === obj.points[3].x).to.be.true;
+        expect(clone.points[3].y === obj.points[3].y).to.be.true;
+    });
+
+    it('contains and no size', function () {
+        var obj = new Polygon();
+        expect(obj.contains(0, 0)).to.be.false;
     });
 });

--- a/test/unit/pixi/core/Rectangle.js
+++ b/test/unit/pixi/core/Rectangle.js
@@ -9,7 +9,29 @@ describe('pixi/core/Rectangle', function () {
     });
 
     it('Confirm new instance', function () {
-        var rect = new Rectangle();
-        pixi_core_Rectangle_confirm(rect, 0, 0, 0, 0);
+        var obj = new Rectangle();
+        pixi_core_Rectangle_confirm(obj, 0, 0, 0, 0);
+    });
+
+    it('clone', function () {
+        var obj = new Rectangle(10, 30, 100, 200);
+        var clone = obj.clone();
+
+        expect(clone === obj).to.be.false;
+        pixi_core_Rectangle_confirm(obj, 10, 30, 100, 200);
+    });
+
+    // it('contains', function () {
+    //     var obj = new Rectangle(0, 0, 50, 100);
+    //     expect(obj.contains(0, 0)).to.be.true;   // center
+    //     expect(obj.contains(0, -50)).to.be.true; // top
+    //     expect(obj.contains(25, 0)).to.be.true;  // right
+    //     expect(obj.contains(0, 50)).to.be.true;  // bottom
+    //     expect(obj.contains(-25, 0)).to.be.true; // left
+    // });
+
+    it('contains and no size', function () {
+        var obj = new Rectangle();
+        expect(obj.contains(0, 0)).to.be.false;
     });
 });


### PR DESCRIPTION
Wrote some tests to see coverage go up (at least on local reports ATM).

Notes:
- I'm not sure if I should test any of the `mat4` and `mat3.toMat4` stuff, as it is not used anywhere in pixi
- I'm not sure of the proper way to test the `mat3` methods
- There are some problems with the `contains` methods in `PIXI.Ellipse` and `PIXI.Rectangle`
- I didn't test the `PIXI.Polygon` `contains` method
