### PR TITLE
[CanvasRenderer] Native "alpha" Context Attribute

### DIFF
--- a/src/pixi/renderers/canvas/CanvasRenderer.js
+++ b/src/pixi/renderers/canvas/CanvasRenderer.js
@@ -19,7 +19,7 @@ PIXI.CanvasRenderer = function(width, height, view, transparent)
 
     this.type = PIXI.CANVAS_RENDERER;
 
-    this.transparent = transparent;
+    this.transparent = !!transparent;
 
     if(!PIXI.blendModesCanvas)
     {
@@ -73,7 +73,7 @@ PIXI.CanvasRenderer = function(width, height, view, transparent)
      * @property context
      * @type Canvas 2d Context
      */
-    this.context = this.view.getContext( "2d" );
+    this.context = this.view.getContext( "2d" , { alpha: this.transparent } );
 
     //some filter variables
     this.smoothProperty = null;


### PR DESCRIPTION
WHATWG Reference: http://wiki.whatwg.org/wiki/CanvasOpaque
Chromium Ticket: https://code.google.com/p/chromium/issues/detail?id=234297

This API feature is now shipping in Chrome 32 stable.  Tested there, as well as in Safari 7 and Firefox 26 (which do not yet support it).  The desired effect is exhibited with no known regressions, and should provide performance improvements, where supported, akin to the same feature in WebGL.

NOTE: As is the case with WebGLRenderer, PIXI.Stage.setBackgroundColor will currently have no effect when transparent is false.
