### PR TITLE
Protect against NaN rotation

### DIFF
--- a/src/pixi/display/DisplayObject.js
+++ b/src/pixi/display/DisplayObject.js
@@ -402,9 +402,12 @@ PIXI.DisplayObject.prototype.updateTransform = function()
     // TODO OPTIMIZE THIS!! with dirty
     if(this.rotation !== this.rotationCache)
     {
-        this.rotationCache = this.rotation;
-        this._sr =  Math.sin(this.rotation);
-        this._cr =  Math.cos(this.rotation);
+        if(!isNaN(parseFloat(this.rotation)))
+        {
+            this.rotationCache = this.rotation;
+            this._sr =  Math.sin(this.rotation);
+            this._cr =  Math.cos(this.rotation);
+        }
     }
 
    // var localTransform = this.localTransform//.toArray();


### PR DESCRIPTION
A simple check against NaN values being set to this.rotation. Without this patch, a NaN rotation value will make a Sprite's texture disappear, which can be confusing. It seems that the rotation should simply not update if a NaN value is passed in, rather than cause other, more confusing side effects.
