### PR TITLE
Protect against NaN rotation values

### DIFF
--- a/src/pixi/display/DisplayObject.js
+++ b/src/pixi/display/DisplayObject.js
@@ -402,6 +402,9 @@ PIXI.DisplayObject.prototype.updateTransform = function()
     // TODO OPTIMIZE THIS!! with dirty
     if(this.rotation !== this.rotationCache)
     {
+        if(isNaN(parseFloat(this.rotation)))
+            throw new Error('DisplayObject rotation values must be numeric.');
+
         this.rotationCache = this.rotation;
         this._sr =  Math.sin(this.rotation);
         this._cr =  Math.cos(this.rotation);


### PR DESCRIPTION
Throws an Error if a DisplayObject's rotation was set to NaN. Without this check, Sprite's textures could disappear silently, with no reference to an improper rotation value as the culprit.
