### PR TITLE
tweak for tinted bitmap text

### DIFF
--- a/src/pixi/text/BitmapText.js
+++ b/src/pixi/text/BitmapText.js
@@ -61,6 +61,7 @@ PIXI.BitmapText.prototype.setStyle = function(style)
     this.fontSize = font.length >= 2 ? parseInt(font[font.length - 2], 10) : PIXI.BitmapText.fonts[this.fontName].size;
 
     this.dirty = true;
+    this.tint = style.tint == null ? 0xFFFFFF : style.tint;
 };
 
 /**
@@ -79,6 +80,8 @@ PIXI.BitmapText.prototype.updateText = function()
     var lineWidths = [];
     var line = 0;
     var scale = this.fontSize / data.size;
+    var tint = this.tint;
+    
     for(var i = 0; i < this.text.length; i++)
     {
         var charCode = this.text.charCodeAt(i);
@@ -131,6 +134,7 @@ PIXI.BitmapText.prototype.updateText = function()
         c.position.x = (chars[i].position.x + lineAlignOffsets[chars[i].line]) * scale;
         c.position.y = chars[i].position.y * scale;
         c.scale.x = c.scale.y = scale;
+        c.tint = tint;
         this.addChild(c);
     }
 


### PR DESCRIPTION
Tiny tweak to add tinting to BitmapText

Just wondering if BitmapText should inherit from SpriteBatch instead of DisplayObjectContainer ? 
