### PR TITLE
Fixes a rogue new-line character on the end of Text objects

### DIFF
--- a/src/pixi/text/Text.js
+++ b/src/pixi/text/Text.js
@@ -287,7 +287,11 @@ PIXI.Text.prototype.wordWrap = function(text)
                 result += words[j] + ' ';
             }
         }
-        result += '\n';
+
+        if (i < lines.length-1)
+        {
+            result += '\n';
+        }
     }
     return result;
 };


### PR DESCRIPTION
.. that have word wrapping enabled, causing the Text bounds to be 1 line too high.
