### PR TITLE
Changed karma to have a 60,000 ms capture timeout

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -57,8 +57,8 @@ module.exports = function(config) {
         browsers : ['Firefox'],
 
         // If browser does not capture in given timeout [ms], kill it
-        // CLI --capture-timeout 5000
-        captureTimeout : 5000,
+        // CLI --capture-timeout 60000
+        captureTimeout : 60000,
 
         // Auto run tests on start (when browsers are captured) and exit
         // CLI --single-run --no-single-run


### PR DESCRIPTION
The previous captureTimeout was so short that on computers with even average hardware couldn't open Firefox fast enough for Karma's liking, mostly killing the process whilst Firefox was still starting up.

Changing the global default to something reasonable sounds better than forcing everyone to change their local config just to compile on slower computers.

I chose 60,000 milliseconds as that is what [Karma's default is](http://karma-runner.github.io/0.8/config/configuration-file.html).
