### PR TITLE
Fix PIXI.Texture.removeTextureFromCache()

### DIFF
--- a/src/pixi/textures/Texture.js
+++ b/src/pixi/textures/Texture.js
@@ -230,7 +230,8 @@ PIXI.Texture.addTextureToCache = function(texture, id)
 PIXI.Texture.removeTextureFromCache = function(id)
 {
     var texture = PIXI.TextureCache[id];
-    PIXI.TextureCache[id] = null;
+    delete PIXI.TextureCache[id];
+    delete PIXI.BaseTextureCache[id];
     return texture;
 };
 


### PR DESCRIPTION
This fixes a couple of issues:
- Cached textures should also be removed from PIXI.BaseTextureCache to be fully removed. This was discussed here: http://www.html5gamedevs.com/topic/2182-pixi-web-app-slows-down-after-loading-20mb-of-images-on-ipad-mini2/?p=14945
- Base64-encoded images loaded with PIXI.Texture.fromImage() use the full base64 string as the hash key (rather than a much smaller image URL string for "normal" texture loading). This essentially doubles the browser memory usage for each cached image. Previously, when setting the value as null, the key remained, leaving an image worth of data still in the TextureCache. This fix is essential if loading & clearing lots of base64-encoded images.
