### PR TITLE
Fixed TilingSprite not render children on canvas.

### DIFF
--- a/src/pixi/extras/TilingSprite.js
+++ b/src/pixi/extras/TilingSprite.js
@@ -202,7 +202,9 @@ PIXI.TilingSprite.prototype._renderCanvas = function(renderSession)
     if(this.visible === false || this.alpha === 0)return;
     
     var context = renderSession.context;
-
+    
+    var i,j;
+    
     if(this._mask)
     {
         renderSession.maskManager.pushMask(this._mask, context);


### PR DESCRIPTION
TilingSprite does not render children on 2d canvas. The call to children's renderCanvas method is missing.
