### PR TITLE
Sprite Canvas Render: Add texture loaded check before drawing

### DIFF
--- a/src/pixi/display/Sprite.js
+++ b/src/pixi/display/Sprite.js
@@ -338,7 +338,7 @@ PIXI.Sprite.prototype._renderCanvas = function(renderSession)
     
 
     //ignore null sources
-    if(frame && frame.width && frame.height && texture.baseTexture.source)
+    if(frame && frame.width && frame.height && texture.baseTexture.source && texture.baseTexture.hasLoaded)
     {
         context.globalAlpha = this.worldAlpha;
 
@@ -365,9 +365,6 @@ PIXI.Sprite.prototype._renderCanvas = function(renderSession)
             
             if(this.cachedTint !== this.tint)
             {
-                // no point tinting an image that has not loaded yet!
-                if(!texture.baseTexture.hasLoaded)return;
-
                 this.cachedTint = this.tint;
                 
                 //TODO clean up caching - how to clean up the caches?


### PR DESCRIPTION
I've run into an inconsistency between the WebGL rendering and canvas rendering where the canvas render for a sprite would throw an InvalidStateError when attempting to draw a sprite before the texture has loaded (or if the texture failed to load due to missing image file).  Adding a check before drawing to ensure the texture is loaded prevents this error from being thrown.

It appears the cause of this exception is related to passing in a 0 width image context.drawImage, see http://lists.whatwg.org/htdig.cgi/whatwg-whatwg.org/2013-September/040873.html for some discussion on this issue.

This error is occurring on Chrome 32.0.1700.107

Let me know if you need any more info on this!
