### PR TITLE
Fixed TilingSprite not render children on canvas

### DIFF
--- a/src/pixi/extras/TilingSprite.js
+++ b/src/pixi/extras/TilingSprite.js
@@ -241,6 +241,8 @@ PIXI.TilingSprite.prototype._renderCanvas = function(renderSession)
     
     var transform = this.worldTransform;
 
+    var i,j;
+
     // allow for trimming
 
     context.setTransform(transform.a, transform.c, transform.b, transform.d, transform.tx, transform.ty);
@@ -287,6 +289,11 @@ PIXI.TilingSprite.prototype._renderCanvas = function(renderSession)
     if(this._mask)
     {
         renderSession.maskManager.popMask(renderSession.context);
+    }
+
+    for(i=0,j=this.children.length; i<j; i++)
+    {
+        this.children[i]._renderCanvas(renderSession);
     }
 };
 


### PR DESCRIPTION
TilingSprite does not render children on 2d canvas. The call to
children's renderCanvas method is missing.
