### PR TITLE
Read custom JSON files

### DIFF
--- a/src/pixi/loaders/JsonLoader.js
+++ b/src/pixi/loaders/JsonLoader.js
@@ -132,6 +132,7 @@ PIXI.JsonLoader.prototype.onJSONLoaded = function () {
             }
             else
             {
+                PIXI.JsonCache[this.url] = this.json;
                 this.onLoaded();
             }
         }
@@ -168,3 +169,5 @@ PIXI.JsonLoader.prototype.onError = function () {
         content: this
     });
 };
+
+PIXI.JsonCache = {};


### PR DESCRIPTION
Currently custom JSON files only get loaded, but this will allow you to read them:

```
var json = PIXI.JsonCache['data.json'];
```
