### PR TITLE
Grunt Watch to use concat_sourcemap

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -185,10 +185,11 @@ module.exports = function(grunt) {
                 }
             }
         },
+        //Watches and builds for _development_ (source maps)
         watch: {
             scripts: {
                 files: ['<%= dirs.src %>/**/*.js'],
-                tasks: ['concat'],
+                tasks: ['concat_sourcemap'],
                 options: {
                     spawn: false,
                 }
@@ -214,6 +215,6 @@ module.exports = function(grunt) {
     grunt.registerTask('travis', ['build', 'test']);
 
     grunt.registerTask('default', ['build', 'test']);
-
-    grunt.registerTask('debug-watch', ['concat', 'watch']);
+    
+    grunt.registerTask('debug-watch', ['concat_sourcemap', 'watch:debug']);
 };

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "karma-chrome-launcher": "~0.1",
         "karma-firefox-launcher": "~0.1",
         "karma-mocha": "~0.1",
-        "karma-spec-reporter": "~0.0.6"
+        "karma-spec-reporter": "~0.0.6",
+        "grunt-contrib-watch": "~0.5.3"
     }
 }


### PR DESCRIPTION
Firstly; grunt-watch was not included as a dependency in `package.json`.

Secondly; watch now uses `concat_sourcemap` by default. This makes debugging easier during development.
