### PR TITLE
Bug fix: Siblings' event priority 

### DIFF
--- a/src/pixi/InteractionManager.js
+++ b/src/pixi/InteractionManager.js
@@ -119,7 +119,7 @@ PIXI.InteractionManager.prototype.collectInteractiveSprite = function(displayObj
     var length = children.length;
 
     // make an interaction tree... {item.__interactiveParent}
-    for (var i = length-1; i >= 0; i--)
+    for (var i = 0; i < length; i++)
     {
         var child = children[i];
 


### PR DESCRIPTION
A bug fix for issue #641

Sprites are collected in the same order as in the scene graph now, but hit-testing still occurs in reverse
