### PR TITLE
Fix Text.destroy() and memory leak in BaseTexture.destroy()

### DIFF
--- a/src/pixi/text/Text.js
+++ b/src/pixi/text/Text.js
@@ -302,15 +302,11 @@ PIXI.Text.prototype.wordWrap = function(text)
  * Destroys this text object
  *
  * @method destroy
- * @param destroyTexture {Boolean}
+ * @param destroyBaseTexture {Boolean} whether to destroy the base texture as well
  */
-PIXI.Text.prototype.destroy = function(destroyTexture)
+PIXI.Text.prototype.destroy = function(destroyBaseTexture)
 {
-    if(destroyTexture)
-    {
-        this.texture.destroy();
-    }
-
+    this.texture.destroy(destroyBaseTexture);
 };
 
 PIXI.Text.heightCache = {};

--- a/src/pixi/textures/BaseTexture.js
+++ b/src/pixi/textures/BaseTexture.js
@@ -118,6 +118,10 @@ PIXI.BaseTexture.prototype.destroy = function()
         this.imageUrl = null;
         this.source.src = null;
     }
+    else if (this.source && this.source._pixiId)
+    {
+        delete PIXI.BaseTextureCache[this.source._pixiId];
+    }
     this.source = null;
     PIXI.texturesToDestroy.push(this);
 };


### PR DESCRIPTION
Text.destroy() previously always called Texture.destroy() without parameters, which does nothing.

BaseTexture.destroy() only deleted the texture from cache if it was created from an image. It left dangling textures whose cache id can't be accessed if it was made with fromCanvas() ( see http://jsfiddle.net/9UPr9/4/ )
