### PR TITLE
added removeChildAt, added removeChildren

### DIFF
--- a/src/pixi/display/DisplayObjectContainer.js
+++ b/src/pixi/display/DisplayObjectContainer.js
@@ -170,7 +170,7 @@ PIXI.DisplayObjectContainer.prototype.removeChild = function(child)
 PIXI.DisplayObjectContainer.prototype.removeChildAt = function(index)
 {
     var child = this.getChildAt( index );
-    if( this.stage )
+    if(this.stage)
         child.removeStageReference();
 
     child.parent = undefined;


### PR DESCRIPTION
Updated the logic on how `removeChild()` worked. Now its the `removeChildAt()` method that splices the children array. The `removeChild()` calls the `removeChildAt()`. Also, renamed the untested `removeAll()` (which wasn't in the ActionScript 3.0 specification, and rename it to `removeChildren()`. `removeChildren()`. Hope that's clear.
