### PR TITLE
Text support for CocoonJS

### DIFF
--- a/src/pixi/text/Text.js
+++ b/src/pixi/text/Text.js
@@ -130,7 +130,6 @@ PIXI.Text.prototype.updateText = function()
 
     //calculate text height
     var lineHeight = this.determineFontHeight('font: ' + this.style.font  + ';') + this.style.strokeThickness;
-    this.canvas.height = lineHeight * lines.length;
 
     if (navigator.isCocoonJS)
     {
@@ -139,6 +138,7 @@ PIXI.Text.prototype.updateText = function()
     }
     
     //set canvas text styles
+    this.canvas.height = lineHeight * lines.length;
     this.context.fillStyle = this.style.fill;
     this.context.font = this.style.font;
 


### PR DESCRIPTION
Adds determineFontHeightInPixels for calculating the exact height of 'gM' in a given size and font.

Calls the function if it detects CocoonJS. The normal determineFontHeight will fail since CocoonJS' accelerated mode doesn't have CSS support to calculate the correct element.offsetHeight value.
