### PR TITLE
Implemented animationSpeed for Spine animations.

### DIFF
--- a/bin/pixi.dev.js
+++ b/bin/pixi.dev.js
@@ -10977,6 +10977,7 @@ spine.AnimationState = function (stateData) {
     this.queue = [];
 };
 spine.AnimationState.prototype = {
+    animationSpeed: 1,
     current: null,
     previous: null,
     currentTime: 0,
@@ -10986,7 +10987,7 @@ spine.AnimationState.prototype = {
     mixTime: 0,
     mixDuration: 0,
     update: function (delta) {
-        this.currentTime += delta;
+        this.currentTime += (delta * this.animationSpeed); //timeScale: Multiply delta by the speed of animation required.
         this.previousTime += delta;
         this.mixTime += delta;
 

--- a/docs/files/src_pixi_extras_Spine.js.html
+++ b/docs/files/src_pixi_extras_Spine.js.html
@@ -971,6 +971,7 @@ spine.AnimationState = function (stateData) {
     this.queue = [];
 };
 spine.AnimationState.prototype = {
+    animationSpeed: 1,
     current: null,
     previous: null,
     currentTime: 0,
@@ -980,7 +981,7 @@ spine.AnimationState.prototype = {
     mixTime: 0,
     mixDuration: 0,
     update: function (delta) {
-        this.currentTime += delta;
+        this.currentTime += (delta * this.animationSpeed); //timeScale: Multiply delta by the speed of animation required.
         this.previousTime += delta;
         this.mixTime += delta;
 

--- a/src/pixi/extras/Spine.js
+++ b/src/pixi/extras/Spine.js
@@ -791,6 +791,7 @@ spine.AnimationState = function (stateData) {
     this.queue = [];
 };
 spine.AnimationState.prototype = {
+    animationSpeed: 1,
     current: null,
     previous: null,
     currentTime: 0,
@@ -800,7 +801,7 @@ spine.AnimationState.prototype = {
     mixTime: 0,
     mixDuration: 0,
     update: function (delta) {
-        this.currentTime += delta;
+        this.currentTime += (delta * this.animationSpeed); //timeScale: Multiply delta by the speed of animation required.
         this.previousTime += delta;
         this.mixTime += delta;
 


### PR DESCRIPTION
Default value is 1.
This is simply the "timeScale" value from the Spine runtime, but with a more friendly name.

It allows the user to easily change the playback speed of a Spine animation in Pixi.js.
