### PR TITLE
Fix AssetLoader which was preventing access to loader.content on progres...

### DIFF
--- a/src/pixi/loaders/AssetLoader.js
+++ b/src/pixi/loaders/AssetLoader.js
@@ -113,7 +113,7 @@ PIXI.AssetLoader.prototype.load = function()
     var scope = this;
 
     function onLoad(evt) {
-        scope.onAssetLoaded(evt.loader);
+        scope.onAssetLoaded(evt.content);
     }
 
     this.loadCount = this.assetURLs.length;


### PR DESCRIPTION
Fix AssetLoader which was preventing access to loader.content on progress event

All loaders emit the `loaded` event with a `content` param. The AssetLoader was sending `loader` instead of `content` to the onLoad callback, so accessing event.content resulted to `undefined.
