### PR TITLE
Fixed prototype of DotScreenFilter

### DIFF
--- a/src/pixi/filters/DotScreenFilter.js
+++ b/src/pixi/filters/DotScreenFilter.js
@@ -50,7 +50,7 @@ PIXI.DotScreenFilter = function()
     ];
 };
 
-PIXI.DotScreenFilter.prototype = Object.create( PIXI.DotScreenFilter.prototype );
+PIXI.DotScreenFilter.prototype = Object.create( PIXI.AbstractFilter.prototype );
 PIXI.DotScreenFilter.prototype.constructor = PIXI.DotScreenFilter;
 
 /**


### PR DESCRIPTION
DotScreenFilter prototype was not extending from AbstractFilter.
