### PR TITLE
Correct Graphics().boundsPadding documentation

### DIFF
--- a/src/pixi/primitives/Graphics.js
+++ b/src/pixi/primitives/Graphics.js
@@ -107,7 +107,7 @@ PIXI.Graphics = function()
     /**
      * the bounds' padding used for bounds calculation
      *
-     * @property bounds
+     * @property boundsPadding
      * @type Number
      */
     this.boundsPadding = 10;


### PR DESCRIPTION
Two properties were incorrectly called "bounds" under Graphics'
documentation.
