### PR TITLE
Removed the trailing whitespace when wordwrapping a textfield

### DIFF
--- a/src/pixi/text/Text.js
+++ b/src/pixi/text/Text.js
@@ -331,7 +331,7 @@ PIXI.Text.prototype.wordWrap = function(text)
         {
             var wordWidth = this.context.measureText(words[j]).width;
             var wordWidthWithSpace = wordWidth + this.context.measureText(' ').width;
-            if(wordWidthWithSpace > spaceLeft)
+            if(j === 0 || wordWidthWithSpace > spaceLeft)
             {
                 // Skip printing the newline if it's the first word of the line that is
                 // greater than the word wrap width.
@@ -339,13 +339,13 @@ PIXI.Text.prototype.wordWrap = function(text)
                 {
                     result += '\n';
                 }
-                result += words[j] + ' ';
+                result += words[j];
                 spaceLeft = this.style.wordWrapWidth - wordWidth;
             }
             else
             {
                 spaceLeft -= wordWidthWithSpace;
-                result += words[j] + ' ';
+                result += ' ' + words[j];
             }
         }
 


### PR DESCRIPTION
When wordwrapping occurs in the Text class a trailing whitespace is added to wrapped lines. This causes central aligned texts not to be centred. as the whitespace is included when calculating the width of the textfield.

Please see this fiddle: http://jsfiddle.net/Mowday/24vmw/

This will add a whitespace before a word if it's not the first word of that line, instead of always adding a whitespace after each word.
