### PR TITLE
Compensates for the pivot point to prevent it from altering the X and Y ...

### DIFF
--- a/src/pixi/display/DisplayObject.js
+++ b/src/pixi/display/DisplayObject.js
@@ -442,8 +442,8 @@ PIXI.DisplayObject.prototype.updateTransform = function()
         a01 = -this._sr * this.scale.y,
         a10 = this._sr * this.scale.x,
         a11 = this._cr * this.scale.y,
-        a02 = this.position.x - a00 * px - py * a01,
-        a12 = this.position.y - a11 * py - px * a10,
+        a02 = (this.position.x + px) - a00 * px - py * a01,
+        a12 = (this.position.y +  py) - a11 * py - px * a10,
         b00 = parentTransform.a, b01 = parentTransform.b,
         b10 = parentTransform.c, b11 = parentTransform.d;
 
@@ -547,7 +547,6 @@ PIXI.DisplayObject.prototype._generateCachedSprite = function()//renderSession)
 
     this._cachedSprite.anchor.x = -( bounds.x / bounds.width );
     this._cachedSprite.anchor.y = -( bounds.y / bounds.height );
-
 
     this._filters = tempFilters;
 


### PR DESCRIPTION
I'm not sure how it's intended to work, but I don't believe the pivot point should alter the X and Y position of an object. It should only define the axle to rotate an object round.
Right now, setting the pivot point alters X and Y of the position.

Please see this fiddle:
http://jsfiddle.net/Mowday/b2jpK/
At first the object has a pivot point set to it's center/middle (0.5 \* width, 0.5 \* height).
This forces the object to be rendered outside of the stage as the pivot point has altered X and Y.

In the code I have added some parts you uncomment to see more examples of this behaviour as well as an example of the fix.
