### PR TITLE
A way to disable premultipliedAlpha on transparent webGL context

### DIFF
--- a/src/pixi/renderers/webgl/WebGLRenderer.js
+++ b/src/pixi/renderers/webgl/WebGLRenderer.js
@@ -72,7 +72,7 @@ PIXI.WebGLRenderer = function(width, height, view, transparent, antialias)
     this.options = {
         alpha: this.transparent,
         antialias:!!antialias, // SPEED UP??
-        premultipliedAlpha:!!transparent,
+        premultipliedAlpha:!!transparent && transparent !== 'notMultiplied',
         stencil:true
     };
 


### PR DESCRIPTION
This is a cross-renderer way to disable premultipliedAlpha on webGL renderer. You just pass `notMultiplied` as `transparent` parameter. This way it works with renderer detection and is ignored gracefully.

``` js
new PIXI.WebGLRenderer(width, height, canvas, 'notMultiplied');
```

Rationale: Disabling premultipliedAlpha is required if you want to export the transparent canvas with toDataURI/toBlob
