### PR TITLE
If the texture is destroyed, it should be removed from TextureCache too

### DIFF
--- a/src/pixi/textures/BaseTexture.js
+++ b/src/pixi/textures/BaseTexture.js
@@ -115,6 +115,7 @@ PIXI.BaseTexture.prototype.destroy = function()
     if(this.imageUrl)
     {
         delete PIXI.BaseTextureCache[this.imageUrl];
+        delete PIXI.TextureCache[this.imageUrl];
         this.imageUrl = null;
         this.source.src = null;
     }


### PR DESCRIPTION
Otherwise it will be picked up if the same image is used again, but the baseTexture will be nullified!
