### PR TITLE
Added an error event dispatch when an image cannot be loaded.

### DIFF
--- a/src/pixi/textures/BaseTexture.js
+++ b/src/pixi/textures/BaseTexture.js
@@ -95,7 +95,7 @@ PIXI.BaseTexture = function(source, scaleMode)
             scope.dispatchEvent( { type: 'loaded', content: scope } );
         };
         this.source.onerror = function() {
-            scope.dispatchEvent( {type: 'error', content: scope } );
+            scope.dispatchEvent( { type: 'error', content: scope } );
         };
     }
 


### PR DESCRIPTION
Helpful when loading assets using BaseTexture.fromImage(...).

Tested by trying to load images that do not exist on Windows 8.1 using:
Chrome Version 34.0.1847.131 m
Firefox 26.0
Firefox 29.0
Internet Explorer 11.0.9600.17105
