### PR TITLE
Small bug when creating webgl prevents some browsers from working

### DIFF
--- a/src/pixi/renderers/webgl/WebGLRenderer.js
+++ b/src/pixi/renderers/webgl/WebGLRenderer.js
@@ -80,7 +80,7 @@ PIXI.WebGLRenderer = function(width, height, view, transparent, antialias)
 
     ['experimental-webgl', 'webgl'].forEach(function(name) {
         try {
-            gl = this.view.getContext(name,  this.options);
+            gl = gl || this.view.getContext(name,  this.options);
         } catch(e) {}
     }, this);
 


### PR DESCRIPTION
@englercj a small bug in this [PR](https://github.com/GoodBoyDigital/pixi.js/pull/739) went under the radar. On opera mobile and firefox mobile calling getContext() twice results in an error. This will fix that.
