### PR TITLE
Fix touch move event handling

### DIFF
--- a/src/pixi/InteractionManager.js
+++ b/src/pixi/InteractionManager.js
@@ -575,7 +575,7 @@ PIXI.InteractionManager.prototype.onTouchMove = function(event)
         for (var j = 0; j < this.interactiveItems.length; j++)
         {
             var item = this.interactiveItems[j];
-            if(item.touchmove && item.__touchData[touchEvent.identifier]) item.touchmove(touchData);
+            if(item.touchmove && item.__touchData && item.__touchData[touchEvent.identifier]) item.touchmove(touchData);
         }
     }
 };


### PR DESCRIPTION
The "pixi.js example 8 - Dragging" was not working correctly for me on my Android phone -- I was not getting the `touchmove` events in most cases. I looked in the code and it seems that it was throwing an exception on the modified line if the sprite did not have the `__touchData` member value set. With the following fix applied, the example behaves correctly.
