### PR TITLE
Added CSS Color Converter to Utils

### DIFF
--- a/src/pixi/utils/Utils.js
+++ b/src/pixi/utils/Utils.js
@@ -77,7 +77,7 @@ PIXI.rgb2hex = function(rgb) {
  */
 PIXI.css2rgb = function(cssString) {
     var r,g,b;
-    cssString = cssString.replace(' ',''); //remove spaces
+    cssString = cssString.toLowerCase(cssString.replace(' ','')); //remove spaces, case insensitivity
     if (cssString.charAt(0) === '#') {
         if (cssString.length === 4) { //#fff format
             r = (parseInt(cssString.charAt(1),16)*0x11) << 16;


### PR DESCRIPTION
This was suggested in this issue: https://github.com/GoodBoyDigital/pixi.js/issues/458

The css2rgb function supports color formats #fff, #ffffff, and rgb(255,255,255).

I excluded support for CSS named colors to avoid over-complicating this.
