### PR TITLE
Only use XDomainRequest in IE, if a crossorigin request is needed

### DIFF
--- a/src/pixi/loaders/JsonLoader.js
+++ b/src/pixi/loaders/JsonLoader.js
@@ -64,7 +64,7 @@ PIXI.JsonLoader.prototype.load = function () {
 
     var scope = this;
 
-    if(window.XDomainRequest)
+    if(window.XDomainRequest && scope.crossorigin)
     {
         this.ajaxRequest = new window.XDomainRequest();
 


### PR DESCRIPTION
The JsonLoader was always using XDomainRequest in IE, even if a cross origin request wasn't needed (for example: new PIXI.AssetLoader(myJsonAssets, false);).

Due to this, the response headers from the request were checked on cross origin rules. Which doesn't make sense if the request is to the same host, resulting in the request to fail if the host from the same origin doesn't respond with these headers.
