### PR TITLE
Fix off-by-one error

### DIFF
--- a/examples/example 3 - MovieClip/index.html
+++ b/examples/example 3 - MovieClip/index.html
@@ -44,9 +44,9 @@
 		// create an array to store the textures
 		var explosionTextures = [];
 
-		for (var i=0; i < 26; i++)
+		for (var i=1; i <= 27; i++)
 		{
-		 	var texture = PIXI.Texture.fromFrame("Explosion_Sequence_A " + (i+1) + ".png");
+		 	var texture = PIXI.Texture.fromFrame("Explosion_Sequence_A " + (i) + ".png");
 		 	explosionTextures.push(texture);
 		};
 


### PR DESCRIPTION
Logic was `0<=x<26`, which is `0 -> 25`.
The spritesheet has `1 -> 27`.
Fix the off by one and remove the need to do `i+1`, just start at 1.
