### PR TITLE
Fix to roundPixels property in CanvasRenderer

### DIFF
--- a/src/pixi/renderers/canvas/CanvasRenderer.js
+++ b/src/pixi/renderers/canvas/CanvasRenderer.js
@@ -149,7 +149,7 @@ PIXI.CanvasRenderer = function(width, height, view, transparent)
          * If true Pixi will Math.floor() x/y values when rendering, stopping pixel interpolation.
          * Handy for crisp pixel art and speed on legacy devices.
          */
-        roundPixels = false
+        roundPixels: false
     };
 
     if("imageSmoothingEnabled" in this.context)


### PR DESCRIPTION
The roundPixels property in the CanvasRenderer should be a property of the renderSession to be correctly applied in the _renderCanvas methods of the Sprite and SpriteBatch classes.
