### PR TITLE
Improved handling of children removal from empty DisplayObjectContainers

### DIFF
--- a/src/pixi/display/DisplayObjectContainer.js
+++ b/src/pixi/display/DisplayObjectContainer.js
@@ -203,6 +203,10 @@ PIXI.DisplayObjectContainer.prototype.removeChildren = function(beginIndex, endI
         }
         return removed;
     }
+    else if (range === 0 && this.children.length === 0)
+    {
+        return [];
+    }
     else
     {
         throw new Error( 'Range Error, numeric values are outside the acceptable range' );


### PR DESCRIPTION
Calling removeChildren() on an already empty DisplayObjectContainer should not fail with out of range error, but instead do nothing (as the container is already empty) and return an empty array of removed elements for consistency.
