### PR TITLE
`this.textureChange` is no longer used in any object, ...

### DIFF
--- a/src/pixi/display/Sprite.js
+++ b/src/pixi/display/Sprite.js
@@ -132,17 +132,7 @@ Object.defineProperty(PIXI.Sprite.prototype, 'height', {
  */
 PIXI.Sprite.prototype.setTexture = function(texture)
 {
-    // stop current texture;
-    if(this.texture.baseTexture !== texture.baseTexture)
-    {
-        this.textureChange = true;
-        this.texture = texture;
-    }
-    else
-    {
-        this.texture = texture;
-    }
-
+    this.texture = texture;
     this.cachedTint = 0xFFFFFF;
 };
 


### PR DESCRIPTION
... anywhere within Pixi, so this check now appears to be redundant - and is changing the internal class shape of Pixi.Sprite as a result (adding a property that doesn't exist).
