### PR TITLE
Remove trailing commas for Google Closure compatibility

### DIFF
--- a/src/pixi/extras/Spine.js
+++ b/src/pixi/extras/Spine.js
@@ -1286,7 +1286,7 @@ spine.AtlasRegion.prototype = {
     index: 0,
     rotate: false,
     splits: null,
-    pads: null,
+    pads: null
 };
 
 spine.AtlasReader = function (text) {

--- a/src/pixi/filters/BlurXFilter.js
+++ b/src/pixi/filters/BlurXFilter.js
@@ -10,7 +10,7 @@ PIXI.BlurXFilter = function()
 
     // set the uniforms
     this.uniforms = {
-        blur: {type: '1f', value: 1/512},
+        blur: {type: '1f', value: 1/512}
     };
 
     this.fragmentSrc = [

--- a/src/pixi/filters/BlurYFilter.js
+++ b/src/pixi/filters/BlurYFilter.js
@@ -10,7 +10,7 @@ PIXI.BlurYFilter = function()
 
     // set the uniforms
     this.uniforms = {
-        blur: {type: '1f', value: 1/512},
+        blur: {type: '1f', value: 1/512}
     };
 
     this.fragmentSrc = [

--- a/src/pixi/filters/ColorMatrixFilter.js
+++ b/src/pixi/filters/ColorMatrixFilter.js
@@ -21,7 +21,7 @@ PIXI.ColorMatrixFilter = function()
         matrix: {type: 'mat4', value: [1,0,0,0,
                                        0,1,0,0,
                                        0,0,1,0,
-                                       0,0,0,1]},
+                                       0,0,0,1]}
     };
 
     this.fragmentSrc = [

--- a/src/pixi/filters/ColorStepFilter.js
+++ b/src/pixi/filters/ColorStepFilter.js
@@ -16,7 +16,7 @@ PIXI.ColorStepFilter = function()
 
     // set the uniforms
     this.uniforms = {
-        step: {type: '1f', value: 5},
+        step: {type: '1f', value: 5}
     };
 
     this.fragmentSrc = [

--- a/src/pixi/filters/CrossHatchFilter.js
+++ b/src/pixi/filters/CrossHatchFilter.js
@@ -10,7 +10,7 @@ PIXI.CrossHatchFilter = function()
 
     // set the uniforms
     this.uniforms = {
-        blur: {type: '1f', value: 1 / 512},
+        blur: {type: '1f', value: 1 / 512}
     };
 
     this.fragmentSrc = [

--- a/src/pixi/filters/GrayFilter.js
+++ b/src/pixi/filters/GrayFilter.js
@@ -16,7 +16,7 @@ PIXI.GrayFilter = function()
 
     // set the uniforms
     this.uniforms = {
-        gray: {type: '1f', value: 1},
+        gray: {type: '1f', value: 1}
     };
 
     this.fragmentSrc = [

--- a/src/pixi/filters/InvertFilter.js
+++ b/src/pixi/filters/InvertFilter.js
@@ -16,7 +16,7 @@ PIXI.InvertFilter = function()
 
     // set the uniforms
     this.uniforms = {
-        invert: {type: '1f', value: 1},
+        invert: {type: '1f', value: 1}
     };
 
     this.fragmentSrc = [

--- a/src/pixi/filters/PixelateFilter.js
+++ b/src/pixi/filters/PixelateFilter.js
@@ -18,7 +18,7 @@ PIXI.PixelateFilter = function()
     this.uniforms = {
         invert: {type: '1f', value: 0},
         dimensions: {type: '4fv', value:new Float32Array([10000, 100, 10, 10])},
-        pixelSize: {type: '2f', value:{x:10, y:10}},
+        pixelSize: {type: '2f', value:{x:10, y:10}}
     };
 
     this.fragmentSrc = [

--- a/src/pixi/filters/SepiaFilter.js
+++ b/src/pixi/filters/SepiaFilter.js
@@ -16,7 +16,7 @@ PIXI.SepiaFilter = function()
 
     // set the uniforms
     this.uniforms = {
-        sepia: {type: '1f', value: 1},
+        sepia: {type: '1f', value: 1}
     };
 
     this.fragmentSrc = [

--- a/src/pixi/filters/SmartBlurFilter.js
+++ b/src/pixi/filters/SmartBlurFilter.js
@@ -10,7 +10,7 @@ PIXI.SmartBlurFilter = function()
 
     // set the uniforms
     this.uniforms = {
-        blur: {type: '1f', value: 1/512},
+        blur: {type: '1f', value: 1/512}
     };
 
     this.fragmentSrc = [

--- a/src/pixi/filters/TwistFilter.js
+++ b/src/pixi/filters/TwistFilter.js
@@ -18,7 +18,7 @@ PIXI.TwistFilter = function()
     this.uniforms = {
         radius: {type: '1f', value:0.5},
         angle: {type: '1f', value:5},
-        offset: {type: '2f', value:{x:0.5, y:0.5}},
+        offset: {type: '2f', value:{x:0.5, y:0.5}}
     };
 
     this.fragmentSrc = [


### PR DESCRIPTION
By default, the Google Closure Compiler is rather pedantic about backward compatibility and chokes on trailing commas. Removing them would allow Pixi to be compiled with Closure, and improve stylistic consistency. (As far as I see, trailing-less is already the dominant style in your codebase; I suppose the occasional trailing comma springs up because JSHint does not detect it.)

It seems that Pixi does not support advanced Closure compilation (#573), but basic compatibility would be nice nonetheless.

For context, I should add that I am writing a Pixi wrapper in Clojurescript, which uses Closure. Compiling the wrapped library is [generally desirable](http://lukevanderhart.com/2011/09/30/using-javascript-and-clojurescript.html).
