### PR TITLE
Fix WebGlContextLost handling.

### DIFF
--- a/src/pixi/renderers/webgl/WebGLRenderer.js
+++ b/src/pixi/renderers/webgl/WebGLRenderer.js
@@ -77,10 +77,10 @@ PIXI.WebGLRenderer = function(width, height, view, transparent, antialias, prese
 
     // deal with losing context..
     this.contextLostFunction = this.handleContextLost.bind(this);
-    this.contextRestoredLostFunction = this.handleContextRestored.bind(this);
+    this.contextRestoredFunction = this.handleContextRestored.bind(this);
 
     this.view.addEventListener('webglcontextlost', this.contextLostFunction, false);
-    this.view.addEventListener('webglcontextrestored', this.contextRestoredLostFunction, false);
+    this.view.addEventListener('webglcontextrestored', this.contextRestoredFunction, false);
 
     this.options = {
         alpha: this.transparent,
@@ -573,7 +573,7 @@ PIXI.WebGLRenderer.prototype.destroy = function()
 
     // remove listeners
     this.view.removeEventListener('webglcontextlost', this.contextLostFunction);
-    this.view.removeEventListener('webglcontextrestored', this.contextRestoredLostFunction);
+    this.view.removeEventListener('webglcontextrestored', this.contextRestoredFunction);
 
     PIXI.glContexts[this.glContextId] = null;
 


### PR DESCRIPTION
In WebGlRenderer.js, this.contextLost was being used both as a function
created by bind() and as a boolean variable. Not only is this
incorrect, it also would cause problems in Firefox when calling
removeEventListener, as it would expect contextLost to be a function,
but instead it would get a boolean and would raise an error. Chrome did
not raise an error when calling removeEventListener with a boolean
value as the second argument instead of a function.

This patch separates the two uses of this.contextLost, which is how it
should be.
