### PR TITLE
Fixes .visible on SpriteBatch using Canvas

### DIFF
--- a/src/pixi/display/SpriteBatch.js
+++ b/src/pixi/display/SpriteBatch.js
@@ -94,6 +94,8 @@ PIXI.SpriteBatch.prototype._renderWebGL = function(renderSession)
 */
 PIXI.SpriteBatch.prototype._renderCanvas = function(renderSession)
 {
+    if(!this.visible || this.alpha <= 0 || !this.children.length)return;
+    
     var context = renderSession.context;
     context.globalAlpha = this.worldAlpha;
 


### PR DESCRIPTION
Prevents SpriteBatch from rendering in Canvas mode when visible is false.
