### PR TITLE
added view frustum culling to webGL and canvas render process

### DIFF
--- a/src/pixi/display/DisplayObject.js
+++ b/src/pixi/display/DisplayObject.js
@@ -414,6 +414,25 @@ Object.defineProperty(PIXI.DisplayObject.prototype, 'cacheAsBitmap', {
     }
 });
 
+/**
+ * Checks this objects world bounds for intersection with the stage viewport
+ *
+ * @method frustumCheck
+ * @return {Boolean} true if bounds rect does intersect with the stage rect
+ */
+PIXI.DisplayObject.prototype.frustumCheck = function(renderSession){
+    //get world bounds
+    var bounds = this.getBounds();
+    //get stage rect from the renderer via the renderSession object
+    var stageW = renderSession.renderer.width;
+    var stageH = renderSession.renderer.height;
+    //check bounds against stage rect
+    if(bounds.x > stageW || bounds.y > stageH || bounds.x + bounds.width < 0 || bounds.y + bounds.height < 0) {
+        return false;
+    }
+    return true;
+};
+
 /*
  * Updates the object transform for rendering
  *

--- a/src/pixi/display/Sprite.js
+++ b/src/pixi/display/Sprite.js
@@ -244,7 +244,10 @@ PIXI.Sprite.prototype._renderWebGL = function(renderSession)
 {
     // if the sprite is not visible or the alpha is 0 then no need to render this element
     if(!this.visible || this.alpha <= 0)return;
-    
+
+    //apply frustum culling
+    if(renderSession.useFrustum && ! this.frustumCheck(renderSession)) return;
+
     var i,j;
 
     // do a quick check to see if this element has a mask or a filter.
@@ -309,7 +312,10 @@ PIXI.Sprite.prototype._renderCanvas = function(renderSession)
 {
     // If the sprite is not visible or the alpha is 0 then no need to render this element
     if (this.visible === false || this.alpha === 0) return;
-    
+
+    //apply frustum culling
+    if(renderSession.useFrustum && ! this.frustumCheck(renderSession)) return;
+
     if (this.blendMode !== renderSession.currentBlendMode)
     {
         renderSession.currentBlendMode = this.blendMode;

--- a/src/pixi/primitives/Graphics.js
+++ b/src/pixi/primitives/Graphics.js
@@ -639,7 +639,8 @@ PIXI.Graphics.prototype._renderWebGL = function(renderSession)
 {
     // if the sprite is not visible or the alpha is 0 then no need to render this element
     if(this.visible === false || this.alpha === 0 || this.isMask === true)return;
-    
+    //apply frustum culling
+    if(renderSession.useFrustum && ! this.frustumCheck(renderSession)) return;
 
     if(this._cacheAsBitmap)
     {
@@ -715,7 +716,9 @@ PIXI.Graphics.prototype._renderCanvas = function(renderSession)
 {
     // if the sprite is not visible or the alpha is 0 then no need to render this element
     if(this.visible === false || this.alpha === 0 || this.isMask === true)return;
-    
+    //apply frustum culling
+    if(renderSession.useFrustum && ! this.frustumCheck(renderSession)) return;
+
     var context = renderSession.context;
     var transform = this.worldTransform;
     

--- a/src/pixi/renderers/canvas/CanvasRenderer.js
+++ b/src/pixi/renderers/canvas/CanvasRenderer.js
@@ -148,6 +148,8 @@ PIXI.CanvasRenderer = function(width, height, view, transparent)
         maskManager: this.maskManager,
         scaleMode: null,
         smoothProperty: null,
+        renderer: this,//used to get stage dimensions for frustum culling
+        useFrustum: true,//used to disable frustum culling eg when drawing to RenderTexture
 
         /**
          * If true Pixi will Math.floor() x/y values when rendering, stopping pixel interpolation.

--- a/src/pixi/renderers/webgl/WebGLRenderer.js
+++ b/src/pixi/renderers/webgl/WebGLRenderer.js
@@ -163,6 +163,7 @@ PIXI.WebGLRenderer = function(width, height, view, transparent, antialias, prese
     this.renderSession.spriteBatch = this.spriteBatch;
     this.renderSession.stencilManager = this.stencilManager;
     this.renderSession.renderer = this;
+    this.renderSession.useFrustum = true;//used to disable frustum culling eg when drawing to RenderTexture
 
     gl.useProgram(this.shaderManager.defaultShader.program);
 

--- a/src/pixi/textures/RenderTexture.js
+++ b/src/pixi/textures/RenderTexture.js
@@ -206,8 +206,12 @@ PIXI.RenderTexture.prototype.renderWebGL = function(displayObject, position, cle
     PIXI.WebGLRenderer.updateTextures();
 
     this.renderer.spriteBatch.dirty = true;
-    
+
+    //store old value
+    var useFrustum = this.renderer.renderSession.useFrustum;
+    this.renderer.renderSession.useFrustum = false;    //turn off culling
     this.renderer.renderDisplayObject(displayObject, this.projection, this.textureBuffer.frameBuffer);
+    this.renderer.renderSession.useFrustum = useFrustum;
 
     displayObject.worldTransform = originalWorldTransform;
 
@@ -251,7 +255,11 @@ PIXI.RenderTexture.prototype.renderCanvas = function(displayObject, position, cl
 
     var context = this.textureBuffer.context;
 
+    //store old value
+    var useFrustum = this.renderer.renderSession.useFrustum;
+    this.renderer.renderSession.useFrustum = false;    //turn off culling
     this.renderer.renderDisplayObject(displayObject, context);
+    this.renderer.renderSession.useFrustum = useFrustum;
 
     context.setTransform(1,0,0,1,0,0);
 


### PR DESCRIPTION
did some performance profiling with chrome dev tools in a side scrolling game and saw some decent speed up to the render cycle from this.
