### PR TITLE
Test if browser supports ES5 Object methods

### DIFF
--- a/src/pixi/Pixi.js
+++ b/src/pixi/Pixi.js
@@ -101,3 +101,12 @@ PIXI.sayHello = function (type)
 
     PIXI.dontSayHello = true;
 };
+
+// If browser doesn't support ES5 Object methods (create, keys etc.),
+// terminate the script, leaving PIXI undefined.
+// This prevents script failure in old browsers like IE8.
+// http://kangax.github.io/compat-table/es5/
+if(!Object['create'])
+{
+    return;
+}


### PR DESCRIPTION
PIXI doesn't support IE8, but at least we can add a short test to prevent an error on script load.
The test checks if the browser supports Object.create. If not we terminate the script. PIXI stays undefined.
The reference support table is http://kangax.github.io/compat-table/es5/

I wanted to put this test as earlier in the script as possible. It could be moved to a separate file.

This could be useful in cases when developers don't need a full support for IE8 for their pages, but at least the page loads with basic content.
