### PR TITLE
Add clearBeforeRender for <webgl>

### DIFF
--- a/src/pixi/renderers/webgl/WebGLRenderer.js
+++ b/src/pixi/renderers/webgl/WebGLRenderer.js
@@ -266,9 +266,7 @@ PIXI.WebGLRenderer.prototype.render = function(stage)
         
         gl.clear (gl.COLOR_BUFFER_BIT);
     }
-
-    gl.clear(gl.COLOR_BUFFER_BIT);
-
+    
     this.renderDisplayObject( stage, this.projection );
 
     // interaction


### PR DESCRIPTION
Maybe "clearBeforeRender" this is not the best naming (since it will clear anyway..), but this aligns canvas and webgl:

Basically it allows the user to do clearColor whenever they want, instead of this being done for them. This is useful in the following circumstance:

1) The game/program loads a background image, but not right away.
2) Before the background image is loaded, we want to fill the canvas with a certain color (for example, white).
3) In canvas mode, this is done by setting `clearBeforeRender` to false and then adding a single `fillRect` command.
4) In webGL mode, the equivalent is running `gl.clearColor` and then `gl.clear`.
5) We can of course set the background color in webGL mode and this probably won't be expensive (although I don't know), but in canvas it _is_ expensive to clear/fill on every frame.
6) Thus (under the current implementation), the user would have to detect webGL mode or canvas mode themselves, and either set the background color or not -- set it for webGL (because manual setting is ignored, since there is no `clearBeforeRender`), don't set it for canvas (because manual setting isn't ignored).
7) To eliminate this coding complexity for the user, this small bit of extra code aligns `clearBeforeRender` (or, as much as possible) to the canvas implementation.
