### PR TITLE
Function.bind() polyfill should return the bound function's return value...

### DIFF
--- a/src/pixi/utils/Utils.js
+++ b/src/pixi/utils/Utils.js
@@ -91,7 +91,7 @@ if (typeof Function.prototype.bind !== 'function') {
                 var i = arguments.length, args = new Array(i);
                 while (i--) args[i] = arguments[i];
                 args = boundArgs.concat(args);
-                target.apply(this instanceof bound ? this : thisArg, args);
+                return target.apply(this instanceof bound ? this : thisArg, args);
             }
 
             bound.prototype = (function F(proto) {


### PR DESCRIPTION
See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind

``` js
function add(x, y){
  console.log('Adding' + x + 'and' + y + '...');
  return x + y;
}
addToOne = add.bind(null, 1);
console.log(addToOne(2));
```

This is expected to log:

```
Adding 1 and 2...
3
```

but instead logs:

```
Adding 1 and 2...
undefined
```

as the return value of the bound function is completely discarded. 

Besides this fix, there really should be some tests around this method... In our codebase, we didn't realize that pixi.js provides a polyfill for `bind`, and because we happened to load pixi.js before our own (valid) polyfill, some functionality unexpectedly broke in phantomjs (which does not have a native `bind` function).
