### PR TITLE
fixes #1023 - PIXI.Graphics initial width and height is 0

### DIFF
--- a/src/pixi/primitives/Graphics.js
+++ b/src/pixi/primitives/Graphics.js
@@ -102,7 +102,7 @@ PIXI.Graphics = function()
      * @property bounds
      * @type Rectangle
      */
-    this.bounds = null;
+    this.bounds = new PIXI.Rectangle(0, 0, 0, 0);
 
     /**
      * the bounds' padding used for bounds calculation

--- a/test/unit/pixi/primitives/Graphics.js
+++ b/test/unit/pixi/primitives/Graphics.js
@@ -35,6 +35,8 @@ describe('pixi/primitives/Graphics', function () {
         expect(obj).to.have.property('renderable', true);
         expect(obj).to.have.property('fillAlpha', 1);
         expect(obj).to.have.property('lineWidth', 0);
+        expect(obj).to.have.property('width', 0);
+        expect(obj).to.have.property('height', 0);
         expect(obj).to.have.property('lineColor', 'black');
         expect(obj).to.have.deep.property('graphicsData.length', 0);
         expect(obj).to.have.deep.property('currentPath.points.length', 0);


### PR DESCRIPTION
fixes #1023
