### PR TITLE
Fix for Stage.setInteractionDelegate

### DIFF
--- a/src/pixi/renderers/webgl/WebGLRenderer.js
+++ b/src/pixi/renderers/webgl/WebGLRenderer.js
@@ -190,7 +190,7 @@ PIXI.WebGLRenderer.prototype.render = function(stage)
     // if rendering a new stage clear the batches..
     if(this.__stage !== stage)
     {
-        if(stage.interactive)stage.interactionManager.removeEvents();
+        if(stage.interactive && this.__stage)stage.interactionManager.removeEvents();
 
         // TODO make this work
         // dont think this is needed any more?


### PR DESCRIPTION
If stage.setInteractionDelegate was used before rendering, then the WebGL Renderer will remove the events and revert to renderer.view. 
That's why we should only remove the events if a stage was previously set.
