### PR TITLE
Fix for blendMode bug in CanvasRenderer

### DIFF
--- a/src/pixi/renderers/canvas/CanvasRenderer.js
+++ b/src/pixi/renderers/canvas/CanvasRenderer.js
@@ -164,6 +164,9 @@ PIXI.CanvasRenderer.prototype.render = function(stage)
 
     this.context.globalAlpha = 1;
 
+    this.renderSession.currentBlendMode = PIXI.blendModes.NORMAL;
+    this.context.globalCompositeOperation = PIXI.blendModesCanvas[PIXI.blendModes.NORMAL];
+
     if (navigator.isCocoonJS && this.view.screencanvas) {
         this.context.fillStyle = "black";
         this.context.clear();


### PR DESCRIPTION
The stage background (fill) was affected by the last used blendMode. In my case the stage quickly turned white after having PIXI.blendModes.ADD Sprites being rendered last on my stage.
