### PR TITLE
jsdoc fixes for all the Loader classes. SpriteSheetLoader is redundant a...

### DIFF
--- a/src/pixi/loaders/AssetLoader.js
+++ b/src/pixi/loaders/AssetLoader.js
@@ -12,7 +12,7 @@
  * @class AssetLoader
  * @constructor
  * @uses EventTarget
- * @param {Array<String>} assetURLs an array of image/sprite sheet urls that you would like loaded
+ * @param assetURLs {Array<String>} An array of image/sprite sheet urls that you would like loaded
  *      supported. Supported image formats include 'jpeg', 'jpg', 'png', 'gif'. Supported
  *      sprite sheet data formats only include 'JSON' at this time. Supported bitmap font
  *      data formats include 'xml' and 'fnt'.
@@ -72,7 +72,7 @@ PIXI.EventTarget.mixin(PIXI.AssetLoader.prototype);
 PIXI.AssetLoader.prototype.constructor = PIXI.AssetLoader;
 
 /**
- * Given a filename, returns its extension, wil
+ * Given a filename, returns its extension.
  *
  * @method _getDataType
  * @param str {String} the name of the asset

--- a/src/pixi/loaders/AtlasLoader.js
+++ b/src/pixi/loaders/AtlasLoader.js
@@ -3,16 +3,19 @@
  */
 
 /**
- * The atlas file loader is used to load in Atlas data and parse it
- * When loaded this class will dispatch a 'loaded' event
- * If loading fails this class will dispatch an 'error' event
+ * The atlas file loader is used to load in Texture Atlas data and parse it. When loaded this class will dispatch a 'loaded' event. If loading fails this class will dispatch an 'error' event.
+ *
+ * To generate the data you can use http://www.codeandweb.com/texturepacker and publish in the 'JSON' format.
+ * 
+ * It is highly recommended to use texture atlases (also know as 'sprite sheets') as it allowed sprites to be batched and drawn together for highly increased rendering speed.
+ * Once the data has been loaded the frames are stored in the PIXI texture cache and can be accessed though PIXI.Texture.fromFrameId() and PIXI.Sprite.fromFrameId()
+ * 
  * @class AtlasLoader
  * @uses EventTarget
  * @constructor
- * @param {String} url the url of the JSON file
- * @param {Boolean} crossorigin
+ * @param url {String} The url of the JSON file
+ * @param crossorigin {Boolean} Whether requests should be treated as crossorigin
  */
-
 PIXI.AtlasLoader = function (url, crossorigin) {
     this.url = url;
     this.baseUrl = url.replace(/[^\/]*$/, '');
@@ -41,7 +44,8 @@ PIXI.AtlasLoader.prototype.load = function () {
 };
 
 /**
- * Invoke when JSON file is loaded
+ * Invoked when the Atlas has fully loaded. Parses the JSON and builds the texture frames.
+ * 
  * @method onAtlasLoaded
  * @private
  */
@@ -160,7 +164,8 @@ PIXI.AtlasLoader.prototype.onAtlasLoaded = function () {
 };
 
 /**
- * Invoke when json file has loaded
+ * Invoked when json file has loaded.
+ * 
  * @method onLoaded
  * @private
  */
@@ -175,7 +180,8 @@ PIXI.AtlasLoader.prototype.onLoaded = function () {
 };
 
 /**
- * Invoke when error occured
+ * Invoked when an error occurs.
+ * 
  * @method onError
  * @private
  */

--- a/src/pixi/loaders/BitmapFontLoader.js
+++ b/src/pixi/loaders/BitmapFontLoader.js
@@ -16,12 +16,6 @@
  */
 PIXI.BitmapFontLoader = function(url, crossorigin)
 {
-    /*
-     * I use texture packer to load the assets..
-     * http://www.codeandweb.com/texturepacker
-     * make sure to set the format as 'JSON'
-     */
-
     /**
      * The url of the bitmap font data
      *
@@ -50,8 +44,8 @@ PIXI.BitmapFontLoader = function(url, crossorigin)
     /**
      * [read-only] The texture of the bitmap font
      *
-     * @property baseUrl
-     * @type String
+     * @property texture
+     * @type Texture
      */
     this.texture = null;
 };
@@ -76,7 +70,7 @@ PIXI.BitmapFontLoader.prototype.load = function()
 };
 
 /**
- * Invoked when the XML file is loaded, parses the data
+ * Invoked when the XML file is loaded, parses the data.
  *
  * @method onXMLLoaded
  * @private

--- a/src/pixi/loaders/ImageLoader.js
+++ b/src/pixi/loaders/ImageLoader.js
@@ -36,6 +36,7 @@ PIXI.ImageLoader = function(url, crossorigin)
 
 // constructor
 PIXI.ImageLoader.prototype.constructor = PIXI.ImageLoader;
+
 PIXI.EventTarget.mixin(PIXI.ImageLoader.prototype);
 
 /**
@@ -68,7 +69,6 @@ PIXI.ImageLoader.prototype.onLoaded = function()
 
 /**
  * Loads image and split it to uniform sized frames
- *
  *
  * @method loadFramedSpriteSheet
  * @param frameWidth {Number} width of each frame

--- a/src/pixi/loaders/JsonLoader.js
+++ b/src/pixi/loaders/JsonLoader.js
@@ -14,6 +14,7 @@
  * @param crossorigin {Boolean} Whether requests should be treated as crossorigin
  */
 PIXI.JsonLoader = function (url, crossorigin) {
+
     /**
      * The url of the bitmap font data
      *
@@ -52,6 +53,7 @@ PIXI.JsonLoader = function (url, crossorigin) {
 
 // constructor
 PIXI.JsonLoader.prototype.constructor = PIXI.JsonLoader;
+
 PIXI.EventTarget.mixin(PIXI.JsonLoader.prototype);
 
 /**
@@ -65,7 +67,7 @@ PIXI.JsonLoader.prototype.load = function () {
     {
         this.ajaxRequest = new window.XDomainRequest();
 
-        // XDomainRequest has a few querks. Occasionally it will abort requests
+        // XDomainRequest has a few quirks. Occasionally it will abort requests
         // A way to avoid this is to make sure ALL callbacks are set even if not used
         // More info here: http://stackoverflow.com/questions/15786966/xdomainrequest-aborts-post-on-ie-9
         this.ajaxRequest.timeout = 3000;
@@ -86,8 +88,6 @@ PIXI.JsonLoader.prototype.load = function () {
         this.ajaxRequest = new window.ActiveXObject('Microsoft.XMLHTTP');
     }
 
-
-
     this.ajaxRequest.onload = this.onJSONLoaded.bind(this);
 
     this.ajaxRequest.open('GET',this.url,true);
@@ -96,7 +96,7 @@ PIXI.JsonLoader.prototype.load = function () {
 };
 
 /**
- * Invoke when JSON file is loaded
+ * Invoked when the JSON file is loaded.
  *
  * @method onJSONLoaded
  * @private
@@ -160,7 +160,7 @@ PIXI.JsonLoader.prototype.onJSONLoaded = function () {
 };
 
 /**
- * Invoke when json file loaded
+ * Invoked when the json file has loaded.
  *
  * @method onLoaded
  * @private
@@ -174,7 +174,7 @@ PIXI.JsonLoader.prototype.onLoaded = function () {
 };
 
 /**
- * Invoke when error occured
+ * Invoked if an error occurs.
  *
  * @method onError
  * @private

--- a/src/pixi/loaders/SpineLoader.js
+++ b/src/pixi/loaders/SpineLoader.js
@@ -70,7 +70,7 @@ PIXI.SpineLoader.prototype.load = function () {
 };
 
 /**
- * Invoke when JSON file is loaded
+ * Invoked when JSON file is loaded.
  *
  * @method onLoaded
  * @private
@@ -79,4 +79,3 @@ PIXI.SpineLoader.prototype.onLoaded = function () {
     this.loaded = true;
     this.emit('loaded', { content: this });
 };
-

--- a/src/pixi/loaders/SpriteSheetLoader.js
+++ b/src/pixi/loaders/SpriteSheetLoader.js
@@ -18,14 +18,9 @@
  * @param crossorigin {Boolean} Whether requests should be treated as crossorigin
  */
 PIXI.SpriteSheetLoader = function (url, crossorigin) {
-    /*
-     * i use texture packer to load the assets..
-     * http://www.codeandweb.com/texturepacker
-     * make sure to set the format as 'JSON'
-     */
 
     /**
-     * The url of the bitmap font data
+     * The url of the atlas data
      *
      * @property url
      * @type String


### PR DESCRIPTION
...nd should be removed from the grunt tasks imho.
