### PR TITLE
canvas mask patch

### DIFF
--- a/src/pixi/renderers/canvas/CanvasGraphics.js
+++ b/src/pixi/renderers/canvas/CanvasGraphics.js
@@ -276,12 +276,12 @@ PIXI.CanvasGraphics.renderGraphicsMask = function(graphics, context)
         else if (data.type === PIXI.Graphics.RREC)
         {
         
-            var points = shape.points;
-            var rx = points[0];
-            var ry = points[1];
-            var width = points[2];
-            var height = points[3];
-            var radius = points[4];
+            var pts = shape.points;
+            var rx = pts[0];
+            var ry = pts[1];
+            var width = pts[2];
+            var height = pts[3];
+            var radius = pts[4];
 
             var maxRadius = Math.min(width, height) / 2 | 0;
             radius = radius > maxRadius ? maxRadius : radius;


### PR DESCRIPTION
rect/elip and circ are not defined by points but pixi standard objects.
