### PR TITLE
jshint complains of missing semicolon

### DIFF
--- a/src/pixi/textures/BaseTexture.js
+++ b/src/pixi/textures/BaseTexture.js
@@ -218,7 +218,7 @@ PIXI.BaseTexture.unloadFromGPU = function()
     }
 
     this._glTextures.length = 0;
-}
+};
 
 /**
  * Helper function that creates a base texture from the given image url.


### PR DESCRIPTION
Added semicolon to /src/pixi/textures/BaseTexture.js.
