### PR TITLE
fix eventTarget emit bug

### DIFF
--- a/src/pixi/utils/EventTarget.js
+++ b/src/pixi/utils/EventTarget.js
@@ -75,7 +75,7 @@ PIXI.EventTarget = {
 
             //iterate the listeners
             if(this._listeners && this._listeners[eventName]) {
-                var listeners = this._listeners[eventName],
+                var listeners = this._listeners[eventName].slice(0),
                     length = listeners.length,
                     fn = listeners[0],
                     i;

--- a/test/unit/pixi/utils/EventTarget.js
+++ b/test/unit/pixi/utils/EventTarget.js
@@ -334,4 +334,28 @@ describe('pixi/utils/EventTarget', function () {
 
         expect(called).to.equal(5);
     });
+
+    it('event remove during emit call properly', function () {
+        var called = 0;
+
+        function cb1() {
+            called++;
+            obj.off('myevent', cb1);
+        }
+        function cb2() {
+            called++;
+            obj.off('myevent', cb2);
+        }
+        function cb3() {
+            called++;
+            obj.off('myevent', cb3);
+        }
+
+        obj.on('myevent', cb1);
+        obj.on('myevent', cb2);
+        obj.on('myevent', cb3);
+        obj.emit('myevent', '');
+
+        expect(called).to.equal(3);
+    });
 });


### PR DESCRIPTION
Related issue: https://github.com/GoodBoyDigital/pixi.js/issues/1131

http://jsfiddle.net/rz553zr3/

Before:

``` js
var listeners = this._listeners[eventName],
    length = listeners.length,
    fn = listeners[0],
    i;

for(i = 0; i < length; fn = listeners[++i]) {
    //call the event listener
    fn.call(this, data);
```

If the callback function included a off() call of the event, the listeners variable will be updated and the for loop call will be messed up.
