### PR TITLE
JsonLoader spritesheet format validation

### DIFF
--- a/src/pixi/loaders/JsonLoader.js
+++ b/src/pixi/loaders/JsonLoader.js
@@ -111,7 +111,7 @@ PIXI.JsonLoader.prototype.onJSONLoaded = function () {
 
     this.json = JSON.parse(this.ajaxRequest.responseText);
 
-    if(this.json.frames)
+    if(this.json.frames && this.json.meta && this.json.meta.image)
     {
         // sprite sheet
         var textureUrl = this.baseUrl + this.json.meta.image;


### PR DESCRIPTION
JsonLoader should verify that the JSON data include a `meta.image` value and not just `frames`.
