### PR TITLE
Switch b and c in getBounds()

### DIFF
--- a/src/pixi/display/Sprite.js
+++ b/src/pixi/display/Sprite.js
@@ -181,8 +181,8 @@ PIXI.Sprite.prototype.getBounds = function(matrix)
     var worldTransform = matrix || this.worldTransform ;
 
     var a = worldTransform.a;
-    var b = worldTransform.c;
-    var c = worldTransform.b;
+    var b = worldTransform.b;
+    var c = worldTransform.c;
     var d = worldTransform.d;
     var tx = worldTransform.tx;
     var ty = worldTransform.ty;

--- a/src/pixi/extras/TilingSprite.js
+++ b/src/pixi/extras/TilingSprite.js
@@ -297,8 +297,8 @@ PIXI.TilingSprite.prototype.getBounds = function()
     var worldTransform = this.worldTransform;
 
     var a = worldTransform.a;
-    var b = worldTransform.c;
-    var c = worldTransform.b;
+    var b = worldTransform.b;
+    var c = worldTransform.c;
     var d = worldTransform.d;
     var tx = worldTransform.tx;
     var ty = worldTransform.ty;

--- a/src/pixi/primitives/Graphics.js
+++ b/src/pixi/primitives/Graphics.js
@@ -821,8 +821,8 @@ PIXI.Graphics.prototype.getBounds = function( matrix )
     var worldTransform = matrix || this.worldTransform;
 
     var a = worldTransform.a;
-    var b = worldTransform.c;
-    var c = worldTransform.b;
+    var b = worldTransform.b;
+    var c = worldTransform.c;
     var d = worldTransform.d;
     var tx = worldTransform.tx;
     var ty = worldTransform.ty;


### PR DESCRIPTION
Fixes transform problems with rotated sprites.
