### PR TITLE
RenderTexture - preserve world transform

### DIFF
--- a/src/pixi/textures/RenderTexture.js
+++ b/src/pixi/textures/RenderTexture.js
@@ -200,10 +200,11 @@ PIXI.RenderTexture.prototype.renderWebGL = function(displayObject, matrix, clear
     if(!this.valid)return;
     if(typeof preserveWorldTransform === 'undefined')preserveWorldTransform = true;
 
+    var tempAlpha, tempTransform;
     if (preserveWorldTransform)
     {
-        PIXI.RenderTexture.tempAlpha = displayObject.worldAlpha;
-        PIXI.RenderTexture.tempTransform = displayObject.worldTransform.toArray();
+        tempAlpha = displayObject.worldAlpha;
+        tempTransform = displayObject.worldTransform.toArray();
     }
 
     //TOOD replace position with matrix..
@@ -244,8 +245,8 @@ PIXI.RenderTexture.prototype.renderWebGL = function(displayObject, matrix, clear
 
     if (preserveWorldTransform)
     {
-        displayObject.worldAlpha = PIXI.RenderTexture.tempAlpha;
-        displayObject.worldTransform.fromArray(PIXI.RenderTexture.tempTransform);
+        displayObject.worldAlpha = tempAlpha;
+        displayObject.worldTransform.fromArray(tempTransform);
 
         for(i = 0, j = children.length; i < j; i++)
         {
@@ -270,10 +271,11 @@ PIXI.RenderTexture.prototype.renderCanvas = function(displayObject, matrix, clea
     if(!this.valid)return;
     if(typeof preserveWorldTransform === 'undefined')preserveWorldTransform = true;
 
+    var tempAlpha, tempTransform;
     if (preserveWorldTransform)
     {
-        PIXI.RenderTexture.tempAlpha = displayObject.worldAlpha;
-        PIXI.RenderTexture.tempTransform = displayObject.worldTransform.toArray();
+        tempAlpha = displayObject.worldAlpha;
+        tempTransform = displayObject.worldTransform.toArray();
     }
 
     var wt = displayObject.worldTransform;
@@ -306,8 +308,8 @@ PIXI.RenderTexture.prototype.renderCanvas = function(displayObject, matrix, clea
 
     if (preserveWorldTransform)
     {
-        displayObject.worldAlpha = PIXI.RenderTexture.tempAlpha;
-        displayObject.worldTransform.fromArray(PIXI.RenderTexture.tempTransform);
+        displayObject.worldAlpha = tempAlpha;
+        displayObject.worldTransform.fromArray(tempTransform);
 
         for(i = 0, j = children.length; i < j; i++)
         {
@@ -373,9 +375,3 @@ PIXI.RenderTexture.prototype.getCanvas = function()
         return this.textureBuffer.canvas;
     }
 };
-
-// Temporary alpha used to restore the worldAlpha of the DisplayObject being rendered.
-PIXI.RenderTexture.tempAlpha = 1;
-
-// Temporary array/object re-used to store the worldTransform of the DisplayObject being rendered.
-PIXI.RenderTexture.tempTransform = null;


### PR DESCRIPTION
The renderCanvas and renderWebGL modify the worldTransform, worldAlpha,
and update the transformations of the children. This code adds in a
parameter to the these methods (true by default now, but that can be
changed) to indicate that these transformations should be undone when the
rendering is complete.

While restoring the previous transformations does add a little bit of
overhead this is adventageous in two important ways:
- The default (or requested) behavior works in an "unsurprising manner"
  and does not leave a temporary transformation applied permamently when
  the render operation completes.
- Even if the restore/preserve operation is not done the documentation, and addition
  of method parameter, makes this behavior more apparent.

Ref. https://github.com/GoodBoyDigital/pixi.js/issues/1174
