### PR TITLE
Documentation - type cleanup and fixes

### DIFF
--- a/src/pixi/display/DisplayObject.js
+++ b/src/pixi/display/DisplayObject.js
@@ -383,7 +383,7 @@ Object.defineProperty(PIXI.DisplayObject.prototype, 'mask', {
  * * IMPORTANT: This is a webGL only feature and will be ignored by the canvas renderer.
  * To remove filters simply set this property to 'null'
  * @property filters
- * @type {Array(Filter)}
+ * @type Array(Filter)
  */
 Object.defineProperty(PIXI.DisplayObject.prototype, 'filters', {
 

--- a/src/pixi/display/MovieClip.js
+++ b/src/pixi/display/MovieClip.js
@@ -18,7 +18,7 @@ PIXI.MovieClip = function(textures)
      * The array of textures that make up the animation
      *
      * @property textures
-     * @type Array
+     * @type Array(Texture)
      */
     this.textures = textures;
 

--- a/src/pixi/display/Sprite.js
+++ b/src/pixi/display/Sprite.js
@@ -78,7 +78,7 @@ PIXI.Sprite = function(texture)
      * The shader that will be used to render the texture to the stage. Set to null to remove a current shader.
      *
      * @property shader
-     * @type PIXI.AbstractFilter
+     * @type AbstractFilter
      * @default null
      */
     this.shader = null;

--- a/src/pixi/filters/BlurFilter.js
+++ b/src/pixi/filters/BlurFilter.js
@@ -25,7 +25,7 @@ PIXI.BlurFilter.prototype.constructor = PIXI.BlurFilter;
  * Sets the strength of both the blurX and blurY properties simultaneously
  *
  * @property blur
- * @type Number the strength of the blur
+ * @type Number
  * @default 2
  */
 Object.defineProperty(PIXI.BlurFilter.prototype, 'blur', {
@@ -41,7 +41,7 @@ Object.defineProperty(PIXI.BlurFilter.prototype, 'blur', {
  * Sets the strength of the blurX property
  *
  * @property blurX
- * @type Number the strength of the blurX
+ * @type Number
  * @default 2
  */
 Object.defineProperty(PIXI.BlurFilter.prototype, 'blurX', {
@@ -57,7 +57,7 @@ Object.defineProperty(PIXI.BlurFilter.prototype, 'blurX', {
  * Sets the strength of the blurY property
  *
  * @property blurY
- * @type Number the strength of the blurY
+ * @type Number
  * @default 2
  */
 Object.defineProperty(PIXI.BlurFilter.prototype, 'blurY', {

--- a/src/pixi/filters/BlurXFilter.js
+++ b/src/pixi/filters/BlurXFilter.js
@@ -52,7 +52,7 @@ PIXI.BlurXFilter.prototype.constructor = PIXI.BlurXFilter;
  * Sets the strength of both the blur.
  *
  * @property blur
- * @type Number the strength of the blur
+ * @type Number
  * @default 2
  */
 Object.defineProperty(PIXI.BlurXFilter.prototype, 'blur', {

--- a/src/pixi/filters/BlurYFilter.js
+++ b/src/pixi/filters/BlurYFilter.js
@@ -52,7 +52,7 @@ PIXI.BlurYFilter.prototype.constructor = PIXI.BlurYFilter;
  * Sets the strength of both the blur.
  *
  * @property blur
- * @type Number the strength of the blur
+ * @type Number
  * @default 2
  */
 Object.defineProperty(PIXI.BlurYFilter.prototype, 'blur', {

--- a/src/pixi/filters/CrossHatchFilter.js
+++ b/src/pixi/filters/CrossHatchFilter.js
@@ -66,7 +66,7 @@ PIXI.CrossHatchFilter.prototype.constructor = PIXI.CrossHatchFilter;
  * Sets the strength of both the blur.
  *
  * @property blur
- * @type Number the strength of the blur
+ * @type Number
  * @default 2
  */
 Object.defineProperty(PIXI.CrossHatchFilter.prototype, 'blur', {

--- a/src/pixi/filters/SmartBlurFilter.js
+++ b/src/pixi/filters/SmartBlurFilter.js
@@ -62,7 +62,7 @@ PIXI.SmartBlurFilter.prototype.constructor = PIXI.SmartBlurFilter;
  * The strength of the blur.
  *
  * @property blur
- * @type Number the strength of the blur
+ * @type Number
  * @default 2
  */
 Object.defineProperty(PIXI.SmartBlurFilter.prototype, 'blur', {

--- a/src/pixi/geom/RoundedRectangle.js
+++ b/src/pixi/geom/RoundedRectangle.js
@@ -3,9 +3,9 @@
  */
 
 /**
- * the Rounded Rectangle object is an area defined by its position and has nice rounded corners, as indicated by its top-left corner point (x, y) and by its width and its height.
+ * The Rounded Rectangle object is an area defined by its position and has nice rounded corners, as indicated by its top-left corner point (x, y) and by its width and its height.
  *
- * @class Rounded Rectangle
+ * @class RoundedRectangle
  * @constructor
  * @param x {Number} The X coordinate of the upper-left corner of the rounded rectangle
  * @param y {Number} The Y coordinate of the upper-left corner of the rounded rectangle
@@ -55,7 +55,7 @@ PIXI.RoundedRectangle = function(x, y, width, height, radius)
  * Creates a clone of this Rounded Rectangle
  *
  * @method clone
- * @return {rounded Rectangle} a copy of the rounded rectangle
+ * @return {RoundedRectangle} a copy of the rounded rectangle
  */
 PIXI.RoundedRectangle.prototype.clone = function()
 {

--- a/src/pixi/renderers/webgl/shaders/ComplexPrimitiveShader.js
+++ b/src/pixi/renderers/webgl/shaders/ComplexPrimitiveShader.js
@@ -25,7 +25,7 @@ PIXI.ComplexPrimitiveShader = function(gl)
     /**
      * The WebGL program.
      * @property program
-     * @type {Any}
+     * @type Any
      */
     this.program = null;
 

--- a/src/pixi/renderers/webgl/shaders/PixiFastShader.js
+++ b/src/pixi/renderers/webgl/shaders/PixiFastShader.js
@@ -25,7 +25,7 @@ PIXI.PixiFastShader = function(gl)
     /**
      * The WebGL program.
      * @property program
-     * @type {Any}
+     * @type Any
      */
     this.program = null;
 

--- a/src/pixi/renderers/webgl/shaders/PixiShader.js
+++ b/src/pixi/renderers/webgl/shaders/PixiShader.js
@@ -26,7 +26,7 @@ PIXI.PixiShader = function(gl)
     /**
      * The WebGL program.
      * @property program
-     * @type {Any}
+     * @type Any
      */
     this.program = null;
 

--- a/src/pixi/renderers/webgl/shaders/PrimitiveShader.js
+++ b/src/pixi/renderers/webgl/shaders/PrimitiveShader.js
@@ -25,7 +25,7 @@ PIXI.PrimitiveShader = function(gl)
     /**
      * The WebGL program.
      * @property program
-     * @type {Any}
+     * @type Any
      */
     this.program = null;
 

--- a/src/pixi/renderers/webgl/shaders/StripShader.js
+++ b/src/pixi/renderers/webgl/shaders/StripShader.js
@@ -25,7 +25,7 @@ PIXI.StripShader = function(gl)
     /**
      * The WebGL program.
      * @property program
-     * @type {Any}
+     * @type Any
      */
     this.program = null;
 

--- a/src/pixi/textures/BaseTexture.js
+++ b/src/pixi/textures/BaseTexture.js
@@ -47,7 +47,7 @@ PIXI.BaseTexture = function(source, scaleMode)
      * The scale mode to apply when scaling this texture
      * 
      * @property scaleMode
-     * @type PIXI.scaleModes
+     * @type {Number}
      * @default PIXI.scaleModes.LINEAR
      */
     this.scaleMode = scaleMode || PIXI.scaleModes.DEFAULT;

--- a/src/pixi/textures/VideoTexture.js
+++ b/src/pixi/textures/VideoTexture.js
@@ -114,7 +114,7 @@ PIXI.VideoTexture.prototype.destroy = function()
  * @method baseTextureFromVideo
  * @param video {HTMLVideoElement}
  * @param scaleMode {Number} See {{#crossLink "PIXI/scaleModes:property"}}PIXI.scaleModes{{/crossLink}} for possible values
- * @returns {VideoTexture}
+ * @return {VideoTexture}
  */
 PIXI.VideoTexture.baseTextureFromVideo = function( video, scaleMode )
 {
@@ -141,7 +141,7 @@ PIXI.VideoTexture.baseTextureFromVideo = function( video, scaleMode )
  * @method textureFromVideo 
  * @param video {HTMLVideoElement}
  * @param scaleMode {Number} See {{#crossLink "PIXI/scaleModes:property"}}PIXI.scaleModes{{/crossLink}} for possible values
- * @returns {Texture} A Texture, but not a VideoTexture.
+ * @return {Texture} A Texture, but not a VideoTexture.
  */
 PIXI.VideoTexture.textureFromVideo = function( video, scaleMode )
 {
@@ -156,7 +156,7 @@ PIXI.VideoTexture.textureFromVideo = function( video, scaleMode )
  * @method fromUrl 
  * @param videoSrc {String} The URL for the video.
  * @param scaleMode {Number} See {{#crossLink "PIXI/scaleModes:property"}}PIXI.scaleModes{{/crossLink}} for possible values
- * @returns {VideoTexture}
+ * @return {VideoTexture}
  */
 PIXI.VideoTexture.fromUrl = function( videoSrc, scaleMode )
 {

--- a/src/pixi/utils/EventTarget.js
+++ b/src/pixi/utils/EventTarget.js
@@ -43,7 +43,7 @@ PIXI.EventTarget = {
          *
          * @method listeners
          * @param eventName {String} The events that should be listed.
-         * @returns {Array} An array of listener functions
+         * @return {Array} An array of listener functions
          */
         obj.listeners = function listeners(eventName) {
             this._listeners = this._listeners || {};
@@ -57,7 +57,7 @@ PIXI.EventTarget = {
          * @method emit
          * @alias dispatchEvent
          * @param eventName {String} The name of the event.
-         * @returns {Boolean} Indication if we've emitted an event.
+         * @return {Boolean} Indication if we've emitted an event.
          */
         obj.emit = obj.dispatchEvent = function emit(eventName, data) {
             this._listeners = this._listeners || {};


### PR DESCRIPTION
- {Number ..} was incorrectly used as a type in a few placed; updated to
  {Number}.
- Removed {} braces incorrectly used with @type; it doesn't affect the
  document rendering, but it does affect the YUIDoc metadata..
- Removed space in "Rounded Rectangle" type
- Fixed over-qualified type name
- Changed over-qualified {PIXI.scaleModes} back to {Number} for
  consistency with rest of documentation where scale modes are used.
- @returns to @return
