### PR TITLE
export stub when in node environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+// no need to load in node environments
+module.exports = { };

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
         "url": "https://github.com/GoodBoyDigital/pixi.js.git"
     },
 
-    "main": "bin/pixi.js",
+    "browser": "bin/pixi.js",
+
+    "main": "index.js",
 
     "scripts": {
         "test": "grunt travis --verbose"


### PR DESCRIPTION
This PR addresses the issue of requiring pixi in a node environment-- doing so will break due to e.g. references to `document` during module evaluation.

This normally isn't a problem, as running pixi outside of the browser doesn't make much sense.

However, if there is some shared code between client and server, or potential code that is evaluated to walk dependency graphs, then this is an issue.
### Changes
- Module now exports an empty object `{ }` by default inside of node environments
- The `browser` field in `package.json` now points to `bin/pixi.js`, like the `main` field used to, so tools like Browserify still work correctly
