### PR TITLE
[Enhancement] Improved performance of adding and removing particles

### DIFF
--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -137,7 +137,7 @@ Container.prototype.addChildAt = function (child, index)
         child.parent = this;
 
         this.children.splice(index, 0, child);
-        this.onChildrenChange();
+        this.onChildrenChange(index);
 
         child.emit('added', this);
 
@@ -172,7 +172,7 @@ Container.prototype.swapChildren = function (child, child2)
 
     this.children[index1] = child2;
     this.children[index2] = child;
-    this.onChildrenChange();
+    this.onChildrenChange(index1 < index2 ? index1 : index2);
 };
 
 /**
@@ -210,7 +210,7 @@ Container.prototype.setChildIndex = function (child, index)
 
     this.children.splice(currentIndex, 1); //remove from old position
     this.children.splice(index, 0, child); //add at new position
-    this.onChildrenChange();
+    this.onChildrenChange(index);
 };
 
 /**
@@ -259,7 +259,7 @@ Container.prototype.removeChildAt = function (index)
 
     child.parent = null;
     this.children.splice(index, 1);
-    this.onChildrenChange();
+    this.onChildrenChange(index);
 
     child.emit('removed', this);
 
@@ -287,7 +287,7 @@ Container.prototype.removeChildren = function (beginIndex, endIndex)
             removed[i].parent = null;
         }
 
-        this.onChildrenChange();
+        this.onChildrenChange(beginIndex);
 
         for (var i = 0; i < removed.length; ++i)
         {

--- a/src/core/particles/ParticleContainer.js
+++ b/src/core/particles/ParticleContainer.js
@@ -83,7 +83,7 @@ function ParticleContainer(maxSize, properties, batchSize)
      * @member {boolean}
      * @private
      */
-    this._updateStatic = false;
+    this._bufferToUpdate = 0;
 
     /**
      * @member {boolean}
@@ -165,9 +165,12 @@ ParticleContainer.prototype.renderWebGL = function (renderer)
  *
  * @private
  */
-ParticleContainer.prototype.onChildrenChange = function ()
+ParticleContainer.prototype.onChildrenChange = function (smallestChildIndex)
 {
-    this._updateStatic = true;
+    var bufferIndex = Math.floor(smallestChildIndex / this._batchSize);
+    if (bufferIndex < this._bufferToUpdate) {
+        this._bufferToUpdate = bufferIndex;
+    }
 }
 
 /**

--- a/src/core/particles/ParticleContainer.js
+++ b/src/core/particles/ParticleContainer.js
@@ -80,7 +80,7 @@ function ParticleContainer(maxSize, properties, batchSize)
     this._buffers = null;
 
     /**
-     * @member {boolean}
+     * @member {number}
      * @private
      */
     this._bufferToUpdate = 0;


### PR DESCRIPTION
Whenever a particle was being added or removed, the static data of every particle buffer was being uploaded. Now, only the static data of the children whose index have changed are being uploaded.

This shows good performance boost on the bunnymark when chosing moderate batch size (= 3000). The demo does not lag anymore whenever bunnies are being added.

However, the bunnymark is a perfect showcase for this optimisation as elements are only being added. Therefore only one particle buffer needs to be updated whenever a particle is being added. Actually, in average, half the particle buffer would need to be updated whenever a particle is being either added or removed. And in the worst case all the buffers have to be uploaded, as it was already the case.