### PR TITLE
Only add "update" listener to texture if baseTexture has a source

### DIFF
--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -164,7 +164,7 @@ Object.defineProperties(Sprite.prototype, {
                 {
                     this._onTextureUpdate();
                 }
-                else
+                else if (value.baseTexture.source)
                 {
                     value.once('update', this._onTextureUpdate, this);
                 }


### PR DESCRIPTION
baseTextures without a source will have `hasLoaded` set to false and never update. As a result, without this change "update" listeners are added but never get called, which can result in a memory leak. This leak is seen in our app, where the `._events.update` array is populated with hundreds of thousands of entries resulting in memory usage of > 250MB.

This is working on the assumption that "update" will only be called for textures with a source. If that's not necessarily the case then maybe there should be an alternate solution to the problem.