### PR TITLE
Buff MovieClip: Added support for timed frames

### DIFF
--- a/src/extras/MovieClip.js
+++ b/src/extras/MovieClip.js
@@ -19,16 +19,25 @@ var core = require('../core');
  * @class
  * @extends PIXI.Sprite
  * @memberof PIXI.extras
- * @param textures {Texture[]} an array of {Texture} objects that make up the animation
+ * @param textures {PIXI.Texture[]|Object[]} an array of {PIXI.Texture} or frame objects that make up the animation
+ * @param textures[].texture {PIXI.Texture} the {PIXI.Texture} of the frame
+ * @param textures[].time {number} the duration of the frame in ms
  */
 function MovieClip(textures)
 {
-    core.Sprite.call(this, textures[0]);
+    core.Sprite.call(this, textures[0] instanceof core.Texture ? textures[0] : textures[0].texture);
 
     /**
      * @private
      */
-    this._textures = textures;
+    this._textures = null;
+
+    /**
+     * @private
+     */
+    this._durations = null;
+
+    this.textures = textures;
 
     /**
      * The speed that the MovieClip will play at. Higher is faster, lower is slower
@@ -37,6 +46,13 @@ function MovieClip(textures)
      * @default 1
      */
     this.animationSpeed = 1;
+
+    /**
+     * Elepsed Time of current frame in ms (Only active if timed frames are used)
+     *
+     * @private
+     */
+    this._lag = 0;
 
     /**
      * Whether or not the movie clip repeats after playing.
@@ -107,9 +123,21 @@ Object.defineProperties(MovieClip.prototype, {
         },
         set: function (value)
         {
-            this._textures = value;
-
-            this.texture = this._textures[Math.floor(this._currentTime) % this._textures.length];
+            if(value[0] instanceof core.Texture)
+            {
+                this._textures = value;
+                this._durations = null;
+            }
+            else
+            {
+                this._textures = [];
+                this._durations = [];
+                for(var i = 0; i < value.length; i++)
+                {
+                    this._textures.push(value[i].texture);
+                    this._durations.push(value[i].time);
+                }
+            }
         }
     },
 
@@ -123,7 +151,12 @@ Object.defineProperties(MovieClip.prototype, {
     currentFrame: {
         get: function ()
         {
-            return Math.floor(this._currentTime) % this._textures.length;
+            var currentFrame = Math.floor(this._currentTime) % this._textures.length;
+            if (currentFrame < 0)
+            {
+                currentFrame += this._textures.length;
+            }
+            return currentFrame;
         }
     }
 
@@ -170,8 +203,16 @@ MovieClip.prototype.gotoAndStop = function (frameNumber)
 
     this._currentTime = frameNumber;
 
-    var round = Math.floor(this._currentTime);
-    this._texture = this._textures[round % this._textures.length];
+    if (this._durations !== null)
+    {
+        this._lag = frameNumber % 1 * this._durations[this.currentFrame];
+        if(this._lag < 0)
+        {
+            this._currentTime++;
+        }
+    }
+
+    this._texture = this._textures[this.currentFrame];
 };
 
 /**
@@ -182,6 +223,16 @@ MovieClip.prototype.gotoAndStop = function (frameNumber)
 MovieClip.prototype.gotoAndPlay = function (frameNumber)
 {
     this._currentTime = frameNumber;
+
+    if (this._durations !== null)
+    {
+        this._lag = frameNumber % 1 * this._durations[this.currentFrame];
+        if(this._lag < 0)
+        {
+            this._currentTime++;
+        }
+    }
+
     this.play();
 };
 
@@ -191,40 +242,57 @@ MovieClip.prototype.gotoAndPlay = function (frameNumber)
  */
 MovieClip.prototype.update = function (deltaTime)
 {
+    var elapsed = this.animationSpeed * deltaTime;
 
-    this._currentTime += this.animationSpeed * deltaTime;
-
-    var floor = Math.floor(this._currentTime);
-
-    if (floor < 0)
+    if (this._durations !== null)
     {
-        if (this.loop)
+        this._lag += elapsed / 60 * 1000;
+
+        while (this._lag < 0)
         {
-            this._texture = this._textures[this._textures.length - 1 + floor % this._textures.length];
+            this._currentTime--;
+            this._lag += this._durations[this.currentFrame];
         }
-        else
-        {
-            this.gotoAndStop(0);
 
-            if (this.onComplete)
-            {
-                this.onComplete();
-            }
+        var sign = Math.sign(this.animationSpeed * deltaTime);
+        this._currentTime = Math.floor(this._currentTime);
+
+        while (this._lag >= this._durations[this.currentFrame])
+        {
+            this._lag -= this._durations[this.currentFrame] * sign;
+            this._currentTime += sign;
         }
+
+        this._currentTime += this._lag / this._durations[this.currentFrame];
     }
-    else if (this.loop || floor < this._textures.length)
+    else
     {
-        this._texture = this._textures[floor % this._textures.length];
+        this._currentTime += elapsed;
     }
-    else if (floor >= this._textures.length)
+
+    if (this._currentTime < 0 && !this.loop)
     {
-        this.gotoAndStop(this.textures.length - 1);
+        this.gotoAndStop(0);
 
         if (this.onComplete)
         {
             this.onComplete();
         }
     }
+    else if (this._currentTime >= this._textures.length && !this.loop)
+    {
+        this.gotoAndStop(this._textures.length - 1);
+
+        if (this.onComplete)
+        {
+            this.onComplete();
+        }
+    }
+    else
+    {
+        this._texture = this._textures[this.currentFrame];
+    }
+
 };
 
 /*

--- a/src/extras/MovieClip.js
+++ b/src/extras/MovieClip.js
@@ -48,13 +48,6 @@ function MovieClip(textures)
     this.animationSpeed = 1;
 
     /**
-     * Elepsed Time of current frame in ms (Only active if timed frames are used)
-     *
-     * @private
-     */
-    this._lag = 0;
-
-    /**
      * Whether or not the movie clip repeats after playing.
      *
      * @member {boolean}
@@ -203,15 +196,6 @@ MovieClip.prototype.gotoAndStop = function (frameNumber)
 
     this._currentTime = frameNumber;
 
-    if (this._durations !== null)
-    {
-        this._lag = frameNumber % 1 * this._durations[this.currentFrame];
-        if(this._lag < 0)
-        {
-            this._currentTime++;
-        }
-    }
-
     this._texture = this._textures[this.currentFrame];
 };
 
@@ -223,15 +207,6 @@ MovieClip.prototype.gotoAndStop = function (frameNumber)
 MovieClip.prototype.gotoAndPlay = function (frameNumber)
 {
     this._currentTime = frameNumber;
-
-    if (this._durations !== null)
-    {
-        this._lag = frameNumber % 1 * this._durations[this.currentFrame];
-        if(this._lag < 0)
-        {
-            this._currentTime++;
-        }
-    }
 
     this.play();
 };
@@ -246,24 +221,26 @@ MovieClip.prototype.update = function (deltaTime)
 
     if (this._durations !== null)
     {
-        this._lag += elapsed / 60 * 1000;
+        var lag = this._currentTime % 1 * this._durations[this.currentFrame];
 
-        while (this._lag < 0)
+        lag += elapsed / 60 * 1000;
+
+        while (lag < 0)
         {
             this._currentTime--;
-            this._lag += this._durations[this.currentFrame];
+            lag += this._durations[this.currentFrame];
         }
 
         var sign = Math.sign(this.animationSpeed * deltaTime);
         this._currentTime = Math.floor(this._currentTime);
 
-        while (this._lag >= this._durations[this.currentFrame])
+        while (lag >= this._durations[this.currentFrame])
         {
-            this._lag -= this._durations[this.currentFrame] * sign;
+            lag -= this._durations[this.currentFrame] * sign;
             this._currentTime += sign;
         }
 
-        this._currentTime += this._lag / this._durations[this.currentFrame];
+        this._currentTime += lag / this._durations[this.currentFrame];
     }
     else
     {

--- a/src/extras/MovieClip.js
+++ b/src/extras/MovieClip.js
@@ -19,8 +19,8 @@ var core = require('../core');
  * @class
  * @extends PIXI.Sprite
  * @memberof PIXI.extras
- * @param textures {PIXI.Texture[]|Object[]} an array of {PIXI.Texture} or frame objects that make up the animation
- * @param textures[].texture {PIXI.Texture} the {PIXI.Texture} of the frame
+ * @param textures {PIXI.Texture[]|Object[]} an array of {@link PIXI.Texture} or frame objects that make up the animation
+ * @param textures[].texture {PIXI.Texture} the {@link PIXI.Texture} of the frame
  * @param textures[].time {number} the duration of the frame in ms
  */
 function MovieClip(textures)

--- a/src/polyfill/Math.sign.js
+++ b/src/polyfill/Math.sign.js
@@ -1,0 +1,14 @@
+// References:
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sign
+
+if (!Math.sign)
+{
+    Math.sign = function (x) {
+        x = +x;
+        if (x === 0 || isNaN(x))
+        {
+            return x;
+        }
+        return x > 0 ? 1 : -1;
+    };
+}

--- a/src/polyfill/index.js
+++ b/src/polyfill/index.js
@@ -1,2 +1,3 @@
 require('./Object.assign');
 require('./requestAnimationFrame');
+require('./Math.sign');


### PR DESCRIPTION
Examle:

    var animation = new MovieClip([
        { texture: Texture(...), time: 100 },    // show 100 ms
        { texture: Texture(...), time: 0 },      // skip frame
        { texture: Texture(...), time: 500 }     // show 500 ms
    ]);

    console.log(animation.animatinSpeed);        // --> 1
    animation.animationSpeed = 2;                // play animation twice as fast

Like last time feedback is welcome ;)

regards