### PR TITLE
Fix bug #1999

### DIFF
--- a/src/core/textures/RenderTexture.js
+++ b/src/core/textures/RenderTexture.js
@@ -306,7 +306,6 @@ RenderTexture.prototype.renderCanvas = function (displayObject, matrix, clear, u
     }
 
     updateTransform = !!updateTransform;
-    var cachedWt = displayObject.worldTransform;
 
     var wt = tempMatrix;
 
@@ -318,6 +317,7 @@ RenderTexture.prototype.renderCanvas = function (displayObject, matrix, clear, u
     }
 
     displayObject.worldTransform = wt;
+    var cachedWt = displayObject.worldTransform;
 
     // setWorld Alpha to ensure that the object is renderer at full opacity
     displayObject.worldAlpha = 1;


### PR DESCRIPTION
Fixed bug where RenderTexture.render() does not handle Martix when using CanvasRenderer:
https://github.com/pixijs/pixi.js/issues/1999