### PR TITLE
Bugfix for arc, always use startX and startY as first point.

### DIFF
--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -483,26 +483,11 @@ Graphics.prototype.arc = function(cx, cy, radius, startAngle, endAngle, anticloc
 
     if (this.currentPath)
     {
-        if (anticlockwise && this.filling)
-        {
-            this.currentPath.shape.points.push(cx, cy);
-        }
-        else
-        {
-            this.currentPath.shape.points.push(startX, startY);
-        }
+        this.currentPath.shape.points.push(startX, startY);
     }
     else
     {
-        if (anticlockwise && this.filling)
-        {
-
-            this.moveTo(cx, cy);
-        }
-        else
-        {
-            this.moveTo(startX, startY);
-        }
+        this.moveTo(startX, startY);
     }
 
     var points = this.currentPath.shape.points;


### PR DESCRIPTION
Bugfix for https://github.com/pixijs/pixi.js/issues/1844