### PR TITLE
Added DisplayObject.setParent

### DIFF
--- a/src/core/display/DisplayObject.js
+++ b/src/core/display/DisplayObject.js
@@ -431,6 +431,25 @@ DisplayObject.prototype.generateTexture = function (renderer, scaleMode, resolut
 };
 
 /**
+ * Set the parent Container of this DisplayObject
+ *
+ * @param container {Container} The Container to add this DisplayObject to
+ * @return {DisplayObject} This DisplayObject
+ */
+DisplayObject.prototype.setParent = function (container)
+{
+    if (!container || !container.addChild)
+    {
+        throw new Error('setParent: Argument must be a Container');
+    }
+    else
+    {
+        container.addChild(this);
+        return this;
+    }
+};
+
+/**
  * Base destroy method for generic display objects
  *
  */

--- a/src/core/display/DisplayObject.js
+++ b/src/core/display/DisplayObject.js
@@ -434,7 +434,7 @@ DisplayObject.prototype.generateTexture = function (renderer, scaleMode, resolut
  * Set the parent Container of this DisplayObject
  *
  * @param container {Container} The Container to add this DisplayObject to
- * @return {DisplayObject} This DisplayObject
+ * @return {Container} The Container that this DisplayObject was added to
  */
 DisplayObject.prototype.setParent = function (container)
 {
@@ -442,11 +442,9 @@ DisplayObject.prototype.setParent = function (container)
     {
         throw new Error('setParent: Argument must be a Container');
     }
-    else
-    {
-        container.addChild(this);
-        return this;
-    }
+
+    container.addChild(this);
+    return container;
 };
 
 /**

--- a/test/lib/pixi/display/DisplayObject.js
+++ b/test/lib/pixi/display/DisplayObject.js
@@ -7,6 +7,7 @@ function pixi_display_DisplayObject_confirmNew(obj) {
     //expect(obj).to.respondTo('addFilter');
     //expect(obj).to.respondTo('removeFilter');
     expect(obj).to.respondTo('updateTransform');
+    expect(obj).to.respondTo('setParent');
 
     expect(obj).to.contain.property('position');
     pixi_core_Point_confirm(obj.position, 0, 0);

--- a/test/unit/core/display/DisplayObject.test.js
+++ b/test/unit/core/display/DisplayObject.test.js
@@ -1,0 +1,11 @@
+describe('PIXI.DisplayObject', function () {
+    it('should be able to add itself to a Container', function() {
+        var child = new PIXI.DisplayObject(),
+            container = new PIXI.Container();
+
+        expect(container.children.length).to.equal(0);
+        child.setParent(container);
+        expect(container.children.length).to.equal(1);
+        expect(child.parent).to.equal(container);
+    });
+});


### PR DESCRIPTION
Because sometimes I would like to do this:

```
var container = new pixi.Container(),
    graphic = new pixi.Graphics().setParent(container);
```

instead of this:

```
var container = new pixi.Container(),
    graphic = new pixi.Graphics();

container.addChild(graphic);
```