### PR TITLE
Add calls to super destructors and other extra cleanup work.

### DIFF
--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -310,6 +310,7 @@ WebGLRenderer.prototype.setObjectRenderer = function (objectRenderer)
     }
 
     this.currentRenderer.stop();
+    this.currentRenderer.destroy();
     this.currentRenderer = objectRenderer;
     this.currentRenderer.start();
 };
@@ -480,11 +481,13 @@ WebGLRenderer.prototype.destroy = function (removeView)
     this.maskManager.destroy();
     this.stencilManager.destroy();
     this.filterManager.destroy();
+    this.blendModeManager.destroy();
 
     this.shaderManager = null;
     this.maskManager = null;
     this.filterManager = null;
     this.blendModeManager = null;
+    this.currentRenderer = null;
 
     this.handleContextLost = null;
     this.handleContextRestored = null;

--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -310,7 +310,6 @@ WebGLRenderer.prototype.setObjectRenderer = function (objectRenderer)
     }
 
     this.currentRenderer.stop();
-    this.currentRenderer.destroy();
     this.currentRenderer = objectRenderer;
     this.currentRenderer.start();
 };

--- a/src/core/renderers/webgl/managers/FilterManager.js
+++ b/src/core/renderers/webgl/managers/FilterManager.js
@@ -421,6 +421,8 @@ FilterManager.prototype.resize = function ( width, height )
  */
 FilterManager.prototype.destroy = function ()
 {
+    WebGLManager.prototype.destroy.call(this);
+    
     this.filterStack = null;
     this.offsetY = 0;
 

--- a/src/core/sprites/webgl/SpriteRenderer.js
+++ b/src/core/sprites/webgl/SpriteRenderer.js
@@ -446,6 +446,8 @@ SpriteRenderer.prototype.start = function ()
  */
 SpriteRenderer.prototype.destroy = function ()
 {
+    ObjectRenderer.prototype.destroy.call(this);
+    
     this.renderer.gl.deleteBuffer(this.vertexBuffer);
     this.renderer.gl.deleteBuffer(this.indexBuffer);
 

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -261,6 +261,9 @@ Texture.prototype.destroy = function (destroyBase)
     this.crop = null;
 
     this.valid = false;
+
+    this.off('dispose', this.dispose, this);
+    this.off('update', this.update, this);
 };
 
 Texture.prototype.clone = function ()

--- a/src/mesh/webgl/MeshRenderer.js
+++ b/src/mesh/webgl/MeshRenderer.js
@@ -209,4 +209,7 @@ MeshRenderer.prototype.start = function ()
  */
 MeshRenderer.prototype.destroy = function ()
 {
+    if (this.renderer) {
+        ObjectRenderer.prototype.destroy.call(this);
+    }
 };

--- a/src/mesh/webgl/MeshRenderer.js
+++ b/src/mesh/webgl/MeshRenderer.js
@@ -209,7 +209,5 @@ MeshRenderer.prototype.start = function ()
  */
 MeshRenderer.prototype.destroy = function ()
 {
-    if (this.renderer) {
-        ObjectRenderer.prototype.destroy.call(this);
-    }
+    ObjectRenderer.prototype.destroy.call(this);
 };


### PR DESCRIPTION
Hi guys,

We've been doing some intensive memory usage testing here, and found that when running our app with Pixi for 12 hours for a KPI test we had some JavaScript memory leaks, some of which we tracked down to Pixi. The problems are:

* Super destructors (destroy) not always being called - this can result in hanging event subscriptions
* Not all managers being destroyed and nulled
* A couple of event subscriptions on Texture not being unsubscribed

What's your thoughts?