### PR TITLE
updated deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,13 +35,13 @@
     "earcut": "^2.0.2",
     "eventemitter3": "^1.1.1",
     "gulp-header": "^1.2.2",
-    "object-assign": "^2.0.0",
+    "object-assign": "^3.0.0",
     "resource-loader": "^1.6.1"
   },
   "devDependencies": {
     "browserify": "^11.0.1",
     "chai": "^3.2.0",
-    "del": "^1.2.0",
+    "del": "^1.2.1",
     "gulp": "^3.9.0",
     "gulp-cached": "^1.1.0",
     "gulp-concat": "^2.6.0",
@@ -60,7 +60,7 @@
     "mocha": "^2.2.5",
     "require-dir": "^0.3.0",
     "run-sequence": "^1.1.2",
-    "testem": "^0.8.5",
+    "testem": "^0.9.2",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.3.1"


### PR DESCRIPTION
object-assign 3.0 contains some bugfixes, del 1.2.0 depended on object-assign 2.0.

Also updated testem, the tests are running and passing.