### PR TITLE
Fix renderer plugin destruction exceptions

### DIFF
--- a/src/core/sprites/webgl/SpriteRenderer.js
+++ b/src/core/sprites/webgl/SpriteRenderer.js
@@ -446,10 +446,10 @@ SpriteRenderer.prototype.start = function ()
  */
 SpriteRenderer.prototype.destroy = function ()
 {
-    ObjectRenderer.prototype.destroy.call(this);
-    
     this.renderer.gl.deleteBuffer(this.vertexBuffer);
     this.renderer.gl.deleteBuffer(this.indexBuffer);
+
+    ObjectRenderer.prototype.destroy.call(this);
 
     this.shader.destroy();
 

--- a/src/mesh/webgl/MeshRenderer.js
+++ b/src/mesh/webgl/MeshRenderer.js
@@ -209,5 +209,5 @@ MeshRenderer.prototype.start = function ()
  */
 MeshRenderer.prototype.destroy = function ()
 {
-    ObjectRenderer.prototype.destroy.call(this);
+    core.ObjectRenderer.prototype.destroy.call(this);
 };


### PR DESCRIPTION
Closes pixijs/pixi.js#2086. Trivial fix, so I included another that popped up for `MeshRenderer`. [Fixed jsFiddle](http://jsfiddle.net/ho6qdzxk/4/).