### PR TITLE
WebGLRenderer texture event listener cleanup

### DIFF
--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -475,6 +475,12 @@ WebGLRenderer.prototype.destroy = function (removeView)
     this.view.removeEventListener('webglcontextlost', this.handleContextLost);
     this.view.removeEventListener('webglcontextrestored', this.handleContextRestored);
 
+    for (var key in utils.BaseTextureCache) {
+        var texture = utils.BaseTextureCache[key];
+        texture.off('update', this.updateTexture, this);
+        texture.off('dispose', this.destroyTexture, this);
+    }
+
     // call base destroy
     SystemRenderer.prototype.destroy.call(this, removeView);
 

--- a/src/loaders/textureParser.js
+++ b/src/loaders/textureParser.js
@@ -11,7 +11,7 @@ module.exports = function ()
             baseTexture.imageUrl = resource.url;
             resource.texture = new core.Texture(baseTexture);
             // lets also add the frame to pixi's global cache for fromFrame and fromImage fucntions
-            core.utils.BaseTextureCache[resource.url] = resource.texture;
+            core.utils.BaseTextureCache[resource.url] = baseTexture;
             core.utils.TextureCache[resource.url] = resource.texture;
         }
 


### PR DESCRIPTION
[Fixed jsFiddle](http://jsfiddle.net/q3byr0wz/2/) that includes these changes for #1968 on top of those from #2087. While touching every texture's listeners twice can be expensive, destroying a renderer should never be in performance-critical code paths anyway.

The JSHint failure is fixed by #2087.