### PR TITLE
Fixed resolution not being respected when set externally - fixes #1867

### DIFF
--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -109,11 +109,11 @@ Object.defineProperties(Sprite.prototype, {
     width: {
         get: function ()
         {
-            return Math.abs(this.scale.x) * this.texture._frame.width;
+            return Math.abs(this.scale.x) * this.texture.width;
         },
         set: function (value)
         {
-            this.scale.x = utils.sign(this.scale.x) * value / this.texture._frame.width;
+            this.scale.x = utils.sign(this.scale.x) * value / this.texture.width;
             this._width = value;
         }
     },
@@ -127,11 +127,11 @@ Object.defineProperties(Sprite.prototype, {
     height: {
         get: function ()
         {
-            return  Math.abs(this.scale.y) * this.texture._frame.height;
+            return  Math.abs(this.scale.y) * this.texture.height;
         },
         set: function (value)
         {
-            this.scale.y = utils.sign(this.scale.y) * value / this.texture._frame.height;
+            this.scale.y = utils.sign(this.scale.y) * value / this.texture.height;
             this._height = value;
         }
     },
@@ -183,12 +183,12 @@ Sprite.prototype._onTextureUpdate = function ()
     // so if _width is 0 then width was not set..
     if (this._width)
     {
-        this.scale.x = utils.sign(this.scale.x) * this._width / this.texture.frame.width;
+        this.scale.x = utils.sign(this.scale.x) * this._width / this.texture.width;
     }
 
     if (this._height)
     {
-        this.scale.y = utils.sign(this.scale.y) * this._height / this.texture.frame.height;
+        this.scale.y = utils.sign(this.scale.y) * this._height / this.texture.height;
     }
 };
 
@@ -216,8 +216,8 @@ Sprite.prototype.getBounds = function (matrix)
     if(!this._currentBounds)
     {
 
-        var width = this._texture._frame.width;
-        var height = this._texture._frame.height;
+        var width = this._texture.width;
+        var height = this._texture.height;
 
         var w0 = width * (1-this.anchor.x);
         var w1 = width * -this.anchor.x;
@@ -333,10 +333,10 @@ Sprite.prototype.getBounds = function (matrix)
  */
 Sprite.prototype.getLocalBounds = function ()
 {
-    this._bounds.x = -this._texture._frame.width * this.anchor.x;
-    this._bounds.y = -this._texture._frame.height * this.anchor.y;
-    this._bounds.width = this._texture._frame.width;
-    this._bounds.height = this._texture._frame.height;
+    this._bounds.x = -this._texture.width * this.anchor.x;
+    this._bounds.y = -this._texture.height * this.anchor.y;
+    this._bounds.width = this._texture.width;
+    this._bounds.height = this._texture.height;
     return this._bounds;
 };
 
@@ -350,8 +350,8 @@ Sprite.prototype.containsPoint = function( point )
 {
     this.worldTransform.applyInverse(point,  tempPoint);
 
-    var width = this._texture._frame.width;
-    var height = this._texture._frame.height;
+    var width = this._texture.width;
+    var height = this._texture.height;
     var x1 = -width * this.anchor.x;
     var y1;
 
@@ -435,16 +435,16 @@ Sprite.prototype._renderCanvas = function (renderer)
             dy = (texture.trim) ? texture.trim.y - this.anchor.y * texture.trim.height : this.anchor.y * -texture._frame.height;
         }
 
-
+        var resolution = texture.baseTexture.resolution;
 
         // Allow for pixel rounding
         if (renderer.roundPixels)
         {
             renderer.context.setTransform(
-                wt.a,
-                wt.b,
-                wt.c,
-                wt.d,
+                wt.a / resolution,
+                wt.b / resolution,
+                wt.c / resolution,
+                wt.d / resolution,
                 (wt.tx * renderer.resolution) | 0,
                 (wt.ty * renderer.resolution) | 0
             );
@@ -456,18 +456,16 @@ Sprite.prototype._renderCanvas = function (renderer)
         {
 
             renderer.context.setTransform(
-                wt.a,
-                wt.b,
-                wt.c,
-                wt.d,
+                wt.a / resolution,
+                wt.b / resolution,
+                wt.c / resolution,
+                wt.d / resolution,
                 wt.tx * renderer.resolution,
                 wt.ty * renderer.resolution
             );
 
 
         }
-
-        var resolution = texture.baseTexture.resolution;
 
         if (this.tint !== 0xFFFFFF)
         {
@@ -483,8 +481,8 @@ Sprite.prototype._renderCanvas = function (renderer)
                 this.tintedTexture,
                 0,
                 0,
-                width * resolution,
-                height * resolution,
+                width,
+                height,
                 dx * renderer.resolution,
                 dy * renderer.resolution,
                 width * renderer.resolution,
@@ -495,10 +493,10 @@ Sprite.prototype._renderCanvas = function (renderer)
         {
             renderer.context.drawImage(
                 texture.baseTexture.source,
-                texture.crop.x * resolution,
-                texture.crop.y * resolution,
-                width * resolution,
-                height * resolution,
+                texture.crop.x,
+                texture.crop.y,
+                width,
+                height,
                 dx  * renderer.resolution,
                 dy  * renderer.resolution,
                 width * renderer.resolution,

--- a/src/core/sprites/webgl/SpriteRenderer.js
+++ b/src/core/sprites/webgl/SpriteRenderer.js
@@ -203,11 +203,13 @@ SpriteRenderer.prototype.render = function (sprite)
     var index = this.currentBatchSize * this.vertByteSize;
 
     var worldTransform = sprite.worldTransform;
+    
+    var resolution = texture.baseTexture.resolution;
 
-    var a = worldTransform.a;
-    var b = worldTransform.b;
-    var c = worldTransform.c;
-    var d = worldTransform.d;
+    var a = worldTransform.a / resolution;
+    var b = worldTransform.b / resolution;
+    var c = worldTransform.c / resolution;
+    var d = worldTransform.d / resolution;
     var tx = worldTransform.tx;
     var ty = worldTransform.ty;
 

--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -108,11 +108,11 @@ Object.defineProperties(Text.prototype, {
                 this.updateText();
             }
 
-            return this.scale.x * this._texture._frame.width;
+            return this.scale.x * this._texture.width;
         },
         set: function (value)
         {
-            this.scale.x = value / this._texture._frame.width;
+            this.scale.x = value / this._texture.width;
             this._width = value;
         }
     },
@@ -131,11 +131,11 @@ Object.defineProperties(Text.prototype, {
                 this.updateText();
             }
 
-            return  this.scale.y * this._texture._frame.height;
+            return  this.scale.y * this._texture.height;
         },
         set: function (value)
         {
-            this.scale.y = value / this._texture._frame.height;
+            this.scale.y = value / this._texture.height;
             this._height = value;
         }
     },
@@ -373,9 +373,12 @@ Text.prototype.updateTexture = function ()
 
     texture.baseTexture.hasLoaded = true;
     texture.baseTexture.resolution = this.resolution;
+    
+    texture.baseTexture.realWidth = this.canvas.width;
+    texture.baseTexture.realHeight = this.canvas.height;
 
-    texture.baseTexture.width = this.canvas.width / this.resolution;
-    texture.baseTexture.height = this.canvas.height / this.resolution;
+    texture.width = texture.baseTexture.width = this.canvas.width / this.resolution;
+    texture.height = texture.baseTexture.height = this.canvas.height / this.resolution;
     texture.crop.width = texture._frame.width = this.canvas.width / this.resolution;
     texture.crop.height = texture._frame.height = this.canvas.height / this.resolution;
 

--- a/src/core/textures/RenderTexture.js
+++ b/src/core/textures/RenderTexture.js
@@ -67,6 +67,8 @@ function RenderTexture(renderer, width, height, scaleMode, resolution)
     var baseTexture = new BaseTexture();
     baseTexture.width = width;
     baseTexture.height = height;
+    baseTexture.realWidth = width * resolution;
+    baseTexture.realHeight = height * resolution;
     baseTexture.resolution = resolution;
     baseTexture.scaleMode = scaleMode || CONST.SCALE_MODES.DEFAULT;
     baseTexture.hasLoaded = true;
@@ -74,7 +76,7 @@ function RenderTexture(renderer, width, height, scaleMode, resolution)
 
     Texture.call(this,
         baseTexture,
-        new math.Rectangle(0, 0, width, height)
+        new math.Rectangle(0, 0, baseTexture.realWidth, baseTexture.realHeight)
     );
 
 
@@ -146,7 +148,7 @@ function RenderTexture(renderer, width, height, scaleMode, resolution)
     {
 
         this.render = this.renderCanvas;
-        this.textureBuffer = new CanvasBuffer(this.width* this.resolution, this.height* this.resolution);
+        this.textureBuffer = new CanvasBuffer(this.baseTexture.realWidth, this.baseTexture.realHeight);
         this.baseTexture.source = this.textureBuffer.canvas;
     }
 
@@ -178,11 +180,15 @@ RenderTexture.prototype.resize = function (width, height, updateBase)
 
     this.valid = (width > 0 && height > 0);
 
-    this.width = this._frame.width = this.crop.width = width;
-    this.height =  this._frame.height = this.crop.height = height;
+    this.width = width;
+    this.height = height;
+    this._frame.width = this.crop.width = width * this.resolution;
+    this._frame.height = this.crop.height = height * this.resolution;
 
     if (updateBase)
     {
+        this.baseTexture.realWidth = width * this.resolution;
+        this.baseTexture.realHeight = height * this.resolution;
         this.baseTexture.width = this.width;
         this.baseTexture.height = this.height;
     }
@@ -192,7 +198,14 @@ RenderTexture.prototype.resize = function (width, height, updateBase)
         return;
     }
 
-    this.textureBuffer.resize(this.width, this.height);
+    if (this.renderer.type === CONST.RENDERER_TYPE.WEBGL)
+    {
+        this.textureBuffer.resize(this.width, this.height);
+    }
+    else
+    {
+        this.textureBuffer.resize(this.baseTexture.realWidth, this.baseTexture.realHeight);
+    }
 
     if(this.filterManager)
     {

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -125,10 +125,8 @@ function Texture(baseTexture, frame, crop, trim, rotate)
     {
         if (this.noFrame)
         {
-            frame = new math.Rectangle(0, 0, baseTexture.width, baseTexture.height);
+            frame = new math.Rectangle(0, 0, baseTexture.realWidth, baseTexture.realHeight);
 
-            // if there is no frame we should monitor for any base texture changes..
-            baseTexture.on('update', this.onBaseTextureUpdated, this);
         }
         this.frame = frame;
     }
@@ -136,6 +134,9 @@ function Texture(baseTexture, frame, crop, trim, rotate)
     {
         baseTexture.once('loaded', this.onBaseTextureLoaded, this);
     }
+    
+    //we should monitor for any base texture changes in case the resolution is changed, etc.
+    baseTexture.on('update', this.onBaseTextureUpdated, this);
 
     /**
      * Fired when the texture is updated. This happens if the frame or the baseTexture is updated.
@@ -167,11 +168,13 @@ Object.defineProperties(Texture.prototype, {
             this._frame = frame;
 
             this.noFrame = false;
+            
+            var resolution = this.baseTexture.resolution;
 
-            this.width = frame.width;
-            this.height = frame.height;
+            this.width = frame.width / resolution;
+            this.height = frame.height / resolution;
 
-            if (!this.trim && !this.rotate && (frame.x + frame.width > this.baseTexture.width || frame.y + frame.height > this.baseTexture.height))
+            if (!this.trim && !this.rotate && (frame.x + frame.width > this.baseTexture.realWidth || frame.y + frame.height > this.baseTexture.realHeight))
             {
                 throw new Error('Texture Error: frame does not fit inside the base Texture dimensions ' + this);
             }
@@ -181,8 +184,8 @@ Object.defineProperties(Texture.prototype, {
 
             if (this.trim)
             {
-                this.width = this.trim.width;
-                this.height = this.trim.height;
+                this.width = this.trim.width / resolution;
+                this.height = this.trim.height / resolution;
                 this._frame.width = this.trim.width;
                 this._frame.height = this.trim.height;
             }
@@ -218,7 +221,7 @@ Texture.prototype.onBaseTextureLoaded = function (baseTexture)
     // TODO this code looks confusing.. boo to abusing getters and setterss!
     if (this.noFrame)
     {
-        this.frame = new math.Rectangle(0, 0, baseTexture.width, baseTexture.height);
+        this.frame = new math.Rectangle(0, 0, baseTexture.realWidth, baseTexture.realHeight);
     }
     else
     {
@@ -235,8 +238,15 @@ Texture.prototype.onBaseTextureLoaded = function (baseTexture)
  */
 Texture.prototype.onBaseTextureUpdated = function (baseTexture)
 {
-    this._frame.width = baseTexture.width;
-    this._frame.height = baseTexture.height;
+    if(this.noFrame)
+    {
+        this._frame.width = baseTexture.realWidth;
+        this._frame.height = baseTexture.realHeight;
+    }
+    else
+    {
+        this.frame = this._frame;
+    }
 
     this.emit('update', this);
 };

--- a/src/core/textures/TextureUvs.js
+++ b/src/core/textures/TextureUvs.js
@@ -32,8 +32,8 @@ module.exports = TextureUvs;
  */
 TextureUvs.prototype.set = function (frame, baseFrame, rotate)
 {
-    var tw = baseFrame.width;
-    var th = baseFrame.height;
+    var tw = baseFrame.realWidth;
+    var th = baseFrame.realHeight;
 
     if(rotate)
     {


### PR DESCRIPTION
This fixes inconsistencies with how Texture & BaseTexture width/height is used with the BaseTexture's resolution.
An [updated JSFiddle](http://jsfiddle.net/qhyh3otr/5/) from #1867 shows that it works properly for both asset resolutions as well as Canvas and WebGL rendering.
I haven't tested it, but this might also fix any issues with Canvas tinting at resolutions other than 1.