### PR TITLE
Cleanup primitive and complex shader during ShaderManager destroy

### DIFF
--- a/src/core/renderers/webgl/managers/ShaderManager.js
+++ b/src/core/renderers/webgl/managers/ShaderManager.js
@@ -155,6 +155,8 @@ ShaderManager.prototype.setShader = function (shader)
  */
 ShaderManager.prototype.destroy = function ()
 {
+    this.primitiveShader.destroy();
+    this.complexPrimitiveShader.destroy();
     WebGLManager.prototype.destroy.call(this);
 
     this.destroyPlugins();


### PR DESCRIPTION
Not doing this causes more shaders to be created then destroyed.