### PR TITLE
Clean up quad webgl buffers

### DIFF
--- a/src/core/renderers/webgl/managers/FilterManager.js
+++ b/src/core/renderers/webgl/managers/FilterManager.js
@@ -433,6 +433,8 @@ FilterManager.prototype.resize = function ( width, height )
  */
 FilterManager.prototype.destroy = function ()
 {
+    this.quad.destroy();
+    
     WebGLManager.prototype.destroy.call(this);
     
     this.filterStack = null;

--- a/src/core/renderers/webgl/utils/Quad.js
+++ b/src/core/renderers/webgl/utils/Quad.js
@@ -140,6 +140,14 @@ Quad.prototype.upload = function()
     gl.bufferSubData(gl.ARRAY_BUFFER, (8 + 8) * 4, this.colors);
 };
 
+Quad.prototype.destroy = function()
+{
+    var gl = this.gl;
+    
+     gl.deleteBuffer(this.vertexBuffer);
+     gl.deleteBuffer(this.indexBuffer);
+};
+
 module.exports = Quad;
 
 


### PR DESCRIPTION
These buffers were remaining after "exiting" Pixi.