### PR TITLE
roundPixels for WebGL

### DIFF
--- a/src/core/renderers/SystemRenderer.js
+++ b/src/core/renderers/SystemRenderer.js
@@ -21,6 +21,7 @@ var utils = require('../utils'),
  * @param [options.clearBeforeRender=true] {boolean} This sets if the CanvasRenderer will clear the canvas or
  *      not before the new render pass.
  * @param [options.backgroundColor=0x000000] {number} The background color of the rendered area (shown if not transparent).
+ * @param [options.roundPixels=false] {boolean} If true Pixi will Math.floor() x/y values when rendering, stopping pixel interpolation.
  */
 function SystemRenderer(system, width, height, options)
 {
@@ -122,6 +123,14 @@ function SystemRenderer(system, width, height, options)
      * @default
      */
     this.clearBeforeRender = options.clearBeforeRender;
+
+    /**
+     * If true Pixi will Math.floor() x/y values when rendering, stopping pixel interpolation.
+     * Handy for crisp pixel art and speed on legacy devices.
+     *
+     * @member {boolean}
+     */
+    this.roundPixels = options.roundPixels;
 
     /**
      * The background color as a number.

--- a/src/core/renderers/SystemRenderer.js
+++ b/src/core/renderers/SystemRenderer.js
@@ -251,6 +251,8 @@ SystemRenderer.prototype.destroy = function (removeView) {
     this.preserveDrawingBuffer = false;
     this.clearBeforeRender = false;
 
+    this.roundPixels = false;
+
     this._backgroundColor = 0;
     this._backgroundColorRgb = null;
     this._backgroundColorString = null;

--- a/src/core/renderers/canvas/CanvasRenderer.js
+++ b/src/core/renderers/canvas/CanvasRenderer.js
@@ -53,14 +53,6 @@ function CanvasRenderer(width, height, options)
     this.maskManager = new CanvasMaskManager();
 
     /**
-     * If true Pixi will Math.floor() x/y values when rendering, stopping pixel interpolation.
-     * Handy for crisp pixel art and speed on legacy devices.
-     *
-     * @member {boolean}
-     */
-    this.roundPixels = options.roundPixels;
-
-    /**
      * The canvas property used to set the canvas smoothing property.
      *
      * @member {string}

--- a/src/core/renderers/canvas/CanvasRenderer.js
+++ b/src/core/renderers/canvas/CanvasRenderer.js
@@ -169,8 +169,6 @@ CanvasRenderer.prototype.destroy = function (removeView)
     this.maskManager.destroy();
     this.maskManager = null;
 
-    this.roundPixels = false;
-
     this.smoothProperty = null;
 };
 

--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -32,6 +32,7 @@ var SystemRenderer = require('../SystemRenderer'),
  *      not before the new render pass. If you wish to set this to false, you *must* set preserveDrawingBuffer to `true`.
  * @param [options.preserveDrawingBuffer=false] {boolean} enables drawing buffer preservation, enable this if
  *      you need to call toDataUrl on the webgl context.
+ * @param [options.roundPixels=false] {boolean} If true Pixi will Math.floor() x/y values when rendering, stopping pixel interpolation.
  */
 function WebGLRenderer(width, height, options)
 {


### PR DESCRIPTION
I have noticed an issue with text being blurry when the anchor was set to 0.5 (iPad 2 - resolution 1)

I managed to fix the issue by setting `roundPixels = true` in both Canvas and WebGL renderers even though the property is only available in `CanvasRenderer`.

I am not sure why `roundPixels` was omitted in WebGLRenderer but any how I moved it to SystemRender so that it can be used for both the renderers.