### PR TITLE
Issue #2159: Force to sign=1 when scale=0

### DIFF
--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -113,7 +113,8 @@ Object.defineProperties(Sprite.prototype, {
         },
         set: function (value)
         {
-            this.scale.x = utils.sign(this.scale.x) * value / this.texture._frame.width;
+            var sign = utils.sign(this.scale.x) || 1;
+            this.scale.x = sign * value / this.texture._frame.width;
             this._width = value;
         }
     },
@@ -131,7 +132,8 @@ Object.defineProperties(Sprite.prototype, {
         },
         set: function (value)
         {
-            this.scale.y = utils.sign(this.scale.y) * value / this.texture._frame.height;
+            var sign = utils.sign(this.scale.y) || 1;
+            this.scale.y = sign * value / this.texture._frame.height;
             this._height = value;
         }
     },


### PR DESCRIPTION
Thanks to response issue #2159, @englercj san!

I try to fix this problem, and i confirmed this fix works well in my environment.

But, i am not sure, this fix are best fit to this problem.

As well, https://github.com/pixijs/pixi.js/blob/master/src/core/sprites/Sprite.js#L186 has codes like `utils.sign(this.scale.x)` too, but there are not need to convert zero sign, i seem.
