### PR TITLE
Standardized the class construction and inheritance

### DIFF
--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -28,10 +28,7 @@ function Container()
     this.children = [];
 }
 
-// constructor
-Container.prototype = Object.create(DisplayObject.prototype);
-Container.prototype.constructor = Container;
-module.exports = Container;
+module.exports = DisplayObject.extend(Container);
 
 Object.defineProperties(Container.prototype, {
     /**

--- a/src/core/display/DisplayObject.js
+++ b/src/core/display/DisplayObject.js
@@ -1,4 +1,5 @@
 var math = require('../math'),
+    utils = require('../utils'),
     RenderTexture = require('../textures/RenderTexture'),
     EventEmitter = require('eventemitter3'),
     CONST = require('../const'),
@@ -150,10 +151,7 @@ function DisplayObject()
     this._mask = null;
 }
 
-// constructor
-DisplayObject.prototype = Object.create(EventEmitter.prototype);
-DisplayObject.prototype.constructor = DisplayObject;
-module.exports = DisplayObject;
+module.exports = utils.extend(DisplayObject, EventEmitter);
 
 Object.defineProperties(DisplayObject.prototype, {
     /**

--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -158,10 +158,7 @@ function Graphics()
      */
 }
 
-// constructor
-Graphics.prototype = Object.create(Container.prototype);
-Graphics.prototype.constructor = Graphics;
-module.exports = Graphics;
+module.exports = Container.extend(Graphics);
 
 /**
  * Creates a new Graphics object with the same values as this one.

--- a/src/core/graphics/GraphicsData.js
+++ b/src/core/graphics/GraphicsData.js
@@ -1,3 +1,5 @@
+var utils = require('../utils');
+
 /**
  * A GraphicsData object.
  *
@@ -62,8 +64,7 @@ function GraphicsData(lineWidth, lineColor, lineAlpha, fillColor, fillAlpha, fil
     this.type = shape.type;
 }
 
-GraphicsData.prototype.constructor = GraphicsData;
-module.exports = GraphicsData;
+module.exports = utils.extend(GraphicsData);
 
 /**
  * Creates a new GraphicsData object with the same values as this one.

--- a/src/core/graphics/webgl/GraphicsRenderer.js
+++ b/src/core/graphics/webgl/GraphicsRenderer.js
@@ -31,9 +31,7 @@ function GraphicsRenderer(renderer)
     this.maximumSimplePolySize = 200;
 }
 
-GraphicsRenderer.prototype = Object.create(ObjectRenderer.prototype);
-GraphicsRenderer.prototype.constructor = GraphicsRenderer;
-module.exports = GraphicsRenderer;
+module.exports = ObjectRenderer.extend(GraphicsRenderer);
 
 WebGLRenderer.registerPlugin('graphics', GraphicsRenderer);
 

--- a/src/core/graphics/webgl/WebGLGraphicsData.js
+++ b/src/core/graphics/webgl/WebGLGraphicsData.js
@@ -1,3 +1,5 @@
+var utils = require('../../utils');
+
 /**
  * An object containing WebGL specific properties to be used by the WebGL renderer
  *
@@ -67,8 +69,7 @@ function WebGLGraphicsData(gl) {
     this.glIndices = null;
 }
 
-WebGLGraphicsData.prototype.constructor = WebGLGraphicsData;
-module.exports = WebGLGraphicsData;
+module.exports = utils.extend(WebGLGraphicsData);
 
 /**
  * Resets the vertices and the indices

--- a/src/core/math/Matrix.js
+++ b/src/core/math/Matrix.js
@@ -2,7 +2,8 @@
 // should either fix it or change the jshint config
 // jshint -W072
 
-var Point = require('./Point');
+var Point = require('./Point'),
+    utils = require('../utils');
 
 /**
  * The pixi Matrix class as an object, which makes it a lot faster,
@@ -53,8 +54,7 @@ function Matrix()
     this.ty = 0;
 }
 
-Matrix.prototype.constructor = Matrix;
-module.exports = Matrix;
+module.exports = utils.extend(Matrix);
 
 /**
  * Creates a Matrix object based on the given array. The Element to Matrix mapping order is as follows:

--- a/src/core/math/Point.js
+++ b/src/core/math/Point.js
@@ -1,3 +1,5 @@
+var utils = require('../utils');
+
 /**
  * The Point object represents a location in a two-dimensional coordinate system, where x represents
  * the horizontal axis and y represents the vertical axis.
@@ -22,8 +24,7 @@ function Point(x, y)
     this.y = y || 0;
 }
 
-Point.prototype.constructor = Point;
-module.exports = Point;
+module.exports = utils.extend(Point);
 
 /**
  * Creates a clone of this point

--- a/src/core/math/shapes/Circle.js
+++ b/src/core/math/shapes/Circle.js
@@ -1,4 +1,5 @@
 var Rectangle = require('./Rectangle'),
+    utils = require('../../utils'),
     CONST = require('../../const');
 
 /**
@@ -38,8 +39,7 @@ function Circle(x, y, radius)
     this.type = CONST.SHAPES.CIRC;
 }
 
-Circle.prototype.constructor = Circle;
-module.exports = Circle;
+module.exports = utils.extend(Circle);
 
 /**
  * Creates a clone of this Circle instance

--- a/src/core/math/shapes/Ellipse.js
+++ b/src/core/math/shapes/Ellipse.js
@@ -1,4 +1,5 @@
 var Rectangle = require('./Rectangle'),
+    utils = require('../../utils'),
     CONST = require('../../const');
 
 /**
@@ -45,8 +46,7 @@ function Ellipse(x, y, width, height)
     this.type = CONST.SHAPES.ELIP;
 }
 
-Ellipse.prototype.constructor = Ellipse;
-module.exports = Ellipse;
+module.exports = utils.extend(Ellipse);
 
 /**
  * Creates a clone of this Ellipse instance

--- a/src/core/math/shapes/Polygon.js
+++ b/src/core/math/shapes/Polygon.js
@@ -1,4 +1,5 @@
 var Point = require('../Point'),
+    utils = require('../../utils'),
     CONST = require('../../const');
 
 /**
@@ -57,8 +58,7 @@ function Polygon(points_)
     this.type = CONST.SHAPES.POLY;
 }
 
-Polygon.prototype.constructor = Polygon;
-module.exports = Polygon;
+module.exports = utils.extend(Polygon);
 
 /**
  * Creates a clone of this polygon

--- a/src/core/math/shapes/Rectangle.js
+++ b/src/core/math/shapes/Rectangle.js
@@ -1,4 +1,5 @@
-var CONST = require('../../const');
+var CONST = require('../../const'),
+    utils = require('../../utils');
 
 /**
  * the Rectangle object is an area defined by its position, as indicated by its top-left corner point (x, y) and by its width and its height.
@@ -44,8 +45,7 @@ function Rectangle(x, y, width, height)
     this.type = CONST.SHAPES.RECT;
 }
 
-Rectangle.prototype.constructor = Rectangle;
-module.exports = Rectangle;
+module.exports = utils.extend(Rectangle);
 
 /**
  * A constant empty rectangle.

--- a/src/core/math/shapes/RoundedRectangle.js
+++ b/src/core/math/shapes/RoundedRectangle.js
@@ -1,4 +1,5 @@
-var CONST = require('../../const');
+var CONST = require('../../const'),
+    utils = require('../../utils');
 
 /**
  * The Rounded Rectangle object is an area that has nice rounded corners, as indicated by its top-left corner point (x, y) and by its width and its height and its radius.
@@ -51,8 +52,7 @@ function RoundedRectangle(x, y, width, height, radius)
     this.type = CONST.SHAPES.RREC;
 }
 
-RoundedRectangle.prototype.constructor = RoundedRectangle;
-module.exports = RoundedRectangle;
+module.exports = utils.extend(RoundedRectangle);
 
 /**
  * Creates a clone of this Rounded Rectangle

--- a/src/core/particles/ParticleContainer.js
+++ b/src/core/particles/ParticleContainer.js
@@ -110,9 +110,7 @@ function ParticleContainer(maxSize, properties, batchSize)
     this.setProperties(properties);
 }
 
-ParticleContainer.prototype = Object.create(Container.prototype);
-ParticleContainer.prototype.constructor = ParticleContainer;
-module.exports = ParticleContainer;
+module.exports = Container.extend(ParticleContainer);
 
 /**
  * Sets the private properties array to dynamic / static based on the passed properties object

--- a/src/core/particles/webgl/ParticleBuffer.js
+++ b/src/core/particles/webgl/ParticleBuffer.js
@@ -1,3 +1,4 @@
+var utils = require('../../utils');
 
 /**
  * @author Mat Groves
@@ -87,8 +88,7 @@ function ParticleBuffer(gl, properties, dynamicPropertyFlags, size)
 
 }
 
-ParticleBuffer.prototype.constructor = ParticleBuffer;
-module.exports = ParticleBuffer;
+module.exports = utils.extend(ParticleBuffer);
 
 /**
  * Sets up the renderer context and necessary buffers.

--- a/src/core/particles/webgl/ParticleRenderer.js
+++ b/src/core/particles/webgl/ParticleRenderer.js
@@ -63,9 +63,7 @@ function ParticleRenderer(renderer)
     this.tempMatrix = new math.Matrix();
 }
 
-ParticleRenderer.prototype = Object.create(ObjectRenderer.prototype);
-ParticleRenderer.prototype.constructor = ParticleRenderer;
-module.exports = ParticleRenderer;
+module.exports = ObjectRenderer.extend(ParticleRenderer);
 
 WebGLRenderer.registerPlugin('particle', ParticleRenderer);
 

--- a/src/core/particles/webgl/ParticleShader.js
+++ b/src/core/particles/webgl/ParticleShader.js
@@ -70,7 +70,4 @@ function ParticleShader(shaderManager)
 
 }
 
-ParticleShader.prototype = Object.create(TextureShader.prototype);
-ParticleShader.prototype.constructor = ParticleShader;
-
-module.exports = ParticleShader;
+module.exports = TextureShader.extend(ParticleShader);

--- a/src/core/renderers/SystemRenderer.js
+++ b/src/core/renderers/SystemRenderer.js
@@ -175,10 +175,7 @@ function SystemRenderer(system, width, height, options)
     this._lastObjectRendered = this._tempDisplayObjectParent;
 }
 
-// constructor
-SystemRenderer.prototype = Object.create(EventEmitter.prototype);
-SystemRenderer.prototype.constructor = SystemRenderer;
-module.exports = SystemRenderer;
+module.exports = utils.extend(SystemRenderer, EventEmitter);
 
 Object.defineProperties(SystemRenderer.prototype, {
     /**

--- a/src/core/renderers/canvas/CanvasRenderer.js
+++ b/src/core/renderers/canvas/CanvasRenderer.js
@@ -98,11 +98,8 @@ function CanvasRenderer(width, height, options)
     this.resize(width, height);
 }
 
-// constructor
-CanvasRenderer.prototype = Object.create(SystemRenderer.prototype);
-CanvasRenderer.prototype.constructor = CanvasRenderer;
-module.exports = CanvasRenderer;
-utils.pluginTarget.mixin(CanvasRenderer);
+module.exports = SystemRenderer.extend(CanvasRenderer, true);
+
 
 /**
  * Renders the object to this canvas view

--- a/src/core/renderers/canvas/CanvasRenderer.js
+++ b/src/core/renderers/canvas/CanvasRenderer.js
@@ -98,8 +98,8 @@ function CanvasRenderer(width, height, options)
     this.resize(width, height);
 }
 
-module.exports = SystemRenderer.extend(CanvasRenderer, true);
-
+module.exports = SystemRenderer.extend(CanvasRenderer);
+utils.pluginTarget.mixin(CanvasRenderer);
 
 /**
  * Renders the object to this canvas view

--- a/src/core/renderers/canvas/utils/CanvasBuffer.js
+++ b/src/core/renderers/canvas/utils/CanvasBuffer.js
@@ -1,3 +1,5 @@
+var utils = require('../../../utils');
+
 /**
  * Creates a Canvas element of the given size.
  *
@@ -26,8 +28,7 @@ function CanvasBuffer(width, height)
     this.canvas.height = height;
 }
 
-CanvasBuffer.prototype.constructor = CanvasBuffer;
-module.exports = CanvasBuffer;
+module.exports = utils.extend(CanvasBuffer);
 
 Object.defineProperties(CanvasBuffer.prototype, {
     /**

--- a/src/core/renderers/canvas/utils/CanvasMaskManager.js
+++ b/src/core/renderers/canvas/utils/CanvasMaskManager.js
@@ -1,4 +1,5 @@
-var CanvasGraphics = require('./CanvasGraphics');
+var CanvasGraphics = require('./CanvasGraphics'),
+    utils = require('../../../utils');
 
 /**
  * A set of functions used to handle masking.
@@ -9,8 +10,7 @@ var CanvasGraphics = require('./CanvasGraphics');
 function CanvasMaskManager()
 {}
 
-CanvasMaskManager.prototype.constructor = CanvasMaskManager;
-module.exports = CanvasMaskManager;
+module.exports = utils.extend(CanvasMaskManager);
 
 /**
  * This method adds it to the current stack of masks.

--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -159,7 +159,8 @@ function WebGLRenderer(width, height, options)
     this._renderTargetStack = [];
 }
 
-module.exports = SystemRenderer.extend(WebGLRenderer, true);
+module.exports = SystemRenderer.extend(WebGLRenderer);
+utils.pluginTarget.mixin(WebGLRenderer);
 
 WebGLRenderer.glContextId = 0;
 

--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -159,11 +159,7 @@ function WebGLRenderer(width, height, options)
     this._renderTargetStack = [];
 }
 
-// constructor
-WebGLRenderer.prototype = Object.create(SystemRenderer.prototype);
-WebGLRenderer.prototype.constructor = WebGLRenderer;
-module.exports = WebGLRenderer;
-utils.pluginTarget.mixin(WebGLRenderer);
+module.exports = SystemRenderer.extend(WebGLRenderer, true);
 
 WebGLRenderer.glContextId = 0;
 

--- a/src/core/renderers/webgl/filters/AbstractFilter.js
+++ b/src/core/renderers/webgl/filters/AbstractFilter.js
@@ -1,4 +1,5 @@
-var DefaultShader = require('../shaders/TextureShader');
+var DefaultShader = require('../shaders/TextureShader'),
+    utils = require('../../../utils');
 
 /**
  * This is the base class for creating a PIXI filter. Currently only WebGL supports filters.
@@ -53,8 +54,7 @@ function AbstractFilter(vertexSrc, fragmentSrc, uniforms)
 
 }
 
-AbstractFilter.prototype.constructor = AbstractFilter;
-module.exports = AbstractFilter;
+module.exports = utils.extend(AbstractFilter);
 
 /**
  * Grabs a shader from the current renderer

--- a/src/core/renderers/webgl/filters/FXAAFilter.js
+++ b/src/core/renderers/webgl/filters/FXAAFilter.js
@@ -32,9 +32,7 @@ function FXAAFilter()
 
 }
 
-FXAAFilter.prototype = Object.create(AbstractFilter.prototype);
-FXAAFilter.prototype.constructor = FXAAFilter;
-module.exports = FXAAFilter;
+module.exports = AbstractFilter.extend(FXAAFilter);
 
 /**
  * Applies the filter

--- a/src/core/renderers/webgl/filters/SpriteMaskFilter.js
+++ b/src/core/renderers/webgl/filters/SpriteMaskFilter.js
@@ -30,9 +30,7 @@ function SpriteMaskFilter(sprite)
     this.maskMatrix = maskMatrix;
 }
 
-SpriteMaskFilter.prototype = Object.create(AbstractFilter.prototype);
-SpriteMaskFilter.prototype.constructor = SpriteMaskFilter;
-module.exports = SpriteMaskFilter;
+module.exports = AbstractFilter.extend(SpriteMaskFilter);
 
 /**
  * Applies the filter

--- a/src/core/renderers/webgl/managers/BlendModeManager.js
+++ b/src/core/renderers/webgl/managers/BlendModeManager.js
@@ -16,9 +16,7 @@ function BlendModeManager(renderer)
     this.currentBlendMode = 99999;
 }
 
-BlendModeManager.prototype = Object.create(WebGLManager.prototype);
-BlendModeManager.prototype.constructor = BlendModeManager;
-module.exports = BlendModeManager;
+module.exports = WebGLManager.extend(BlendModeManager);
 
 /**
  * Sets-up the given blendMode from WebGL's point of view.

--- a/src/core/renderers/webgl/managers/FilterManager.js
+++ b/src/core/renderers/webgl/managers/FilterManager.js
@@ -48,10 +48,7 @@ function FilterManager(renderer)
     this.currentFrame = null;
 }
 
-FilterManager.prototype = Object.create(WebGLManager.prototype);
-FilterManager.prototype.constructor = FilterManager;
-module.exports = FilterManager;
-
+module.exports = WebGLManager.extend(FilterManager);
 
 /**
  * Called when there is a WebGL context change.

--- a/src/core/renderers/webgl/managers/MaskManager.js
+++ b/src/core/renderers/webgl/managers/MaskManager.js
@@ -17,9 +17,7 @@ function MaskManager(renderer)
     this.alphaMaskPool = [];
 }
 
-MaskManager.prototype = Object.create(WebGLManager.prototype);
-MaskManager.prototype.constructor = MaskManager;
-module.exports = MaskManager;
+module.exports = WebGLManager.extend(MaskManager);
 
 /**
  * Applies the Mask and adds it to the current filter stack.

--- a/src/core/renderers/webgl/managers/ShaderManager.js
+++ b/src/core/renderers/webgl/managers/ShaderManager.js
@@ -1,7 +1,8 @@
 var WebGLManager = require('./WebGLManager'),
     TextureShader = require('../shaders/TextureShader'),
     ComplexPrimitiveShader = require('../shaders/ComplexPrimitiveShader'),
-    PrimitiveShader = require('../shaders/PrimitiveShader');
+    PrimitiveShader = require('../shaders/PrimitiveShader'),
+    utils = require('../../../utils');
 
 /**
  * @class
@@ -53,7 +54,8 @@ function ShaderManager(renderer)
 //    this.initPlugins();
 }
 
-module.exports = WebGLManager.extend(ShaderManager, true);
+module.exports = WebGLManager.extend(ShaderManager);
+utils.pluginTarget.mixin(ShaderManager);
 
 /**
  * Called when there is a WebGL context change.

--- a/src/core/renderers/webgl/managers/ShaderManager.js
+++ b/src/core/renderers/webgl/managers/ShaderManager.js
@@ -1,8 +1,7 @@
 var WebGLManager = require('./WebGLManager'),
     TextureShader = require('../shaders/TextureShader'),
     ComplexPrimitiveShader = require('../shaders/ComplexPrimitiveShader'),
-    PrimitiveShader = require('../shaders/PrimitiveShader'),
-    utils = require('../../../utils');
+    PrimitiveShader = require('../shaders/PrimitiveShader');
 
 /**
  * @class
@@ -54,11 +53,7 @@ function ShaderManager(renderer)
 //    this.initPlugins();
 }
 
-ShaderManager.prototype = Object.create(WebGLManager.prototype);
-ShaderManager.prototype.constructor = ShaderManager;
-utils.pluginTarget.mixin(ShaderManager);
-
-module.exports = ShaderManager;
+module.exports = WebGLManager.extend(ShaderManager, true);
 
 /**
  * Called when there is a WebGL context change.

--- a/src/core/renderers/webgl/managers/StencilManager.js
+++ b/src/core/renderers/webgl/managers/StencilManager.js
@@ -12,9 +12,7 @@ function WebGLMaskManager(renderer)
     this.stencilMaskStack = null;
 }
 
-WebGLMaskManager.prototype = Object.create(WebGLManager.prototype);
-WebGLMaskManager.prototype.constructor = WebGLMaskManager;
-module.exports = WebGLMaskManager;
+module.exports = WebGLManager.extend(WebGLMaskManager);
 
 /**
  * Changes the mask stack that is used by this manager.

--- a/src/core/renderers/webgl/managers/WebGLManager.js
+++ b/src/core/renderers/webgl/managers/WebGLManager.js
@@ -1,3 +1,5 @@
+var utils = require('../../../utils');
+
 /**
  * @class
  * @memberof PIXI
@@ -15,8 +17,7 @@ function WebGLManager(renderer)
     this.renderer.on('context', this.onContextChange, this);
 }
 
-WebGLManager.prototype.constructor = WebGLManager;
-module.exports = WebGLManager;
+module.exports = utils.extend(WebGLManager);
 
 /**
  * Generic method called when there is a WebGL context change.

--- a/src/core/renderers/webgl/shaders/ComplexPrimitiveShader.js
+++ b/src/core/renderers/webgl/shaders/ComplexPrimitiveShader.js
@@ -55,6 +55,4 @@ function ComplexPrimitiveShader(shaderManager)
     );
 }
 
-ComplexPrimitiveShader.prototype = Object.create(Shader.prototype);
-ComplexPrimitiveShader.prototype.constructor = ComplexPrimitiveShader;
-module.exports = ComplexPrimitiveShader;
+module.exports = Shader.extend(ComplexPrimitiveShader);

--- a/src/core/renderers/webgl/shaders/PrimitiveShader.js
+++ b/src/core/renderers/webgl/shaders/PrimitiveShader.js
@@ -56,6 +56,4 @@ function PrimitiveShader(shaderManager)
     );
 }
 
-PrimitiveShader.prototype = Object.create(Shader.prototype);
-PrimitiveShader.prototype.constructor = PrimitiveShader;
-module.exports = PrimitiveShader;
+module.exports = Shader.extend(PrimitiveShader);

--- a/src/core/renderers/webgl/shaders/Shader.js
+++ b/src/core/renderers/webgl/shaders/Shader.js
@@ -82,8 +82,7 @@ function Shader(shaderManager, vertexSrc, fragmentSrc, uniforms, attributes)
     this.init();
 }
 
-Shader.prototype.constructor = Shader;
-module.exports = Shader;
+module.exports = utils.extend(Shader);
 
 /**
  * Creates the shader and uses it

--- a/src/core/renderers/webgl/shaders/TextureShader.js
+++ b/src/core/renderers/webgl/shaders/TextureShader.js
@@ -60,10 +60,7 @@ function TextureShader(shaderManager, vertexSrc, fragmentSrc, customUniforms, cu
     Shader.call(this, shaderManager, vertexSrc, fragmentSrc, uniforms, attributes);
 }
 
-// constructor
-TextureShader.prototype = Object.create(Shader.prototype);
-TextureShader.prototype.constructor = TextureShader;
-module.exports = TextureShader;
+module.exports = Shader.extend(TextureShader);
 
 /**
  * The default vertex shader source

--- a/src/core/renderers/webgl/utils/ObjectRenderer.js
+++ b/src/core/renderers/webgl/utils/ObjectRenderer.js
@@ -13,10 +13,7 @@ function ObjectRenderer(renderer)
     WebGLManager.call(this, renderer);
 }
 
-
-ObjectRenderer.prototype = Object.create(WebGLManager.prototype);
-ObjectRenderer.prototype.constructor = ObjectRenderer;
-module.exports = ObjectRenderer;
+module.exports = WebGLManager.extend(ObjectRenderer);
 
 /**
  * Starts the renderer and sets the shader

--- a/src/core/renderers/webgl/utils/Quad.js
+++ b/src/core/renderers/webgl/utils/Quad.js
@@ -1,3 +1,5 @@
+var utils = require('../../../utils');
+
 /**
  * Helper class to create a quad
  *
@@ -148,6 +150,4 @@ Quad.prototype.destroy = function()
      gl.deleteBuffer(this.indexBuffer);
 };
 
-module.exports = Quad;
-
-
+module.exports = utils.extend(Quad);

--- a/src/core/renderers/webgl/utils/RenderTarget.js
+++ b/src/core/renderers/webgl/utils/RenderTarget.js
@@ -165,8 +165,7 @@ var RenderTarget = function(gl, width, height, scaleMode, resolution, root)
     this.resize(width, height);
 };
 
-RenderTarget.prototype.constructor = RenderTarget;
-module.exports = RenderTarget;
+module.exports = utils.extend(RenderTarget);
 
 /**
  * Clears the filter texture.

--- a/src/core/renderers/webgl/utils/StencilMaskStack.js
+++ b/src/core/renderers/webgl/utils/StencilMaskStack.js
@@ -1,3 +1,5 @@
+var utils = require('../../../utils');
+
 /**
  * Generic Mask Stack data structure
  * @class
@@ -27,5 +29,4 @@ function StencilMaskStack()
     this.count = 0;
 }
 
-StencilMaskStack.prototype.constructor = StencilMaskStack;
-module.exports = StencilMaskStack;
+module.exports = utils.extend(StencilMaskStack);

--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -94,10 +94,7 @@ function Sprite(texture)
     this.texture = texture || Texture.EMPTY;
 }
 
-// constructor
-Sprite.prototype = Object.create(Container.prototype);
-Sprite.prototype.constructor = Sprite;
-module.exports = Sprite;
+module.exports = Container.extend(Sprite);
 
 Object.defineProperties(Sprite.prototype, {
     /**

--- a/src/core/sprites/webgl/SpriteRenderer.js
+++ b/src/core/sprites/webgl/SpriteRenderer.js
@@ -115,9 +115,7 @@ function SpriteRenderer(renderer)
     this.shader = null;
 }
 
-SpriteRenderer.prototype = Object.create(ObjectRenderer.prototype);
-SpriteRenderer.prototype.constructor = SpriteRenderer;
-module.exports = SpriteRenderer;
+module.exports = ObjectRenderer.extend(SpriteRenderer);
 
 WebGLRenderer.registerPlugin('sprite', SpriteRenderer);
 

--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -84,10 +84,7 @@ function Text(text, style, resolution)
     this.style = style;
 }
 
-// constructor
-Text.prototype = Object.create(Sprite.prototype);
-Text.prototype.constructor = Text;
-module.exports = Text;
+module.exports = Sprite.extend(Text);
 
 Text.fontPropertiesCache = {};
 Text.fontPropertiesCanvas = document.createElement('canvas');

--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -160,9 +160,7 @@ function BaseTexture(source, scaleMode, resolution)
      */
 }
 
-BaseTexture.prototype = Object.create(EventEmitter.prototype);
-BaseTexture.prototype.constructor = BaseTexture;
-module.exports = BaseTexture;
+module.exports = utils.extend(BaseTexture, EventEmitter);
 
 /**
  * Updates the texture on all the webgl renderers, this also assumes the src has changed.

--- a/src/core/textures/RenderTexture.js
+++ b/src/core/textures/RenderTexture.js
@@ -159,9 +159,7 @@ function RenderTexture(renderer, width, height, scaleMode, resolution)
     this._updateUvs();
 }
 
-RenderTexture.prototype = Object.create(Texture.prototype);
-RenderTexture.prototype.constructor = RenderTexture;
-module.exports = RenderTexture;
+module.exports = Texture.extend(RenderTexture);
 
 /**
  * Resizes the RenderTexture.

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -146,9 +146,7 @@ function Texture(baseTexture, frame, crop, trim, rotate)
      */
 }
 
-Texture.prototype = Object.create(EventEmitter.prototype);
-Texture.prototype.constructor = Texture;
-module.exports = Texture;
+module.exports = utils.extend(Texture, EventEmitter);
 
 Object.defineProperties(Texture.prototype, {
     /**

--- a/src/core/textures/VideoBaseTexture.js
+++ b/src/core/textures/VideoBaseTexture.js
@@ -70,9 +70,7 @@ function VideoBaseTexture(source, scaleMode)
     this.__loaded = false;
 }
 
-VideoBaseTexture.prototype = Object.create(BaseTexture.prototype);
-VideoBaseTexture.prototype.constructor = VideoBaseTexture;
-module.exports = VideoBaseTexture;
+module.exports = BaseTexture.extend(VideoBaseTexture);
 
 /**
  * The internal update loop of the video base texture, only runs when autoUpdate is set to true

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -16,11 +16,10 @@ var utils = module.exports = {
      * have other classes extend it, e.g., `Container.extend(MyContainer)`
      *
      * @param child {function} child The child class
-     * @param parent {function} parent The parent class to extend
-     * @param isPluginTarget=false {Boolean} If the child can have plugins
-     * @return {function} The child class
+     * @param [parent=null] {function} parent The parent class to extend
+     * @return {function} The reference to the child class
      */
-    extend: function(child, parent, isPluginTarget)
+    extend: function(child, parent)
     {
         if (parent)
         {
@@ -29,18 +28,14 @@ var utils = module.exports = {
             child.prototype.__parent = p;
         }
         // Add extend to each class to easily extend
-        child.extend = function(subchild, pluginable)
+        child.extend = function(subchild)
         {
-            return utils.extend(subchild, child, pluginable);
+            return utils.extend(subchild, child);
         };
 
         // Add the constructor
         child.prototype.constructor = child;
-
-        if (isPluginTarget)
-        {
-            utils.pluginTarget.mixin(child);
-        }
+        
         return child;
     },
 

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -12,6 +12,39 @@ var utils = module.exports = {
     async:          require('async'),
 
     /**
+     * Extend from one class to another and give child class ability to
+     * have other classes extend it, e.g., `Container.extend(MyContainer)`
+     *
+     * @param child {function} child The child class
+     * @param parent {function} parent The parent class to extend
+     * @param isPluginTarget=false {Boolean} If the child can have plugins
+     * @return {function} The child class
+     */
+    extend: function(child, parent, isPluginTarget)
+    {
+        if (parent)
+        {
+            var p = parent.prototype;
+            child.prototype = Object.create(p);
+            child.prototype.__parent = p;
+        }
+        // Add extend to each class to easily extend
+        child.extend = function(subchild, pluginable)
+        {
+            return utils.extend(subchild, child, pluginable);
+        };
+
+        // Add the constructor
+        child.prototype.constructor = child;
+
+        if (isPluginTarget)
+        {
+            utils.pluginTarget.mixin(child);
+        }
+        return child;
+    },
+
+    /**
      * Gets the next unique identifier
      *
      * @return {number} The next unique identifier to use.

--- a/src/extras/BitmapText.js
+++ b/src/extras/BitmapText.js
@@ -114,10 +114,7 @@ function BitmapText(text, style)
     this.updateText();
 }
 
-// constructor
-BitmapText.prototype = Object.create(core.Container.prototype);
-BitmapText.prototype.constructor = BitmapText;
-module.exports = BitmapText;
+module.exports = core.Container.extend(BitmapText);
 
 Object.defineProperties(BitmapText.prototype, {
     /**

--- a/src/extras/MovieClip.js
+++ b/src/extras/MovieClip.js
@@ -80,10 +80,7 @@ function MovieClip(textures)
     this.playing = false;
 }
 
-// constructor
-MovieClip.prototype = Object.create(core.Sprite.prototype);
-MovieClip.prototype.constructor = MovieClip;
-module.exports = MovieClip;
+module.exports = core.Sprite.extend(MovieClip);
 
 Object.defineProperties(MovieClip.prototype, {
     /**

--- a/src/extras/TilingSprite.js
+++ b/src/extras/TilingSprite.js
@@ -117,10 +117,7 @@ function TilingSprite(texture, width, height)
       );
 }
 
-TilingSprite.prototype = Object.create(core.Sprite.prototype);
-TilingSprite.prototype.constructor = TilingSprite;
-module.exports = TilingSprite;
-
+module.exports = core.Sprite.extend(TilingSprite);
 
 Object.defineProperties(TilingSprite.prototype, {
     /**

--- a/src/filters/ascii/AsciiFilter.js
+++ b/src/filters/ascii/AsciiFilter.js
@@ -31,9 +31,7 @@ function AsciiFilter()
     );
 }
 
-AsciiFilter.prototype = Object.create(core.AbstractFilter.prototype);
-AsciiFilter.prototype.constructor = AsciiFilter;
-module.exports = AsciiFilter;
+module.exports = core.AbstractFilter.extend(AsciiFilter);
 
 Object.defineProperties(AsciiFilter.prototype, {
     /**

--- a/src/filters/bloom/BloomFilter.js
+++ b/src/filters/bloom/BloomFilter.js
@@ -20,9 +20,7 @@ function BloomFilter()
     this.defaultFilter = new core.AbstractFilter();
 }
 
-BloomFilter.prototype = Object.create(core.AbstractFilter.prototype);
-BloomFilter.prototype.constructor = BloomFilter;
-module.exports = BloomFilter;
+module.exports = core.AbstractFilter.extend(BloomFilter);
 
 BloomFilter.prototype.applyFilter = function (renderer, input, output)
 {

--- a/src/filters/blur/BlurDirFilter.js
+++ b/src/filters/blur/BlurDirFilter.js
@@ -54,9 +54,7 @@ function BlurDirFilter(dirX, dirY)
     this.strength = 4;
 }
 
-BlurDirFilter.prototype = Object.create(core.AbstractFilter.prototype);
-BlurDirFilter.prototype.constructor = BlurDirFilter;
-module.exports = BlurDirFilter;
+module.exports = core.AbstractFilter.extend(BlurDirFilter);
 
 BlurDirFilter.prototype.applyFilter = function (renderer, input, output, clear) {
 

--- a/src/filters/blur/BlurFilter.js
+++ b/src/filters/blur/BlurFilter.js
@@ -18,9 +18,7 @@ function BlurFilter()
     this.blurYFilter = new BlurYFilter();
 }
 
-BlurFilter.prototype = Object.create(core.AbstractFilter.prototype);
-BlurFilter.prototype.constructor = BlurFilter;
-module.exports = BlurFilter;
+module.exports = core.AbstractFilter.extend(BlurFilter);
 
 BlurFilter.prototype.applyFilter = function (renderer, input, output)
 {

--- a/src/filters/blur/BlurXFilter.js
+++ b/src/filters/blur/BlurXFilter.js
@@ -33,9 +33,7 @@ function BlurXFilter()
     this.strength = 4;
 }
 
-BlurXFilter.prototype = Object.create(core.AbstractFilter.prototype);
-BlurXFilter.prototype.constructor = BlurXFilter;
-module.exports = BlurXFilter;
+module.exports = core.AbstractFilter.extend(BlurXFilter);
 
 BlurXFilter.prototype.applyFilter = function (renderer, input, output, clear)
 {

--- a/src/filters/blur/BlurYFilter.js
+++ b/src/filters/blur/BlurYFilter.js
@@ -26,9 +26,7 @@ function BlurYFilter()
     this.strength = 4;
 }
 
-BlurYFilter.prototype = Object.create(core.AbstractFilter.prototype);
-BlurYFilter.prototype.constructor = BlurYFilter;
-module.exports = BlurYFilter;
+module.exports = core.AbstractFilter.extend(BlurYFilter);
 
 BlurYFilter.prototype.applyFilter = function (renderer, input, output, clear)
 {

--- a/src/filters/blur/SmartBlurFilter.js
+++ b/src/filters/blur/SmartBlurFilter.js
@@ -23,6 +23,4 @@ function SmartBlurFilter()
     );
 }
 
-SmartBlurFilter.prototype = Object.create(core.AbstractFilter.prototype);
-SmartBlurFilter.prototype.constructor = SmartBlurFilter;
-module.exports = SmartBlurFilter;
+module.exports = core.AbstractFilter.extend(SmartBlurFilter);

--- a/src/filters/color/ColorMatrixFilter.js
+++ b/src/filters/color/ColorMatrixFilter.js
@@ -38,9 +38,7 @@ function ColorMatrixFilter()
     );
 }
 
-ColorMatrixFilter.prototype = Object.create(core.AbstractFilter.prototype);
-ColorMatrixFilter.prototype.constructor = ColorMatrixFilter;
-module.exports = ColorMatrixFilter;
+module.exports = core.AbstractFilter.extend(ColorMatrixFilter);
 
 
 /**

--- a/src/filters/color/ColorStepFilter.js
+++ b/src/filters/color/ColorStepFilter.js
@@ -23,9 +23,7 @@ function ColorStepFilter()
     );
 }
 
-ColorStepFilter.prototype = Object.create(core.AbstractFilter.prototype);
-ColorStepFilter.prototype.constructor = ColorStepFilter;
-module.exports = ColorStepFilter;
+module.exports = core.AbstractFilter.extend(ColorStepFilter);
 
 Object.defineProperties(ColorStepFilter.prototype, {
     /**

--- a/src/filters/convolution/ConvolutionFilter.js
+++ b/src/filters/convolution/ConvolutionFilter.js
@@ -31,9 +31,7 @@ function ConvolutionFilter(matrix, width, height)
     );
 }
 
-ConvolutionFilter.prototype = Object.create(core.AbstractFilter.prototype);
-ConvolutionFilter.prototype.constructor = ConvolutionFilter;
-module.exports = ConvolutionFilter;
+module.exports = core.AbstractFilter.extend(ConvolutionFilter);
 
 Object.defineProperties(ConvolutionFilter.prototype, {
     /**

--- a/src/filters/crosshatch/CrossHatchFilter.js
+++ b/src/filters/crosshatch/CrossHatchFilter.js
@@ -19,6 +19,4 @@ function CrossHatchFilter()
     );
 }
 
-CrossHatchFilter.prototype = Object.create(core.AbstractFilter.prototype);
-CrossHatchFilter.prototype.constructor = CrossHatchFilter;
-module.exports = CrossHatchFilter;
+module.exports = core.AbstractFilter.extend(CrossHatchFilter);

--- a/src/filters/displacement/DisplacementFilter.js
+++ b/src/filters/displacement/DisplacementFilter.js
@@ -41,9 +41,7 @@ function DisplacementFilter(sprite, scale)
     this.scale = new core.Point(scale, scale);
 }
 
-DisplacementFilter.prototype = Object.create(core.AbstractFilter.prototype);
-DisplacementFilter.prototype.constructor = DisplacementFilter;
-module.exports = DisplacementFilter;
+module.exports = core.AbstractFilter.extend(DisplacementFilter);
 
 DisplacementFilter.prototype.applyFilter = function (renderer, input, output)
 {

--- a/src/filters/dot/DotScreenFilter.js
+++ b/src/filters/dot/DotScreenFilter.js
@@ -31,9 +31,7 @@ function DotScreenFilter()
     );
 }
 
-DotScreenFilter.prototype = Object.create(core.AbstractFilter.prototype);
-DotScreenFilter.prototype.constructor = DotScreenFilter;
-module.exports = DotScreenFilter;
+module.exports = core.AbstractFilter.extend(DotScreenFilter);
 
 Object.defineProperties(DotScreenFilter.prototype, {
     /**

--- a/src/filters/dropshadow/BlurYTintFilter.js
+++ b/src/filters/dropshadow/BlurYTintFilter.js
@@ -31,9 +31,7 @@ function BlurYTintFilter()
     this.strength = 4;
 }
 
-BlurYTintFilter.prototype = Object.create(core.AbstractFilter.prototype);
-BlurYTintFilter.prototype.constructor = BlurYTintFilter;
-module.exports = BlurYTintFilter;
+module.exports = core.AbstractFilter.extend(BlurYTintFilter);
 
 BlurYTintFilter.prototype.applyFilter = function (renderer, input, output, clear)
 {

--- a/src/filters/dropshadow/DropShadowFilter.js
+++ b/src/filters/dropshadow/DropShadowFilter.js
@@ -29,9 +29,7 @@ function DropShadowFilter()
     this.blendMode = core.BLEND_MODES.MULTIPLY;
 }
 
-DropShadowFilter.prototype = Object.create(core.AbstractFilter.prototype);
-DropShadowFilter.prototype.constructor = DropShadowFilter;
-module.exports = DropShadowFilter;
+module.exports = core.AbstractFilter.extend(DropShadowFilter);
 
 DropShadowFilter.prototype.applyFilter = function (renderer, input, output)
 {

--- a/src/filters/gray/GrayFilter.js
+++ b/src/filters/gray/GrayFilter.js
@@ -23,9 +23,7 @@ function GrayFilter()
     );
 }
 
-GrayFilter.prototype = Object.create(core.AbstractFilter.prototype);
-GrayFilter.prototype.constructor = GrayFilter;
-module.exports = GrayFilter;
+module.exports = core.AbstractFilter.extend(GrayFilter);
 
 Object.defineProperties(GrayFilter.prototype, {
     /**

--- a/src/filters/invert/InvertFilter.js
+++ b/src/filters/invert/InvertFilter.js
@@ -23,9 +23,7 @@ function InvertFilter()
     );
 }
 
-InvertFilter.prototype = Object.create(core.AbstractFilter.prototype);
-InvertFilter.prototype.constructor = InvertFilter;
-module.exports = InvertFilter;
+module.exports = core.AbstractFilter.extend(InvertFilter);
 
 Object.defineProperties(InvertFilter.prototype, {
     /**

--- a/src/filters/noise/NoiseFilter.js
+++ b/src/filters/noise/NoiseFilter.js
@@ -28,9 +28,7 @@ function NoiseFilter()
     );
 }
 
-NoiseFilter.prototype = Object.create(core.AbstractFilter.prototype);
-NoiseFilter.prototype.constructor = NoiseFilter;
-module.exports = NoiseFilter;
+module.exports = core.AbstractFilter.extend(NoiseFilter);
 
 Object.defineProperties(NoiseFilter.prototype, {
     /**

--- a/src/filters/pixelate/PixelateFilter.js
+++ b/src/filters/pixelate/PixelateFilter.js
@@ -24,9 +24,7 @@ function PixelateFilter()
     );
 }
 
-PixelateFilter.prototype = Object.create(core.AbstractFilter.prototype);
-PixelateFilter.prototype.constructor = PixelateFilter;
-module.exports = PixelateFilter;
+module.exports = core.AbstractFilter.extend(PixelateFilter);
 
 Object.defineProperties(PixelateFilter.prototype, {
     /**

--- a/src/filters/rgb/RGBSplitFilter.js
+++ b/src/filters/rgb/RGBSplitFilter.js
@@ -26,9 +26,7 @@ function RGBSplitFilter()
     );
 }
 
-RGBSplitFilter.prototype = Object.create(core.AbstractFilter.prototype);
-RGBSplitFilter.prototype.constructor = RGBSplitFilter;
-module.exports = RGBSplitFilter;
+module.exports = core.AbstractFilter.extend(RGBSplitFilter);
 
 Object.defineProperties(RGBSplitFilter.prototype, {
     /**

--- a/src/filters/sepia/SepiaFilter.js
+++ b/src/filters/sepia/SepiaFilter.js
@@ -23,9 +23,7 @@ function SepiaFilter()
     );
 }
 
-SepiaFilter.prototype = Object.create(core.AbstractFilter.prototype);
-SepiaFilter.prototype.constructor = SepiaFilter;
-module.exports = SepiaFilter;
+module.exports = core.AbstractFilter.extend(SepiaFilter);
 
 Object.defineProperties(SepiaFilter.prototype, {
     /**

--- a/src/filters/shockwave/ShockwaveFilter.js
+++ b/src/filters/shockwave/ShockwaveFilter.js
@@ -27,9 +27,7 @@ function ShockwaveFilter()
     );
 }
 
-ShockwaveFilter.prototype = Object.create(core.AbstractFilter.prototype);
-ShockwaveFilter.prototype.constructor = ShockwaveFilter;
-module.exports = ShockwaveFilter;
+module.exports = core.AbstractFilter.extend(ShockwaveFilter);
 
 Object.defineProperties(ShockwaveFilter.prototype, {
     /**

--- a/src/filters/tiltshift/TiltShiftAxisFilter.js
+++ b/src/filters/tiltshift/TiltShiftAxisFilter.js
@@ -35,9 +35,7 @@ function TiltShiftAxisFilter()
     this.updateDelta();
 }
 
-TiltShiftAxisFilter.prototype = Object.create(core.AbstractFilter.prototype);
-TiltShiftAxisFilter.prototype.constructor = TiltShiftAxisFilter;
-module.exports = TiltShiftAxisFilter;
+module.exports = core.AbstractFilter.extend(TiltShiftAxisFilter);
 
 /**
  * Updates the filter delta values.

--- a/src/filters/tiltshift/TiltShiftFilter.js
+++ b/src/filters/tiltshift/TiltShiftFilter.js
@@ -22,9 +22,7 @@ function TiltShiftFilter()
     this.tiltShiftYFilter = new TiltShiftYFilter();
 }
 
-TiltShiftFilter.prototype = Object.create(core.AbstractFilter.prototype);
-TiltShiftFilter.prototype.constructor = TiltShiftFilter;
-module.exports = TiltShiftFilter;
+module.exports = core.AbstractFilter.extend(TiltShiftFilter);
 
 TiltShiftFilter.prototype.applyFilter = function (renderer, input, output)
 {

--- a/src/filters/tiltshift/TiltShiftXFilter.js
+++ b/src/filters/tiltshift/TiltShiftXFilter.js
@@ -17,9 +17,7 @@ function TiltShiftXFilter()
     TiltShiftAxisFilter.call(this);
 }
 
-TiltShiftXFilter.prototype = Object.create(TiltShiftAxisFilter.prototype);
-TiltShiftXFilter.prototype.constructor = TiltShiftXFilter;
-module.exports = TiltShiftXFilter;
+module.exports = TiltShiftAxisFilter.extend(TiltShiftXFilter);
 
 /**
  * Updates the filter delta values.

--- a/src/filters/tiltshift/TiltShiftYFilter.js
+++ b/src/filters/tiltshift/TiltShiftYFilter.js
@@ -17,9 +17,7 @@ function TiltShiftYFilter()
     TiltShiftAxisFilter.call(this);
 }
 
-TiltShiftYFilter.prototype = Object.create(TiltShiftAxisFilter.prototype);
-TiltShiftYFilter.prototype.constructor = TiltShiftYFilter;
-module.exports = TiltShiftYFilter;
+module.exports = TiltShiftAxisFilter.extend(TiltShiftYFilter);
 
 /**
  * Updates the filter delta values.

--- a/src/filters/twist/TwistFilter.js
+++ b/src/filters/twist/TwistFilter.js
@@ -25,9 +25,7 @@ function TwistFilter()
     );
 }
 
-TwistFilter.prototype = Object.create(core.AbstractFilter.prototype);
-TwistFilter.prototype.constructor = TwistFilter;
-module.exports = TwistFilter;
+module.exports = core.AbstractFilter.extend(TwistFilter);
 
 Object.defineProperties(TwistFilter.prototype, {
     /**

--- a/src/interaction/InteractionData.js
+++ b/src/interaction/InteractionData.js
@@ -30,8 +30,7 @@ function InteractionData()
     this.originalEvent = null;
 }
 
-InteractionData.prototype.constructor = InteractionData;
-module.exports = InteractionData;
+module.exports = core.utils.extend(InteractionData);
 
 /**
  * This will return the local coordinates of the specified displayObject for this InteractionData

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -164,8 +164,8 @@ function InteractionManager(renderer, options)
     this.setTargetElement(this.renderer.view, this.renderer.resolution);
 }
 
-InteractionManager.prototype.constructor = InteractionManager;
-module.exports = InteractionManager;
+module.exports = core.utils.extend(InteractionManager);
+
 
 /**
  * Sets the DOM element which will receive mouse/touch events. This is useful for when you have

--- a/src/loaders/loader.js
+++ b/src/loaders/loader.js
@@ -1,7 +1,8 @@
 var ResourceLoader = require('resource-loader'),
     textureParser = require('./textureParser'),
     spritesheetParser = require('./spritesheetParser'),
-    bitmapFontParser = require('./bitmapFontParser');
+    bitmapFontParser = require('./bitmapFontParser'),
+    utils = require('../core/utils');
 
 /**
  *
@@ -34,10 +35,7 @@ function Loader(baseUrl, concurrency)
     }
 }
 
-Loader.prototype = Object.create(ResourceLoader.prototype);
-Loader.prototype.constructor = Loader;
-
-module.exports = Loader;
+module.exports = utils.extend(Loader, ResourceLoader);
 
 Loader._pixiMiddleware = [
     // parse any blob into more usable objects (e.g. Image)

--- a/src/mesh/Mesh.js
+++ b/src/mesh/Mesh.js
@@ -86,10 +86,7 @@ function Mesh(texture, vertices, uvs, indices, drawMode)
     this.texture = texture;
 }
 
-// constructor
-Mesh.prototype = Object.create(core.Container.prototype);
-Mesh.prototype.constructor = Mesh;
-module.exports = Mesh;
+module.exports = core.Container.extend(Mesh);
 
 Object.defineProperties(Mesh.prototype, {
     /**

--- a/src/mesh/Rope.js
+++ b/src/mesh/Rope.js
@@ -60,10 +60,7 @@ function Rope(texture, points)
 }
 
 
-// constructor
-Rope.prototype = Object.create(Mesh.prototype);
-Rope.prototype.constructor = Rope;
-module.exports = Rope;
+module.exports = Mesh.extend(Rope);
 
 /**
  * Refreshes

--- a/src/mesh/webgl/MeshRenderer.js
+++ b/src/mesh/webgl/MeshRenderer.js
@@ -44,9 +44,7 @@ function MeshRenderer(renderer)
     }
 }
 
-MeshRenderer.prototype = Object.create(core.ObjectRenderer.prototype);
-MeshRenderer.prototype.constructor = MeshRenderer;
-module.exports = MeshRenderer;
+module.exports = core.ObjectRenderer.extend(MeshRenderer);
 
 core.WebGLRenderer.registerPlugin('mesh', MeshRenderer);
 

--- a/src/mesh/webgl/MeshShader.js
+++ b/src/mesh/webgl/MeshShader.js
@@ -52,8 +52,6 @@ function MeshShader(shaderManager)
     );
 }
 
-MeshShader.prototype = Object.create(core.Shader.prototype);
-MeshShader.prototype.constructor = MeshShader;
-module.exports = MeshShader;
+module.exports = core.Shader.extend(MeshShader);
 
 core.ShaderManager.registerPlugin('meshShader', MeshShader);


### PR DESCRIPTION
## Overview

* Adds `PIXI.utils.extend`, for instance `PIXI.utils.extend(MyClass, EventEmitter);`
 * Adds the `constructor` property to the prototype
 * Extends the prototype from the parent to the child using `Object.create(parent.prototype)`
 * Adds a static `extend` function to the child class for extending further
 * Gives a return value of the child class (first parameter)
* Where applicable, replaced class constructor/inheritance with short-hand (e.g.,
`DisplayObject.extend(Container)`). This does the same thing as calling `PIXI.utils.extend`.

## Example Usage 

```js
function MySprite(texture)
{
	Sprite.call(this, texture);
}
Sprite.extend(MySprite);
```

Or alternately: 

```js
var MySprite = Sprite.extend(function(texture)
{
	Sprite.call(this, texture);
});
```

As opposed to the more verbose:

```js
function MySprite(texture)
{
	Sprite.call(this, texture);
};
MySprite.prototype = Object.create(Sprite.prototype);
MySprite.prototype.constructor = MySprite;
```