### PR TITLE
inline Sprite.destroy logic with Text.destroy

### DIFF
--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -522,7 +522,7 @@ Sprite.prototype.destroy = function (destroyTexture, destroyBaseTexture)
 
     if (destroyTexture)
     {
-        this._texture.destroy(destroyBaseTexture);
+        this._texture.destroy(destroyBaseTexture === undefined ? true : destroyBaseTexture);
     }
 
     this._texture = null;


### PR DESCRIPTION
When Sprite.destroy called from Container.destroy 2nd parameter is undefined and should be interpreted as true.
Opposite solution to add destroyBaseTexture parameter to all destroy functions.