### PR TITLE
replaced native Array.splice to reduce gc churn

### DIFF
--- a/src/accessibility/AccessibilityManager.js
+++ b/src/accessibility/AccessibilityManager.js
@@ -201,7 +201,7 @@ AccessibilityManager.prototype.update = function()
 		{
 			child._accessibleActive = false;
 
-			this.children.splice(i, 1);
+			core.utils.spliceOne(this.children, i);
 			this.div.removeChild( child._accessibleDiv );
 			this.pool.push(child._accessibleDiv);
 			child._accessibleDiv = null;

--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -1,4 +1,5 @@
 var math = require('../math'),
+    utils = require('../utils'),
     DisplayObject = require('./DisplayObject'),
     RenderTexture = require('../textures/RenderTexture'),
     _tempMatrix = new math.Matrix();
@@ -233,8 +234,8 @@ Container.prototype.setChildIndex = function (child, index)
 
     var currentIndex = this.getChildIndex(child);
 
-    this.children.splice(currentIndex, 1); //remove from old position
-    this.children.splice(index, 0, child); //add at new position
+    utils.spliceOne(this.children, currentIndex); // remove from old position
+    this.children.splice(index, 0, child); // add at new position
     this.onChildrenChange(index);
 };
 
@@ -284,7 +285,7 @@ Container.prototype.removeChild = function (child)
         }
 
         child.parent = null;
-        this.children.splice(index, 1);
+        utils.spliceOne(this.children, index);
 
         // TODO - lets either do all callbacks or all events.. not both!
         this.onChildrenChange(index);
@@ -305,7 +306,7 @@ Container.prototype.removeChildAt = function (index)
     var child = this.getChildAt(index);
 
     child.parent = null;
-    this.children.splice(index, 1);
+    utils.spliceOne(this.children, index);
 
     // TODO - lets either do all callbacks or all events.. not both!
     this.onChildrenChange(index);

--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -449,7 +449,7 @@ WebGLRenderer.prototype.destroyTexture = function (texture, _skipRemove)
         {
             var i = this._managedTextures.indexOf(texture);
             if (i !== -1) {
-                this._managedTextures.splice(i, 1);
+                utils.spliceOne(this._managedTextures, i);
             }
         }
     }

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -22,6 +22,28 @@ var utils = module.exports = {
     },
 
     /**
+     * Remove one item from an array.
+     * Javascript's native array splice method is slow, and generates garbage.
+     *
+     * @param arr {Array} The array to remove the item from
+     * @param index {number} The index at which the item is removed
+     */
+    spliceOne: function (arr, index)
+    {
+        if (index >= arr.length)
+        {
+            return;
+        }
+
+        for (var i = index, len = arr.length - 1; i < len; i++)
+        {
+            arr[i] = arr[i + 1];
+        }
+
+        arr.length = len;
+    },
+
+    /**
      * Converts a hex color number to an [R, G, B] array
      *
      * @param hex {number}


### PR DESCRIPTION
Javascripts' built-in `Array.splice` is pretty slow, and generates garbage because it returns a newly created array containing the removed objects.

I've only replaced `Array.splice` where 1 item is removed. That seems to be the most common code path. Might be able to use this replacement function for removing multiple indices but I haven't looked into it.