### PR TITLE
Replace native Array.splice with manual removeItems

### DIFF
--- a/src/accessibility/AccessibilityManager.js
+++ b/src/accessibility/AccessibilityManager.js
@@ -201,7 +201,7 @@ AccessibilityManager.prototype.update = function()
 		{
 			child._accessibleActive = false;
 
-			this.children.splice(i, 1);
+            core.utils.removeItems(this.children, i, 1);
 			this.div.removeChild( child._accessibleDiv );
 			this.pool.push(child._accessibleDiv);
 			child._accessibleDiv = null;

--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -1,4 +1,5 @@
 var math = require('../math'),
+    utils = require('../utils'),
     DisplayObject = require('./DisplayObject'),
     RenderTexture = require('../textures/RenderTexture'),
     _tempMatrix = new math.Matrix();
@@ -233,7 +234,7 @@ Container.prototype.setChildIndex = function (child, index)
 
     var currentIndex = this.getChildIndex(child);
 
-    this.children.splice(currentIndex, 1); //remove from old position
+    utils.removeItems(this.children, currentIndex, 1); // remove from old position
     this.children.splice(index, 0, child); //add at new position
     this.onChildrenChange(index);
 };
@@ -284,7 +285,7 @@ Container.prototype.removeChild = function (child)
         }
 
         child.parent = null;
-        this.children.splice(index, 1);
+        utils.removeItems(this.children, index, 1);
 
         // TODO - lets either do all callbacks or all events.. not both!
         this.onChildrenChange(index);
@@ -305,7 +306,7 @@ Container.prototype.removeChildAt = function (index)
     var child = this.getChildAt(index);
 
     child.parent = null;
-    this.children.splice(index, 1);
+    utils.removeItems(this.children, index, 1);
 
     // TODO - lets either do all callbacks or all events.. not both!
     this.onChildrenChange(index);

--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -449,7 +449,7 @@ WebGLRenderer.prototype.destroyTexture = function (texture, _skipRemove)
         {
             var i = this._managedTextures.indexOf(texture);
             if (i !== -1) {
-                this._managedTextures.splice(i, 1);
+                utils.removeItems(this._managedTextures, i, 1);
             }
         }
     }

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -231,8 +231,34 @@ var utils = module.exports = {
      * @param n {number}
      * @returns {number} 0 if n is 0, -1 if n is negative, 1 if n i positive
      */
-    sign: function (n) {
+    sign: function (n)
+    {
         return n ? (n < 0 ? -1 : 1) : 0;
+    },
+
+    /**
+     * removeItems
+     *
+     * @param {array} arr The target array
+     * @param {number} startIdx The index to begin removing from (inclusive)
+     * @param {number} removeCount How many items to remove
+     */
+    removeItems: function (arr, startIdx, removeCount)
+    {
+        var length = arr.length;
+
+        if (startIdx >= length || removeCount === 0)
+        {
+            return;
+        }
+
+        removeCount = (startIdx+removeCount > length ? length-startIdx : removeCount);
+        for (var i = startIdx, len = length-removeCount; i < len; ++i)
+        {
+            arr[i] = arr[i + removeCount];
+        }
+
+        arr.length = len;
     },
 
     /**

--- a/src/extras/BitmapText.js
+++ b/src/extras/BitmapText.js
@@ -253,7 +253,7 @@ BitmapText.prototype.updateText = function ()
 
         if (lastSpace !== -1 && this.maxWidth > 0 && pos.x * scale > this.maxWidth)
         {
-            chars.splice(lastSpace, i - lastSpace);
+            core.utils.removeItems(chars, lastSpace, i - lastSpace);
             i = lastSpace;
             lastSpace = -1;
 

--- a/test/unit/core/utils/util.test.js
+++ b/test/unit/core/utils/util.test.js
@@ -107,4 +107,34 @@ describe('PIXI.utils', function () {
             }
         });
     });
+
+    describe('.removeItems', function () {
+        var arr;
+
+        beforeEach(function () {
+            arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        });
+
+        it('should return if the start index is greater than or equal to the length of the array', function () {
+            PIXI.utils.removeItems(arr, arr.length+1, 5);
+            expect(arr.length).to.be.equal(10);
+        });
+
+        it('should return if the remove count is 0', function () {
+            PIXI.utils.removeItems(arr, 2, 0);
+            expect(arr.length).to.be.equal(10);
+        });
+
+        it('should remove the number of elements specified from the array, starting from the start index', function () {
+            var res = [ 1, 2, 3, 8, 9, 10 ];
+            PIXI.utils.removeItems(arr, 3, 4);
+            expect(arr).to.be.deep.equal(res);
+        });
+
+        it('should remove rest of elements if the delete count is > than the number of elements after start index', function () {
+            var res = [ 1, 2, 3, 4, 5, 6, 7 ];
+            PIXI.utils.removeItems(arr, 7, 10);
+            expect(arr).to.be.deep.equal(res);
+        });
+    });
 });


### PR DESCRIPTION
Added a ```removeItems``` function to the ```utils``` module to replace the native Array.splice for removing array items.  Unit tests also added.

Related to #2205. This PR adds the ability to remove multiple items.