### PR TITLE
Remove texture from cache if it will be added by fromImage

### DIFF
--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -317,7 +317,6 @@ BaseTexture.prototype.destroy = function ()
     if (this.imageUrl)
     {
         delete utils.BaseTextureCache[this.imageUrl];
-        delete utils.TextureCache[this.imageUrl];
 
         this.imageUrl = null;
 

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -250,6 +250,11 @@ Texture.prototype.destroy = function (destroyBase)
 {
     if (this.baseTexture)
     {
+        if (this.baseTexture.imageUrl)
+        {
+            delete utils.TextureCache[this.baseTexture.imageUrl];
+        }
+
         if (destroyBase)
         {
             this.baseTexture.destroy();


### PR DESCRIPTION
Problem:
```javascript
var IMAGE_URL = 'any-image.png';

// create any container with sprite, use... then destroy
var container = new PIXI.Container();
var sprite = new PIXI.Sprite.fromImage(IMAGE_URL); 

container.addChild(sprite);
container.destroy(true);

// fail to create sprite from image with url IMAGE_URL
var sprite2 = new PIXI.Sprite.fromImage(IMAGE_URL); 
// Uncaught TypeError: Cannot read property 'hasLoaded' of null
```

fixed #1741