### PR TITLE
try optimize updateTransform

### DIFF
--- a/src/core/display/DisplayObject.js
+++ b/src/core/display/DisplayObject.js
@@ -140,6 +140,8 @@ function DisplayObject()
      * @private
      */
     this._mask = null;
+
+    this._transformDirty = true;
 }
 
 // constructor
@@ -148,6 +150,16 @@ DisplayObject.prototype.constructor = DisplayObject;
 module.exports = DisplayObject;
 
 Object.defineProperties(DisplayObject.prototype, {
+    transformDirty: {
+        get: function()
+        {
+            return this._transformDirty;
+        },
+        set: function(value)
+        {
+            this._transformDirty = value;
+        }
+    },
     /**
      * The position of the displayObject on the x axis relative to the local coordinates of the parent.
      *
@@ -161,6 +173,8 @@ Object.defineProperties(DisplayObject.prototype, {
         },
         set: function (value)
         {
+            if(value === this.position.x) return;
+            this.transformDirty = true;
             this.position.x = value;
         }
     },
@@ -178,6 +192,8 @@ Object.defineProperties(DisplayObject.prototype, {
         },
         set: function (value)
         {
+            if(value === this.position.y) return;
+            this.transformDirty = true;
             this.position.y = value;
         }
     },

--- a/src/extras/index.js
+++ b/src/extras/index.js
@@ -8,6 +8,7 @@
 require('./cacheAsBitmap');
 require('./getChildByName');
 require('./getGlobalPosition');
+require('./optimizeUpdateTransform');
 
 /**
  * @namespace PIXI.extras

--- a/src/extras/optimizeUpdateTransform.js
+++ b/src/extras/optimizeUpdateTransform.js
@@ -1,0 +1,30 @@
+var core = require('../core'),
+    DisplayObject = core.DisplayObject,
+    Container = core.Container;
+
+DisplayObject.prototype.updateTransform = function (transformDirty)
+{
+    transformDirty = transformDirty || this.transformDirty || false;
+    if(transformDirty) {
+        this.displayObjectUpdateTransform();
+        this.transformDirty = false;
+    }
+};
+
+Container.prototype.updateTransform = function(transformDirty) {
+    if (!this.visible)
+    {
+        return;
+    }
+
+    transformDirty = transformDirty || this.transformDirty || false;
+    if(transformDirty) {
+        this.displayObjectUpdateTransform();
+        this.transformDirty = false;
+    }
+
+    for (var i = 0, j = this.children.length; i < j; ++i)
+    {
+        this.children[i].updateTransform(transformDirty);
+    }
+};


### PR DESCRIPTION
PS: This pull request is just for discussion because the code is incomplete.

`updateTransform` is called each frame, i found this would cost a lot of time with the following profiling:

<img width=400 src="https://cloud.githubusercontent.com/assets/843422/11649555/288fba5c-9dbb-11e5-80ab-d46ec778e52f.png">

In simple terms, the worldTransform of DisplayObject should not be update if it's local transform(position, scale, rotation, anchor ...etc) and the worldTransform of it's parent wasn't changed. This could be done with a flag `transformDirty` in calling chain, review the code of this pull request.

After optimized:

<img width=400 src="https://cloud.githubusercontent.com/assets/843422/11649708/d2b8ffc4-9dbc-11e5-8978-075bd45c12ee.png">

both tow profiling use the Container example of `pixijs/example`
