### PR TITLE
Setting blend mode when using CanvasRenderer.

### DIFF
--- a/src/core/particles/ParticleContainer.js
+++ b/src/core/particles/ParticleContainer.js
@@ -196,6 +196,12 @@ ParticleContainer.prototype.renderCanvas = function (renderer)
     var finalWidth = 0;
     var finalHeight = 0;
 
+    var compositeOperation = renderer.blendModes[this.blendMode];
+    if (compositeOperation !== context.globalCompositeOperation)
+    {
+        context.globalCompositeOperation = compositeOperation;
+    }
+
     context.globalAlpha = this.worldAlpha;
 
     this.displayObjectUpdateTransform();


### PR DESCRIPTION
When rendering on canvas, the blend mode of the previously rendered object was used. The blend mode of the particle container will now be set correctly.