### PR TITLE
Fix for using the loader when loading images

### DIFF
--- a/src/loaders/textureParser.js
+++ b/src/loaders/textureParser.js
@@ -11,8 +11,10 @@ module.exports = function ()
             baseTexture.imageUrl = resource.url;
             resource.texture = new core.Texture(baseTexture);
             // lets also add the frame to pixi's global cache for fromFrame and fromImage fucntions
-            core.utils.BaseTextureCache[resource.url] = baseTexture;
-            core.utils.TextureCache[resource.url] = resource.texture;
+            // we use the provided name if available, otherwise the url of the resource
+            var id = resource.name || resource.url; 
+            core.utils.BaseTextureCache[id] = baseTexture;
+            core.utils.TextureCache[id] = resource.texture;
         }
 
         next();


### PR DESCRIPTION
If I use the loader to load images manually and gave them a name, the
images are not added to the texture cache with that name.

We have to use the original url to get them. In could be annoying
because if you load images that could be retina (@2x) you have to acces
them also with the retina url. If I can use the normal url as an
identifier I don’t have to have retina logic to get the right url
spread throughout my code.

For my this fixes this issue, but I don’t know if this will break
existing usage of the loader and cache…