### PR TITLE
Make brfs a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
   ],
   "dependencies": {
     "async": "^1.5.0",
-    "brfs": "^1.4.1",
     "earcut": "^2.0.7",
     "eventemitter3": "^1.1.1",
     "object-assign": "^4.0.1",
     "resource-loader": "^1.6.4"
   },
   "devDependencies": {
+    "brfs": "^1.4.1",
     "browserify": "^11.1.0",
     "chai": "^3.2.0",
     "del": "^2.0.2",


### PR DESCRIPTION
Since it is used in the build step, `brfs` should be a devDependency, not a dependency.