### PR TITLE
create baseTexture in the middleware before loading starts

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "earcut": "^2.0.7",
     "eventemitter3": "^1.1.1",
     "object-assign": "^4.0.1",
-    "resource-loader": "^1.6.4"
+    "resource-loader": "^1.6.5"
   },
   "devDependencies": {
     "browserify": "^11.1.0",

--- a/src/loaders/loader.js
+++ b/src/loaders/loader.js
@@ -28,7 +28,9 @@ var ResourceLoader = require('resource-loader'),
 function Loader(baseUrl, concurrency)
 {
     ResourceLoader.call(this, baseUrl, concurrency);
-
+    // create textures before they are loaded, special for dynamic images
+    this.before(textureParser());
+    // pixi middlewares, defined below
     for (var i = 0; i < Loader._pixiMiddleware.length; ++i) {
         this.use(Loader._pixiMiddleware[i]());
     }
@@ -42,7 +44,6 @@ module.exports = Loader;
 Loader._pixiMiddleware = [
     // parse any blob into more usable objects (e.g. Image)
     ResourceLoader.middleware.parsing.blob,
-    // parse any Image objects into textures
     textureParser,
     // parse any spritesheet data into multiple textures
     spritesheetParser,

--- a/src/loaders/textureParser.js
+++ b/src/loaders/textureParser.js
@@ -1,16 +1,20 @@
-var core = require('../core');
+var core = require('../core'), Resource = require('resource-loader').Resource;
 
 module.exports = function ()
 {
     return function (resource, next)
     {
         // create a new texture if the data is an Image object
-        if (resource.data && resource.isImage)
+        // middleware can be executed before or after image is loaded
+        if (resource.loadType === Resource.LOAD_TYPE.IMAGE)
         {
+            if (!resource.data) {
+                resource.prepareImage();
+            }
             var baseTexture = new core.BaseTexture(resource.data, null, core.utils.getResolutionOfUrl(resource.url));
             baseTexture.imageUrl = resource.url;
             resource.texture = new core.Texture(baseTexture);
-            // lets also add the frame to pixi's global cache for fromFrame and fromImage fucntions
+            // lets also add the frame to pixi's global cache for fromFrame and fromImage functions
             core.utils.BaseTextureCache[resource.url] = baseTexture;
             core.utils.TextureCache[resource.url] = resource.texture;
         }


### PR DESCRIPTION
this code will work:

loader.add('something.png');
loader.load();
 //loading started but we want to use that NOW
var tex = Texture.fromImage('something.png');
