### PR TITLE
Fix InteractionManager fatal: If an interaction leads to a child being removed this loop could potentially throw an error

### DIFF
--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -392,7 +392,7 @@ InteractionManager.prototype.processInteractive = function (point, displayObject
                 
                 // If the child is interactive , that means that the object hit was actually interactive and not just the child of an interactive object. 
                 // This means we no longer need to hit test anything else. We still need to run through all objects, but we don't need to perform any hit tests.
-                if(children[i].interactive)
+                if(children[i] && children[i].interactive)
                 {
                     hitTest = false;
                 }


### PR DESCRIPTION
There is an error in the newest version of PIXI that causes an error when a child of a class removes itself during an interaction event: http://jsbin.com/zoyeyugede/edit?js,output

This patch stops the intermediate error, but it would be probably cleaner to defer all calls to func() to the next tick. Any suggestions or thoughts?


