### PR TITLE
Don't fire interaction event when not interacting with object

### DIFF
--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -565,7 +565,10 @@ InteractionManager.prototype.onMouseMove = function (event)
  */
 InteractionManager.prototype.processMouseMove = function ( displayObject, hit )
 {
-    this.dispatchEvent( displayObject, 'mousemove', this.eventData);
+    if(hit)
+    {
+        this.dispatchEvent( displayObject, 'mousemove', this.eventData);
+    }
     this.processMouseOverOut(displayObject, hit);
 };
 
@@ -780,8 +783,10 @@ InteractionManager.prototype.onTouchMove = function (event)
  */
 InteractionManager.prototype.processTouchMove = function ( displayObject, hit )
 {
-    hit = hit;
-    this.dispatchEvent( displayObject, 'touchmove', this.eventData);
+    if(hit)
+    {
+        this.dispatchEvent( displayObject, 'touchmove', this.eventData);
+    }
 };
 
 /**


### PR DESCRIPTION
- Don't fire mousemove or touchmove unless hit is true
- Fixes issue described in #2310

Maybe its a conscious choice not to respect the `hit` flag for these event. Let me know if so....... 