### PR TITLE
Update const.js to use browserify-versionify

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "async": "^1.5.0",
     "brfs": "^1.4.1",
+    "browserify-versionify": "^1.0.6",
     "earcut": "^2.0.7",
     "eventemitter3": "^1.1.1",
     "object-assign": "^4.0.1",
@@ -67,6 +68,7 @@
   },
   "browserify": {
     "transform": [
+      "browserify-versionify",
       "brfs"
     ]
   }

--- a/src/core/const.js
+++ b/src/core/const.js
@@ -11,7 +11,7 @@ var CONST = {
      * @constant
      * @property {string} VERSION
      */
-    VERSION: require('../../package.json').version,
+    VERSION: '__VERSION__',
 
     /**
      * @property {number} PI_2 - Two Pi


### PR DESCRIPTION
Currently `const.js` uses require to load in the project's package.json. After Browserify has bundled the source the full contents of the `package.json` file is included into `pixi.js` and `pixi.min.js`. The only reason it's being included is to get the correct version number of the `package.json` file. By including a new Browserify transform `browserify-versionify` and changing the require statement to a unique string we can reduce the size of the bundled file.


#### Now this:

```js
},{}],12:[function(require,module,exports){
module.exports={
  "name": "pixi.js",
  "version": "3.0.9-dev",
  "description": "Pixi.js is a fast lightweight 2D library that works across all devices.",
  "author": "Mat Groves",
  "contributors": [
    "Chad Engler <chad@pantherdev.com>",
    "Richard Davey <rdavey@gmail.com>"
  ],
  "main": "./src/index.js",
  "homepage": "http://goodboydigital.com/",
  "bugs": "https://github.com/pixijs/pixi.js/issues",
  "license": "MIT",
  "repository": {
    "type": "git",
    "url": "https://github.com/pixijs/pixi.js.git"
  },
  "scripts": {
    "start": "gulp && gulp watch",
    "test": "gulp && testem ci",
    "build": "gulp",
    "docs": "jsdoc -c ./gulp/util/jsdoc.conf.json -R README.md"
  },
  "files": [
    "bin/",
    "src/",
    "CONTRIBUTING.md",
    "LICENSE",
    "package.json",
    "README.md"
  ],
  "dependencies": {
    "async": "^1.4.2",
    "brfs": "^1.4.1",
    "earcut": "^2.0.2",
    "eventemitter3": "^1.1.1",
    "gulp-header": "^1.7.1",
    "object-assign": "^4.0.1",
    "resource-loader": "^1.6.2"
  },
  "devDependencies": {
    "browserify": "^11.1.0",
    "chai": "^3.2.0",
    "del": "^2.0.2",
    "gulp": "^3.9.0",
    "gulp-cached": "^1.1.0",
    "gulp-concat": "^2.6.0",
    "gulp-debug": "^2.1.0",
    "gulp-jshint": "^1.11.2",
    "gulp-mirror": "^0.4.0",
    "gulp-plumber": "^1.0.1",
    "gulp-rename": "^1.2.2",
    "gulp-sourcemaps": "^1.5.2",
    "gulp-uglify": "^1.4.1",
    "gulp-util": "^3.0.6",
    "jaguarjs-jsdoc": "git+https://github.com/davidshimjs/jaguarjs-jsdoc.git",
    "jsdoc": "^3.3.2",
    "jshint-summary": "^0.4.0",
    "minimist": "^1.2.0",
    "mocha": "^2.3.2",
    "require-dir": "^0.3.0",
    "run-sequence": "^1.1.2",
    "testem": "^0.9.4",
    "vinyl-buffer": "^1.0.0",
    "vinyl-source-stream": "^1.1.0",
    "watchify": "^3.4.0"
  },
  "browserify": {
    "transform": [
      "brfs"
    ]
  }
}

...

},{"./AccessibilityManager":13,"./accessibleTarget":14}],16:[function(require,module,exports){
/**
 * Constant values used in pixi
 *
 * @lends PIXI
 */
var CONST = {
    /**
     * String of the current PIXI version
     *
     * @static
     * @constant
     * @property {string} VERSION
     */
    VERSION: require('../../package.json').version,
```

#### Turns into this:

```js
},{"./AccessibilityManager":19,"./accessibleTarget":20}],22:[function(require,module,exports){
/**
 * Constant values used in pixi
 *
 * @lends PIXI
 */
var CONST = {
    /**
     * String of the current PIXI version
     *
     * @static
     * @constant
     * @property {string} VERSION
     */
    VERSION: '3.0.10-dev',
```