### PR TITLE
flush all webgl commands before the renderer is completely destroyed.

### DIFF
--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -536,6 +536,8 @@ WebGLRenderer.prototype.destroy = function (removeView)
 
     this.gl.useProgram(null);
 
+    this.gl.flush();
+
     this.gl = null;
 };
 


### PR DESCRIPTION
**TL;DR** Frees texture memory more quickly (which can reduce crashes on Android) after destroying a WebGLRenderer in chromium-based browsers.

This ensures that all commands are processed in a timely fashion (especially in browsers with multi-process or multi-threaded graphics architectures like chrome). Noteably, this ensures that gl textures are actually deleted around the same time that the renderer is destroyed.

This fix was found to help reduce WebGL-related crashes on older Android-based phones running chromium (in our case, an app using crosswalk to wrap up a chromium webview). This especially helps when renderers are routinely created/destroyed. 

I did some remote memory tracing using chrome's "MemoryInfra" tool. I found that without a flush at the end of the renderer destroy, there was no guarantee that the textures inside chrome's GPU process would be cleaned up quickly. After destroy, we often load a new page with a bunch of new images and content. This new memory usage sometimes would push the memory limits of our app over the acceptable limit for an Android process and cause a crash.

In the test, I switched between a page that had no pixi renderer, and a page that did (single-page app using react-router to switch pages). Before the fix, this is what the memory profile looked like:

![no-flush-profile](https://cloud.githubusercontent.com/assets/4540723/13016773/c990c188-d18e-11e5-9fe9-132084b41e32.png)

Blue lines are when I switched to a page with **NO** PIXI renderer.
Yellow lines are when I switched to a page with a PIXI renderer.

As you can see, the memory in the GPU process does not get freed immediately. It takes a couple of seconds, and even then, the overall memory use (solid green graph at the top) stays almost consistent (with minor fluctuations).

This is what the profile looks like after the fix:

![with-flush-profile](https://cloud.githubusercontent.com/assets/4540723/13016870/58f6181e-d18f-11e5-9cd3-2f2cf22e7f3a.png)

The memory is freed much more quickly and consistently. Also, the overall memory graph follows what is happening on the GPU process more closely (i.e. this change actually decreases overall memory usage in the app by freeing up GPU process memory).