### PR TITLE
Proposal for issue #2377, SpritesheetParser middleware may block UI for large spritesheets

### DIFF
--- a/src/loaders/spritesheetParser.js
+++ b/src/loaders/spritesheetParser.js
@@ -9,8 +9,10 @@ module.exports = function ()
 {
     return function (resource, next)
     {
-        // skip if no data, its not json, or it isn't spritesheet data
-        if (!resource.data || !resource.isJson || !resource.data.frames)
+        var imageResourceName = resource.name + '_image';
+
+        // skip if no data, its not json, it isn't spritesheet data, or the image resource already exists
+        if (!resource.data || !resource.isJson || !resource.data.frames || this.resources[imageResourceName])
         {
             return next();
         }
@@ -23,15 +25,14 @@ module.exports = function ()
 
         var route = path.dirname(resource.url.replace(this.baseUrl, ''));
 
-        var resolution = core.utils.getResolutionOfUrl(resource.url);
-
         // load the image for this sheet
-        this.add(resource.name + '_image', route + '/' + resource.data.meta.image, loadOptions, function (res)
+        this.add(imageResourceName, route + '/' + resource.data.meta.image, loadOptions, function (res)
         {
             resource.textures = {};
 
             var frames = resource.data.frames;
             var frameKeys = Object.keys(frames);
+            var resolution = core.utils.getResolutionOfUrl(resource.url);
             var batchIndex = 0;
 
             function processFrames(initialFrameIndex, maxFrames)

--- a/src/loaders/spritesheetParser.js
+++ b/src/loaders/spritesheetParser.js
@@ -1,6 +1,9 @@
 var Resource = require('resource-loader').Resource,
     path = require('path'),
-    core = require('../core');
+    core = require('../core'),
+    async = require('async');
+
+var BATCH_SIZE = 1000;
 
 module.exports = function ()
 {
@@ -20,7 +23,7 @@ module.exports = function ()
 
         var route = path.dirname(resource.url.replace(this.baseUrl, ''));
 
-        var resolution = core.utils.getResolutionOfUrl( resource.url );
+        var resolution = core.utils.getResolutionOfUrl(resource.url);
 
         // load the image for this sheet
         this.add(resource.name + '_image', route + '/' + resource.data.meta.image, loadOptions, function (res)
@@ -28,55 +31,74 @@ module.exports = function ()
             resource.textures = {};
 
             var frames = resource.data.frames;
+            var frameKeys = Object.keys(frames);
+            var batchIndex = 0;
 
-            for (var i in frames)
+            function shouldProcessNextBatch()
             {
-                var rect = frames[i].frame;
-
-                if (rect)
-                {
-                    var size = null;
-                    var trim = null;
-
-                    if (frames[i].rotated) {
-                        size = new core.Rectangle(rect.x, rect.y, rect.h, rect.w);
-                    }
-                    else {
-                        size = new core.Rectangle(rect.x, rect.y, rect.w, rect.h);
-                    }
-
-                    //  Check to see if the sprite is trimmed
-                    if (frames[i].trimmed)
-                    {
-                        trim = new core.Rectangle(
-                            frames[i].spriteSourceSize.x / resolution,
-                            frames[i].spriteSourceSize.y / resolution,
-                            frames[i].sourceSize.w / resolution,
-                            frames[i].sourceSize.h / resolution
-                         );
-                    }
-
-                    // flip the width and height!
-                    if (frames[i].rotated)
-                    {
-                        var temp = size.width;
-                        size.width = size.height;
-                        size.height = temp;
-                    }
-
-                    size.x /= resolution;
-                    size.y /= resolution;
-                    size.width /= resolution;
-                    size.height /= resolution;
-
-                    resource.textures[i] = new core.Texture(res.texture.baseTexture, size, size.clone(), trim, frames[i].rotated ? 2 : 0);
-
-                    // lets also add the frame to pixi's global cache for fromFrame and fromImage functions
-                    core.utils.TextureCache[i] = resource.textures[i];
-                }
+                return batchIndex * BATCH_SIZE < frameKeys.length;
             }
 
-            next();
+            function processNextBatch(done)
+            {
+                var initialFrameIndex = batchIndex * BATCH_SIZE;
+                var frameIndex = initialFrameIndex;
+
+                while (frameIndex - initialFrameIndex < BATCH_SIZE && frameIndex < frameKeys.length)
+                {
+                    var frame = frames[frameKeys[frameIndex]];
+                    var rect = frame.frame;
+
+                    if (rect)
+                    {
+                        var size = null;
+                        var trim = null;
+
+                        if (frame.rotated)
+                        {
+                            size = new core.Rectangle(rect.x, rect.y, rect.h, rect.w);
+                        }
+                        else
+                        {
+                            size = new core.Rectangle(rect.x, rect.y, rect.w, rect.h);
+                        }
+
+                        //  Check to see if the sprite is trimmed
+                        if (frame.trimmed)
+                        {
+                            trim = new core.Rectangle(
+                                frame.spriteSourceSize.x / resolution,
+                                frame.spriteSourceSize.y / resolution,
+                                frame.sourceSize.w / resolution,
+                                frame.sourceSize.h / resolution
+                            );
+                        }
+
+                        // flip the width and height!
+                        if (frame.rotated)
+                        {
+                            var temp = size.width;
+                            size.width = size.height;
+                            size.height = temp;
+                        }
+
+                        size.x /= resolution;
+                        size.y /= resolution;
+                        size.width /= resolution;
+                        size.height /= resolution;
+
+                        resource.textures[frameKeys[frameIndex]] = new core.Texture(res.texture.baseTexture, size, size.clone(), trim, frame.rotated);
+
+                        // lets also add the frame to pixi's global cache for fromFrame and fromImage functions
+                        core.utils.TextureCache[frameKeys[frameIndex]] = resource.textures[frameKeys[frameIndex]];
+                    }
+                    frameIndex++;
+                }
+                batchIndex++;
+                setTimeout(done, 0);
+            }
+
+            async.whilst(shouldProcessNextBatch, processNextBatch, next);
         });
     };
 };


### PR DESCRIPTION
* This changes the sprite sheet parser to automatically parse a sprite sheet in batches of 1000 frames if it contains more than 1000 frames
* After each batch, the event loop is skipped once to not block the UI
* Not implemented: As discussed in the previous version of this pull request, it might be a good idea to make batching optional via a parameter; as this might influence the interface of the loader, this was not implemented here
* Also fixes a problem where, when calling loader.reset() after loading a sprite sheet JSON has started but before its corresponding image resource has started loading, a left-over …_image resource might remain in loader.resources[], leading to an error message when trying to load the corresponding JSON again