### PR TITLE
Fixed the alpha for the ColorMatrixFilter

### DIFF
--- a/src/filters/color/colorMatrix.frag
+++ b/src/filters/color/colorMatrix.frag
@@ -13,24 +13,24 @@ void main(void)
         gl_FragColor.r += (m[1] * c.g);
         gl_FragColor.r += (m[2] * c.b);
         gl_FragColor.r += (m[3] * c.a);
-        gl_FragColor.r += m[4];
+        gl_FragColor.r += m[4] * c.a;
 
     gl_FragColor.g = (m[5] * c.r);
         gl_FragColor.g += (m[6] * c.g);
         gl_FragColor.g += (m[7] * c.b);
         gl_FragColor.g += (m[8] * c.a);
-        gl_FragColor.g += m[9];
+        gl_FragColor.g += m[9] * c.a;
 
      gl_FragColor.b = (m[10] * c.r);
         gl_FragColor.b += (m[11] * c.g);
         gl_FragColor.b += (m[12] * c.b);
         gl_FragColor.b += (m[13] * c.a);
-        gl_FragColor.b += m[14];
+        gl_FragColor.b += m[14] * c.a;
 
      gl_FragColor.a = (m[15] * c.r);
         gl_FragColor.a += (m[16] * c.g);
         gl_FragColor.a += (m[17] * c.b);
         gl_FragColor.a += (m[18] * c.a);
-        gl_FragColor.a += m[19];
+        gl_FragColor.a += m[19] * c.a;
 
 }


### PR DESCRIPTION
I believe this fixes issues #1342 and #2302. Alpha now is handled correctly when applying additive color. Credit to @andrewstart for [this fix](https://github.com/CloudKidStudio/PixiFlash/blob/master/src/ColorMatrixFilter.js).

### Before
<img width="200" alt="screen shot 2016-03-15 at 9 37 36 pm" src="https://cloud.githubusercontent.com/assets/864393/13799560/e0c44d12-eaf6-11e5-9d3c-c49d86523488.png">

### After
<img width="200" alt="screen shot 2016-03-15 at 9 37 04 pm" src="https://cloud.githubusercontent.com/assets/864393/13799561/e2d94a8a-eaf6-11e5-9ee3-0abab67e1830.png">

### Example Code
```html
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="utf-8">
    <title>Example</title>
    <link rel="stylesheet" href="style.css">
    <script src="pixi.js/bin/pixi.js"></script>
  </head>
  <body>
    <canvas id="stage" width="200" height="200"></canvas>
    <script>
      var renderer = new PIXI.autoDetectRenderer(200, 200, {
        view: document.getElementById("stage"),
        backgroundColor: 0x000000,
        antialias: true
      });
      var stage = new PIXI.Container();
      var filter = new PIXI.filters.ColorMatrixFilter();
      filter.matrix = [
         0.4, 0, 0, 0, 0.4, 
         0, 0.4, 0, 0, 0.4, 
         0, 0, 0.4, 0, 0.4, 
         0, 0, 0, 1, 0
      ];
      var gfx = new PIXI.Graphics()
        .beginFill(0xff0000, 1)
        .drawCircle(100, 100, 50);
      gfx.filters = [filter];
      gfx.alpha = 1;
      stage.addChild(gfx);
      function update() {
        requestAnimationFrame(update);
        renderer.render(stage);
      }
      update();
    </script>
  </body>
```