### PR TITLE
Don't pass Container's destroyChildren parameter to a Sprite's destroyTexture parameter

### DIFF
--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -628,8 +628,7 @@ Container.prototype.destroy = function (destroyChildren)
 {
     DisplayObject.prototype.destroy.call(this);
 
-    if (!destroyChildren) {
-    } else {
+    if (destroyChildren) {
         for (var i = 0, j = this.children.length; i < j; ++i) {
             var child = this.children[i];
             var isSprite = !!child._texture; //TODO: Need a better way to detect if it's a sprite

--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -628,11 +628,20 @@ Container.prototype.destroy = function (destroyChildren)
 {
     DisplayObject.prototype.destroy.call(this);
 
-    if (destroyChildren)
-    {
-        for (var i = 0, j = this.children.length; i < j; ++i)
-        {
-            this.children[i].destroy(destroyChildren);
+    if (!destroyChildren) {
+    } else {
+        for (var i = 0, j = this.children.length; i < j; ++i) {
+            var child = this.children[i];
+            var isSprite = !!child._texture; //TODO: Need a better way to detect if it's a sprite
+
+            if (isSprite)
+            {
+                child.destroy();
+            }
+            else
+            {
+                child.destroy(destroyChildren);
+            }
         }
     }
 


### PR DESCRIPTION
I don't think it's intended that a Container's destroyChildren parameter is passed to the Sprite's s destroyTexture parameter. This leads to the unintentional destruction of shared textures. 