### PR TITLE
Adding aria-label to accessiblility

### DIFF
--- a/src/accessibility/AccessibilityManager.js
+++ b/src/accessibility/AccessibilityManager.js
@@ -305,9 +305,16 @@ AccessibilityManager.prototype.addChild = function(displayObject)
 	}
 
 
+	if(displayObject.accessibleTitle) {
+		div.title = displayObject.accessibleTitle;
+	} else if (!displayObject.accessibleTitle && !displayObject.accessibleHint) {
+		div.title = 'displayObject ' + this.tabIndex;
+	}
 
-
-	div.title = displayObject.accessibleTitle || 'displayObject ' + this.tabIndex;
+	if(displayObject.accessibleHint) {
+		div.setAttribute('aria-label', displayObject.accessibleHint);	
+	}
+	
 
 	//
 

--- a/src/accessibility/accessibleTarget.js
+++ b/src/accessibility/accessibleTarget.js
@@ -15,14 +15,27 @@
 var accessibleTarget = {
     
     /**
-     * @todo Needs docs.
+     *  Flag for if the object is accessible. If true AccessibilityManager will overlay a 
+     *   shadow div with attributes set
+     * 
+     * @member {boolean}
      */
     accessible:false,
 
     /**
-     * @todo Needs docs.
+     * Sets the title attribute of the shadow div
+     * If accessibleTitle AND accessibleHint has not been this will default to 'displayObject [tabIndex]'
+     * 
+     * @member {string}
      */
     accessibleTitle:null,
+
+    /**
+     * Sets the aria-label attribute of the shadow div
+     * 
+     * @member {string}
+     */
+    accessibleHint:null,
 
     /**
      * @todo Needs docs.


### PR DESCRIPTION
Giving the ability to set the aria-label attribute for screen readers when working with accessibility

- Adding an hint property to the AccessibleTarget
- Setting aria-label attribute on div in AccessibilityManager
- Only setting default title if both `accessibleTitle` and `accessibleHint` are not set