### PR TITLE
Add jshint to dev-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "gulp-util": "^3.0.6",
     "jaguarjs-jsdoc": "git+https://github.com/davidshimjs/jaguarjs-jsdoc.git",
     "jsdoc": "^3.4.0",
+    "jshint": "^2.9.1",
     "jshint-summary": "^0.4.0",
     "minimist": "^1.2.0",
     "mocha": "^2.4.5",


### PR DESCRIPTION
Previously this wasn't required because `gulp-jshint` would install it. With `gulp-jshint@^2.0.0`  `jshint` is now a peer-dependency.

https://github.com/spalger/gulp-jshint/tree/v2.0.0