### PR TITLE
BaseTexture.scaleMode default should be PIXI.SCALE_MODES.DEFAULT, not…

### DIFF
--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -61,7 +61,7 @@ function BaseTexture(source, scaleMode, resolution)
      * The scale mode to apply when scaling this texture
      *
      * @member {number}
-     * @default PIXI.SCALE_MODES.LINEAR
+     * @default PIXI.SCALE_MODES.DEFAULT
      * @see PIXI.SCALE_MODES
      */
     this.scaleMode = scaleMode || CONST.SCALE_MODES.DEFAULT;


### PR DESCRIPTION
… PIXI.SCALE_MODES.LINEAR

I know it's insignificantly tiny typo, but still :).