### PR TITLE
Better, more useable deprecation warnings

### DIFF
--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -9,19 +9,25 @@ var core = require('./core'),
 // useful for tracking-down where deprecated methods/properties/classes
 // are being used within the code
 function warn(msg) {
-    var stack = new Error().stack; 
+    var stack = new Error().stack;
 
-    // chop off the stack trace which includes pixi.js internal calls
-    stack = stack.split('\n').splice(3).join('\n');
-
-    if (console.groupCollapsed) {
-        console.groupCollapsed('%cDeprecation Warning: %c%s', 'color:#614108;background:#fffbe6', 'font-weight:normal;color:#614108;background:#fffbe6', msg);
-        console.warn(stack);
-        console.groupEnd();
+    // Handle IE < 10 and Safari < 6
+    if (typeof stack === 'undefined') {
+        console.warn('Deprecation Warning: ', msg);
     }
     else {
-        console.warn('Deprecation Warning: ', msg);
-        console.warn(stack);
+        // chop off the stack trace which includes pixi.js internal calls
+        stack = stack.split('\n').splice(3).join('\n');
+
+        if (console.groupCollapsed) {
+            console.groupCollapsed('%cDeprecation Warning: %c%s', 'color:#614108;background:#fffbe6', 'font-weight:normal;color:#614108;background:#fffbe6', msg);
+            console.warn(stack);
+            console.groupEnd();
+        }
+        else {
+            console.warn('Deprecation Warning: ', msg);
+            console.warn(stack);
+        }
     }
 }
 

--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -5,6 +5,26 @@ var core = require('./core'),
     extras = require('./extras'),
     filters = require('./filters');
 
+// provide method to give a stack track for warnings
+// useful for tracking-down where deprecated methods/properties/classes
+// are being used within the code
+function warn(msg) {
+    var stack = new Error().stack; 
+
+    // chop off the stack trace which includes pixi.js internal calls
+    stack = stack.split('\n').splice(3).join('\n');
+
+    if (console.groupCollapsed) {
+        console.groupCollapsed('%cDeprecation Warning: %c%s', 'color:#614108;background:#fffbe6', 'font-weight:normal;color:#614108;background:#fffbe6', msg);
+        console.warn(stack);
+        console.groupEnd();
+    }
+    else {
+        console.warn('Deprecation Warning: ', msg);
+        console.warn(stack);
+    }
+}
+
 /**
  * @class
  * @private
@@ -46,7 +66,7 @@ Object.defineProperties(core, {
     Stage: {
         get: function()
         {
-            console.warn('You do not need to use a PIXI Stage any more, you can simply render any container.');
+            warn('You do not need to use a PIXI Stage any more, you can simply render any container.');
             return core.Container;
         }
     },
@@ -62,7 +82,7 @@ Object.defineProperties(core, {
     DisplayObjectContainer: {
         get: function()
         {
-            console.warn('DisplayObjectContainer has been shortened to Container, please use Container from now on.');
+            warn('DisplayObjectContainer has been shortened to Container, please use Container from now on.');
             return core.Container;
         }
     },
@@ -78,7 +98,7 @@ Object.defineProperties(core, {
     Strip: {
         get: function()
         {
-            console.warn('The Strip class has been renamed to Mesh and moved to mesh.Mesh, please use mesh.Mesh from now on.');
+            warn('The Strip class has been renamed to Mesh and moved to mesh.Mesh, please use mesh.Mesh from now on.');
             return mesh.Mesh;
         }
     },
@@ -94,7 +114,7 @@ Object.defineProperties(core, {
     Rope: {
         get: function()
         {
-            console.warn('The Rope class has been moved to mesh.Rope, please use mesh.Rope from now on.');
+            warn('The Rope class has been moved to mesh.Rope, please use mesh.Rope from now on.');
             return mesh.Rope;
         }
     },
@@ -109,7 +129,7 @@ Object.defineProperties(core, {
      */
     ParticleContainer: {
         get: function() {
-            console.warn('The ParticleContainer class has been moved to particles.ParticleContainer, please use particles.ParticleContainer from now on.');
+            warn('The ParticleContainer class has been moved to particles.ParticleContainer, please use particles.ParticleContainer from now on.');
             return particles.ParticleContainer;
         }
     },
@@ -125,7 +145,7 @@ Object.defineProperties(core, {
     MovieClip: {
         get: function()
         {
-            console.warn('The MovieClip class has been moved to extras.MovieClip, please use extras.MovieClip from now on.');
+            warn('The MovieClip class has been moved to extras.MovieClip, please use extras.MovieClip from now on.');
             return extras.MovieClip;
         }
     },
@@ -141,7 +161,7 @@ Object.defineProperties(core, {
     TilingSprite: {
         get: function()
         {
-            console.warn('The TilingSprite class has been moved to extras.TilingSprite, please use extras.TilingSprite from now on.');
+            warn('The TilingSprite class has been moved to extras.TilingSprite, please use extras.TilingSprite from now on.');
             return extras.TilingSprite;
         }
     },
@@ -157,7 +177,7 @@ Object.defineProperties(core, {
     BitmapText: {
         get: function()
         {
-            console.warn('The BitmapText class has been moved to extras.BitmapText, please use extras.BitmapText from now on.');
+            warn('The BitmapText class has been moved to extras.BitmapText, please use extras.BitmapText from now on.');
             return extras.BitmapText;
         }
     },
@@ -173,7 +193,7 @@ Object.defineProperties(core, {
     blendModes: {
         get: function()
         {
-            console.warn('The blendModes has been moved to BLEND_MODES, please use BLEND_MODES from now on.');
+            warn('The blendModes has been moved to BLEND_MODES, please use BLEND_MODES from now on.');
             return core.BLEND_MODES;
         }
     },
@@ -189,7 +209,7 @@ Object.defineProperties(core, {
     scaleModes: {
         get: function()
         {
-            console.warn('The scaleModes has been moved to SCALE_MODES, please use SCALE_MODES from now on.');
+            warn('The scaleModes has been moved to SCALE_MODES, please use SCALE_MODES from now on.');
             return core.SCALE_MODES;
         }
     },
@@ -205,7 +225,7 @@ Object.defineProperties(core, {
     BaseTextureCache: {
         get: function ()
         {
-            console.warn('The BaseTextureCache class has been moved to utils.BaseTextureCache, please use utils.BaseTextureCache from now on.');
+            warn('The BaseTextureCache class has been moved to utils.BaseTextureCache, please use utils.BaseTextureCache from now on.');
             return core.utils.BaseTextureCache;
         }
     },
@@ -221,7 +241,7 @@ Object.defineProperties(core, {
     TextureCache: {
         get: function ()
         {
-            console.warn('The TextureCache class has been moved to utils.TextureCache, please use utils.TextureCache from now on.');
+            warn('The TextureCache class has been moved to utils.TextureCache, please use utils.TextureCache from now on.');
             return core.utils.TextureCache;
         }
     },
@@ -237,7 +257,7 @@ Object.defineProperties(core, {
     math: {
         get: function ()
         {
-            console.warn('The math namespace is deprecated, please access members already accessible on PIXI.');
+            warn('The math namespace is deprecated, please access members already accessible on PIXI.');
             return core;
         }
     },
@@ -252,7 +272,7 @@ Object.defineProperties(core, {
     AbstractFilter: {
         get: function()
         {
-            console.warn('AstractFilter has been renamed to Filter, please use PIXI.Filter');
+            warn('AstractFilter has been renamed to Filter, please use PIXI.Filter');
             return core.Filter;
         }
     },
@@ -260,44 +280,44 @@ Object.defineProperties(core, {
 
 core.DisplayObject.prototype.generateTexture = function(renderer, scaleMode, resolution)
 {
-    console.warn('generateTexture has moved to the renderer, please use renderer.generateTexture(displayObject)');
+    warn('generateTexture has moved to the renderer, please use renderer.generateTexture(displayObject)');
     return renderer.generateTexture(renderer, scaleMode, resolution);
 };
 
 
 core.Graphics.prototype.generateTexture = function(scaleMode, resolution)
 {
-    console.warn('graphics generate texture has moved to the renderer. Or to render a graphics to a texture using canvas please use generateCanvasTexture');
+    warn('graphics generate texture has moved to the renderer. Or to render a graphics to a texture using canvas please use generateCanvasTexture');
     return this.generateCanvasTexture(scaleMode, resolution);
 };
 
 core.RenderTexture.prototype.render = function(displayObject)
 {
     this.legacyRenderer.render(displayObject, this);
-    console.warn('RenderTexture.render is now deprecated, please use renderer.render(displayObject, renderTexture)');
+    warn('RenderTexture.render is now deprecated, please use renderer.render(displayObject, renderTexture)');
 };
 
 core.RenderTexture.prototype.getImage = function(target)
 {
-    console.warn('RenderTexture.getImage is now deprecated, please use renderer.extract.image(target)');
+    warn('RenderTexture.getImage is now deprecated, please use renderer.extract.image(target)');
     return this.legacyRenderer.extract.image(target);
 };
 
 core.RenderTexture.prototype.getBase64 = function(target)
 {
-    console.warn('RenderTexture.getBase64 is now deprecated, please use renderer.extract.base64(target)');
+    warn('RenderTexture.getBase64 is now deprecated, please use renderer.extract.base64(target)');
     this.legacyRenderer.extract.base64(target);
 };
 
 core.RenderTexture.prototype.getCanvas = function(target)
 {
-    console.warn('RenderTexture.getCanvas is now deprecated, please use renderer.extract.canvas(target)');
+    warn('RenderTexture.getCanvas is now deprecated, please use renderer.extract.canvas(target)');
     this.legacyRenderer.extract.canvas(target);
 };
 
 core.RenderTexture.prototype.getPixels = function(target)
 {
-    console.warn('RenderTexture.getPixels is now deprecated, please use renderer.extract.pixels(target)');
+    warn('RenderTexture.getPixels is now deprecated, please use renderer.extract.pixels(target)');
     this.legacyRenderer.pixels(target);
 };
 
@@ -313,7 +333,7 @@ core.RenderTexture.prototype.getPixels = function(target)
 core.Sprite.prototype.setTexture = function(texture)
 {
     this.texture = texture;
-    console.warn('setTexture is now deprecated, please use the texture property, e.g : sprite.texture = texture;');
+    warn('setTexture is now deprecated, please use the texture property, e.g : sprite.texture = texture;');
 };
 
 
@@ -327,7 +347,7 @@ core.Sprite.prototype.setTexture = function(texture)
 extras.BitmapText.prototype.setText = function(text)
 {
     this.text = text;
-    console.warn('setText is now deprecated, please use the text property, e.g : myBitmapText.text = \'my text\';');
+    warn('setText is now deprecated, please use the text property, e.g : myBitmapText.text = \'my text\';');
 };
 
 /**
@@ -339,7 +359,7 @@ extras.BitmapText.prototype.setText = function(text)
 core.Text.prototype.setText = function(text)
 {
     this.text = text;
-    console.warn('setText is now deprecated, please use the text property, e.g : myText.text = \'my text\';');
+    warn('setText is now deprecated, please use the text property, e.g : myText.text = \'my text\';');
 };
 
 /**
@@ -351,7 +371,7 @@ core.Text.prototype.setText = function(text)
 core.Text.prototype.setStyle = function(style)
 {
     this.style = style;
-    console.warn('setStyle is now deprecated, please use the style property, e.g : myText.style = style;');
+    warn('setStyle is now deprecated, please use the style property, e.g : myText.style = style;');
 };
 
 /**
@@ -363,7 +383,7 @@ core.Text.prototype.setStyle = function(style)
 core.Texture.prototype.setFrame = function(frame)
 {
     this.frame = frame;
-    console.warn('setFrame is now deprecated, please use the frame property, e.g : myTexture.frame = frame;');
+    warn('setFrame is now deprecated, please use the frame property, e.g : myTexture.frame = frame;');
 };
 
 Object.defineProperties(filters, {
@@ -378,7 +398,7 @@ Object.defineProperties(filters, {
     AbstractFilter: {
         get: function()
         {
-            console.warn('AstractFilter has been renamed to Filter, please use PIXI.Filter');
+            warn('AstractFilter has been renamed to Filter, please use PIXI.Filter');
             return core.AbstractFilter;
         }
     },
@@ -393,7 +413,7 @@ Object.defineProperties(filters, {
     FXAAFilter: {
         get: function()
         {
-            console.warn('filters.FXAAFilter is an undocumented alias, please use FXAAFilter from now on.');
+            warn('filters.FXAAFilter is an undocumented alias, please use FXAAFilter from now on.');
             return core.FXAAFilter;
         }
     },
@@ -408,7 +428,7 @@ Object.defineProperties(filters, {
     SpriteMaskFilter: {
         get: function()
         {
-            console.warn('filters.SpriteMaskFilter is an undocumented alias, please use SpriteMaskFilter from now on.');
+            warn('filters.SpriteMaskFilter is an undocumented alias, please use SpriteMaskFilter from now on.');
             return core.SpriteMaskFilter;
         }
     }
@@ -422,12 +442,12 @@ Object.defineProperties(filters, {
  */
 core.utils.uuid = function ()
 {
-    console.warn('utils.uuid() is deprecated, please use utils.uid() from now on.');
+    warn('utils.uuid() is deprecated, please use utils.uid() from now on.');
     return core.utils.uid();
 };
 
 core.utils.canUseNewCanvasBlendModes = function() {
-    console.warn('utils.canUseNewCanvasBlendModes() is deprecated, please use CanvasTinter.canUseMultiply from now on');
+    warn('utils.canUseNewCanvasBlendModes() is deprecated, please use CanvasTinter.canUseMultiply from now on');
     return core.CanvasTinter.canUseMultiply;
 };
 


### PR DESCRIPTION
### Overview

Added support for a collapsable stack trace in deprecation warnings. Makes it easier to track-down usage of deprecated methods/properties/classes. Added some styling to the warning to clearly indicate deprecation (as opposed to WebGL warnings or other console.log warnings). For browsers that don't support `groupCollapsed`, fallback to regular `console.warn`.

**Before**
![screen shot 2016-04-04 at 4 29 52 pm](https://cloud.githubusercontent.com/assets/864393/14262287/be03ed46-fa82-11e5-8e9a-2874a8219864.png)

**After**
![screen shot 2016-04-04 at 4 30 18 pm](https://cloud.githubusercontent.com/assets/864393/14262286/bdff70e0-fa82-11e5-8545-34311747a9b8.png)

### Test
```html
<!DOCTYPE html>
<html>
    <head>
        <meta charset="utf-8">
        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
        <title>Deprecation</title>
        <meta name='viewport' content='width=device-width, initial-scale=1.0'>
    </head>
    <body>
        <canvas id="stage" width="550" height="400"></canvas>
        <script src="pixi.js/bin/pixi.min.js"></script>
        <script>
            var renderer = new PIXI.autoDetectRenderer(550, 400, {
                view: document.getElementById("stage"),
                backgroundColor: 0xffffff,
                antialias: true
            });
            var stage;
            function create() {
                stage = new PIXI.Stage();
                stage = new PIXI.DisplayObjectContainer();
            }
            create();
            function update() {
                renderer.render(stage);
                requestAnimationFrame(update);
            }
            update();
        </script>
    </body>
</html>
```