### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "gulp-util": "^3.0.6",
     "jaguarjs-jsdoc": "git+https://github.com/davidshimjs/jaguarjs-jsdoc.git",
     "jsdoc": "^3.4.0",
+    "jshint": "^2.9.1",
     "jshint-summary": "^0.4.0",
     "minimist": "^1.2.0",
     "mocha": "^2.4.5",


### PR DESCRIPTION
Fix not found module jshint during gulp build , jshint needs to be installed with gulp-jshint.