### PR TITLE
TextStyle, a more flexible and fluent interface for modifying text styling

### DIFF
--- a/src/core/const.js
+++ b/src/core/const.js
@@ -178,7 +178,7 @@ var CONST = {
      * The DEFAULT Garbage Collection mode for pixi textures is MANUAL
      * If set to DEFAULT, the renderer will occasianally check textures usage. If they are not used for a specified period of time they will be removed from the GPU.
      * They will of corse be uploaded again when they are required. This is a silent behind the scenes process that should ensure that the GPU does not  get filled up.
-     * Handy for mobile devices! 
+     * Handy for mobile devices!
      * This property only affects WebGL
      * @static
      * @constant
@@ -215,7 +215,7 @@ var CONST = {
     RESOLUTION:1,
 
     FILTER_RESOLUTION:1,
-    
+
     /**
      * The default render options if none are supplied to {@link PIXI.WebGLRenderer}
      * or {@link PIXI.CanvasRenderer}.
@@ -269,7 +269,8 @@ var CONST = {
     // TODO: maybe change to SPRITE.BATCH_SIZE: 2000
     // TODO: maybe add PARTICLE.BATCH_SIZE: 15000
     SPRITE_BATCH_SIZE: 4096, //nice balance between mobile and desktop machines
-    SPRITE_MAX_TEXTURES: require('./utils/maxRecommendedTextures')(32)//this is the MAXIMUM - various gpus will have there own limits.
+    SPRITE_MAX_TEXTURES: require('./utils/maxRecommendedTextures')(32), //this is the MAXIMUM - various gpus will have there own limits.
+    TEXT_STYLE_CHANGED: 'changed' //
 };
 
 module.exports = CONST;

--- a/src/core/const.js
+++ b/src/core/const.js
@@ -270,7 +270,6 @@ var CONST = {
     // TODO: maybe add PARTICLE.BATCH_SIZE: 15000
     SPRITE_BATCH_SIZE: 4096, //nice balance between mobile and desktop machines
     SPRITE_MAX_TEXTURES: require('./utils/maxRecommendedTextures')(32), //this is the MAXIMUM - various gpus will have there own limits.
-    TEXT_STYLE_CHANGED: 'changed' //
 };
 
 module.exports = CONST;

--- a/src/core/const.js
+++ b/src/core/const.js
@@ -270,6 +270,7 @@ var CONST = {
     // TODO: maybe add PARTICLE.BATCH_SIZE: 15000
     SPRITE_BATCH_SIZE: 4096, //nice balance between mobile and desktop machines
     SPRITE_MAX_TEXTURES: require('./utils/maxRecommendedTextures')(32), //this is the MAXIMUM - various gpus will have there own limits.
+    TEXT_STYLE_CHANGED: 'changed' //
 };
 
 module.exports = CONST;

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -25,7 +25,7 @@ var core = module.exports = Object.assign(require('./const'), require('./math'),
 
     // text
     Text:                   require('./text/Text'),
-
+    TextStyle:              require('./text/TextStyle'),
     // primitives
     Graphics:               require('./graphics/Graphics'),
     GraphicsData:           require('./graphics/GraphicsData'),

--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -92,10 +92,7 @@ Object.defineProperties(Text.prototype, {
     width: {
         get: function ()
         {
-            if (this.dirty)
-            {
-                this.updateText();
-            }
+            this.updateText(true);
 
             return this.scale.x * this._texture._frame.width;
         },
@@ -115,10 +112,7 @@ Object.defineProperties(Text.prototype, {
     height: {
         get: function ()
         {
-            if (this.dirty)
-            {
-                this.updateText();
-            }
+            this.updateText(true);
 
             return  this.scale.y * this._texture._frame.height;
         },
@@ -187,11 +181,14 @@ Object.defineProperties(Text.prototype, {
 
 /**
  * Renders text and updates it when needed
- *
+ * @param respectDirty {boolean} Whether to abort updating the text if the Text isn't dirty and the function is called.
  * @private
  */
-Text.prototype.updateText = function ()
+Text.prototype.updateText = function (respectDirty)
 {
+    if (!this.dirty && respectDirty) {
+        return;
+    }
     var style = this._style;
     this.context.font = style.font;
 
@@ -353,12 +350,7 @@ Text.prototype.updateTexture = function ()
  */
 Text.prototype.renderWebGL = function (renderer)
 {
-    if (this.dirty)
-    {
-        //this.resolution = 1//renderer.resolution;
-
-        this.updateText();
-    }
+    this.updateText(true);
 
     Sprite.prototype.renderWebGL.call(this, renderer);
 };
@@ -371,10 +363,7 @@ Text.prototype.renderWebGL = function (renderer)
  */
 Text.prototype._renderCanvas = function (renderer)
 {
-    if (this.dirty)
-    {
-        this.updateText();
-    }
+    this.updateText(true);
 
     Sprite.prototype._renderCanvas.call(this, renderer);
 };
@@ -537,10 +526,7 @@ Text.prototype.wordWrap = function (text)
  */
 Text.prototype.getBounds = function (matrix)
 {
-    if (this.dirty)
-    {
-        this.updateText();
-    }
+    this.updateText(true);
 
     return Sprite.prototype.getBounds.call(this, matrix);
 };

--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -57,14 +57,13 @@ function Text(text, style, resolution)
      * @private
      */
     this._style = null;
-
     /**
-     * Last rendered version number of the style object.
+     * Private listener to track style changes.
      *
      * @member {Function}
      * @private
      */
-    this._styleVersion = null;
+    this._styleListener = null;
 
     var texture = Texture.fromCanvas(this.canvas);
     texture.trim = new math.Rectangle();
@@ -93,7 +92,11 @@ Object.defineProperties(Text.prototype, {
     width: {
         get: function ()
         {
-            this.updateText(true);
+            if (this.dirty)
+            {
+                this.updateText();
+            }
+
             return this.scale.x * this._texture._frame.width;
         },
         set: function (value)
@@ -112,7 +115,11 @@ Object.defineProperties(Text.prototype, {
     height: {
         get: function ()
         {
-            this.updateText(true);
+            if (this.dirty)
+            {
+                this.updateText();
+            }
+
             return  this.scale.y * this._texture._frame.height;
         },
         set: function (value)
@@ -135,6 +142,10 @@ Object.defineProperties(Text.prototype, {
         },
         set: function (style)
         {
+            if (this._style) {
+                this._style.off(CONST.TEXT_STYLE_CHANGED, this._onStyleChange, this);
+            }
+
             style = style || {};
             if (style instanceof TextStyle)
             {
@@ -143,7 +154,8 @@ Object.defineProperties(Text.prototype, {
             {
                 this._style = new TextStyle(style);
             }
-            this._styleVersion = -1;  // Force it to re-render and grab the version number.
+            this._style.on(CONST.TEXT_STYLE_CHANGED, this._onStyleChange, this);
+            this.dirty = true;
         }
     },
 
@@ -170,36 +182,16 @@ Object.defineProperties(Text.prototype, {
             this._text = text;
             this.dirty = true;
         }
-    },
-
-    /**
-     * Indicates whether the text should be re-rendered. Takes into account style changes.
-     *
-     * @param dirty {boolean} Whether the text should be rerendered
-     * @memberof PIXI.Text#
-     */
-    dirty: {
-        get: function() {
-            return this._dirty || this._styleVersion !== this.style.version;
-        },
-        set: function (dirty) {
-            this._dirty = dirty;
-        }
     }
-
 });
 
 /**
  * Renders text and updates it when needed
  *
- * @param [respectDirty=true] {boolean} Whether to ignore the dirty indicator and force a re-render.
  * @private
  */
-Text.prototype.updateText = function (respectDirty)
+Text.prototype.updateText = function ()
 {
-    if (!this.dirty && respectDirty) {  // If for
-        return;
-    }
     var style = this._style;
     this.context.font = style.font;
 
@@ -352,7 +344,6 @@ Text.prototype.updateTexture = function ()
     texture.baseTexture.emit('update',  texture.baseTexture);
 
     this.dirty = false;
-    this._styleVersion = this._style.version;
 };
 
 /**
@@ -362,7 +353,12 @@ Text.prototype.updateTexture = function ()
  */
 Text.prototype.renderWebGL = function (renderer)
 {
-    this.updateText(true);
+    if (this.dirty)
+    {
+        //this.resolution = 1//renderer.resolution;
+
+        this.updateText();
+    }
 
     Sprite.prototype.renderWebGL.call(this, renderer);
 };
@@ -375,7 +371,10 @@ Text.prototype.renderWebGL = function (renderer)
  */
 Text.prototype._renderCanvas = function (renderer)
 {
-    this.updateText(true);
+    if (this.dirty)
+    {
+        this.updateText();
+    }
 
     Sprite.prototype._renderCanvas.call(this, renderer);
 };
@@ -538,9 +537,20 @@ Text.prototype.wordWrap = function (text)
  */
 Text.prototype.getBounds = function (matrix)
 {
-    this.updateText(true);
+    if (this.dirty)
+    {
+        this.updateText();
+    }
 
     return Sprite.prototype.getBounds.call(this, matrix);
+};
+
+/**
+ * Method to be called upon a TextStyle change.
+ */
+Text.prototype._onStyleChange = function ()
+{
+    this.dirty = true;
 };
 
 /**
@@ -553,6 +563,8 @@ Text.prototype.destroy = function (destroyBaseTexture)
     // make sure to reset the the context and canvas.. dont want this hanging around in memory!
     this.context = null;
     this.canvas = null;
+
+    this._style.off(CONST.TEXT_STYLE_CHANGED, this._onStyleChange, this);
     this._style = null;
 
     this._texture.destroy(destroyBaseTexture === undefined ? true : destroyBaseTexture);

--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -143,7 +143,7 @@ Object.defineProperties(Text.prototype, {
         set: function (style)
         {
             if (this._style) {
-                this._style.removeListener(this._styleListener);
+                this._style.off(CONST.TEXT_STYLE_CHANGED, this._onStyleChange, this);
             }
 
             style = style || {};
@@ -154,10 +154,7 @@ Object.defineProperties(Text.prototype, {
             {
                 this._style = new TextStyle(style);
             }
-            this._styleListener = this._style.on(CONST.TEXT_STYLE_CHANGED, function ()
-            {
-                this.dirty = true;
-            }.bind(this));
+            this._style.on(CONST.TEXT_STYLE_CHANGED, this._onStyleChange, this);
         }
     },
 
@@ -548,6 +545,14 @@ Text.prototype.getBounds = function (matrix)
 };
 
 /**
+ * Method to be called upon a TextStyle change.
+ */
+Text.prototype._onStyleChange = function ()
+{
+    this.dirty = true;
+};
+
+/**
  * Destroys this text object.
  *
  * @param [destroyBaseTexture=true] {boolean} whether to destroy the base texture as well
@@ -558,7 +563,7 @@ Text.prototype.destroy = function (destroyBaseTexture)
     this.context = null;
     this.canvas = null;
 
-    this._style.removeListener(this._styleListener);
+    this._style.off(CONST.TEXT_STYLE_CHANGED, this._onStyleChange, this);
     this._style = null;
 
     this._texture.destroy(destroyBaseTexture === undefined ? true : destroyBaseTexture);

--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -1,8 +1,8 @@
 var Sprite = require('../sprites/Sprite'),
     Texture = require('../textures/Texture'),
     math = require('../math'),
-    utils = require('../utils'),
-    CONST = require('../const');
+    CONST = require('../const'),
+    TextStyle = require('./TextStyle');
 
 /**
  * A Text Object will create a line or multiple lines of text. To split a line you can use '\n' in your text string,
@@ -18,27 +18,8 @@ var Sprite = require('../sprites/Sprite'),
  * @extends PIXI.Sprite
  * @memberof PIXI
  * @param text {string} The copy that you would like the text to display
- * @param [style] {object} The style parameters
- * @param [style.font] {string} default 'bold 20px Arial' The style and size of the font
- * @param [style.fill='black'] {String|Number} A canvas fillstyle that will be used on the text e.g 'red', '#00FF00'
- * @param [style.align='left'] {string} Alignment for multiline text ('left', 'center' or 'right'), does not affect single line text
- * @param [style.stroke] {String|Number} A canvas fillstyle that will be used on the text stroke e.g 'blue', '#FCFF00'
- * @param [style.strokeThickness=0] {number} A number that represents the thickness of the stroke. Default is 0 (no stroke)
- * @param [style.wordWrap=false] {boolean} Indicates if word wrap should be used
- * @param [style.wordWrapWidth=100] {number} The width at which text will wrap, it needs wordWrap to be set to true
- * @param [style.lineHeight] {number} The line height, a number that represents the vertical space that a letter uses
- * @param [style.dropShadow=false] {boolean} Set a drop shadow for the text
- * @param [style.dropShadowColor='#000000'] {string} A fill style to be used on the dropshadow e.g 'red', '#00FF00'
- * @param [style.dropShadowAngle=Math.PI/4] {number} Set a angle of the drop shadow
- * @param [style.dropShadowDistance=5] {number} Set a distance of the drop shadow
- * @param [style.dropShadowBlur=0] {number} Set a shadow blur radius
- * @param [style.padding=0] {number} Occasionally some fonts are cropped on top or bottom. Adding some padding will
- *      prevent this from happening by adding padding to the top and bottom of text height.
- * @param [style.textBaseline='alphabetic'] {string} The baseline of the text that is rendered.
- * @param [style.lineJoin='miter'] {string} The lineJoin property sets the type of corner created, it can resolve
- *      spiked text issues. Default is 'miter' (creates a sharp corner).
- * @param [style.miterLimit=10] {number} The miter limit to use when using the 'miter' lineJoin mode. This can reduce
- *      or increase the spikiness of rendered text.
+ * @param [style] {object|TextStyle} The style parameters
+ * @param [resolution=CONST.RESOLUTION] The resolution of the canvas
  */
 function Text(text, style, resolution)
 {
@@ -76,6 +57,13 @@ function Text(text, style, resolution)
      * @private
      */
     this._style = null;
+    /**
+     * Private listener to track style changes.
+     *
+     * @member {Function}
+     * @private
+     */
+    this._styleListener = null;
 
     var texture = Texture.fromCanvas(this.canvas);
     texture.trim = new math.Rectangle();
@@ -142,29 +130,9 @@ Object.defineProperties(Text.prototype, {
     },
 
     /**
-     * Set the style of the text
+     * Set the style of the text. Set up an event listener to listen for changes on the style object and mark the text as dirty.
      *
-     * @param [style] {object} The style parameters
-     * @param [style.font='bold 20pt Arial'] {string} The style and size of the font
-     * @param [style.fill='black'] {string|number} A canvas fillstyle that will be used on the text eg 'red', '#00FF00'
-     * @param [style.align='left'] {string} Alignment for multiline text ('left', 'center' or 'right'), does not affect single line text
-     * @param [style.stroke='black'] {string|number} A canvas fillstyle that will be used on the text stroke eg 'blue', '#FCFF00'
-     * @param [style.strokeThickness=0] {number} A number that represents the thickness of the stroke. Default is 0 (no stroke)
-     * @param [style.wordWrap=false] {boolean} Indicates if word wrap should be used
-     * @param [style.wordWrapWidth=100] {number} The width at which text will wrap
-     * @param [style.lineHeight] {number} The line height, a number that represents the vertical space that a letter uses
-     * @param [style.dropShadow=false] {boolean} Set a drop shadow for the text
-     * @param [style.dropShadowColor='#000000'] {string|number} A fill style to be used on the dropshadow e.g 'red', '#00FF00'
-     * @param [style.dropShadowAngle=Math.PI/6] {number} Set a angle of the drop shadow
-     * @param [style.dropShadowDistance=5] {number} Set a distance of the drop shadow
-     * @param [style.dropShadowBlur=0] {number} Set a shadow blur radius
-     * @param [style.padding=0] {number} Occasionally some fonts are cropped on top or bottom. Adding some padding will
-     *      prevent this from happening by adding padding to the top and bottom of text height.
-     * @param [style.textBaseline='alphabetic'] {string} The baseline of the text that is rendered.
-     * @param [style.lineJoin='miter'] {string} The lineJoin property sets the type of corner created, it can resolve
-     *      spiked text issues. Default is 'miter' (creates a sharp corner).
-     * @param [style.miterLimit=10] {number} The miter limit to use when using the 'miter' lineJoin mode. This can reduce
-     *      or increase the spikiness of rendered text.
+     * @param [style] {object|TextStyle} The style parameters
      * @memberof PIXI.Text#
      */
     style: {
@@ -175,42 +143,17 @@ Object.defineProperties(Text.prototype, {
         set: function (style)
         {
             style = style || {};
-
-            if (typeof style.fill === 'number') {
-                style.fill = utils.hex2string(style.fill);
+            if (style instanceof TextStyle)
+            {
+                this._style = style;
+            } else
+            {
+                this._style = new TextStyle(style);
             }
-
-            if (typeof style.stroke === 'number') {
-                style.stroke = utils.hex2string(style.stroke);
-            }
-
-            if (typeof style.dropShadowColor === 'number') {
-                style.dropShadowColor = utils.hex2string(style.dropShadowColor);
-            }
-
-            style.font = style.font || 'bold 20pt Arial';
-            style.fill = style.fill || 'black';
-            style.align = style.align || 'left';
-            style.stroke = style.stroke || 'black'; //provide a default, see: https://github.com/pixijs/pixi.js/issues/136
-            style.strokeThickness = style.strokeThickness || 0;
-            style.wordWrap = style.wordWrap || false;
-            style.wordWrapWidth = style.wordWrapWidth || 100;
-
-            style.dropShadow = style.dropShadow || false;
-            style.dropShadowColor = style.dropShadowColor || '#000000';
-            style.dropShadowAngle = style.dropShadowAngle !== undefined ? style.dropShadowAngle : Math.PI / 6;
-            style.dropShadowDistance = style.dropShadowDistance !== undefined ? style.dropShadowDistance : 5;
-            style.dropShadowBlur = style.dropShadowBlur !== undefined ? style.dropShadowBlur : 0; //shadowBlur is '0' by default according to HTML
-
-            style.padding = style.padding || 0;
-
-            style.textBaseline = style.textBaseline || 'alphabetic';
-
-            style.lineJoin = style.lineJoin || 'miter';
-            style.miterLimit = style.miterLimit || 10;
-
-            this._style = style;
-            this.dirty = true;
+            this._styleListener = this._style.on('styleChanged', function ()
+            {
+                this.dirty = true;
+            }.bind(this));
         }
     },
 
@@ -229,7 +172,7 @@ Object.defineProperties(Text.prototype, {
 
             text = text || ' ';
             text = text.toString();
-            
+
             if (this._text === text)
             {
                 return;
@@ -294,9 +237,6 @@ Text.prototype.updateText = function ()
         this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);
 
     }
-
-    //this.context.fillStyle="#FF0000";
-    //this.context.fillRect(0, 0, this.canvas.width, this.canvas.height);
 
     this.context.font = style.font;
     this.context.strokeStyle = style.stroke;
@@ -431,8 +371,6 @@ Text.prototype._renderCanvas = function (renderer)
 {
     if (this.dirty)
     {
-     //   this.resolution = 1//renderer.resolution;
-
         this.updateText();
     }
 
@@ -616,7 +554,9 @@ Text.prototype.destroy = function (destroyBaseTexture)
     this.context = null;
     this.canvas = null;
 
+    this._style.removeListener(this._styleListener);
     this._style = null;
 
     this._texture.destroy(destroyBaseTexture === undefined ? true : destroyBaseTexture);
+
 };

--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -142,6 +142,10 @@ Object.defineProperties(Text.prototype, {
         },
         set: function (style)
         {
+            if (this._style) {
+                this._style.removeListener(this._styleListener);
+            }
+
             style = style || {};
             if (style instanceof TextStyle)
             {
@@ -150,7 +154,7 @@ Object.defineProperties(Text.prototype, {
             {
                 this._style = new TextStyle(style);
             }
-            this._styleListener = this._style.on('styleChanged', function ()
+            this._styleListener = this._style.on(CONST.TEXT_STYLE_CHANGED, function ()
             {
                 this.dirty = true;
             }.bind(this));

--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -155,6 +155,7 @@ Object.defineProperties(Text.prototype, {
                 this._style = new TextStyle(style);
             }
             this._style.on(CONST.TEXT_STYLE_CHANGED, this._onStyleChange, this);
+            this.dirty = true;
         }
     },
 

--- a/src/core/text/TextStyle.js
+++ b/src/core/text/TextStyle.js
@@ -1,4 +1,5 @@
 var EventEmitter = require('eventemitter3'),
+    CONST = require('../const'),
     utils = require('../utils');
 
 /**
@@ -82,6 +83,17 @@ TextStyle.prototype.clone = function ()
 };
 
 /**
+ * Resets all properties to the defaults specified in TextStyle.prototype._default
+ */
+TextStyle.prototype.reset = function ()
+{
+    for (var property in this._defaults)
+    {
+        this[property] = this._defaults[property];
+    }
+};
+
+/**
  * Create setters and getters for each of the style properties. Converts colors where necessary.
  * Any set operation will emit a styleChanged event.
  */
@@ -95,7 +107,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._font !== font)
             {
                 this._font = font;
-                this.emit('styleChanged');
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -109,7 +121,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._fill !== outputColor)
             {
                 this._fill = outputColor;
-                this.emit('styleChanged');
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -122,7 +134,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._align !== align)
             {
                 this._align = align;
-                this.emit('styleChanged');
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -136,7 +148,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._stroke !== outputColor)
             {
                 this._stroke = outputColor;
-                this.emit('styleChanged');
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -149,7 +161,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._strokeThickness !== strokeThickness)
             {
                 this._strokeThickness = strokeThickness;
-                this.emit('styleChanged');
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -162,7 +174,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._wordWrap !== wordWrap)
             {
                 this._wordWrap = wordWrap;
-                this.emit('styleChanged');
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -175,7 +187,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._wordWrapWidth !== wordWrapWidth)
             {
                 this._wordWrapWidth = wordWrapWidth;
-                this.emit('styleChanged');
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -188,7 +200,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._dropShadow !== dropShadow)
             {
                 this._dropShadow = dropShadow;
-                this.emit('styleChanged');
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -202,7 +214,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._dropShadowColor !== outputColor)
             {
                 this._dropShadowColor = outputColor;
-                this.emit('styleChanged');
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -215,7 +227,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._dropShadowAngle !== dropShadowAngle)
             {
                 this._dropShadowAngle = dropShadowAngle;
-                this.emit('styleChanged');
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -228,7 +240,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._dropShadowDistance !== dropShadowDistance)
             {
                 this._dropShadowDistance = dropShadowDistance;
-                this.emit('styleChanged');
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -241,7 +253,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._dropShadowBlur !== dropShadowBlur)
             {
                 this._dropShadowBlur = dropShadowBlur;
-                this.emit('styleChanged');
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -254,7 +266,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._padding !== padding)
             {
                 this._padding = padding;
-                this.emit('styleChanged');
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -267,7 +279,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._textBaseline !== textBaseline)
             {
                 this._textBaseline = textBaseline;
-                this.emit('styleChanged');
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -280,7 +292,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._lineJoin !== lineJoin)
             {
                 this._lineJoin = lineJoin;
-                this.emit('styleChanged');
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -293,7 +305,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._lineHeight !== lineHeight)
             {
                 this._lineHeight = lineHeight;
-                this.emit('styleChanged');
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -306,7 +318,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._miterLimit !== miterLimit)
             {
                 this._miterLimit = miterLimit;
-                this.emit('styleChanged');
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     }

--- a/src/core/text/TextStyle.js
+++ b/src/core/text/TextStyle.js
@@ -110,7 +110,7 @@ Object.defineProperties(TextStyle.prototype, {
             return this._fill;
         }, set: function (fill)
         {
-            var outputColor = typeof fill === 'number' ? utils.hex2string(fill) : fill;
+            var outputColor = getColor(fill);
             if (this._fill !== outputColor)
             {
                 this._fill = outputColor;
@@ -137,7 +137,7 @@ Object.defineProperties(TextStyle.prototype, {
             return this._stroke;
         }, set: function (stroke)
         {
-            var outputColor = typeof stroke === 'number' ? utils.hex2string(stroke) : stroke;
+            var outputColor = getColor(stroke);
             if (this._stroke !== outputColor)
             {
                 this._stroke = outputColor;
@@ -203,7 +203,7 @@ Object.defineProperties(TextStyle.prototype, {
             return this._dropShadowColor;
         }, set: function (dropShadowColor)
         {
-            var outputColor = typeof dropShadowColor === 'number' ? utils.hex2string(dropShadowColor) : dropShadowColor;
+            var outputColor = getColor(dropShadowColor);
             if (this._dropShadowColor !== outputColor)
             {
                 this._dropShadowColor = outputColor;
@@ -317,4 +317,18 @@ Object.defineProperties(TextStyle.prototype, {
     }
 });
 
-
+/**
+ * Utility function to convert hexadecimal colors to strings, and simply return the color if it's a string.
+ *
+ * @return {string} The color as a string.
+ */
+function getColor(color)
+{
+    if (typeof color === 'number')
+    {
+        return utils.hex2string(color);
+    } else
+    {
+        return color;
+    }
+}

--- a/src/core/text/TextStyle.js
+++ b/src/core/text/TextStyle.js
@@ -92,8 +92,11 @@ Object.defineProperties(TextStyle.prototype, {
             return this._font;
         }, set: function (font)
         {
-            this._font = font;
-            this.emit('styleChanged');
+            if (this._font !== font)
+            {
+                this._font = font;
+                this.emit('styleChanged');
+            }
         }
     },
     fill: {
@@ -102,8 +105,12 @@ Object.defineProperties(TextStyle.prototype, {
             return this._fill;
         }, set: function (fill)
         {
-            this._fill = typeof fill === 'number' ? utils.hex2string(fill) : fill;
-            this.emit('styleChanged');
+            var outputColor = typeof fill === 'number' ? utils.hex2string(fill) : fill;
+            if (this._fill !== outputColor)
+            {
+                this._fill = outputColor;
+                this.emit('styleChanged');
+            }
         }
     },
     align: {
@@ -112,8 +119,11 @@ Object.defineProperties(TextStyle.prototype, {
             return this._align;
         }, set: function (align)
         {
-            this._align = align;
-            this.emit('styleChanged');
+            if (this._align !== align)
+            {
+                this._align = align;
+                this.emit('styleChanged');
+            }
         }
     },
     stroke: {
@@ -122,8 +132,12 @@ Object.defineProperties(TextStyle.prototype, {
             return this._stroke;
         }, set: function (stroke)
         {
-            this._stroke = typeof stroke === 'number' ? utils.hex2string(stroke) : stroke;
-            this.emit('styleChanged');
+            var outputColor = typeof stroke === 'number' ? utils.hex2string(stroke) : stroke;
+            if (this._stroke !== outputColor)
+            {
+                this._stroke = outputColor;
+                this.emit('styleChanged');
+            }
         }
     },
     strokeThickness: {
@@ -132,8 +146,11 @@ Object.defineProperties(TextStyle.prototype, {
             return this._strokeThickness;
         }, set: function (strokeThickness)
         {
-            this._strokeThickness = strokeThickness;
-            this.emit('styleChanged');
+            if (this._strokeThickness !== strokeThickness)
+            {
+                this._strokeThickness = strokeThickness;
+                this.emit('styleChanged');
+            }
         }
     },
     wordWrap: {
@@ -142,8 +159,11 @@ Object.defineProperties(TextStyle.prototype, {
             return this._wordWrap;
         }, set: function (wordWrap)
         {
-            this._wordWrap = wordWrap;
-            this.emit('styleChanged');
+            if (this._wordWrap !== wordWrap)
+            {
+                this._wordWrap = wordWrap;
+                this.emit('styleChanged');
+            }
         }
     },
     wordWrapWidth: {
@@ -152,8 +172,11 @@ Object.defineProperties(TextStyle.prototype, {
             return this._wordWrapWidth;
         }, set: function (wordWrapWidth)
         {
-            this._wordWrapWidth = wordWrapWidth;
-            this.emit('styleChanged');
+            if (this._wordWrapWidth !== wordWrapWidth)
+            {
+                this._wordWrapWidth = wordWrapWidth;
+                this.emit('styleChanged');
+            }
         }
     },
     dropShadow: {
@@ -162,8 +185,11 @@ Object.defineProperties(TextStyle.prototype, {
             return this._dropShadow;
         }, set: function (dropShadow)
         {
-            this._dropShadow = dropShadow;
-            this.emit('styleChanged');
+            if (this._dropShadow !== dropShadow)
+            {
+                this._dropShadow = dropShadow;
+                this.emit('styleChanged');
+            }
         }
     },
     dropShadowColor: {
@@ -172,8 +198,12 @@ Object.defineProperties(TextStyle.prototype, {
             return this._dropShadowColor;
         }, set: function (dropShadowColor)
         {
-            this._dropShadowColor = typeof dropShadowColor === 'number' ? utils.hex2string(dropShadowColor) : dropShadowColor;
-            this.emit('styleChanged');
+            var outputColor = typeof dropShadowColor === 'number' ? utils.hex2string(dropShadowColor) : dropShadowColor;
+            if (this._dropShadowColor !== outputColor)
+            {
+                this._dropShadowColor = outputColor;
+                this.emit('styleChanged');
+            }
         }
     },
     dropShadowAngle: {
@@ -182,8 +212,11 @@ Object.defineProperties(TextStyle.prototype, {
             return this._dropShadowAngle;
         }, set: function (dropShadowAngle)
         {
-            this._dropShadowAngle = dropShadowAngle;
-            this.emit('styleChanged');
+            if (this._dropShadowAngle !== dropShadowAngle)
+            {
+                this._dropShadowAngle = dropShadowAngle;
+                this.emit('styleChanged');
+            }
         }
     },
     dropShadowDistance: {
@@ -192,8 +225,11 @@ Object.defineProperties(TextStyle.prototype, {
             return this._dropShadowDistance;
         }, set: function (dropShadowDistance)
         {
-            this._dropShadowDistance = dropShadowDistance;
-            this.emit('styleChanged');
+            if (this._dropShadowDistance !== dropShadowDistance)
+            {
+                this._dropShadowDistance = dropShadowDistance;
+                this.emit('styleChanged');
+            }
         }
     },
     dropShadowBlur: {
@@ -202,8 +238,11 @@ Object.defineProperties(TextStyle.prototype, {
             return this._dropShadowBlur;
         }, set: function (dropShadowBlur)
         {
-            this._dropShadowBlur = dropShadowBlur;
-            this.emit('styleChanged');
+            if (this._dropShadowBlur !== dropShadowBlur)
+            {
+                this._dropShadowBlur = dropShadowBlur;
+                this.emit('styleChanged');
+            }
         }
     },
     padding: {
@@ -212,8 +251,11 @@ Object.defineProperties(TextStyle.prototype, {
             return this._padding;
         }, set: function (padding)
         {
-            this._padding = padding;
-            this.emit('styleChanged');
+            if (this._padding !== padding)
+            {
+                this._padding = padding;
+                this.emit('styleChanged');
+            }
         }
     },
     textBaseline: {
@@ -222,8 +264,11 @@ Object.defineProperties(TextStyle.prototype, {
             return this._textBaseline;
         }, set: function (textBaseline)
         {
-            this._textBaseline = textBaseline;
-            this.emit('styleChanged');
+            if (this._textBaseline !== textBaseline)
+            {
+                this._textBaseline = textBaseline;
+                this.emit('styleChanged');
+            }
         }
     },
     lineJoin: {
@@ -232,8 +277,11 @@ Object.defineProperties(TextStyle.prototype, {
             return this._lineJoin;
         }, set: function (lineJoin)
         {
-            this._lineJoin = lineJoin;
-            this.emit('styleChanged');
+            if (this._lineJoin !== lineJoin)
+            {
+                this._lineJoin = lineJoin;
+                this.emit('styleChanged');
+            }
         }
     },
     lineHeight: {
@@ -242,8 +290,11 @@ Object.defineProperties(TextStyle.prototype, {
             return this._lineHeight;
         }, set: function (lineHeight)
         {
-            this._lineHeight = lineHeight;
-            this.emit('styleChanged');
+            if (this._lineHeight !== lineHeight)
+            {
+                this._lineHeight = lineHeight;
+                this.emit('styleChanged');
+            }
         }
     },
     miterLimit: {
@@ -252,8 +303,11 @@ Object.defineProperties(TextStyle.prototype, {
             return this._miterLimit;
         }, set: function (miterLimit)
         {
-            this._miterLimit = miterLimit;
-            this.emit('styleChanged');
+            if (this._miterLimit !== miterLimit)
+            {
+                this._miterLimit = miterLimit;
+                this.emit('styleChanged');
+            }
         }
     }
 });

--- a/src/core/text/TextStyle.js
+++ b/src/core/text/TextStyle.js
@@ -1,0 +1,261 @@
+var EventEmitter = require('eventemitter3'),
+    utils = require('../utils');
+
+/**
+ * A TextStyle Object decorates a Text Object. It acts as an event emitter, and can be shared between
+ * multiple Text objects.
+ *
+ * @class
+ * @extends EventEmitter
+ * @memberof PIXI
+ * @param [style] {object} The style parameters
+ * @param [style.font='bold 20pt Arial'] {string} The style and size of the font
+ * @param [style.fill='black'] {String|Number} A canvas fillstyle that will be used on the text e.g 'red', '#00FF00'
+ * @param [style.align='left'] {string} Alignment for multiline text ('left', 'center' or 'right'), does not affect single line text
+ * @param [style.stroke='black'] {String|Number} A canvas fillstyle that will be used on the text stroke e.g 'blue', '#FCFF00'
+ * @param [style.strokeThickness=0] {number} A number that represents the thickness of the stroke. Default is 0 (no stroke)
+ * @param [style.wordWrap=false] {boolean} Indicates if word wrap should be used
+ * @param [style.wordWrapWidth=100] {number} The width at which text will wrap, it needs wordWrap to be set to true
+ * @param [style.lineHeight] {number} The line height, a number that represents the vertical space that a letter uses
+ * @param [style.dropShadow=false] {boolean} Set a drop shadow for the text
+ * @param [style.dropShadowColor='#000000'] {string} A fill style to be used on the dropshadow e.g 'red', '#00FF00'
+ * @param [style.dropShadowAngle=Math.PI/4] {number} Set a angle of the drop shadow
+ * @param [style.dropShadowDistance=5] {number} Set a distance of the drop shadow
+ * @param [style.dropShadowBlur=0] {number} Set a shadow blur radius
+ * @param [style.padding=0] {number} Occasionally some fonts are cropped on top or bottom. Adding some padding will
+ *      prevent this from happening by adding padding to the top and bottom of text height.
+ * @param [style.textBaseline='alphabetic'] {string} The baseline of the text that is rendered.
+ * @param [style.lineJoin='miter'] {string} The lineJoin property sets the type of corner created, it can resolve
+ *      spiked text issues. Default is 'miter' (creates a sharp corner).
+ * @param [style.miterLimit=10] {number} The miter limit to use when using the 'miter' lineJoin mode. This can reduce
+ *      or increase the spikiness of rendered text.
+ */
+function TextStyle(style)
+{
+    EventEmitter.call(this);
+    var properties = Object.assign({}, this._defaults, style);
+    for (var property in properties)
+    {
+        this[property] = properties[property];
+    }
+}
+
+TextStyle.prototype = Object.create(EventEmitter.prototype);
+TextStyle.prototype.constructor = TextStyle;
+module.exports = TextStyle;
+
+// Default settings. Explained in the constructor.
+TextStyle.prototype._defaults = {
+    align: 'left',
+    dropShadow: false,
+    dropShadowAngle: Math.PI / 6,
+    dropShadowBlur: 0,
+    dropShadowColor: '#000000',
+    dropShadowDistance: 5,
+    lineHeight: null,
+    lineJoin: 'miter',
+    fill: 'black',
+    font: 'bold 20pt Arial',
+    miterLimit: 10,
+    padding: 0,
+    stroke: 'black',
+    strokeThickness: 0,
+    textBaseline: 'alphabetic',
+    wordWrap: false,
+    wordWrapWidth: 100
+};
+
+/**
+ * Creates a new TextStyle object with the same values as this one.
+ * Note that the only the properties of the object are cloned, not its event emitter.
+ *
+ * @return {PIXI.TextStyle}
+ */
+TextStyle.prototype.clone = function ()
+{
+    var clonedProperties = {};
+    for (var key in this._defaults)
+    {
+        clonedProperties[key] = this[key];
+    }
+    return new TextStyle(clonedProperties);
+};
+
+/**
+ * Create setters and getters for each of the style properties. Converts colors where necessary.
+ * Any set operation will emit a styleChanged event.
+ */
+Object.defineProperties(TextStyle.prototype, {
+    font: {
+        get: function ()
+        {
+            return this._font;
+        }, set: function (font)
+        {
+            this._font = font;
+            this.emit('styleChanged');
+        }
+    },
+    fill: {
+        get: function ()
+        {
+            return this._fill;
+        }, set: function (fill)
+        {
+            this._fill = typeof fill === 'number' ? utils.hex2string(fill) : fill;
+            this.emit('styleChanged');
+        }
+    },
+    align: {
+        get: function ()
+        {
+            return this._align;
+        }, set: function (align)
+        {
+            this._align = align;
+            this.emit('styleChanged');
+        }
+    },
+    stroke: {
+        get: function ()
+        {
+            return this._stroke;
+        }, set: function (stroke)
+        {
+            this._stroke = typeof stroke === 'number' ? utils.hex2string(stroke) : stroke;
+            this.emit('styleChanged');
+        }
+    },
+    strokeThickness: {
+        get: function ()
+        {
+            return this._strokeThickness;
+        }, set: function (strokeThickness)
+        {
+            this._strokeThickness = strokeThickness;
+            this.emit('styleChanged');
+        }
+    },
+    wordWrap: {
+        get: function ()
+        {
+            return this._wordWrap;
+        }, set: function (wordWrap)
+        {
+            this._wordWrap = wordWrap;
+            this.emit('styleChanged');
+        }
+    },
+    wordWrapWidth: {
+        get: function ()
+        {
+            return this._wordWrapWidth;
+        }, set: function (wordWrapWidth)
+        {
+            this._wordWrapWidth = wordWrapWidth;
+            this.emit('styleChanged');
+        }
+    },
+    dropShadow: {
+        get: function ()
+        {
+            return this._dropShadow;
+        }, set: function (dropShadow)
+        {
+            this._dropShadow = dropShadow;
+            this.emit('styleChanged');
+        }
+    },
+    dropShadowColor: {
+        get: function ()
+        {
+            return this._dropShadowColor;
+        }, set: function (dropShadowColor)
+        {
+            this._dropShadowColor = typeof dropShadowColor === 'number' ? utils.hex2string(dropShadowColor) : dropShadowColor;
+            this.emit('styleChanged');
+        }
+    },
+    dropShadowAngle: {
+        get: function ()
+        {
+            return this._dropShadowAngle;
+        }, set: function (dropShadowAngle)
+        {
+            this._dropShadowAngle = dropShadowAngle;
+            this.emit('styleChanged');
+        }
+    },
+    dropShadowDistance: {
+        get: function ()
+        {
+            return this._dropShadowDistance;
+        }, set: function (dropShadowDistance)
+        {
+            this._dropShadowDistance = dropShadowDistance;
+            this.emit('styleChanged');
+        }
+    },
+    dropShadowBlur: {
+        get: function ()
+        {
+            return this._dropShadowBlur;
+        }, set: function (dropShadowBlur)
+        {
+            this._dropShadowBlur = dropShadowBlur;
+            this.emit('styleChanged');
+        }
+    },
+    padding: {
+        get: function ()
+        {
+            return this._padding;
+        }, set: function (padding)
+        {
+            this._padding = padding;
+            this.emit('styleChanged');
+        }
+    },
+    textBaseline: {
+        get: function ()
+        {
+            return this._textBaseline;
+        }, set: function (textBaseline)
+        {
+            this._textBaseline = textBaseline;
+            this.emit('styleChanged');
+        }
+    },
+    lineJoin: {
+        get: function ()
+        {
+            return this._lineJoin;
+        }, set: function (lineJoin)
+        {
+            this._lineJoin = lineJoin;
+            this.emit('styleChanged');
+        }
+    },
+    lineHeight: {
+        get: function ()
+        {
+            return this._lineHeight;
+        }, set: function (lineHeight)
+        {
+            this._lineHeight = lineHeight;
+            this.emit('styleChanged');
+        }
+    },
+    miterLimit: {
+        get: function ()
+        {
+            return this._miterLimit;
+        }, set: function (miterLimit)
+        {
+            this._miterLimit = miterLimit;
+            this.emit('styleChanged');
+        }
+    }
+});
+
+

--- a/src/core/text/TextStyle.js
+++ b/src/core/text/TextStyle.js
@@ -83,10 +83,7 @@ TextStyle.prototype.clone = function ()
  */
 TextStyle.prototype.reset = function ()
 {
-    for (var property in this._defaults)
-    {
-        this[property] = this._defaults[property];
-    }
+    Object.assign(this, this._defaults);
 };
 
 /**

--- a/src/core/text/TextStyle.js
+++ b/src/core/text/TextStyle.js
@@ -1,10 +1,13 @@
-var utils = require('../utils');
+var EventEmitter = require('eventemitter3'),
+    CONST = require('../const'),
+    utils = require('../utils');
 
 /**
  * A TextStyle Object decorates a Text Object. It acts as an event emitter, and can be shared between
  * multiple Text objects.
  *
  * @class
+ * @extends EventEmitter
  * @memberof PIXI
  * @param [style] {object} The style parameters
  * @param [style.font='bold 20pt Arial'] {string} The style and size of the font
@@ -30,10 +33,11 @@ var utils = require('../utils');
  */
 function TextStyle(style)
 {
+    EventEmitter.call(this);
     Object.assign(this, this._defaults, style);
-    this.version = 0;
 }
 
+TextStyle.prototype = Object.create(EventEmitter.prototype);
 TextStyle.prototype.constructor = TextStyle;
 module.exports = TextStyle;
 
@@ -96,7 +100,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._font !== font)
             {
                 this._font = font;
-                this.version += 1;
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -110,7 +114,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._fill !== outputColor)
             {
                 this._fill = outputColor;
-                this.version += 1;
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -123,7 +127,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._align !== align)
             {
                 this._align = align;
-                this.version += 1;
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -137,7 +141,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._stroke !== outputColor)
             {
                 this._stroke = outputColor;
-                this.version += 1;
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -150,7 +154,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._strokeThickness !== strokeThickness)
             {
                 this._strokeThickness = strokeThickness;
-                this.version += 1;
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -163,7 +167,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._wordWrap !== wordWrap)
             {
                 this._wordWrap = wordWrap;
-                this.version += 1;
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -176,7 +180,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._wordWrapWidth !== wordWrapWidth)
             {
                 this._wordWrapWidth = wordWrapWidth;
-                this.version += 1;
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -189,7 +193,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._dropShadow !== dropShadow)
             {
                 this._dropShadow = dropShadow;
-                this.version += 1;
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -203,7 +207,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._dropShadowColor !== outputColor)
             {
                 this._dropShadowColor = outputColor;
-                this.version += 1;
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -216,7 +220,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._dropShadowAngle !== dropShadowAngle)
             {
                 this._dropShadowAngle = dropShadowAngle;
-                this.version += 1;
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -229,7 +233,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._dropShadowDistance !== dropShadowDistance)
             {
                 this._dropShadowDistance = dropShadowDistance;
-                this.version += 1;
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -242,7 +246,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._dropShadowBlur !== dropShadowBlur)
             {
                 this._dropShadowBlur = dropShadowBlur;
-                this.version += 1;
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -255,7 +259,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._padding !== padding)
             {
                 this._padding = padding;
-                this.version += 1;
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -268,7 +272,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._textBaseline !== textBaseline)
             {
                 this._textBaseline = textBaseline;
-                this.version += 1;
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -281,7 +285,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._lineJoin !== lineJoin)
             {
                 this._lineJoin = lineJoin;
-                this.version += 1;
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -294,7 +298,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._lineHeight !== lineHeight)
             {
                 this._lineHeight = lineHeight;
-                this.version += 1;
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     },
@@ -307,7 +311,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._miterLimit !== miterLimit)
             {
                 this._miterLimit = miterLimit;
-                this.version += 1;
+                this.emit(CONST.TEXT_STYLE_CHANGED);
             }
         }
     }

--- a/src/core/text/TextStyle.js
+++ b/src/core/text/TextStyle.js
@@ -1,13 +1,10 @@
-var EventEmitter = require('eventemitter3'),
-    CONST = require('../const'),
-    utils = require('../utils');
+var utils = require('../utils');
 
 /**
  * A TextStyle Object decorates a Text Object. It acts as an event emitter, and can be shared between
  * multiple Text objects.
  *
  * @class
- * @extends EventEmitter
  * @memberof PIXI
  * @param [style] {object} The style parameters
  * @param [style.font='bold 20pt Arial'] {string} The style and size of the font
@@ -33,11 +30,10 @@ var EventEmitter = require('eventemitter3'),
  */
 function TextStyle(style)
 {
-    EventEmitter.call(this);
     Object.assign(this, this._defaults, style);
+    this.version = 0;
 }
 
-TextStyle.prototype = Object.create(EventEmitter.prototype);
 TextStyle.prototype.constructor = TextStyle;
 module.exports = TextStyle;
 
@@ -100,7 +96,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._font !== font)
             {
                 this._font = font;
-                this.emit(CONST.TEXT_STYLE_CHANGED);
+                this.version += 1;
             }
         }
     },
@@ -114,7 +110,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._fill !== outputColor)
             {
                 this._fill = outputColor;
-                this.emit(CONST.TEXT_STYLE_CHANGED);
+                this.version += 1;
             }
         }
     },
@@ -127,7 +123,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._align !== align)
             {
                 this._align = align;
-                this.emit(CONST.TEXT_STYLE_CHANGED);
+                this.version += 1;
             }
         }
     },
@@ -141,7 +137,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._stroke !== outputColor)
             {
                 this._stroke = outputColor;
-                this.emit(CONST.TEXT_STYLE_CHANGED);
+                this.version += 1;
             }
         }
     },
@@ -154,7 +150,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._strokeThickness !== strokeThickness)
             {
                 this._strokeThickness = strokeThickness;
-                this.emit(CONST.TEXT_STYLE_CHANGED);
+                this.version += 1;
             }
         }
     },
@@ -167,7 +163,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._wordWrap !== wordWrap)
             {
                 this._wordWrap = wordWrap;
-                this.emit(CONST.TEXT_STYLE_CHANGED);
+                this.version += 1;
             }
         }
     },
@@ -180,7 +176,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._wordWrapWidth !== wordWrapWidth)
             {
                 this._wordWrapWidth = wordWrapWidth;
-                this.emit(CONST.TEXT_STYLE_CHANGED);
+                this.version += 1;
             }
         }
     },
@@ -193,7 +189,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._dropShadow !== dropShadow)
             {
                 this._dropShadow = dropShadow;
-                this.emit(CONST.TEXT_STYLE_CHANGED);
+                this.version += 1;
             }
         }
     },
@@ -207,7 +203,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._dropShadowColor !== outputColor)
             {
                 this._dropShadowColor = outputColor;
-                this.emit(CONST.TEXT_STYLE_CHANGED);
+                this.version += 1;
             }
         }
     },
@@ -220,7 +216,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._dropShadowAngle !== dropShadowAngle)
             {
                 this._dropShadowAngle = dropShadowAngle;
-                this.emit(CONST.TEXT_STYLE_CHANGED);
+                this.version += 1;
             }
         }
     },
@@ -233,7 +229,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._dropShadowDistance !== dropShadowDistance)
             {
                 this._dropShadowDistance = dropShadowDistance;
-                this.emit(CONST.TEXT_STYLE_CHANGED);
+                this.version += 1;
             }
         }
     },
@@ -246,7 +242,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._dropShadowBlur !== dropShadowBlur)
             {
                 this._dropShadowBlur = dropShadowBlur;
-                this.emit(CONST.TEXT_STYLE_CHANGED);
+                this.version += 1;
             }
         }
     },
@@ -259,7 +255,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._padding !== padding)
             {
                 this._padding = padding;
-                this.emit(CONST.TEXT_STYLE_CHANGED);
+                this.version += 1;
             }
         }
     },
@@ -272,7 +268,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._textBaseline !== textBaseline)
             {
                 this._textBaseline = textBaseline;
-                this.emit(CONST.TEXT_STYLE_CHANGED);
+                this.version += 1;
             }
         }
     },
@@ -285,7 +281,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._lineJoin !== lineJoin)
             {
                 this._lineJoin = lineJoin;
-                this.emit(CONST.TEXT_STYLE_CHANGED);
+                this.version += 1;
             }
         }
     },
@@ -298,7 +294,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._lineHeight !== lineHeight)
             {
                 this._lineHeight = lineHeight;
-                this.emit(CONST.TEXT_STYLE_CHANGED);
+                this.version += 1;
             }
         }
     },
@@ -311,7 +307,7 @@ Object.defineProperties(TextStyle.prototype, {
             if (this._miterLimit !== miterLimit)
             {
                 this._miterLimit = miterLimit;
-                this.emit(CONST.TEXT_STYLE_CHANGED);
+                this.version += 1;
             }
         }
     }

--- a/src/core/text/TextStyle.js
+++ b/src/core/text/TextStyle.js
@@ -11,9 +11,9 @@ var EventEmitter = require('eventemitter3'),
  * @memberof PIXI
  * @param [style] {object} The style parameters
  * @param [style.font='bold 20pt Arial'] {string} The style and size of the font
- * @param [style.fill='black'] {String|Number} A canvas fillstyle that will be used on the text e.g 'red', '#00FF00'
+ * @param [style.fill='black'] {string|number} A canvas fillstyle that will be used on the text e.g 'red', '#00FF00'
  * @param [style.align='left'] {string} Alignment for multiline text ('left', 'center' or 'right'), does not affect single line text
- * @param [style.stroke='black'] {String|Number} A canvas fillstyle that will be used on the text stroke e.g 'blue', '#FCFF00'
+ * @param [style.stroke='black'] {string|number} A canvas fillstyle that will be used on the text stroke e.g 'blue', '#FCFF00'
  * @param [style.strokeThickness=0] {number} A number that represents the thickness of the stroke. Default is 0 (no stroke)
  * @param [style.wordWrap=false] {boolean} Indicates if word wrap should be used
  * @param [style.wordWrapWidth=100] {number} The width at which text will wrap, it needs wordWrap to be set to true
@@ -34,11 +34,7 @@ var EventEmitter = require('eventemitter3'),
 function TextStyle(style)
 {
     EventEmitter.call(this);
-    var properties = Object.assign({}, this._defaults, style);
-    for (var property in properties)
-    {
-        this[property] = properties[property];
-    }
+    Object.assign(this, this._defaults, style);
 }
 
 TextStyle.prototype = Object.create(EventEmitter.prototype);


### PR DESCRIPTION
This commit introduces `PIXI.TextStyle`. The API for `PIXI.Text` is left mostly unchanged. `TextStyle` extends EventEmitter, and emits a `styleChanged` event every time it is changed. `Text` hooks onto that event and marks `Text.dirty = true`. 

Additionally, `TextStyle` exposes `TextStyle.clone()`, which allows an end user to clone a previously defined text style. 