### PR TITLE
Stop ticker from being able to report a negative deltaTime

### DIFF
--- a/src/core/ticker/Ticker.js
+++ b/src/core/ticker/Ticker.js
@@ -334,7 +334,7 @@ Ticker.prototype.update = function update(currentTime)
     // Allow calling update directly with default currentTime.
     currentTime = currentTime || performance.now();
     // Save uncapped elapsedMS for measurement
-    elapsedMS = this.elapsedMS = currentTime - this.lastTime;
+    Math.max(0, elapsedMS = this.elapsedMS = currentTime - this.lastTime);
 
     // cap the milliseconds elapsed used for deltaTime
     if (elapsedMS > this._maxElapsedMS)


### PR DESCRIPTION
When you start a stopped timer, the very first timeDelta can sometimes be negative. This PR just adds a Math.max to ensure that in this case it would report 0 rather than a negative number.

Example: https://jsfiddle.net/mL4qx95n/9/
Open up the console. It will log when the value of the timeDelta is negative.
