### PR TITLE
JSHint fixes

### DIFF
--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -1,8 +1,6 @@
 var math = require('../math'),
     utils = require('../utils'),
-    DisplayObject = require('./DisplayObject'),
-    RenderTexture = require('../textures/RenderTexture'),
-    _tempMatrix = new math.Matrix();
+    DisplayObject = require('./DisplayObject');
 
 /**
  * A Container represents a collection of display objects.
@@ -440,7 +438,8 @@ Container.prototype.getBounds = function ()
 
         if (!childVisible)
         {
-            return this._currentBounds = math.Rectangle.EMPTY;
+            this._currentBounds = math.Rectangle.EMPTY;
+            return this._currentBounds;
         }
 
         var bounds = this._bounds;

--- a/src/core/display/DisplayObject.js
+++ b/src/core/display/DisplayObject.js
@@ -1,8 +1,6 @@
 var math = require('../math'),
-    RenderTexture = require('../textures/RenderTexture'),
     EventEmitter = require('eventemitter3'),
     Transform = require('./Transform'),
-    _tempMatrix = new math.Matrix(),
     _tempDisplayObjectParent = {worldTransform:new math.Matrix(), worldAlpha:1, children:[]};
 
 

--- a/src/core/display/Transform.js
+++ b/src/core/display/Transform.js
@@ -54,10 +54,10 @@ function Transform()
     this._rotation = 0;
     this._sr = Math.sin(0);
     this._cr = Math.cos(0);
-    this._cy  = Math.cos(0)//skewY);
-    this._sy  = Math.sin(0)//skewY);
-    this._nsx = Math.sin(0)//skewX);
-    this._cx  = Math.cos(0)//skewX);
+    this._cy  = Math.cos(0);
+    this._sy  = Math.sin(0);
+    this._nsx = Math.sin(0);
+    this._cx  = Math.cos(0);
 
     this._dirty = false;
     this.updated = true;
@@ -71,7 +71,7 @@ Transform.prototype.updateSkew = function ()
     this._sy  = Math.sin(this.skew.y);
     this._nsx = Math.sin(this.skew.x);
     this._cx  = Math.cos(this.skew.x);
-}
+};
 
 /**
  * Updates the values of the object and applies the parent's transform.

--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -6,7 +6,6 @@ var Container = require('../display/Container'),
     math = require('../math'),
     CONST = require('../const'),
     bezierCurveTo = require('./utils/bezierCurveTo'),
-    CanvasRenderTarget = require('../renderers/canvas/utils/CanvasRenderTarget'),
     CanvasRenderer = require('../renderers/canvas/CanvasRenderer'),
     canvasRenderer,
     tempMatrix = new math.Matrix(),
@@ -1035,7 +1034,7 @@ Graphics.prototype.generateCanvasTexture = function(scaleMode, resolution)
     texture.baseTexture.resolution = resolution;
 
     return texture;
-}
+};
 
 /**
  * Destroys the Graphics object.

--- a/src/core/graphics/webgl/utils/buildRoundedRectangle.js
+++ b/src/core/graphics/webgl/utils/buildRoundedRectangle.js
@@ -3,6 +3,58 @@ var earcut = require('earcut'),
     utils = require('../../../utils');
 
 /**
+ * Calculate the points for a quadratic bezier curve. (helper function..)
+ * Based on: https://stackoverflow.com/questions/785097/how-do-i-implement-a-bezier-curve-in-c
+ *
+ * @private
+ * @param fromX {number} Origin point x
+ * @param fromY {number} Origin point x
+ * @param cpX {number} Control point x
+ * @param cpY {number} Control point y
+ * @param toX {number} Destination point x
+ * @param toY {number} Destination point y
+ * @param [out] {number[]} The output array to add points into. If not passed, a new array is created.
+ * @return {number[]} an array of points
+ */
+var quadraticBezierCurve = function (fromX, fromY, cpX, cpY, toX, toY, out)
+{
+    var xa,
+        ya,
+        xb,
+        yb,
+        x,
+        y,
+        n = 20,
+        points = out || [];
+
+    function getPt(n1 , n2, perc) {
+        var diff = n2 - n1;
+
+        return n1 + ( diff * perc );
+    }
+
+    var j = 0;
+    for (var i = 0; i <= n; i++ ) {
+        j = i / n;
+
+        // The Green Line
+        xa = getPt( fromX , cpX , j );
+        ya = getPt( fromY , cpY , j );
+        xb = getPt( cpX , toX , j );
+        yb = getPt( cpY , toY , j );
+
+        // The Black Dot
+        x = getPt( xa , xb , j );
+        y = getPt( ya , yb , j );
+
+        points.push(x, y);
+    }
+
+    return points;
+};
+
+
+/**
  * Builds a rounded rectangle to draw
  *
  * @private
@@ -72,57 +124,5 @@ var buildRoundedRectangle = function (graphicsData, webGLData)
         graphicsData.points = tempPoints;
     }
 };
-
-/**
- * Calculate the points for a quadratic bezier curve. (helper function..)
- * Based on: https://stackoverflow.com/questions/785097/how-do-i-implement-a-bezier-curve-in-c
- *
- * @private
- * @param fromX {number} Origin point x
- * @param fromY {number} Origin point x
- * @param cpX {number} Control point x
- * @param cpY {number} Control point y
- * @param toX {number} Destination point x
- * @param toY {number} Destination point y
- * @param [out] {number[]} The output array to add points into. If not passed, a new array is created.
- * @return {number[]} an array of points
- */
-var quadraticBezierCurve = function (fromX, fromY, cpX, cpY, toX, toY, out)
-{
-    var xa,
-        ya,
-        xb,
-        yb,
-        x,
-        y,
-        n = 20,
-        points = out || [];
-
-    function getPt(n1 , n2, perc) {
-        var diff = n2 - n1;
-
-        return n1 + ( diff * perc );
-    }
-
-    var j = 0;
-    for (var i = 0; i <= n; i++ ) {
-        j = i / n;
-
-        // The Green Line
-        xa = getPt( fromX , cpX , j );
-        ya = getPt( fromY , cpY , j );
-        xb = getPt( cpX , toX , j );
-        yb = getPt( cpY , toY , j );
-
-        // The Black Dot
-        x = getPt( xa , xb , j );
-        y = getPt( ya , yb , j );
-
-        points.push(x, y);
-    }
-
-    return points;
-};
-
 
 module.exports = buildRoundedRectangle;

--- a/src/core/math/shapes/Rectangle.js
+++ b/src/core/math/shapes/Rectangle.js
@@ -152,7 +152,10 @@ Rectangle.prototype.fit = function (rectangle)
 };
 
 Rectangle.prototype.enlarge = function (rect) {
-    if (rect === Rectangle.EMPTY) return;
+    if (rect === Rectangle.EMPTY) 
+    {
+        return;
+    }
     var x1 = Math.min(this.x, rect.x);
     var x2 = Math.max(this.x + this.width, rect.x + rect.width);
     var y1 = Math.min(this.y, rect.y);

--- a/src/core/renderers/webgl/TextureGarbageCollector.js
+++ b/src/core/renderers/webgl/TextureGarbageCollector.js
@@ -24,7 +24,10 @@ module.exports = TextureGarbageCollector;
 TextureGarbageCollector.prototype.update = function()
 {
     this.count++;
-    if(this.mode === CONST.GC_MODES.MANUAL)return;
+    if(this.mode === CONST.GC_MODES.MANUAL)
+    {
+        return;
+    }
 
     this.checkCount++;
 
@@ -44,26 +47,26 @@ TextureGarbageCollector.prototype.run = function()
     var wasRemoved = false;
     var i,j;
 
-    for (i = 0; i < managedTextures.length; i++) 
+    for (i = 0; i < managedTextures.length; i++)
     {
         var texture = managedTextures[i];
 
         // only supports non generated textures at the moment!
-        if (!texture._glRenderTargets && this.count - texture.touched > this.maxIdle) 
+        if (!texture._glRenderTargets && this.count - texture.touched > this.maxIdle)
         {
             tm.destroyTexture(texture, true);
             managedTextures[i] = null;
             wasRemoved = true;
         }
     }
-    
-    if (wasRemoved) 
+
+    if (wasRemoved)
     {
         j = 0;
 
-        for (i = 0; i < managedTextures.length; i++) 
+        for (i = 0; i < managedTextures.length; i++)
         {
-            if (managedTextures[i] !== null) 
+            if (managedTextures[i] !== null)
             {
                 managedTextures[j++] = managedTextures[i];
             }

--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -14,6 +14,7 @@ var SystemRenderer = require('../SystemRenderer'),
     CONST = require('../../const');
 
 var CONTEXT_UID = 0;
+var renderTarget;
 
 /**
  * The WebGLRenderer draws the scene and all its content onto a webGL enabled canvas. This renderer
@@ -111,7 +112,7 @@ function WebGLRenderer(width, height, options)
      */
     // initialize the context so it is ready for the managers.
     this.gl = options.context || createContext(this.view, this._contextOptions);
-   
+
     this.CONTEXT_UID = CONTEXT_UID++;
 
     /**
@@ -155,7 +156,7 @@ function WebGLRenderer(width, height, options)
 
     this.setBlendMode(0);
 
-    
+
 }
 
 // constructor
@@ -181,7 +182,7 @@ WebGLRenderer.prototype._initContext = function ()
 
     this.rootRenderTarget = new RenderTarget(gl, this.width, this.height, null, this.resolution, true);
     this.rootRenderTarget.clearColor = this._backgroundColorRgba;
-    
+
 
     this.bindRenderTarget(this.rootRenderTarget);
 
@@ -203,7 +204,7 @@ WebGLRenderer.prototype._initContext = function ()
 WebGLRenderer.prototype.render = function (displayObject, renderTexture, clear, transform, skipUpdateTransform)
 {
 
-    
+
     // can be handy to know!
     this.renderingToScreen = !renderTexture;
 
@@ -216,7 +217,6 @@ WebGLRenderer.prototype.render = function (displayObject, renderTexture, clear, 
         return;
     }
 
-    var gl = this.gl;
 
     this._lastObjectRendered = displayObject;
 
@@ -239,7 +239,7 @@ WebGLRenderer.prototype.render = function (displayObject, renderTexture, clear, 
         renderTarget.clear();
     }
 
-   
+
 
     displayObject.renderWebGL(this);
 
@@ -363,7 +363,7 @@ WebGLRenderer.prototype.bindRenderTexture = function (renderTexture, transform)
         }
 
 
-        renderTarget =  baseTexture._glRenderTargets[this.CONTEXT_UID];
+        renderTarget = baseTexture._glRenderTargets[this.CONTEXT_UID];
         renderTarget.setFrame(renderTexture.frame);
     }
     else
@@ -449,7 +449,7 @@ WebGLRenderer.prototype.bindTexture = function (texture, location)
     {
         // this will also bind the texture..
         this.textureManager.updateTexture(texture);
-       
+
     }
     else
     {
@@ -464,7 +464,7 @@ WebGLRenderer.prototype.bindTexture = function (texture, location)
 WebGLRenderer.prototype.createVao = function ()
 {
     return new glCore.VertexArrayObject(this.gl, this.state.attribState);
-}
+};
 
 /**
  * Resets the WebGL state so you can render things however you fancy!

--- a/src/core/renderers/webgl/WebGLState.js
+++ b/src/core/renderers/webgl/WebGLState.js
@@ -50,14 +50,13 @@ var WebGLState = function(gl)
 
 	this.maxAttribs = gl.getParameter(gl.MAX_VERTEX_ATTRIBS);
 
-	this.attribState = {tempAttribState:new Array(this.maxAttribs)
-                       ,attribState:new Array(this.maxAttribs)};
+    this.attribState = {tempAttribState: new Array(this.maxAttribs), attribState: new Array(this.maxAttribs)};
 
 
 
 	this.blendModes = mapWebGLBlendModesToPixi(gl);
 
-	
+
 	// check we have vao..
 	this.nativeVaoExtension = (
       gl.getExtension('OES_vertex_array_object') ||
@@ -252,8 +251,7 @@ WebGLState.prototype.resetToDefault = function()
 		this.nativeVaoExtension.bindVertexArrayOES(null);
 	}
 
-	var gl = this.gl;
-	// reset all attributs..
+	// reset all attributes..
 	this.resetAttributes();
 
 	// set active state so we can force overrides of gl state

--- a/src/core/renderers/webgl/utils/Quad.js
+++ b/src/core/renderers/webgl/utils/Quad.js
@@ -68,7 +68,7 @@ function Quad(gl, state)
     /*
      * @member {glCore.VertexArrayObject} The index buffer
      */
-    this.vao = new glCore.VertexArrayObject(gl, state)
+    this.vao = new glCore.VertexArrayObject(gl, state);
 
 }
 

--- a/src/core/renderers/webgl/utils/RenderTarget.js
+++ b/src/core/renderers/webgl/utils/RenderTarget.js
@@ -1,6 +1,6 @@
 var math = require('../../../math'),
     CONST = require('../../../const'),
-    GLTexture = require('pixi-gl-core').GLTexture,
+    Rectangle = require('../../../math/shapes/Rectangle'),
     GLFramebuffer = require('pixi-gl-core').GLFramebuffer;
 
 /**
@@ -91,7 +91,7 @@ var RenderTarget = function(gl, width, height, scaleMode, resolution, root)
      *
      * @member {WebGLRenderBuffer}
      */
-    this.defaultFrame = new PIXI.Rectangle();
+    this.defaultFrame = new Rectangle();
     this.destinationFrame = null;
     this.sourceFrame = null;
 

--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -440,7 +440,7 @@ Sprite.prototype.destroy = function (destroyTexture, destroyBaseTexture)
 Sprite.from = function (source)
 {
     return new Sprite(Texture.from(source));
-}
+};
 
 /**
  * Helper function that creates a sprite that will contain a texture from the TextureCache based on the frameId

--- a/src/core/sprites/webgl/SpriteRenderer.js
+++ b/src/core/sprites/webgl/SpriteRenderer.js
@@ -104,12 +104,12 @@ SpriteRenderer.prototype.onContextChange = function ()
 
 
     this.MAX_TEXTURES = Math.min(gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS), CONST.SPRITE_MAX_TEXTURES);
-    
+
     this.shader = generateMultiTextureShader(gl, this.MAX_TEXTURES);
     // create a couple of buffers
     this.indexBuffer = glCore.GLBuffer.createIndexBuffer(gl, this.indices, gl.STATIC_DRAW);
 
-    
+
 
     for (var i = 0; i < this.vaoMax; i++) {
         this.vertexBuffers[i] = glCore.GLBuffer.createVertexBuffer(gl, null, gl.STREAM_DRAW);
@@ -121,7 +121,7 @@ SpriteRenderer.prototype.onContextChange = function ()
         .addAttribute(this.vertexBuffers[i], this.shader.attributes.aColor, gl.UNSIGNED_BYTE, true, this.vertByteSize, 3 * 4)
         .addAttribute(this.vertexBuffers[i], this.shader.attributes.aTextureId, gl.FLOAT, false, this.vertByteSize, 4 * 4);
     }
-    
+
     this.vao = this.vaos[0];
     this.currentBlendMode = 99999;
 };
@@ -246,7 +246,9 @@ SpriteRenderer.prototype.flush = function ()
 
         //TODO this sum does not need to be set each frame..
         tint = (sprite.tint >> 16) + (sprite.tint & 0xff00) + ((sprite.tint & 0xff) << 16) + (sprite.worldAlpha * 255 << 24);
+        /* jshint -W106 */ // Disable JSHint camel case warnings.
         uvs = sprite._texture._uvs.uvs_uint32;
+        /* jshint +W106 */
         textureId = nextTexture._id;
 
         //xy
@@ -285,7 +287,7 @@ SpriteRenderer.prototype.flush = function ()
 
     this.vertexBuffers[this.vertexCount].upload(buffer.vertices, 0);
     this.vao = this.vaos[this.vertexCount].bind();
-   
+
 
     /// render the groups..
     for (i = 0; i < groupCount; i++) {
@@ -327,10 +329,11 @@ SpriteRenderer.prototype.stop = function ()
  */
 SpriteRenderer.prototype.destroy = function ()
 {
-    for (var i = 0; i < this.vaoMax; i++) {
+    var i;
+    for (i = 0; i < this.vaoMax; i++) {
         this.vertexBuffers[i].destroy();
         this.vaoMax[i].destroy();
-    };
+    }
 
     this.indexBuffer.destroy();
 
@@ -346,7 +349,7 @@ SpriteRenderer.prototype.destroy = function ()
     this.sprites = null;
     this.shader = null;
 
-    for (var i = 0; i < this.buffers.length; i++) {
+    for (i = 0; i < this.buffers.length; i++) {
       this.buffers[i].destroy();
     }
 

--- a/src/core/sprites/webgl/SpriteRenderer.js
+++ b/src/core/sprites/webgl/SpriteRenderer.js
@@ -246,9 +246,7 @@ SpriteRenderer.prototype.flush = function ()
 
         //TODO this sum does not need to be set each frame..
         tint = (sprite.tint >> 16) + (sprite.tint & 0xff00) + ((sprite.tint & 0xff) << 16) + (sprite.worldAlpha * 255 << 24);
-        /* jshint -W106 */ // Disable JSHint camel case warnings.
         uvs = sprite._texture._uvs.uvs_uint32;
-        /* jshint +W106 */
         textureId = nextTexture._id;
 
         //xy

--- a/src/core/textures/BaseRenderTexture.js
+++ b/src/core/textures/BaseRenderTexture.js
@@ -1,5 +1,4 @@
 var BaseTexture = require('./BaseTexture'),
-    math = require('../math'),
     CONST = require('../const');
 
 /**

--- a/src/core/textures/RenderTexture.js
+++ b/src/core/textures/RenderTexture.js
@@ -1,3 +1,5 @@
+/*global console */
+
 var BaseRenderTexture = require('./BaseRenderTexture'),
     Texture = require('./Texture');
 

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -438,7 +438,7 @@ Texture.from = function (source)
             return Texture.fromImage(source);
         }
 
-        return texture
+        return texture;
     }
     else if(source instanceof HTMLCanvasElement)
     {
@@ -452,7 +452,7 @@ Texture.from = function (source)
     {
         return new Texture(BaseTexture);
     }
-}
+};
 
 
 /**

--- a/src/core/textures/TextureUvs.js
+++ b/src/core/textures/TextureUvs.js
@@ -8,6 +8,7 @@
  */
 function TextureUvs()
 {
+    /* jshint -W106 */  // Disable JSHint camel case warnings.
     this.x0 = 0;
     this.y0 = 0;
 
@@ -81,8 +82,8 @@ TextureUvs.prototype.set = function (frame, baseFrame, rotate)
         this.y3 = (frame.y + frame.height) / th;
     }
 
-    this.uvs_uint32[0] = (((this.y0 * 65535) & 0xFFFF) << 16) | ((this.x0 * 65535) & 0xFFFF);
-    this.uvs_uint32[1] = (((this.y1 * 65535) & 0xFFFF) << 16) | ((this.x1 * 65535) & 0xFFFF);
-    this.uvs_uint32[2] = (((this.y2 * 65535) & 0xFFFF) << 16) | ((this.x2 * 65535) & 0xFFFF);
-    this.uvs_uint32[3] = (((this.y3 * 65535) & 0xFFFF) << 16) | ((this.x3 * 65535) & 0xFFFF);
+    this.uvs_uint32[0] = (((this.y0 * 65535) & 0xFFFF) << 16) | ((this.x0 * 65535) & 0xFFFF); // jshint ignore:line
+    this.uvs_uint32[1] = (((this.y1 * 65535) & 0xFFFF) << 16) | ((this.x1 * 65535) & 0xFFFF); // jshint ignore:line
+    this.uvs_uint32[2] = (((this.y2 * 65535) & 0xFFFF) << 16) | ((this.x2 * 65535) & 0xFFFF); // jshint ignore:line
+    this.uvs_uint32[3] = (((this.y3 * 65535) & 0xFFFF) << 16) | ((this.x3 * 65535) & 0xFFFF); // jshint ignore:line
 };

--- a/src/core/textures/TextureUvs.js
+++ b/src/core/textures/TextureUvs.js
@@ -8,7 +8,6 @@
  */
 function TextureUvs()
 {
-    /* jshint -W106 */  // Disable JSHint camel case warnings.
     this.x0 = 0;
     this.y0 = 0;
 

--- a/src/core/utils/maxRecommendedTextures.js
+++ b/src/core/utils/maxRecommendedTextures.js
@@ -15,6 +15,6 @@ var maxRecommendedTextures = function(max)
 		// desktop should be ok
 		return max;
 	}
-}
+};
 
 module.exports = maxRecommendedTextures;

--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -245,8 +245,8 @@ Object.defineProperties(core, {
 
 core.DisplayObject.prototype.generateTexture = function(renderer, scaleMode, resolution)
 {
-    return renderer.generateTexture(renderer, scaleMode, resolution)
     console.warn('generateTexture has moved to the renderer, please use renderer.generateTexture(displayObject)');
+    return renderer.generateTexture(renderer, scaleMode, resolution);
 };
 
 
@@ -254,13 +254,12 @@ core.Graphics.prototype.generateTexture = function(scaleMode, resolution)
 {
     console.warn('graphics generate texture has moved to the renderer. Or to render a graphics to a texture using canvas please use generateCanvasTexture');
 
-    return this.generateCanvasTexture(scaleMode, resolution)
-}
+    return this.generateCanvasTexture(scaleMode, resolution);
+};
 
 core.RenderTexture.prototype.render = function(displayObject)
 {
-    this.legacyRenderer.render(displayObject, this)
-    //displayObject, matrix, clear, updateTransform
+    this.legacyRenderer.render(displayObject, this);
     console.warn('RenderTexture.render is now deprecated, please use renderer.render(displayObject, renderTexture)');
 };
 

--- a/src/extract/canvas/CanvasExtract.js
+++ b/src/extract/canvas/CanvasExtract.js
@@ -1,5 +1,5 @@
 var core = require('../../core');
-tempRect = new core.Rectangle();
+var tempRect = new core.Rectangle();
 
 /**
  * The extract manager provides functionality to export content from the renderers
@@ -28,7 +28,7 @@ WebGLExtract.prototype.image = function ( target )
 	var image = new Image();
     image.src = this.base64( target );
     return image;
-}
+};
 
 /**
  * Will return a a base64 encoded string of this target. It works by calling WebGLExtract.getCanvas and then running toDataURL on that.
@@ -47,7 +47,6 @@ WebGLExtract.prototype.base64 = function ( target )
  */
 WebGLExtract.prototype.canvas = function ( target )
 {
-	var renderer = this.renderer;
 	var context;
 	var resolution;
     var frame;
@@ -100,10 +99,10 @@ WebGLExtract.prototype.canvas = function ( target )
  */
 WebGLExtract.prototype.pixels = function ( renderTexture )
 {
-    var renderer = this.renderer;
     var context;
     var resolution;
-
+    var frame;
+    
     if(renderTexture)
     {
         context = renderTexture.baseTexture._canvasRenderTarget.context;

--- a/src/extract/index.js
+++ b/src/extract/index.js
@@ -1,5 +1,4 @@
-
 module.exports = {
     webGL: require('./webgl/WebGLExtract'),
     canvas: require('./canvas/CanvasExtract')
-}
+};

--- a/src/extract/webgl/WebGLExtract.js
+++ b/src/extract/webgl/WebGLExtract.js
@@ -1,5 +1,5 @@
 var core = require('../../core');
-tempRect = new core.Rectangle();
+var tempRect = new core.Rectangle();
 
 /**
  * The extract manager provides functionality to export content from the renderers
@@ -21,18 +21,18 @@ module.exports = Extract;
  * Will return a HTML Image of the target
  *
  * @return {Image}
- * @param target {PIXI.DisplayObject|PIXI.RenderTexture} A displayObject or renderTexture to convert. If left empty will use use the main renderer 
+ * @param target {PIXI.DisplayObject|PIXI.RenderTexture} A displayObject or renderTexture to convert. If left empty will use use the main renderer
  */
 Extract.prototype.image = function ( target )
 {
 	var image = new Image();
     image.src = this.base64( target );
     return image;
-}
+};
 
 /**
  * Will return a a base64 encoded string of this target. It works by calling WebGLExtract.getCanvas and then running toDataURL on that.
- * @param target {PIXI.DisplayObject|PIXI.RenderTexture} A displayObject or renderTexture to convert. If left empty will use use the main renderer 
+ * @param target {PIXI.DisplayObject|PIXI.RenderTexture} A displayObject or renderTexture to convert. If left empty will use use the main renderer
  * @return {string} A base64 encoded string of the texture.
  */
 Extract.prototype.base64 = function ( target )
@@ -42,7 +42,7 @@ Extract.prototype.base64 = function ( target )
 
 /**
  * Creates a Canvas element, renders this target to it and then returns it.
- * @param target {PIXI.DisplayObject|PIXI.RenderTexture} A displayObject or renderTexture to convert. If left empty will use use the main renderer 
+ * @param target {PIXI.DisplayObject|PIXI.RenderTexture} A displayObject or renderTexture to convert. If left empty will use use the main renderer
  * @return {HTMLCanvasElement} A Canvas element with the texture rendered on.
  */
 Extract.prototype.canvas = function ( target )
@@ -63,7 +63,7 @@ Extract.prototype.canvas = function ( target )
         else
         {
             renderTexture = this.renderer.generateTexture(target);
-            
+
         }
     }
 
@@ -83,16 +83,16 @@ Extract.prototype.canvas = function ( target )
         frame = tempRect;
         frame.width = textureBuffer.size.width;
         frame.height = textureBuffer.size.height;
-        
+
 	}
 
-   
+
 
     var width = frame.width * resolution;
     var height = frame.height * resolution;
 
    	var canvasBuffer = new core.CanvasRenderTarget(width, height);
-    
+
     if(textureBuffer)
     {
         // bind the buffer
@@ -100,7 +100,7 @@ Extract.prototype.canvas = function ( target )
 
         // set up an array of pixels
         var webGLPixels = new Uint8Array(4 * width * height);
- 
+
         // read pixels to the array
         var gl = renderer.gl;
         gl.readPixels(frame.x * resolution, frame.y * resolution, width, height, gl.RGBA, gl.UNSIGNED_BYTE, webGLPixels);
@@ -125,15 +125,16 @@ Extract.prototype.canvas = function ( target )
 
 /**
  * Will return a one-dimensional array containing the pixel data of the entire texture in RGBA order, with integer values between 0 and 255 (included).
- * @param target {PIXI.DisplayObject|PIXI.RenderTexture} A displayObject or renderTexture to convert. If left empty will use use the main renderer 
+ * @param target {PIXI.DisplayObject|PIXI.RenderTexture} A displayObject or renderTexture to convert. If left empty will use use the main renderer
  * @return {Uint8ClampedArray}
  */
-Extract.prototype.pixels = function ( renderTexture, area )
+Extract.prototype.pixels = function ( renderTexture )
 {
     var renderer = this.renderer;
     var textureBuffer;
     var resolution;
-
+    var frame;
+    
     if(renderTexture)
     {
         textureBuffer = renderTexture.baseTexture._glRenderTargets[this.renderer.CONTEXT_UID];
@@ -157,13 +158,13 @@ Extract.prototype.pixels = function ( renderTexture, area )
     var gl = this.renderer.gl;
 
     var webGLPixels = new Uint8Array(4 * width * height);
-    
+
     if(textureBuffer)
     {
         // bind the buffer
         renderer.bindRenderTarget(textureBuffer);
         // read pixels to the array
-        var gl = renderer.gl;
+        gl = renderer.gl;
         gl.readPixels(frame.x * resolution, frame.y * resolution, width, height, gl.RGBA, gl.UNSIGNED_BYTE, webGLPixels);
     }
 

--- a/src/extras/TilingSprite.js
+++ b/src/extras/TilingSprite.js
@@ -2,7 +2,7 @@ var core = require('../core'),
     // a sprite use dfor rendering textures..
     tempPoint = new core.Point(),
     CanvasTinter = require('../core/sprites/canvas/CanvasTinter'),
-    TilingShader = require('./webgl/TilingShader')
+    TilingShader = require('./webgl/TilingShader');
 
 /**
  * A tiling sprite is a fast way of rendering a tiling image
@@ -139,7 +139,7 @@ TilingSprite.prototype._renderWebGL = function (renderer)
         glData = {
             shader:new TilingShader(gl),
             quad:new core.Quad(gl)
-        }
+        };
 
         this._glDatas[renderer.CONTEXT_UID] = glData;
         


### PR DESCRIPTION
This resolves every JSHint error/warning, save for three files. 

There is a function in bezierCurveTo.js that has 9 parameters, and the JSHint settings don't like that one bit. I didn't want to change the signature on my own, if indeed it should be changed at all.

Additionally, TextureUvs.js has a bunch of properties that aren't camel cased. Interestingly, 4 of them don't seem to be used at all and could probably be removed (`this.xy0_uint32` through `this.xy3_uint32`), leaving `this.uvs_uint32` as the only one that would need changed, which would also resolve the issue in SpriteRenderer.js. 

Thoughts?