### PR TITLE
JSDoc for interactiveTarget

### DIFF
--- a/src/core/display/DisplayObject.js
+++ b/src/core/display/DisplayObject.js
@@ -73,13 +73,6 @@ function DisplayObject()
     this.filterArea = null;
 
     /**
-     * Interaction shape. Children will be hit first, then this shape will be checked.
-     *
-     * @member {PIXI.Rectangle|PIXI.Circle|PIXI.Ellipse|PIXI.Polygon|PIXI.RoundedRectangle}
-     */
-    this.hitArea = null;
-
-    /**
      * The original, cached bounds of the object
      *
      * @member {PIXI.Rectangle}

--- a/src/core/display/DisplayObject.js
+++ b/src/core/display/DisplayObject.js
@@ -10,6 +10,7 @@ var math = require('../math'),
  *
  * @class
  * @extends EventEmitter
+ * @mixes PIXI.interaction.interactiveTarget
  * @memberof PIXI
  */
 function DisplayObject()

--- a/src/interaction/interactiveTarget.js
+++ b/src/interaction/interactiveTarget.js
@@ -33,7 +33,7 @@ var interactiveTarget = {
      *
      * @member {PIXI.Rectangle|PIXI.Circle|PIXI.Ellipse|PIXI.Polygon|PIXI.RoundedRectangle}
      */
-    hitArea = null,
+    hitArea: null,
     
     /**
      * If enabled, the mouse cursor will change when hovered over the displayObject if it is interactive 
@@ -81,7 +81,7 @@ var interactiveTarget = {
      * @member {boolean}
      * @private
      */
-    _touchDown: false,
+    _touchDown: false
  };
 
 module.exports = interactiveTarget;

--- a/src/interaction/interactiveTarget.js
+++ b/src/interaction/interactiveTarget.js
@@ -14,34 +14,74 @@
  */
 var interactiveTarget = {
     /**
-     * @todo Needs docs.
+     * Determines if the displayObject be clicked/touched
+     * 
+     * @member {boolean}
      */
     interactive: false,
+    
     /**
-     * @todo Needs docs.
-     */
-    buttonMode: false,
-    /**
-     * @todo Needs docs.
+     * Determines if the children to the displayObject can be clicked/touched
+     * Setting this to false allows pixi to bypass a recursive hitTest function 
+     * 
+     * @member {boolean}
      */
     interactiveChildren: true,
+    
     /**
-     * @todo Needs docs.
+     * Interaction shape. Children will be hit first, then this shape will be checked.
+     *
+     * @member {PIXI.Rectangle|PIXI.Circle|PIXI.Ellipse|PIXI.Polygon|PIXI.RoundedRectangle}
+     */
+    hitArea = null,
+    
+    /**
+     * If enabled, the mouse cursor will change when hovered over the displayObject if it is interactive 
+     *
+     * @member {boolean}
+     */
+    buttonMode: false,
+    
+    /**
+     * If buttonMode is enabled, this defines what CSS cursor property is used when the mouse cursor is hovered over the displayObject
+     * https://developer.mozilla.org/en/docs/Web/CSS/cursor
+     *  
+     * @member {string}
      */
     defaultCursor: 'pointer',
 
     // some internal checks..
-
     /**
-     * @todo Needs docs.
+     * Internal check to detect if the mouse cursor is hovered over the displayObject
+     * 
+     * @member {boolean}
      * @private
      */
     _over: false,
+        
     /**
-     * @todo Needs docs.
+     * Internal check to detect if the left mouse button is pressed on the displayObject
+     * 
+     * @member {boolean}
      * @private
      */
-    _touchDown: false
-};
+    _isLeftDown: false,
+    
+    /**
+     * Internal check to detect if the right mouse button is pressed on the displayObject
+     * 
+     * @member {boolean}
+     * @private
+     */
+    _isRightDown: false,
+    
+    /**
+     * Internal check to detect if a user has touched the displayObject
+     * 
+     * @member {boolean}
+     * @private
+     */
+    _touchDown: false,
+ };
 
 module.exports = interactiveTarget;

--- a/src/interaction/interactiveTarget.js
+++ b/src/interaction/interactiveTarget.js
@@ -1,6 +1,6 @@
 /**
  * Default property values of interactive objects
- * used by {@link PIXI.interaction.InteractionManager}.
+ * Used by {@link PIXI.interaction.InteractionManager} to automatically give all DisplayObjects these properties
  *
  * @mixin
  * @memberof PIXI.interaction
@@ -16,7 +16,7 @@ var interactiveTarget = {
     /**
      * Determines if the displayObject be clicked/touched
      * 
-     * @member {boolean}
+     * @inner {boolean}
      */
     interactive: false,
     
@@ -24,21 +24,21 @@ var interactiveTarget = {
      * Determines if the children to the displayObject can be clicked/touched
      * Setting this to false allows pixi to bypass a recursive hitTest function 
      * 
-     * @member {boolean}
+     * @inner {boolean}
      */
     interactiveChildren: true,
     
     /**
      * Interaction shape. Children will be hit first, then this shape will be checked.
      *
-     * @member {PIXI.Rectangle|PIXI.Circle|PIXI.Ellipse|PIXI.Polygon|PIXI.RoundedRectangle}
+     * @inner {PIXI.Rectangle|PIXI.Circle|PIXI.Ellipse|PIXI.Polygon|PIXI.RoundedRectangle}
      */
     hitArea: null,
     
     /**
      * If enabled, the mouse cursor will change when hovered over the displayObject if it is interactive 
      *
-     * @member {boolean}
+     * @inner {boolean}
      */
     buttonMode: false,
     
@@ -46,7 +46,7 @@ var interactiveTarget = {
      * If buttonMode is enabled, this defines what CSS cursor property is used when the mouse cursor is hovered over the displayObject
      * https://developer.mozilla.org/en/docs/Web/CSS/cursor
      *  
-     * @member {string}
+     * @inner {string}
      */
     defaultCursor: 'pointer',
 
@@ -54,7 +54,7 @@ var interactiveTarget = {
     /**
      * Internal check to detect if the mouse cursor is hovered over the displayObject
      * 
-     * @member {boolean}
+     * @inner {boolean}
      * @private
      */
     _over: false,
@@ -62,7 +62,7 @@ var interactiveTarget = {
     /**
      * Internal check to detect if the left mouse button is pressed on the displayObject
      * 
-     * @member {boolean}
+     * @inner {boolean}
      * @private
      */
     _isLeftDown: false,
@@ -70,7 +70,7 @@ var interactiveTarget = {
     /**
      * Internal check to detect if the right mouse button is pressed on the displayObject
      * 
-     * @member {boolean}
+     * @inner {boolean}
      * @private
      */
     _isRightDown: false,
@@ -78,7 +78,7 @@ var interactiveTarget = {
     /**
      * Internal check to detect if a user has touched the displayObject
      * 
-     * @member {boolean}
+     * @inner {boolean}
      * @private
      */
     _touchDown: false


### PR DESCRIPTION
Added JSDoc typing to the interactiveTarget.js file
Moved hitArea out as a property from DisplayObject, since it's an interactive only property
Allowed JSDoc to now show within the DisplayObject page that there can be the interactiveTarget mixin. Previously there was no way of knowing these properties existed as interactiveTarget wasn't generated anywhere in the documentation at all.

DisplayObject now shows:
![it1](https://cloud.githubusercontent.com/assets/1528426/14410213/adfa5cb6-ff21-11e5-9a99-216747b614a6.jpg)

And clicking on that link takes you to:
![it2](https://cloud.githubusercontent.com/assets/1528426/14410214/adfa88d0-ff21-11e5-9adc-27525c4f2b67.jpg)

