### PR TITLE
glslify & async should be listed in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,11 @@
     "README.md"
   ],
   "dependencies": {
+    "async": "^2.0.0-rc.3",
     "bit-twiddle": "^1.0.2",
     "earcut": "^2.0.7",
     "eventemitter3": "^1.1.1",
+    "glslify": "^5.0.2",
     "ismobilejs": "git+https://github.com/kaimallea/isMobile.git",
     "object-assign": "^4.0.1",
     "pixi-gl-core": "git+https://github.com/GoodBoyDigital/pixi-gl-core.git",
@@ -43,7 +45,6 @@
     "browserify-versionify": "^1.0.6",
     "chai": "^3.2.0",
     "del": "^2.0.2",
-    "glslify": "^5.0.2",
     "gulp": "^3.9.0",
     "gulp-cached": "^1.1.0",
     "gulp-concat": "^2.6.0",


### PR DESCRIPTION
Both **async** and **glslify** are using from within the src and are needed for requiring with Node.

### References

**glslify**
* src/core/renderers/webgl/filters/spriteMask/SpriteMaskFilter.js
* src/core/sprites/webgl/generateMultiTextureShader.js
* src/extras/webgl/TilingShader.js
* src/filters/colormatrix/ColorMatrixFilter.js
* src/filters/displacement/DisplacementFilter.js
* src/filters/godray/GodrayFilter.js
* src/filters/gray/GrayFilter.js
* src/filters/twist/TwistFilter.js

**async**
* src/loaders/spritesheetParser.js