### PR TITLE
Dev

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,3 @@ core.loader = new core.loaders.Loader();
 
 // mixin the deprecation features.
 Object.assign(core, require('./deprecation'));
-
-// Always export pixi globally.
-global.PIXI = core;

--- a/src/index.js
+++ b/src/index.js
@@ -24,4 +24,4 @@ core.extract  		= require('./extract');
 core.loader = new core.loaders.Loader();
 
 // mixin the deprecation features.
-Object.assign(core, require('./deprecation'));
+require('./deprecation');


### PR DESCRIPTION
Not sure if there was a reason why Pixi needed to spill to global, the browserify standalone UMD handles this nicely, is there a separate reason?

Also killed the unnecessary, and potentially harmful, assignment in there. Deprecation monkey patches core rather than exporting an object to patch over so the `Object.assign` is just waiting for someone to export something stupid from `deprecation.js` and bring the whole house down.