### PR TITLE
Workaround for Atom's unsafe-eval error in pixi-gl-core

### DIFF
--- a/gulp/util/bundle.js
+++ b/gulp/util/bundle.js
@@ -62,6 +62,7 @@ function createBundler(args) {
     args = args || {};
     args.debug = false;
     args.standalone = 'PIXI';
+    args.builtins = ['_process'];
 
     var bundle = browserify(paths.jsEntry, args),
         argv = require('minimist')(process.argv.slice(2)),

--- a/gulp/util/bundle.js
+++ b/gulp/util/bundle.js
@@ -62,7 +62,7 @@ function createBundler(args) {
     args = args || {};
     args.debug = false;
     args.standalone = 'PIXI';
-    args.builtins = ['_process', 'fs', 'path'];
+    args.builtins = ['_process', 'fs', 'path', 'url'];
 
     var bundle = browserify(paths.jsEntry, args),
         argv = require('minimist')(process.argv.slice(2)),

--- a/gulp/util/bundle.js
+++ b/gulp/util/bundle.js
@@ -62,7 +62,14 @@ function createBundler(args) {
     args = args || {};
     args.debug = false;
     args.standalone = 'PIXI';
-    args.builtins = ['_process', 'fs', 'path', 'url'];
+    args.builtins = [
+        '_process',
+        'fs',
+        'path',
+        'url',
+        'punycode',
+        'querystring'
+    ];
 
     var bundle = browserify(paths.jsEntry, args),
         argv = require('minimist')(process.argv.slice(2)),

--- a/gulp/util/bundle.js
+++ b/gulp/util/bundle.js
@@ -62,7 +62,7 @@ function createBundler(args) {
     args = args || {};
     args.debug = false;
     args.standalone = 'PIXI';
-    args.builtins = ['_process'];
+    args.builtins = ['_process', 'fs', 'path'];
 
     var bundle = browserify(paths.jsEntry, args),
         argv = require('minimist')(process.argv.slice(2)),


### PR DESCRIPTION
_**NOTE:** The [PR found here](https://github.com/pixijs/pixi-gl-core/pull/6) to **pixi-gl-core** needs to be considered first before this change can be merged._

### Overview

This explicitly states which of Browserify's builtins polyfills to use. The advantage is that it _does not_ include the `vm` polyfill, which makes it easier to workaround the unsafe-eval error in Atom by attempting to require `vm` and then falling-back to use `new Function` instead. 