### PR TITLE
Text: automatically call updateText on setters for width and height

### DIFF
--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -98,6 +98,8 @@ Object.defineProperties(Text.prototype, {
         },
         set: function (value)
         {
+            this.updateText(true);
+
             this.scale.x = value / this._texture._frame.width;
             this._width = value;
         }
@@ -118,6 +120,8 @@ Object.defineProperties(Text.prototype, {
         },
         set: function (value)
         {
+            this.updateText(true);
+
             this.scale.y = value / this._texture._frame.height;
             this._height = value;
         }


### PR DESCRIPTION
Getters for width and height already do this.

Fixes problems such as https://github.com/pixijs/pixi.js/issues/2505 and https://github.com/pixijs/pixi.js/issues/2376