### PR TITLE
Add anchor to BitmapText

### DIFF
--- a/src/core/display/ObservablePoint.js
+++ b/src/core/display/ObservablePoint.js
@@ -1,11 +1,12 @@
 /**
+ * The Point object represents a location in a two-dimensional coordinate system, where x represents
+ * the horizontal axis and y represents the vertical axis.
  * An observable point is a point that triggers a callback when the point's position is changed.
  *
  * @class
  * @memberof PIXI
- *
- * @param cb {function} The function to be called when the point changes
- * @param scope {*} The scope to be applied to the cb
+ * @param cb {Function} callback when changed
+ * @param scope {Object} owner of callback
  * @param [x=0] {number} position of the point on the x axis
  * @param [y=0] {number} position of the point on the y axis
  */
@@ -37,8 +38,10 @@ Object.defineProperties(ObservablePoint.prototype, {
         },
         set: function (value)
         {
-            this._x = value;
-            this.cb.call(this.scope);
+            if (this._x !== value) {
+                this._x = value;
+                this.cb.call(this.scope);
+            }
         }
     },
     /**
@@ -54,8 +57,10 @@ Object.defineProperties(ObservablePoint.prototype, {
         },
         set: function (value)
         {
-            this._y = value;
-            this.cb.call(this.scope);
+            if (this._y !== value) {
+                this._y = value;
+                this.cb.call(this.scope);
+            }
         }
     }
 });
@@ -69,8 +74,27 @@ Object.defineProperties(ObservablePoint.prototype, {
  */
 ObservablePoint.prototype.set = function (x, y)
 {
-    this._x = x || 0;
-    this._y = y || ( (y !== 0) ? this._x : 0 );
+    var _x = x || 0;
+    var _y = y || ( (y !== 0) ? _x : 0 );
+    if (this._x !== _x || this._y !== _y)
+    {
+        this._x = _x;
+        this._y = _y;
+        this.cb.call(this.scope);
+    }
+};
 
-    this.transform._versionLocal++; // TODO: Pretty sure this doesn't exist.
+/**
+ * Copies the data from another point
+ *
+ * @param point {PIXI.Point|{PIXI.ObservablePoint} point to copy from
+ */
+ObservablePoint.prototype.copy = function (point)
+{
+    if (this._x !== point.x || this._y !== point.y)
+    {
+        this._x = point.x;
+        this._y = point.y;
+        this.cb.call(this.scope);
+    }
 };

--- a/src/extras/BitmapText.js
+++ b/src/extras/BitmapText.js
@@ -1,4 +1,5 @@
-var core = require('../core');
+var core = require('../core'),
+    math = require('../core/math');
 
 /**
  * A BitmapText object will create a line or multiple lines of text using bitmap font. To
@@ -103,6 +104,24 @@ function BitmapText(text, style)
      * @member {number}
      */
     this.maxLineHeight = 0;
+
+    /**
+     * The anchor sets the origin point of the text.
+     * The default is 0,0 this means the text's origin is the top left
+     * Setting the anchor to 0.5,0.5 means the text's origin is centered
+     * Setting the anchor to 1,1 would mean the text's origin point will be the bottom right corner
+     *
+     * @member {PIXI.Point}
+     */
+    this.anchor = new math.Point();
+
+    /**
+     * Private tracker for the anchor. This allows us to check whether there has been a change
+     *
+     * @member {PIXI.Point}
+     * @private
+     */
+    this._anchor = this.anchor.clone();
 
     /**
      * The dirty state of this object.
@@ -343,6 +362,16 @@ BitmapText.prototype.updateText = function ()
 
     this.textWidth = maxLineWidth * scale;
     this.textHeight = (pos.y + data.lineHeight) * scale;
+
+    // apply anchor
+    if (this.anchor.x !== 0 || this.anchor.y !== 0)
+    {
+        for (i = 0; i < lenChars; i++)
+        {
+            this._glyphs[i].x -= this.textWidth * this.anchor.x;
+            this._glyphs[i].y -= this.textHeight * this.anchor.y;
+        }
+    }
     this.maxLineHeight = maxLineHeight * scale;
 };
 
@@ -376,6 +405,13 @@ BitmapText.prototype.getLocalBounds = function()
  */
 BitmapText.prototype.validate = function()
 {
+    // Detect whether the anchor has been updated
+    if (!this.anchor.equals(this._anchor))
+    {
+        this.dirty = true;
+        this._anchor.copy(this.anchor);
+    }
+
     if (this.dirty)
     {
         this.updateText();

--- a/src/extras/BitmapText.js
+++ b/src/extras/BitmapText.js
@@ -1,5 +1,5 @@
 var core = require('../core'),
-    math = require('../core/math');
+    ObservablePoint = require('../core/display/ObservablePoint');
 
 /**
  * A BitmapText object will create a line or multiple lines of text using bitmap font. To
@@ -106,22 +106,12 @@ function BitmapText(text, style)
     this.maxLineHeight = 0;
 
     /**
-     * The anchor sets the origin point of the text.
-     * The default is 0,0 this means the text's origin is the top left
-     * Setting the anchor to 0.5,0.5 means the text's origin is centered
-     * Setting the anchor to 1,1 would mean the text's origin point will be the bottom right corner
-     *
-     * @member {PIXI.Point}
-     */
-    this.anchor = new math.Point();
-
-    /**
-     * Private tracker for the anchor. This allows us to check whether there has been a change
+     * Text anchor. read-only
      *
      * @member {PIXI.Point}
      * @private
      */
-    this._anchor = this.anchor.clone();
+    this._anchor = new ObservablePoint(this.makeDirty, this, 0, 0);
 
     /**
      * The dirty state of this object.
@@ -175,6 +165,28 @@ Object.defineProperties(BitmapText.prototype, {
             this._font.align = value || 'left';
 
             this.dirty = true;
+        }
+    },
+
+    /**
+     * The anchor sets the origin point of the text.
+     * The default is 0,0 this means the text's origin is the top left
+     * Setting the anchor to 0.5,0.5 means the text's origin is centered
+     * Setting the anchor to 1,1 would mean the text's origin point will be the bottom right corner
+     *
+     * @member {PIXI.Point | number}
+     */
+    anchor: {
+        get : function() {
+            return this._anchor;
+        },
+        set: function(value) {
+            if (typeof value === 'number'){
+                 this._anchor.set(value);
+            }
+            else {
+                this._anchor.copy(value);
+            }
         }
     },
 
@@ -405,18 +417,15 @@ BitmapText.prototype.getLocalBounds = function()
  */
 BitmapText.prototype.validate = function()
 {
-    // Detect whether the anchor has been updated
-    if (!this.anchor.equals(this._anchor))
-    {
-        this.dirty = true;
-        this._anchor.copy(this.anchor);
-    }
-
     if (this.dirty)
     {
         this.updateText();
         this.dirty = false;
     }
+};
+
+BitmapText.prototype.makeDirty = function() {
+    this.dirty = true;
 };
 
 BitmapText.fonts = {};


### PR DESCRIPTION
Fixes #1769 

```BitmapText``` (unlike ```Text```) is inheriting from ```Container``` rather than ```Sprite``` and therefore ```BitmapText.anchor``` does currently not exist. This is slightly confusing and makes aligning BitmapTexts harder than it needs to be. There are workarounds to add centring behaviour (see #1769), but they all rely on manually changing the position. 

This PR adds an ```anchor``` to ```BitmapText``` that behaves similar to ```anchor``` for ```Text```. 

Since every anchor is a ```PIXI.Point``` we can't just use a getter/setter to set ```dirty``` but instead have to regularly compare ```anchor``` against a private copy. I would have rather avoided this, but it's the only solution that I can currently see to detect those changes. Suggestions welcome!

### Performance considerations

In case of ```anchor``` being left at (0, 0) the only costs is a ```PIXI.Point.equals``` every frame to check whether it has changed.  It's a relatively cheap check, so I hope it's not going to be a problem.

If ```anchor``` is set to anything else then there's an additional loop over every glyph during ```#updateText```.

### Backwards compatibility

Unless someone has set (the currently ineffective) ```anchor``` property this change is backwards compatible.