### PR TITLE
Container destruction API unification

### DIFF
--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -606,17 +606,22 @@ Container.prototype.renderCanvas = function (renderer)
 
 /**
  * Destroys the container
- * @param [destroyChildren=false] {boolean} if set to true, all the children will have their destroy method called as well
+ * @param [options] {object} Options parameter
+ * @param [options.children=false] {boolean} if set to true, all the children will have their destroy
+ *      method called as well. 'options' will be passed on to those calls.
+ *
  */
-Container.prototype.destroy = function (destroyChildren)
+Container.prototype.destroy = function (options)
 {
+    options = options || {};
+
     DisplayObject.prototype.destroy.call(this);
 
-    if (destroyChildren)
+    if (options.children)
     {
         for (var i = 0, j = this.children.length; i < j; ++i)
         {
-            this.children[i].destroy(destroyChildren);
+            this.children[i].destroy(options);
         }
     }
 

--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -606,18 +606,16 @@ Container.prototype.renderCanvas = function (renderer)
 
 /**
  * Destroys the container
- * @param [options] {object} Options parameter
+ * @param [options] {object|boolean} Options parameter. A boolean will act as if all options have been set to that value
  * @param [options.children=false] {boolean} if set to true, all the children will have their destroy
  *      method called as well. 'options' will be passed on to those calls.
- *
  */
 Container.prototype.destroy = function (options)
 {
-    options = options || {};
-
     DisplayObject.prototype.destroy.call(this);
 
-    if (options.children)
+    var destroyChildren = typeof options === 'boolean' ? options : options && options.children;
+    if (destroyChildren)
     {
         for (var i = 0, j = this.children.length; i < j; ++i)
         {

--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -407,20 +407,25 @@ Sprite.prototype.containsPoint = function( point )
 
 
 /**
- * Destroys this sprite and optionally its texture
+ * Destroys this sprite and optionally its texture and children
  *
- * @param [destroyTexture=false] {boolean} Should it destroy the current texture of the sprite as well
- * @param [destroyBaseTexture=false] {boolean} Should it destroy the base texture of the sprite as well
+ * @param [options] {object} Options parameter
+ * @param [options.children=false] {boolean} if set to true, all the children will have their destroy
+ *      method called as well. 'options' will be passed on to those calls.
+ * @param [options.texture=false] {boolean} Should it destroy the current texture of the sprite as well
+ * @param [options.baseTexture=false] {boolean} Should it destroy the base texture of the sprite as well
  */
-Sprite.prototype.destroy = function (destroyTexture, destroyBaseTexture)
+Sprite.prototype.destroy = function (options)
 {
-    Container.prototype.destroy.call(this);
+    options = options || {};
+
+    Container.prototype.destroy.call(this, options);
 
     this.anchor = null;
 
-    if (destroyTexture)
+    if (options.texture)
     {
-        this._texture.destroy(destroyBaseTexture);
+        this._texture.destroy(!!options.baseTexture);
     }
 
     this._texture = null;

--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -409,7 +409,7 @@ Sprite.prototype.containsPoint = function( point )
 /**
  * Destroys this sprite and optionally its texture and children
  *
- * @param [options] {object} Options parameter
+ * @param [options] {object|boolean} Options parameter. A boolean will act as if all options have been set to that value
  * @param [options.children=false] {boolean} if set to true, all the children will have their destroy
  *      method called as well. 'options' will be passed on to those calls.
  * @param [options.texture=false] {boolean} Should it destroy the current texture of the sprite as well
@@ -417,15 +417,15 @@ Sprite.prototype.containsPoint = function( point )
  */
 Sprite.prototype.destroy = function (options)
 {
-    options = options || {};
-
     Container.prototype.destroy.call(this, options);
 
     this.anchor = null;
 
-    if (options.texture)
+    var destroyTexture = typeof options === 'boolean' ? options : options && options.texture;
+    if (destroyTexture)
     {
-        this._texture.destroy(!!options.baseTexture);
+        var destroyBaseTexture = typeof options === 'boolean' ? options : options && options.baseTexture;
+        this._texture.destroy(!!destroyBaseTexture);
     }
 
     this._texture = null;

--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -637,18 +637,22 @@ Text.prototype._onStyleChange = function ()
 };
 
 /**
- * Destroys this text object.
+ * Destroys this text
  *
- * @param [destroyBaseTexture=true] {boolean} whether to destroy the base texture as well
+ * @param [options] {object} Options parameter
+ * @param [options.children=false] {boolean} if set to true, all the children will have their destroy
+ *      method called as well. 'options' will be passed on to those calls.
+ * @param [options.texture=false] {boolean} Should it destroy the current texture of the sprite as well
+ * @param [options.baseTexture=false] {boolean} Should it destroy the base texture of the sprite as well
  */
-Text.prototype.destroy = function (destroyBaseTexture)
+Text.prototype.destroy = function (options)
 {
+    Sprite.prototype.destroy.call(this, options);
+
     // make sure to reset the the context and canvas.. dont want this hanging around in memory!
     this.context = null;
     this.canvas = null;
 
     this._style.off(CONST.TEXT_STYLE_CHANGED, this._onStyleChange, this);
     this._style = null;
-
-    this._texture.destroy(destroyBaseTexture === undefined ? true : destroyBaseTexture);
 };

--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -639,7 +639,7 @@ Text.prototype._onStyleChange = function ()
 /**
  * Destroys this text
  *
- * @param [options] {object} Options parameter
+ * @param [options] {object|boolean} Options parameter. A boolean will act as if all options have been set to that value
  * @param [options.children=false] {boolean} if set to true, all the children will have their destroy
  *      method called as well. 'options' will be passed on to those calls.
  * @param [options.texture=false] {boolean} Should it destroy the current texture of the sprite as well

--- a/test/unit/core/display/Container.test.js
+++ b/test/unit/core/display/Container.test.js
@@ -39,4 +39,56 @@ describe('PIXI.Container', function () {
         });
 
     });
+
+    describe('destroy', function () {
+        it('should call through to DisplayContainer.destroy', function () {
+            var container = new PIXI.Container();
+
+            expect(container.position).to.not.equal(null);
+            container.destroy();
+            expect(container.position).to.equal(null);
+        });
+
+        it('should set children to null', function () {
+            var container = new PIXI.Container();
+
+            expect(container.children).to.deep.equal([]);
+            container.destroy();
+            expect(container.children).to.equal(null);
+        });
+
+        it('should by default not destroy children', function () {
+            var container = new PIXI.Container(),
+                child = new PIXI.DisplayObject();
+
+            container.addChild(child);
+            container.destroy();
+            expect(container.position).to.equal(null);
+            expect(child.position).to.not.equal(null);
+        });
+
+        it('should destroy children if children flag is set', function () {
+            var container = new PIXI.Container(),
+                child = new PIXI.DisplayObject();
+
+            container.addChild(child);
+            container.destroy({children: true});
+            expect(container.position).to.equal(null);
+            expect(child.position).to.equal(null);
+        });
+
+        it('should pass opts on to children if children flag is set', function () {
+            var container = new PIXI.Container(),
+                child = new PIXI.DisplayObject(),
+                childDestroyOpts;
+
+            child.destroy = function(opts) {
+                childDestroyOpts = opts;
+            };
+
+            container.addChild(child);
+            container.destroy({children: true, texture: true});
+            expect(childDestroyOpts).to.deep.equal({children: true, texture: true});
+        });
+    });
 });

--- a/test/unit/core/display/Container.test.js
+++ b/test/unit/core/display/Container.test.js
@@ -90,5 +90,19 @@ describe('PIXI.Container', function () {
             container.destroy({children: true, texture: true});
             expect(childDestroyOpts).to.deep.equal({children: true, texture: true});
         });
+
+        it('should accept boolean and pass it on to children', function () {
+            var container = new PIXI.Container(),
+                child = new PIXI.DisplayObject(),
+                childDestroyOpts;
+
+            child.destroy = function(opts) {
+                childDestroyOpts = opts;
+            };
+
+            container.addChild(child);
+            container.destroy(true);
+            expect(childDestroyOpts).to.deep.equal(true);
+        });
     });
 });

--- a/test/unit/core/sprites/Sprite.test.js
+++ b/test/unit/core/sprites/Sprite.test.js
@@ -52,4 +52,78 @@ describe('PIXI.Sprite', function () {
             expect(sprite.scale.y).to.be.below(0);
         });
     });
+
+    describe('destroy', function () {
+        it('should call through to Container.destroy', function () {
+            var sprite = new PIXI.Sprite();
+
+            expect(sprite.children).to.not.equal(null);
+            sprite.destroy();
+            expect(sprite.children).to.equal(null);
+        });
+
+        it('should set anchor and texture to null', function () {
+            var sprite = new PIXI.Sprite();
+
+            expect(sprite.anchor).to.not.equal(null);
+            expect(sprite.texture).to.not.equal(null);
+            sprite.destroy();
+            expect(sprite.anchor).to.equal(null);
+            expect(sprite.texture).to.equal(null);
+        });
+
+        it('by default should not destroy texture', function () {
+            var sprite = new PIXI.Sprite();
+            var textureDestroyed = false;
+
+            sprite.texture.destroy = function() { textureDestroyed = true; };
+
+            sprite.destroy();
+            expect(textureDestroyed).to.equal(false);
+        });
+
+        it('should destroy texture when texture flag is set', function () {
+            var sprite = new PIXI.Sprite();
+            var textureDestroyed = false;
+
+            sprite.texture.destroy = function() { textureDestroyed = true; };
+
+            sprite.destroy({texture: true});
+            expect(textureDestroyed).to.equal(true);
+        });
+
+        it('by default should not destroy baseTexture', function () {
+            var sprite = new PIXI.Sprite();
+            var textureDestroyArg;
+
+            sprite.texture.destroy = function(arg) { textureDestroyArg = arg; };
+
+            sprite.destroy({texture: true});
+            expect(textureDestroyArg).to.equal(false);
+        });
+
+        it('should destroy baseTexture if baseTexture flag is set', function () {
+            var sprite = new PIXI.Sprite();
+            var textureDestroyArg;
+
+            sprite.texture.destroy = function(arg) { textureDestroyArg = arg; };
+
+            sprite.destroy({texture: true, baseTexture: true});
+            expect(textureDestroyArg).to.equal(true);
+        });
+
+        it('should pass opts on to children if children flag is set', function () {
+            var sprite = new PIXI.Sprite(),
+                child = new PIXI.DisplayObject(),
+                childDestroyOpts;
+
+            child.destroy = function(opts) {
+                childDestroyOpts = opts;
+            };
+
+            sprite.addChild(child);
+            sprite.destroy({children: true, texture: true});
+            expect(childDestroyOpts).to.deep.equal({children: true, texture: true});
+        });
+    });
 });

--- a/test/unit/core/sprites/Sprite.test.js
+++ b/test/unit/core/sprites/Sprite.test.js
@@ -112,6 +112,16 @@ describe('PIXI.Sprite', function () {
             expect(textureDestroyArg).to.equal(true);
         });
 
+        it('should correctly handle boolean', function () {
+            var sprite = new PIXI.Sprite();
+            var textureDestroyArg;
+
+            sprite.texture.destroy = function(arg) { textureDestroyArg = arg; };
+
+            sprite.destroy(true);
+            expect(textureDestroyArg).to.equal(true);
+        });
+
         it('should pass opts on to children if children flag is set', function () {
             var sprite = new PIXI.Sprite(),
                 child = new PIXI.DisplayObject(),
@@ -124,6 +134,20 @@ describe('PIXI.Sprite', function () {
             sprite.addChild(child);
             sprite.destroy({children: true, texture: true});
             expect(childDestroyOpts).to.deep.equal({children: true, texture: true});
+        });
+
+        it('should pass bool on to children', function () {
+            var sprite = new PIXI.Sprite(),
+                child = new PIXI.DisplayObject(),
+                childDestroyOpts;
+
+            child.destroy = function(opts) {
+                childDestroyOpts = opts;
+            };
+
+            sprite.addChild(child);
+            sprite.destroy(true);
+            expect(childDestroyOpts).to.deep.equal(true);
         });
     });
 });

--- a/test/unit/core/text/Text.test.js
+++ b/test/unit/core/text/Text.test.js
@@ -1,0 +1,43 @@
+describe('PIXI.Text', function () {
+    describe('destroy', function () {
+        it('should call through to Sprite.destroy', function () {
+            var text = new PIXI.Text("foo");
+
+            expect(text.anchor).to.not.equal(null);
+            text.destroy();
+            expect(text.anchor).to.equal(null);
+        });
+
+        it('should set context to null', function () {
+            var text = new PIXI.Text("foo");
+
+            expect(text.style).to.not.equal(null);
+            text.destroy();
+            expect(text.style).to.equal(null);
+        });
+
+        it('should destroy children if children flag is set', function () {
+            var text = new PIXI.Text("foo"),
+                child = new PIXI.DisplayObject();
+
+            text.addChild(child);
+            text.destroy({children: true});
+            expect(text.position).to.equal(null);
+            expect(child.position).to.equal(null);
+        });
+
+        it('should pass opts on to children if children flag is set', function () {
+            var text = new PIXI.Text("foo"),
+                child = new PIXI.DisplayObject(),
+                childDestroyOpts;
+
+            child.destroy = function(opts) {
+                childDestroyOpts = opts;
+            };
+
+            text.addChild(child);
+            text.destroy({children: true, texture: true});
+            expect(childDestroyOpts).to.deep.equal({children: true, texture: true});
+        });
+    });
+});

--- a/test/unit/core/text/Text.test.js
+++ b/test/unit/core/text/Text.test.js
@@ -26,6 +26,16 @@ describe('PIXI.Text', function () {
             expect(child.position).to.equal(null);
         });
 
+        it('should accept boolean correctly', function () {
+            var text = new PIXI.Text("foo"),
+                child = new PIXI.DisplayObject();
+
+            text.addChild(child);
+            text.destroy(true);
+            expect(text.position).to.equal(null);
+            expect(child.position).to.equal(null);
+        });
+
         it('should pass opts on to children if children flag is set', function () {
             var text = new PIXI.Text("foo"),
                 child = new PIXI.DisplayObject(),


### PR DESCRIPTION
Based on #2536 

This is a breaking change for V4, the signature for ```Container.destroy()```. ```Sprite.destroy()``` and ```Text.destroy()``` will now only accept an optional object with the following fields. Passing a bool in (v3 behaviour) will cause an error to be thrown.

```javascript
var container = new Container();
container.destroy({children: true, texture: true, baseTexture: true});
```

All parameters default to ```false``` and will be passed on in case of ```children == true```.

As an aside, since I couldn't find anything: Is there a changelog or some sort of update instructions where breaking changes are outlined?