### PR TITLE
Converts git+https dependencies to releases, fixes pixi-gl-core usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "glslify": "^5.0.2",
     "ismobilejs": "^0.4.0",
     "object-assign": "^4.0.1",
-    "pixi-gl-core": "^1.0.1",
+    "pixi-gl-core": "^1.0.2",
     "resource-loader": "^1.6.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "earcut": "^2.0.7",
     "eventemitter3": "^1.1.1",
     "glslify": "^5.0.2",
-    "ismobilejs": "git+https://github.com/kaimallea/isMobile.git",
+    "ismobilejs": "^0.4.0",
     "object-assign": "^4.0.1",
-    "pixi-gl-core": "git+https://github.com/GoodBoyDigital/pixi-gl-core.git",
+    "pixi-gl-core": "^1.0.1",
     "resource-loader": "^1.6.4"
   },
   "devDependencies": {
@@ -57,7 +57,7 @@
     "gulp-sourcemaps": "^1.5.2",
     "gulp-uglify": "^1.5.1",
     "gulp-util": "^3.0.6",
-    "jaguarjs-jsdoc": "git+https://github.com/davidshimjs/jaguarjs-jsdoc.git",
+    "jaguarjs-jsdoc": "^0.0.1",
     "jsdoc": "^3.4.0",
     "jshint": "^2.9.1",
     "jshint-summary": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "gulp-sourcemaps": "^1.5.2",
     "gulp-uglify": "^1.5.1",
     "gulp-util": "^3.0.6",
-    "jaguarjs-jsdoc": "^0.0.1",
+    "jaguarjs-jsdoc": "git+https://github.com/davidshimjs/jaguarjs-jsdoc.git",
     "jsdoc": "^3.4.0",
     "jshint": "^2.9.1",
     "jshint-summary": "^0.4.0",

--- a/src/core/renderers/webgl/filters/extractUniformsFromSrc.js
+++ b/src/core/renderers/webgl/filters/extractUniformsFromSrc.js
@@ -1,5 +1,5 @@
-var defaultValue = require('pixi-gl-core/lib/shader/defaultValue');
-var mapSize = require('pixi-gl-core/lib/shader/mapSize');
+var defaultValue = require('pixi-gl-core').shader.defaultValue;
+var mapSize = require('pixi-gl-core').shader.mapSize;
 
 function extractUniformsFromSrc(vertexSrc, fragmentSrc, mask)
 {


### PR DESCRIPTION
### Overview

* Updates package.json dependencies to pull from NPM releases instead of git+https.
* Updated **pixi-gl-core** implementation to match the latest publish release.