### PR TITLE
Fix jaguarjs-jsdoc dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "gulp-sourcemaps": "^1.5.2",
     "gulp-uglify": "^1.5.1",
     "gulp-util": "^3.0.6",
-    "jaguarjs-jsdoc": "git+https://github.com/davidshimjs/jaguarjs-jsdoc.git",
+    "jaguarjs-jsdoc": "^1.0.0",
     "jsdoc": "^3.4.0",
     "jshint": "^2.9.1",
     "jshint-summary": "^0.4.0",


### PR DESCRIPTION
Follow-up to #2607 cc: @englercj & @themoonrat

I forked **jaguarjs-jsdoc** here: https://github.com/pixijs/jaguarjs-jsdoc

Also, I emailed with original NPM publisher and got added as an owner: https://www.npmjs.com/package/jaguarjs-jsdoc

I then published version 1.0.0 of the template. 