### PR TITLE
Fixed a typo in core/const.js

### DIFF
--- a/src/core/const.js
+++ b/src/core/const.js
@@ -187,8 +187,6 @@ var CONST = {
      * If set to DEFAULT, the renderer will occasianally check textures usage. If they are not used for a specified period of time they will be removed from the GPU.
      * They will of corse be uploaded again when they are required. This is a silent behind the scenes process that should ensure that the GPU does not  get filled up.
      * Handy for mobile devices!
-     * This property only affects WebGL
-     * Handy for mobile devices!
      * This property only affects WebGL.
      *
      * @static


### PR DESCRIPTION
```
* Handy for mobile devices!
* This property only affects WebGL.
```

The comment was repeated twice.