### PR TITLE
Fixes JSDoc not running to completion

### DIFF
--- a/src/accessibility/AccessibilityManager.js
+++ b/src/accessibility/AccessibilityManager.js
@@ -75,7 +75,7 @@ function AccessibilityManager(renderer)
    	/**
      * The array of currently active accessible items.
      *
-     * @member {*[]}
+     * @member {Array<*>}
      * @private
      */
    	this.children = [];
@@ -89,7 +89,7 @@ function AccessibilityManager(renderer)
    	/**
      * stores the state of the manager. If there are no accessible objects or the mouse is moving the will be false.
      *
-     * @member {*[]}
+     * @member {Array<*>}
      * @private
      */
    	this.isActive = false;

--- a/src/core/renderers/webgl/TextureManager.js
+++ b/src/core/renderers/webgl/TextureManager.js
@@ -29,7 +29,7 @@ var TextureManager = function(renderer)
 	/**
      * Track textures in the renderer so we can no longer listen to them on destruction.
      *
-     * @member {*[]}
+     * @member {Array<*>}
      * @private
      */
 	this._managedTextures = [];

--- a/src/core/renderers/webgl/WebGLState.js
+++ b/src/core/renderers/webgl/WebGLState.js
@@ -35,7 +35,7 @@ var WebGLState = function(gl)
     /**
      * The stack holding all the different states
      *
-     * @member {*[]}
+     * @member {Array<*>}
      * @private
      */
 	this.stack = [];

--- a/src/core/renderers/webgl/managers/MaskManager.js
+++ b/src/core/renderers/webgl/managers/MaskManager.js
@@ -29,7 +29,7 @@ module.exports = MaskManager;
  * Applies the Mask and adds it to the current filter stack.
  *
  * @param target {PIXI.DisplayObject}
- * @param maskData {*[]}
+ * @param maskData {Array<*>}
  */
 MaskManager.prototype.pushMask = function (target, maskData)
 {
@@ -68,7 +68,7 @@ MaskManager.prototype.pushMask = function (target, maskData)
  * Removes the last mask from the mask stack and doesn't return it.
  *
  * @param target {PIXI.DisplayObject}
- * @param maskData {*[]}
+ * @param maskData {Array<*>}
  */
 MaskManager.prototype.popMask = function (target, maskData)
 {
@@ -129,7 +129,7 @@ MaskManager.prototype.popSpriteMask = function ()
 /**
  * Applies the Mask and adds it to the current filter stack.
  *
- * @param maskData {*[]}
+ * @param maskData {Array<*>}
  */
 MaskManager.prototype.pushStencilMask = function (maskData)
 {

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -177,7 +177,7 @@ var utils = module.exports = {
     /**
      * removeItems
      *
-     * @param {*[]} arr The target array
+     * @param {Array<*>} arr The target array
      * @param {number} startIdx The index to begin removing from (inclusive)
      * @param {number} removeCount How many items to remove
      */


### PR DESCRIPTION
The *[] syntax to describe a member that is an array of any type throws errors when trying to generate the docs.

I've changed this to a similar meaning Array<*> which it is happy with