### PR TITLE
Adds missing destroy to Prepare, supports multiple simultaneous uploads

### DIFF
--- a/src/prepare/canvas/CanvasPrepare.js
+++ b/src/prepare/canvas/CanvasPrepare.js
@@ -46,4 +46,13 @@ Prepare.prototype.add = function()
     return this;
 };
 
+/**
+ * Stub method for destroying plugin.
+ * @method destroy
+ */
+Prepare.prototype.destroy = function()
+{
+
+};
+
 core.CanvasRenderer.registerPlugin('prepare', Prepare);

--- a/src/prepare/webgl/WebGLPrepare.js
+++ b/src/prepare/webgl/WebGLPrepare.js
@@ -44,6 +44,13 @@ function Prepare(renderer)
      */
     this.completes = [];
 
+    /**
+     * If prepare is ticking (running).
+     * @type {Boolean}
+     * @private
+     */
+    this.ticking = false;
+
     // Add textures and graphics to upload
     this.register(findBaseTextures, uploadBaseTextures)
         .register(findGraphics, uploadGraphics);


### PR DESCRIPTION
Was crashing when trying to destroy renderer because plugin had not destroy method. 
Also, adds support for multiple simultaneous uploads (calling upload twice in a row).