### PR TITLE
Stopping Ticker from being able to return a negative delta time

### DIFF
--- a/src/core/ticker/Ticker.js
+++ b/src/core/ticker/Ticker.js
@@ -332,7 +332,7 @@ Ticker.prototype.update = function update(currentTime)
     // Allow calling update directly with default currentTime.
     currentTime = currentTime || performance.now();
     // Save uncapped elapsedMS for measurement
-    Math.max(0, elapsedMS = this.elapsedMS = currentTime - this.lastTime);
+    elapsedMS = this.elapsedMS = Math.max(0, currentTime - this.lastTime);
 
     // cap the milliseconds elapsed used for deltaTime
     if (elapsedMS > this._maxElapsedMS)


### PR DESCRIPTION
As noted by @drkibitz - my PR to stop negative delta times contained a glaring assignment error. Sorry all.