### PR TITLE
Fixes loading bitmap fonts from data URIs (both FNT and Image)

### DIFF
--- a/src/loaders/bitmapFontParser.js
+++ b/src/loaders/bitmapFontParser.js
@@ -80,25 +80,27 @@ module.exports = function ()
             return next();
         }
 
-        var xmlUrl = path.dirname(resource.url);
+        var xmlUrl = !resource.isDataUrl ? path.dirname(resource.url) : '';
 
-        if (xmlUrl === '.') {
-            xmlUrl = '';
-        }
-
-        if (this.baseUrl && xmlUrl) {
-            // if baseurl has a trailing slash then add one to xmlUrl so the replace works below
-            if (this.baseUrl.charAt(this.baseUrl.length - 1) === '/') {
-                xmlUrl += '/';
+        if (resource.isDataUrl) {
+            if (xmlUrl === '.') {
+                xmlUrl = '';
             }
 
-            // remove baseUrl from xmlUrl
-            xmlUrl = xmlUrl.replace(this.baseUrl, '');
-        }
+            if (this.baseUrl && xmlUrl) {
+                // if baseurl has a trailing slash then add one to xmlUrl so the replace works below
+                if (this.baseUrl.charAt(this.baseUrl.length - 1) === '/') {
+                    xmlUrl += '/';
+                }
 
-        // if there is an xmlUrl now, it needs a trailing slash. Ensure that it does if the string isn't empty.
-        if (xmlUrl && xmlUrl.charAt(xmlUrl.length - 1) !== '/') {
-            xmlUrl += '/';
+                // remove baseUrl from xmlUrl
+                xmlUrl = xmlUrl.replace(this.baseUrl, '');
+            }
+
+            // if there is an xmlUrl now, it needs a trailing slash. Ensure that it does if the string isn't empty.
+            if (xmlUrl && xmlUrl.charAt(xmlUrl.length - 1) !== '/') {
+                xmlUrl += '/';
+            }
         }
         var textureUrl = xmlUrl + resource.data.getElementsByTagName('page')[0].getAttribute('file');
         if (core.utils.TextureCache[textureUrl]) {


### PR DESCRIPTION
Recreated [pull request](https://github.com/pixijs/pixi.js/pull/2591) this time into the `dev` branch.

PIXI currently fails to load bitmap fonts from data URIs because while it can correctly parse a FNT XML document from a data URI, it fails to load the image specified inside the FNT file because it tries to prepend `xmlUrl` to the file URI.

This will successfully load the FNT file:
```
PIXI.loader.add(['data:application/xml;base64,...'])
```

If the FNT has an embedded data URI in the form:
```
<page id="0" file="/images/font.png"/>
```

This will fail because PIXI will try to prepend the data URI to it when it passes the new URL to the loader.

Fixing this issue will also allow data URIs to be used inside the FNT file to embed the image.