### PR TITLE
fix bug: sprite bounds are incorrect until 1st render

### DIFF
--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -51,7 +51,7 @@ Object.defineProperties(Container.prototype, {
 
             if (width !== 0)
             {
-                this.scale.x = value / width;
+                this.scale.x = value * this.scale.x / width;
             }
             else
             {
@@ -81,7 +81,7 @@ Object.defineProperties(Container.prototype, {
 
             if (height !== 0)
             {
-                this.scale.y = value / height ;
+                this.scale.y = value * this.scale.y / height ;
             }
             else
             {

--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -89,10 +89,11 @@ function Sprite(texture)
      */
     this.cachedTint = 0xFFFFFF;
 
+    // make sure the vertexData is present before setting the texture
+    this.vertexData = new Float32Array(16);
     // call texture setter
     this.texture = texture || Texture.EMPTY;
     this.textureDirty = true;
-    this.vertexData = new Float32Array(16);
 }
 
 // constructor
@@ -186,7 +187,7 @@ Object.defineProperties(Sprite.prototype, {
 Sprite.prototype._onTextureUpdate = function ()
 {
     this.textureDirty = true;
-
+    this.calculateVertices();
     // so if _width is 0 then width was not set..
     if (this._width)
     {


### PR DESCRIPTION
This fix calls calculateVertices() when a texture is set (and loaded)
so users can add stuff to the screen, and use their sizes before having to call render()

fixes displayObject and sprite bugs in  #2631 
