### PR TITLE
Fix #2006 by applying texture resolution to crop size

### DIFF
--- a/src/core/sprites/canvas/CanvasTinter.js
+++ b/src/core/sprites/canvas/CanvasTinter.js
@@ -68,7 +68,7 @@ CanvasTinter.tintWithMultiply = function (texture, color, canvas)
 
     crop.x *= resolution;
     crop.y *= resolution;
-    crop.width *= resolution
+    crop.width *= resolution;
     crop.height *= resolution;
      
     canvas.width = crop.width;
@@ -122,7 +122,7 @@ CanvasTinter.tintWithOverlay = function (texture, color, canvas)
 
     crop.x *= resolution;
     crop.y *= resolution;
-    crop.width *= resolution
+    crop.width *= resolution;
     crop.height *= resolution;
 
     canvas.width = crop.width;
@@ -163,7 +163,7 @@ CanvasTinter.tintWithPerPixel = function (texture, color, canvas)
 
     crop.x *= resolution;
     crop.y *= resolution;
-    crop.width *= resolution
+    crop.width *= resolution;
     crop.height *= resolution;
 
     canvas.width = crop.width;

--- a/src/core/sprites/canvas/CanvasTinter.js
+++ b/src/core/sprites/canvas/CanvasTinter.js
@@ -63,9 +63,14 @@ CanvasTinter.getTintedTexture = function (sprite, color)
 CanvasTinter.tintWithMultiply = function (texture, color, canvas)
 {
     var context = canvas.getContext( '2d' );
+    var crop = texture._frame.clone();
+    var resolution = texture.baseTexture.resolution;
 
-    var crop = texture._frame;
-
+    crop.x *= resolution;
+    crop.y *= resolution;
+    crop.width *= resolution
+    crop.height *= resolution;
+     
     canvas.width = crop.width;
     canvas.height = crop.height;
 
@@ -112,8 +117,13 @@ CanvasTinter.tintWithMultiply = function (texture, color, canvas)
 CanvasTinter.tintWithOverlay = function (texture, color, canvas)
 {
     var context = canvas.getContext( '2d' );
+    var crop = texture._frame.clone();
+    var resolution = texture.baseTexture.resolution;
 
-    var crop = texture._frame;
+    crop.x *= resolution;
+    crop.y *= resolution;
+    crop.width *= resolution
+    crop.height *= resolution;
 
     canvas.width = crop.width;
     canvas.height = crop.height;
@@ -148,7 +158,13 @@ CanvasTinter.tintWithOverlay = function (texture, color, canvas)
 CanvasTinter.tintWithPerPixel = function (texture, color, canvas)
 {
     var context = canvas.getContext( '2d' );
-    var crop = texture._frame;
+    var crop = texture._frame.clone();
+    var resolution = texture.baseTexture.resolution;
+
+    crop.x *= resolution;
+    crop.y *= resolution;
+    crop.width *= resolution
+    crop.height *= resolution;
 
     canvas.width = crop.width;
     canvas.height = crop.height;


### PR DESCRIPTION
This has already been fixed on the master branch through PR #2069. However, the dev branch does not appear to have the same fix. The tinting code is in a different file from master -> dev so i assume it just got lost when this was transferred. This PR restores that fix in the dev tinting code.

Also see issue #2073