### PR TITLE
Takes into account stroke thickness when drawing dropShadow

### DIFF
--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -300,6 +300,13 @@ Text.prototype.updateText = function (respectDirty)
             if (style.fill)
             {
                 this.drawLetterSpacing(lines[i], linePositionX + xShadowOffset, linePositionY + yShadowOffset + style.padding);
+
+                if (style.stroke && style.strokeThickness)
+                {
+                    this.context.strokeStyle = style.dropShadowColor;
+                    this.drawLetterSpacing(lines[i], linePositionX + xShadowOffset, linePositionY + yShadowOffset + style.padding, true);
+                    this.context.strokeStyle = style.stroke;
+			    }
             }
         }
     }


### PR DESCRIPTION
Currently, a drop shadow only takes into account the actual text, and not the stroke. This can make the shadow look odd on large stroke thickness as the shadow appears much thinner than it should be.This PR fixes this issue

As a before and after example: especially note the difference on the 'e' of 'Stroke'

http://www.moonrat.co.uk/html5/pixi_before/
http://www.moonrat.co.uk/html5/pixi_after/
