### PR TITLE
RFC: add sprite mask support for canvas renderer

### DIFF
--- a/src/core/renderers/canvas/utils/CanvasPool.js
+++ b/src/core/renderers/canvas/utils/CanvasPool.js
@@ -1,0 +1,72 @@
+/**
+ * A pool for canvases.
+ *
+ * @class
+ * @memberof PIXI
+ */
+export default class CanvasPool {
+    /**
+     * Constructor
+     */
+    constructor()
+    {
+        this._pool = {};
+    }
+
+    /**
+     * Generate a key for the given element (canvas) based on its height and width
+     * @param {Canvas} element object to generate the key for.
+     * @returns {number} the generated key for the given canvas.
+     */
+    getKey(element)
+    {
+        return ((element.width & 0xFFFF) << 16) | (element.height & 0xFFFF);
+    }
+
+    /**
+     * Whenever possible, pops a canvas from the pool and returns it. If none are free, it calls the given callback
+     * to create a new one.
+     * @param {key} key to identify the type of needed canvas.
+     * @param {function} createCallback callback that retuns a new instance of a canvas.
+     * @returns {Canvas} canvas instance, either recycled or new.
+     */
+    popElementOrCreate(key, createCallback)
+    {
+        if (!this._pool[key])
+        {
+            this._pool[key] = [];
+        }
+
+        return this._pool[key].pop() || createCallback();
+    }
+
+    /**
+     * Frees the given canvas into the pool.
+     * @param {Canvas} element the element to free into the pool
+     */
+    freeElement(element)
+    {
+        const key = this.getKey(element);
+
+        if (!this._pool[key])
+        {
+            this._pool[key] = [];
+        }
+
+        this._pool[key].push(element);
+    }
+
+    /**
+     * Empties the pool, letting the GC collect the stored instances.
+     */
+    emptyPool()
+    {
+        for (const i in this._pool)
+        {
+            this._pool[i].length = 0;
+        }
+
+        this._pool = {};
+    }
+}
+


### PR DESCRIPTION
We are using sprite masks on some of our games and the lack of support for canvas is becoming a bit of an issue. I thought I'd give it a try and try to implement it myself, but even though this solution works (for the cases I've tested so far), I'm not 100% happy with it. 

There is some things in this PR that I'm sure can be cleaned-up, but I'm not familiar with the pixi codebase, so I could use some advice if someone can spot things that are easy to cleanup (specifically, I don't quite like the `_copyCanvas` I had to add and some of the code around it). 

I'm also not convinced this is the best solution, as I had to create 2 different canvases (one to render the stuff that will be masked on, and the other one to apply the mask to that content which is then applied to the 'real' canvas). So if anyone has an alternate solution, tips/advice would be more than welcome.  I had to add the `_makeBlackTransparent` function because this wasn't doing the same as the webgl mask does (even though it seemed arguably correct), which is a nasty I'm not fond of either.

I have tested this using some code based on the examples repo one: 

```
// create the root of the scene graph
var stage = new PIXI.Container();

stage.interactive = true;

var bg = PIXI.Sprite.fromImage('_assets/background.png');

bg.anchor.x = 0.5;
bg.anchor.y = 0.5;

bg.position.x = renderer.width / 2;
bg.position.y = renderer.height / 2;

stage.addChild(bg);

var container = new PIXI.Container();
container.position.x = renderer.width / 2;
container.position.y = renderer.height / 2;

// add a bunch of sprites

var bgFront = PIXI.Sprite.fromImage('_assets/SceneRotate.jpg');
bgFront.anchor.x = 0.5;
bgFront.anchor.y = 0.5;

container.addChild(bgFront);

stage.addChild(container);

// let's create a moving shape
var thing = PIXI.Sprite.fromImage('_assets/stage_mask_alpha_inv.png');
stage.addChild(thing);
thing.anchor.set(0.5);
thing.position.x = renderer.width / 2;
thing.position.y = renderer.height / 2;


container.mask = thing;

var count = 0;

stage.on('click', onClick);
stage.on('tap', onClick);

function onClick()
{
    if(!container.mask)
    {
        container.mask = thing;
    }
    else
    {
        container.mask = null;
    }
}

var help = new PIXI.Text('Click to turn masking on / off.', { font:'bold 12pt Arial', fill: 'white' });
help.position.y = renderer.height - 26;
help.position.x = 10;
stage.addChild(help);

animate();

function animate()
{
    renderer.render(stage);
    requestAnimationFrame(animate);
}
```

As the mask, I have used 3 different images:
![stage_mask_alpha_coloured](https://cloud.githubusercontent.com/assets/610728/16050847/7b1157cc-325d-11e6-9ea4-459b3e869990.png)
![stage_mask_alpha_inv](https://cloud.githubusercontent.com/assets/610728/16050849/7b14aae4-325d-11e6-9a5d-8231b458b63d.png)
![stage_mask_alpha](https://cloud.githubusercontent.com/assets/610728/16050848/7b1388b2-325d-11e6-99b7-93e05ca082fc.png)

For this code, using these images I get the same results with a webgl-enabled browser and a webgl-disabled browser, although there might be some cases that don't work with this.

Could someone give me some help identifying issues/alternate solutions to be able to get this merged in dev?
