### PR TITLE
Global interaction events

### DIFF
--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -195,6 +195,7 @@ function InteractionManager(renderer, options)
     this.setTargetElement(this.renderer.view, this.renderer.resolution);
 }
 
+InteractionManager.prototype = Object.create(EventEmitter.prototype);
 InteractionManager.prototype.constructor = InteractionManager;
 module.exports = InteractionManager;
 
@@ -720,7 +721,13 @@ InteractionManager.prototype.processMouseOverOut = function ( displayObject, hit
     }
 };
 
-InteractionManager.prototype.onMouseOver = function(/*event*/)
+/**
+ * Is called when the mouse enters the renderer element area
+ *
+ * @param event {Event} The DOM event of the mouse moving into the renderer view
+ * @private
+ */
+InteractionManager.prototype.onMouseOver = function(event)
 {
     this.mouse.originalEvent = event;
     this.eventData.data = this.mouse;

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -24,7 +24,7 @@ Object.assign(
 function InteractionManager(renderer, options)
 {
     EventEmitter.call(this);
-    
+
     options = options || {};
 
     /**
@@ -725,7 +725,7 @@ InteractionManager.prototype.onMouseOver = function(/*event*/)
     this.mouse.originalEvent = event;
     this.eventData.data = this.mouse;
     this.eventData.stopped = false;
-    
+
 	this.emit('mouseover', this.eventData);
 };
 


### PR DESCRIPTION
Adds global ("stage") input events to the InteractionManager:
* mousedown/rightdown
* mouseup/rightup
* mousemove
* mouseout (mouse leaves the stage)
* mouseover (mouse enters the stage)
* touchstart
* touchend
* touchmove

This should allow for some of the use cases of event bubbling without the performance hit of deep display lists. It should make things like dragging and gestures a little easier to manage. The events for when the mouse leaves and enters the stage should allow for showing and hiding a custom cursor rendered by Pixi without having to attach DOM events oneself.