### PR TITLE
bitmap font resource loading issue

### DIFF
--- a/src/core/const.js
+++ b/src/core/const.js
@@ -297,10 +297,10 @@ var CONST = {
      * @static
      * @constant
      * @property {object} PRECISION
-     * @property {number} PRECISION.DEFAULT='mediump'
-     * @property {number} PRECISION.LOW='lowp'
-     * @property {number} PRECISION.MEDIUM='mediump'
-     * @property {number} PRECISION.HIGH='highp'
+     * @property {string} PRECISION.DEFAULT='mediump'
+     * @property {string} PRECISION.LOW='lowp'
+     * @property {string} PRECISION.MEDIUM='mediump'
+     * @property {string} PRECISION.HIGH='highp'
      */
     PRECISION: {
         DEFAULT: 'mediump',

--- a/src/loaders/bitmapFontParser.js
+++ b/src/loaders/bitmapFontParser.js
@@ -82,12 +82,12 @@ module.exports = function ()
 
         var xmlUrl = !resource.isDataUrl ? path.dirname(resource.url) : '';
 
-        if (resource.isDataUrl) {
+        if (xmlUrl) {
             if (xmlUrl === '.') {
                 xmlUrl = '';
             }
 
-            if (this.baseUrl && xmlUrl) {
+            if (this.baseUrl) {
                 // if baseurl has a trailing slash then add one to xmlUrl so the replace works below
                 if (this.baseUrl.charAt(this.baseUrl.length - 1) === '/') {
                     xmlUrl += '/';
@@ -98,11 +98,12 @@ module.exports = function ()
             }
 
             // if there is an xmlUrl now, it needs a trailing slash. Ensure that it does if the string isn't empty.
-            if (xmlUrl && xmlUrl.charAt(xmlUrl.length - 1) !== '/') {
+            if (xmlUrl.charAt(xmlUrl.length - 1) !== '/') {
                 xmlUrl += '/';
             }
         }
         var textureUrl = xmlUrl + resource.data.getElementsByTagName('page')[0].getAttribute('file');
+
         if (core.utils.TextureCache[textureUrl]) {
             //reuse existing texture
             parse(resource, core.utils.TextureCache[textureUrl]);


### PR DESCRIPTION
Not sure why `resource.isDataUrl` was added but it's breaking the bitmap font resource url. 