### PR TITLE
Multiple documentation fixes

### DIFF
--- a/src/core/const.js
+++ b/src/core/const.js
@@ -10,34 +10,34 @@ var CONST = {
      *
      * @static
      * @constant
-     * @property {string} VERSION
+     * @type {string}
      */
     VERSION: '__VERSION__',
 
     /**
      * Two Pi.
      *
-     * @property {number} PI_2
-     * @constant
      * @static
+     * @constant
+     * @type {number}
      */
     PI_2: Math.PI * 2,
 
     /**
      * Conversion factor for converting radians to degrees.
      *
-     * @property {number} RAD_TO_DEG
-     * @constant
      * @static
+     * @constant
+     * @type {number}
      */
     RAD_TO_DEG: 180 / Math.PI,
 
     /**
      * Conversion factor for converting degrees to radians.
      *
-     * @property {number} DEG_TO_RAD
-     * @constant
      * @static
+     * @constant
+     * @type {number}
      */
     DEG_TO_RAD: Math.PI / 180,
 
@@ -46,7 +46,8 @@ var CONST = {
      *
      * @static
      * @constant
-     * @property {number} TARGET_FPMS=0.06
+     * @type {number}
+     * @default 0.06
      */
     TARGET_FPMS: 0.06,
 
@@ -55,10 +56,10 @@ var CONST = {
      *
      * @static
      * @constant
-     * @property {object} RENDERER_TYPE
-     * @property {number} RENDERER_TYPE.UNKNOWN
-     * @property {number} RENDERER_TYPE.WEBGL
-     * @property {number} RENDERER_TYPE.CANVAS
+     * @type {object}
+     * @property {number} UNKNOWN - Unknown render type.
+     * @property {number} WEBGL - WebGL render type.
+     * @property {number} CANVAS - Canvas render type.
      */
     RENDERER_TYPE: {
         UNKNOWN:    0,
@@ -74,24 +75,24 @@ var CONST = {
      *
      * @static
      * @constant
-     * @property {object} BLEND_MODES
-     * @property {number} BLEND_MODES.NORMAL
-     * @property {number} BLEND_MODES.ADD
-     * @property {number} BLEND_MODES.MULTIPLY
-     * @property {number} BLEND_MODES.SCREEN
-     * @property {number} BLEND_MODES.OVERLAY
-     * @property {number} BLEND_MODES.DARKEN
-     * @property {number} BLEND_MODES.LIGHTEN
-     * @property {number} BLEND_MODES.COLOR_DODGE
-     * @property {number} BLEND_MODES.COLOR_BURN
-     * @property {number} BLEND_MODES.HARD_LIGHT
-     * @property {number} BLEND_MODES.SOFT_LIGHT
-     * @property {number} BLEND_MODES.DIFFERENCE
-     * @property {number} BLEND_MODES.EXCLUSION
-     * @property {number} BLEND_MODES.HUE
-     * @property {number} BLEND_MODES.SATURATION
-     * @property {number} BLEND_MODES.COLOR
-     * @property {number} BLEND_MODES.LUMINOSITY
+     * @type {object}
+     * @property {number} NORMAL
+     * @property {number} ADD
+     * @property {number} MULTIPLY
+     * @property {number} SCREEN
+     * @property {number} OVERLAY
+     * @property {number} DARKEN
+     * @property {number} LIGHTEN
+     * @property {number} COLOR_DODGE
+     * @property {number} COLOR_BURN
+     * @property {number} HARD_LIGHT
+     * @property {number} SOFT_LIGHT
+     * @property {number} DIFFERENCE
+     * @property {number} EXCLUSION
+     * @property {number} HUE
+     * @property {number} SATURATION
+     * @property {number} COLOR
+     * @property {number} LUMINOSITY
      */
     BLEND_MODES: {
         NORMAL:         0,
@@ -119,14 +120,14 @@ var CONST = {
      *
      * @static
      * @constant
-     * @property {object} DRAW_MODES
-     * @property {number} DRAW_MODES.POINTS
-     * @property {number} DRAW_MODES.LINES
-     * @property {number} DRAW_MODES.LINE_LOOP
-     * @property {number} DRAW_MODES.LINE_STRIP
-     * @property {number} DRAW_MODES.TRIANGLES
-     * @property {number} DRAW_MODES.TRIANGLE_STRIP
-     * @property {number} DRAW_MODES.TRIANGLE_FAN
+     * @type {object}
+     * @property {number} POINTS
+     * @property {number} LINES
+     * @property {number} LINE_LOOP
+     * @property {number} LINE_STRIP
+     * @property {number} TRIANGLES
+     * @property {number} TRIANGLE_STRIP
+     * @property {number} TRIANGLE_FAN
      */
     DRAW_MODES: {
         POINTS:         0,
@@ -146,10 +147,10 @@ var CONST = {
      *
      * @static
      * @constant
-     * @property {object} SCALE_MODES
-     * @property {number} SCALE_MODES.DEFAULT=LINEAR
-     * @property {number} SCALE_MODES.LINEAR Smooth scaling
-     * @property {number} SCALE_MODES.NEAREST Pixelating scaling
+     * @type {object}
+     * @property {number} DEFAULT=LINEAR
+     * @property {number} LINEAR Smooth scaling
+     * @property {number} NEAREST Pixelating scaling
      */
     SCALE_MODES: {
         DEFAULT:    0,
@@ -167,11 +168,11 @@ var CONST = {
      *
      * @static
      * @constant
-     * @property {object} WRAP_MODES
-     * @property {number} WRAP_MODES.DEFAULT=CLAMP
-     * @property {number} WRAP_MODES.CLAMP The textures uvs are clamped
-     * @property {number} WRAP_MODES.REPEAT The texture uvs tile and repeat
-     * @property {number} WRAP_MODES.MIRRORED_REPEAT The texture uvs tile and repeat with mirroring
+     * @type {object}
+     * @property {number} DEFAULT=CLAMP
+     * @property {number} CLAMP - The textures uvs are clamped
+     * @property {number} REPEAT - The texture uvs tile and repeat
+     * @property {number} MIRRORED_REPEAT - The texture uvs tile and repeat with mirroring
      */
     WRAP_MODES: {
         DEFAULT:        0,
@@ -191,10 +192,10 @@ var CONST = {
      *
      * @static
      * @constant
-     * @property {object} GC_MODES
-     * @property {number} GC_MODES.DEFAULT=DEFAULT
-     * @property {number} GC_MODES.AUTO Garbage collection will happen periodically automatically
-     * @property {number} GC_MODES.MANUAL Garbage collection will need to be called manually
+     * @type {object}
+     * @property {number} DEFAULT=MANUAL
+     * @property {number} AUTO - Garbage collection will happen periodically automatically
+     * @property {number} MANUAL - Garbage collection will need to be called manually
      */
     GC_MODES: {
         DEFAULT:        1,
@@ -208,16 +209,16 @@ var CONST = {
      *
      * @static
      * @constant
-     * @property {bool} MIPMAP_TEXTURES
+     * @type {boolean}
      */
-    MIPMAP_TEXTURES:true,
+    MIPMAP_TEXTURES: true,
 
     /**
      * The prefix that denotes a URL is for a retina asset.
      *
      * @static
      * @constant
-     * @property {string} RETINA_PREFIX
+     * @type {RegExp|string}
      * @example `@2x`
      */
     RETINA_PREFIX: /@(.+)x/,
@@ -225,18 +226,18 @@ var CONST = {
     /**
      * Default resolution / device pixel ratio of the renderer.
      *
-     * @property {number} RESOLUTION
-     * @constant
      * @static
+     * @constant
+     * @type {number}
      */
-    RESOLUTION:1,
+    RESOLUTION: 1,
 
     /**
      * Default filter resolution.
      *
-     * @property {number} FILTER_RESOLUTION
-     * @constant
      * @static
+     * @constant
+     * @type {number}
      */
     FILTER_RESOLUTION:1,
 
@@ -246,17 +247,17 @@ var CONST = {
      *
      * @static
      * @constant
-     * @property {object} DEFAULT_RENDER_OPTIONS
-     * @property {HTMLCanvasElement} DEFAULT_RENDER_OPTIONS.view=null
-     * @property {number} DEFAULT_RENDER_OPTIONS.resolution=1
-     * @property {boolean} DEFAULT_RENDER_OPTIONS.antialias=false
-     * @property {boolean} DEFAULT_RENDER_OPTIONS.forceFXAA=false
-     * @property {boolean} DEFAULT_RENDER_OPTIONS.autoResize=false
-     * @property {boolean} DEFAULT_RENDER_OPTIONS.transparent=false
-     * @property {number} DEFAULT_RENDER_OPTIONS.backgroundColor=0x000000
-     * @property {boolean} DEFAULT_RENDER_OPTIONS.clearBeforeRender=true
-     * @property {boolean} DEFAULT_RENDER_OPTIONS.preserveDrawingBuffer=false
-     * @property {boolean} DEFAULT_RENDER_OPTIONS.roundPixels=false
+     * @type {object}
+     * @property {HTMLCanvasElement} view=null
+     * @property {number} resolution=1
+     * @property {boolean} antialias=false
+     * @property {boolean} forceFXAA=false
+     * @property {boolean} autoResize=false
+     * @property {boolean} transparent=false
+     * @property {number} backgroundColor=0x000000
+     * @property {boolean} clearBeforeRender=true
+     * @property {boolean} preserveDrawingBuffer=false
+     * @property {boolean} roundPixels=false
      */
     DEFAULT_RENDER_OPTIONS: {
         view: null,
@@ -276,12 +277,12 @@ var CONST = {
      *
      * @static
      * @constant
-     * @property {object} SHAPES
-     * @property {number} SHAPES.POLY=0
-     * @property {number} SHAPES.RECT=1
-     * @property {number} SHAPES.CIRC=2
-     * @property {number} SHAPES.ELIP=3
-     * @property {number} SHAPES.RREC=4
+     * @type {object}
+     * @property {number} POLY
+     * @property {number} RECT
+     * @property {number} CIRC
+     * @property {number} ELIP
+     * @property {number} RREC
      */
     SHAPES: {
         POLY: 0,
@@ -296,11 +297,11 @@ var CONST = {
      *
      * @static
      * @constant
-     * @property {object} PRECISION
-     * @property {number} PRECISION.DEFAULT='mediump'
-     * @property {number} PRECISION.LOW='lowp'
-     * @property {number} PRECISION.MEDIUM='mediump'
-     * @property {number} PRECISION.HIGH='highp'
+     * @type {object}
+     * @property {number} DEFAULT='mediump'
+     * @property {number} LOW='lowp'
+     * @property {number} MEDIUM='mediump'
+     * @property {number} HIGH='highp'
      */
     PRECISION: {
         DEFAULT: 'mediump',
@@ -309,10 +310,20 @@ var CONST = {
         HIGH: 'highp'
     },
 
+    /**
+     * Constants that specify the transform type.
+     *
+     * @static
+     * @constant
+     * @type {object}
+     * @property {number} DEFAULT=STATIC
+     * @property {number} STATIC
+     * @property {number} DYNAMIC
+     */
     TRANSFORM_MODE:{
-        STATIC:0,
-        DYNAMIC:1,
-        DEFAULT:0
+        DEFAULT:    0,
+        STATIC:     0,
+        DYNAMIC:    1
     },
 
     /**
@@ -320,9 +331,9 @@ var CONST = {
      *
      * @static
      * @constant
-     * @property {object} TEXT_GRADIENT
-     * @property {number} TEXT_GRADIENT.LINEAR_VERTICAL=0
-     * @property {number} TEXT_GRADIENT.LINEAR_HORIZONTAL=1
+     * @type {object}
+     * @property {number} LINEAR_VERTICAL
+     * @property {number} LINEAR_HORIZONTAL
      */
     TEXT_GRADIENT: {
         LINEAR_VERTICAL: 0,
@@ -331,9 +342,36 @@ var CONST = {
 
     // TODO: maybe change to SPRITE.BATCH_SIZE: 2000
     // TODO: maybe add PARTICLE.BATCH_SIZE: 15000
-    SPRITE_BATCH_SIZE: 4096, //nice balance between mobile and desktop machines
-    SPRITE_MAX_TEXTURES: require('./utils/maxRecommendedTextures')(32), //this is the MAXIMUM - various gpus will have there own limits.
-    TEXT_STYLE_CHANGED: 'changed' //Name of the event that fires when a text style is changed
+
+    /**
+     * The default sprite batch size.
+     *
+     * The default aims to balance desktop and mobile devices.
+     *
+     * @static
+     * @constant
+     * @type {number}
+     * @default 4096
+     */
+    SPRITE_BATCH_SIZE: 4096,
+
+    /**
+     * The maximum textures that this device supports.
+     *
+     * @static
+     * @constant
+     * @type {number}
+     */
+    SPRITE_MAX_TEXTURES: require('./utils/maxRecommendedTextures')(32),
+
+    /**
+     * Name of the event that fires when a text style is changed.
+     *
+     * @static
+     * @constant
+     * @type {string}
+     */
+    TEXT_STYLE_CHANGED: 'changed'
 };
 
 module.exports = CONST;

--- a/src/core/display/DisplayObject.js
+++ b/src/core/display/DisplayObject.js
@@ -151,6 +151,7 @@ Object.defineProperties(DisplayObject.prototype, {
      * Current transform of the object based on world (parent) factors
      *
      * @member {PIXI.Matrix}
+     * @memberof PIXI.DisplayObject#
      * @readonly
      */
     worldTransform: {
@@ -164,6 +165,7 @@ Object.defineProperties(DisplayObject.prototype, {
      * Current transform of the object based on local factors: position, scale, other stuff
      *
      * @member {PIXI.Matrix}
+     * @memberof PIXI.DisplayObject#
      * @readonly
      */
     localTransform: {
@@ -432,7 +434,6 @@ DisplayObject.prototype.toLocal = function (position, from, point)
  * Renders the object using the WebGL renderer
  *
  * @param renderer {PIXI.WebGLRenderer} The renderer
- * @private
  */
 DisplayObject.prototype.renderWebGL = function (renderer) // jshint unused:false
 {
@@ -443,7 +444,6 @@ DisplayObject.prototype.renderWebGL = function (renderer) // jshint unused:false
  * Renders the object using the Canvas renderer
  *
  * @param renderer {PIXI.CanvasRenderer} The renderer
- * @private
  */
 DisplayObject.prototype.renderCanvas = function (renderer) // jshint unused:false
 {

--- a/src/core/display/Transform.js
+++ b/src/core/display/Transform.js
@@ -11,11 +11,16 @@ var math = require('../math');
 function Transform()
 {
     /**
-     * @member {PIXI.Matrix} The global matrix transform
+     * The global matrix transform.
+     *
+     * @member {PIXI.Matrix}
      */
     this.worldTransform = new math.Matrix();
+
     /**
-     * @member {PIXI.Matrix} The local matrix transform
+     * The local matrix transform.
+     *
+     * @member {PIXI.Matrix}
      */
     this.localTransform = new math.Matrix();
 

--- a/src/core/display/TransformManual.js
+++ b/src/core/display/TransformManual.js
@@ -11,11 +11,16 @@ var math = require('../math');
 function TransformManual()
 {
     /**
-     * @member {PIXI.Matrix} The global matrix transform
+     * The global matrix transform.
+     *
+     * @member {PIXI.Matrix}
      */
     this.worldTransform = new math.Matrix();
+
     /**
-     * @member {PIXI.Matrix} The local matrix transform
+     * The local matrix transform.
+     *
+     * @member {PIXI.Matrix}
      */
     this.localTransform = new math.Matrix();
 

--- a/src/core/display/TransformStatic.js
+++ b/src/core/display/TransformStatic.js
@@ -10,11 +10,16 @@ var math = require('../math');
 function TransformStatic()
 {
     /**
-     * @member {PIXI.Matrix} The global matrix transform
+     * The global matrix transform.
+     *
+     * @member {PIXI.Matrix}
      */
     this.worldTransform = new math.Matrix();
+
     /**
-     * @member {PIXI.Matrix} The local matrix transform
+     * The local matrix transform.
+     *
+     * @member {PIXI.Matrix}
      */
     this.localTransform = new math.Matrix();
 

--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -982,7 +982,7 @@ Graphics.prototype.updateLocalBounds = function ()
 /**
  * Draws the given shape to this Graphics object. Can be any of Circle, Rectangle, Ellipse, Line or Polygon.
  *
- * @param shape {PIXI.math.Circle|PIXI.math.Ellipse|PIXI.math.Polygon|PIXI.math.Rectangle|PIXI.math.RoundedRectangle} The shape object to draw.
+ * @param shape {PIXI.Circle|PIXI.Ellipse|PIXI.Polygon|PIXI.Rectangle|PIXI.RoundedRectangle} The shape object to draw.
  * @return {PIXI.GraphicsData} The generated GraphicsData object.
  */
 Graphics.prototype.drawShape = function (shape)

--- a/src/core/graphics/GraphicsData.js
+++ b/src/core/graphics/GraphicsData.js
@@ -9,7 +9,7 @@
  * @param fillColor {number} the color of the fill
  * @param fillAlpha {number} the alpha of the fill
  * @param fill      {boolean} whether or not the shape is filled with a colour
- * @param shape     {PIXI.math.Circle|PIXI.math.Rectangle|PIXI.math.Ellipse|PIXI.math.Polygon} The shape object to draw.
+ * @param shape     {PIXI.Circle|PIXI.Rectangle|PIXI.Ellipse|PIXI.Polygon} The shape object to draw.
  */
 function GraphicsData(lineWidth, lineColor, lineAlpha, fillColor, fillAlpha, fill, shape)
 {

--- a/src/core/graphics/utils/bezierCurveTo.js
+++ b/src/core/graphics/utils/bezierCurveTo.js
@@ -2,6 +2,9 @@
 /**
  * Calculate the points for a bezier curve and then draws it.
  *
+ * Ignored from docs since it is not directly exposed.
+ *
+ * @ignore
  * @param fromX {number} Starting point x
  * @param fromY {number} Starting point y
  * @param cpX {number} Control point x

--- a/src/core/graphics/webgl/GraphicsRenderer.js
+++ b/src/core/graphics/webgl/GraphicsRenderer.js
@@ -17,7 +17,6 @@ var utils = require('../../utils'),
  * Renders the graphics object.
  *
  * @class
- * @private
  * @memberof PIXI
  * @extends PIXI.ObjectRenderer
  * @param renderer {PIXI.WebGLRenderer} The renderer this object renderer works for.

--- a/src/core/graphics/webgl/WebGLGraphicsData.js
+++ b/src/core/graphics/webgl/WebGLGraphicsData.js
@@ -5,11 +5,11 @@ var glCore = require('pixi-gl-core');
  * An object containing WebGL specific properties to be used by the WebGL renderer
  *
  * @class
+ * @private
  * @memberof PIXI
  * @param gl {WebGLRenderingContext} The current WebGL drawing context
  * @param shader {PIXI.Shader} The shader
  * @param attribsState {object} The state for the VAO
- * @private
  */
 function WebGLGraphicsData(gl, shader, attribsState)
 {

--- a/src/core/graphics/webgl/utils/buildCircle.js
+++ b/src/core/graphics/webgl/utils/buildCircle.js
@@ -5,6 +5,9 @@ var buildLine = require('./buildLine'),
 /**
  * Builds a circle to draw
  *
+ * Ignored from docs since it is not directly exposed.
+ *
+ * @ignore
  * @private
  * @param graphicsData {PIXI.WebGLGraphicsData} The graphics object to draw
  * @param webGLData {object} an object containing all the webGL-specific information to create this shape

--- a/src/core/graphics/webgl/utils/buildComplexPoly.js
+++ b/src/core/graphics/webgl/utils/buildComplexPoly.js
@@ -5,6 +5,9 @@ var utils = require('../../../utils');
 /**
  * Builds a complex polygon to draw
  *
+ * Ignored from docs since it is not directly exposed.
+ *
+ * @ignore
  * @private
  * @param graphicsData {PIXI.Graphics} The graphics object containing all the necessary properties
  * @param webGLData {object} an object containing all the webGL-specific information to create this shape

--- a/src/core/graphics/webgl/utils/buildLine.js
+++ b/src/core/graphics/webgl/utils/buildLine.js
@@ -4,6 +4,9 @@ var math = require('../../../math'),
 /**
  * Builds a line to draw
  *
+ * Ignored from docs since it is not directly exposed.
+ *
+ * @ignore
  * @private
  * @param graphicsData {PIXI.WebGLGraphicsData} The graphics object containing all the necessary properties
  * @param webGLData {object} an object containing all the webGL-specific information to create this shape
@@ -13,7 +16,7 @@ var buildLine = function (graphicsData, webGLData)
     // TODO OPTIMISE!
     var i = 0;
     var points = graphicsData.points;
-   
+
     if (points.length === 0)
     {
         return;

--- a/src/core/graphics/webgl/utils/buildPoly.js
+++ b/src/core/graphics/webgl/utils/buildPoly.js
@@ -5,6 +5,9 @@ var buildLine = require('./buildLine'),
 /**
  * Builds a polygon to draw
  *
+ * Ignored from docs since it is not directly exposed.
+ *
+ * @ignore
  * @private
  * @param graphicsData {PIXI.WebGLGraphicsData} The graphics object containing all the necessary properties
  * @param webGLData {object} an object containing all the webGL-specific information to create this shape

--- a/src/core/graphics/webgl/utils/buildRectangle.js
+++ b/src/core/graphics/webgl/utils/buildRectangle.js
@@ -4,6 +4,9 @@ var buildLine = require('./buildLine'),
 /**
  * Builds a rectangle to draw
  *
+ * Ignored from docs since it is not directly exposed.
+ *
+ * @ignore
  * @private
  * @param graphicsData {PIXI.WebGLGraphicsData} The graphics object containing all the necessary properties
  * @param webGLData {object} an object containing all the webGL-specific information to create this shape

--- a/src/core/graphics/webgl/utils/buildRoundedRectangle.js
+++ b/src/core/graphics/webgl/utils/buildRoundedRectangle.js
@@ -5,6 +5,9 @@ var earcut = require('earcut'),
 /**
  * Builds a rounded rectangle to draw
  *
+ * Ignored from docs since it is not directly exposed.
+ *
+ * @ignore
  * @private
  * @param graphicsData {PIXI.WebGLGraphicsData} The graphics object containing all the necessary properties
  * @param webGLData {object} an object containing all the webGL-specific information to create this shape
@@ -77,6 +80,9 @@ var buildRoundedRectangle = function (graphicsData, webGLData)
  * Calculate the points for a quadratic bezier curve. (helper function..)
  * Based on: https://stackoverflow.com/questions/785097/how-do-i-implement-a-bezier-curve-in-c
  *
+ * Ignored from docs since it is not directly exposed.
+ *
+ * @ignore
  * @private
  * @param fromX {number} Origin point x
  * @param fromY {number} Origin point x

--- a/src/core/math/Matrix.js
+++ b/src/core/math/Matrix.js
@@ -52,6 +52,7 @@ function Matrix()
      */
     this.ty = 0;
 
+    this.array = null;
 }
 
 Matrix.prototype.constructor = Matrix;
@@ -109,7 +110,7 @@ Matrix.prototype.set = function (a, b, c, d, tx, ty)
  * Creates an array from the current Matrix object.
  *
  * @param transpose {boolean} Whether we need to transpose the matrix or not
- * @param [out=Float32Array[]} If provided the array will be assigned to out
+ * @param [out=new Float32Array(9)] {Float32Array} If provided the array will be assigned to out
  * @return {number[]} the newly created array which contains the matrix
  */
 Matrix.prototype.toArray = function (transpose, out)

--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -85,7 +85,7 @@ function WebGLRenderer(width, height, options)
     /**
      * Manages the stencil buffer.
      *
-     * @member {StencilManager}
+     * @member {PIXI.StencilManager}
      */
     this.stencilManager = new StencilManager(this);
 
@@ -124,7 +124,7 @@ function WebGLRenderer(width, height, options)
     /**
      * The currently active ObjectRenderer.
      *
-     * @member {WebGLState}
+     * @member {PIXI.WebGLState}
      */
     this.state = new WebGLState(this.gl);
 

--- a/src/core/renderers/webgl/WebGLState.js
+++ b/src/core/renderers/webgl/WebGLState.js
@@ -2,27 +2,29 @@ var mapWebGLBlendModesToPixi = require('./utils/mapWebGLBlendModesToPixi');
 
 /**
  * A WebGL state machines
+ *
+ * @memberof PIXI
+ * @class
  * @param gl {WebGLRenderingContext} The current WebGL rendering context
  */
-var WebGLState = function(gl)
+function WebGLState(gl)
 {
-
     /**
      * The current active state
      *
      * @member {Uint8Array}
      */
-	this.activeState = new Uint8Array(16);
+    this.activeState = new Uint8Array(16);
 
     /**
      * The default state
      *
      * @member {Uint8Array}
      */
-	this.defaultState = new Uint8Array(16);
+    this.defaultState = new Uint8Array(16);
 
-	// default blend mode..
-	this.defaultState[0] = 1;
+    // default blend mode..
+    this.defaultState[0] = 1;
 
     /**
      * The current state index in the stack
@@ -30,7 +32,7 @@ var WebGLState = function(gl)
      * @member {number}
      * @private
      */
-	this.stackIndex = 0;
+    this.stackIndex = 0;
 
     /**
      * The stack holding all the different states
@@ -38,27 +40,24 @@ var WebGLState = function(gl)
      * @member {Array<*>}
      * @private
      */
-	this.stack = [];
+    this.stack = [];
 
     /**
      * The current WebGL rendering context
      *
      * @member {WebGLRenderingContext}
      */
-	this.gl = gl;
+    this.gl = gl;
 
-	this.maxAttribs = gl.getParameter(gl.MAX_VERTEX_ATTRIBS);
+    this.maxAttribs = gl.getParameter(gl.MAX_VERTEX_ATTRIBS);
 
-	this.attribState = {tempAttribState:new Array(this.maxAttribs),
+    this.attribState = {tempAttribState:new Array(this.maxAttribs),
                         attribState:new Array(this.maxAttribs)};
 
+    this.blendModes = mapWebGLBlendModesToPixi(gl);
 
-
-	this.blendModes = mapWebGLBlendModesToPixi(gl);
-
-
-	// check we have vao..
-	this.nativeVaoExtension = (
+    // check we have vao..
+    this.nativeVaoExtension = (
       gl.getExtension('OES_vertex_array_object') ||
       gl.getExtension('MOZ_OES_vertex_array_object') ||
       gl.getExtension('WEBKIT_OES_vertex_array_object')
@@ -70,35 +69,35 @@ var WebGLState = function(gl)
  */
 WebGLState.prototype.push = function()
 {
-	// next state..
-	var state = this.state[++this.stackIndex];
+    // next state..
+    var state = this.state[++this.stackIndex];
 
-	if(!state)
-	{
-		state = this.state[this.stackIndex] = new Uint8Array(16);
-	}
+    if(!state)
+    {
+        state = this.state[this.stackIndex] = new Uint8Array(16);
+    }
 
-	// copy state..
-	// set active state so we can force overrides of gl state
-	for (var i = 0; i < this.activeState.length; i++)
-	{
-		this.activeState[i] = state[i];
-	}
+    // copy state..
+    // set active state so we can force overrides of gl state
+    for (var i = 0; i < this.activeState.length; i++)
+    {
+        this.activeState[i] = state[i];
+    }
 };
 
 var BLEND = 0,
-	DEPTH_TEST = 1,
-	FRONT_FACE = 2,
-	CULL_FACE = 3,
-	BLEND_FUNC = 4;
+    DEPTH_TEST = 1,
+    FRONT_FACE = 2,
+    CULL_FACE = 3,
+    BLEND_FUNC = 4;
 
 /**
  * Pops a state out
  */
 WebGLState.prototype.pop = function()
 {
-	var state = this.state[--this.stackIndex];
-	this.setState(state);
+    var state = this.state[--this.stackIndex];
+    this.setState(state);
 };
 
 /**
@@ -107,11 +106,11 @@ WebGLState.prototype.pop = function()
  */
 WebGLState.prototype.setState = function(state)
 {
-	this.setBlend(state[BLEND]);
-	this.setDepthTest(state[DEPTH_TEST]);
-	this.setFrontFace(state[FRONT_FACE]);
-	this.setCullFace(state[CULL_FACE]);
-	this.setBlendMode(state[BLEND_FUNC]);
+    this.setBlend(state[BLEND]);
+    this.setDepthTest(state[DEPTH_TEST]);
+    this.setFrontFace(state[FRONT_FACE]);
+    this.setCullFace(state[CULL_FACE]);
+    this.setBlendMode(state[BLEND_FUNC]);
 };
 
 /**
@@ -120,22 +119,22 @@ WebGLState.prototype.setState = function(state)
  */
 WebGLState.prototype.setBlend = function(value)
 {
-	if(this.activeState[BLEND] === value|0) {
+    if(this.activeState[BLEND] === value|0) {
     return;
   }
 
-	this.activeState[BLEND] = value|0;
+    this.activeState[BLEND] = value|0;
 
-	var gl = this.gl;
+    var gl = this.gl;
 
-	if(value)
-	{
-		gl.enable(gl.BLEND);
-	}
-	else
-	{
-		gl.disable(gl.BLEND);
-	}
+    if(value)
+    {
+        gl.enable(gl.BLEND);
+    }
+    else
+    {
+        gl.disable(gl.BLEND);
+    }
 };
 
 /**
@@ -144,13 +143,13 @@ WebGLState.prototype.setBlend = function(value)
  */
 WebGLState.prototype.setBlendMode = function(value)
 {
-	if(value === this.activeState[BLEND_FUNC]) {
+    if(value === this.activeState[BLEND_FUNC]) {
     return;
   }
 
-	this.activeState[BLEND_FUNC] = value;
+    this.activeState[BLEND_FUNC] = value;
 
-	this.gl.blendFunc(this.blendModes[value][0], this.blendModes[value][1]);
+    this.gl.blendFunc(this.blendModes[value][0], this.blendModes[value][1]);
 };
 
 /**
@@ -159,22 +158,22 @@ WebGLState.prototype.setBlendMode = function(value)
  */
 WebGLState.prototype.setDepthTest = function(value)
 {
-	if(this.activeState[DEPTH_TEST] === value|0) {
-    return;
-  }
+    if(this.activeState[DEPTH_TEST] === value|0) {
+        return;
+    }
 
-	this.activeState[DEPTH_TEST] = value|0;
+    this.activeState[DEPTH_TEST] = value|0;
 
-	var gl = this.gl;
+    var gl = this.gl;
 
-	if(value)
-	{
-		gl.enable(gl.DEPTH_TEST);
-	}
-	else
-	{
-		gl.disable(gl.DEPTH_TEST);
-	}
+    if(value)
+    {
+        gl.enable(gl.DEPTH_TEST);
+    }
+    else
+    {
+        gl.disable(gl.DEPTH_TEST);
+    }
 };
 
 /**
@@ -183,22 +182,22 @@ WebGLState.prototype.setDepthTest = function(value)
  */
 WebGLState.prototype.setCullFace = function(value)
 {
-	if(this.activeState[CULL_FACE] === value|0) {
-    return;
-  }
+    if(this.activeState[CULL_FACE] === value|0) {
+        return;
+    }
 
-	this.activeState[CULL_FACE] = value|0;
+    this.activeState[CULL_FACE] = value|0;
 
-	var gl = this.gl;
+    var gl = this.gl;
 
-	if(value)
-	{
-		gl.enable(gl.CULL_FACE);
-	}
-	else
-	{
-		gl.disable(gl.CULL_FACE);
-	}
+    if(value)
+    {
+        gl.enable(gl.CULL_FACE);
+    }
+    else
+    {
+        gl.disable(gl.CULL_FACE);
+    }
 };
 
 /**
@@ -207,22 +206,22 @@ WebGLState.prototype.setCullFace = function(value)
  */
 WebGLState.prototype.setFrontFace = function(value)
 {
-	if(this.activeState[FRONT_FACE] === value|0) {
-    return;
-  }
+    if(this.activeState[FRONT_FACE] === value|0) {
+        return;
+    }
 
-	this.activeState[FRONT_FACE] = value|0;
+    this.activeState[FRONT_FACE] = value|0;
 
-	var gl = this.gl;
+    var gl = this.gl;
 
-	if(value)
-	{
-		gl.frontFace(gl.CW);
-	}
-	else
-	{
-		gl.frontFace(gl.CCW);
-	}
+    if(value)
+    {
+        gl.frontFace(gl.CW);
+    }
+    else
+    {
+        gl.frontFace(gl.CCW);
+    }
 };
 
 /**
@@ -230,23 +229,23 @@ WebGLState.prototype.setFrontFace = function(value)
  */
 WebGLState.prototype.resetAttributes = function()
 {
-	var i;
+    var i;
 
     for ( i = 0; i < this.attribState.tempAttribState.length; i++) {
-    	this.attribState.tempAttribState[i] = 0;
+        this.attribState.tempAttribState[i] = 0;
     }
 
     for ( i = 0; i < this.attribState.attribState.length; i++) {
-    	this.attribState.attribState[i] = 0;
+        this.attribState.attribState[i] = 0;
     }
 
-	var gl = this.gl;
+    var gl = this.gl;
 
-	// im going to assume one is always active for performance reasons.
-	for (i = 1; i < this.maxAttribs; i++)
-  	{
-		gl.disableVertexAttribArray(i);
-  	}
+    // im going to assume one is always active for performance reasons.
+    for (i = 1; i < this.maxAttribs; i++)
+    {
+        gl.disableVertexAttribArray(i);
+    }
 };
 
 //used
@@ -256,27 +255,27 @@ WebGLState.prototype.resetAttributes = function()
 WebGLState.prototype.resetToDefault = function()
 {
 
-	// unbind any VAO if they exist..
-	if(this.nativeVaoExtension)
-	{
-		this.nativeVaoExtension.bindVertexArrayOES(null);
-	}
+    // unbind any VAO if they exist..
+    if(this.nativeVaoExtension)
+    {
+        this.nativeVaoExtension.bindVertexArrayOES(null);
+    }
 
 
-	// reset all attributs..
-	this.resetAttributes();
+    // reset all attributs..
+    this.resetAttributes();
 
-	// set active state so we can force overrides of gl state
-	for (var i = 0; i < this.activeState.length; i++)
-	{
-		this.activeState[i] = 2;
-	}
+    // set active state so we can force overrides of gl state
+    for (var i = 0; i < this.activeState.length; i++)
+    {
+        this.activeState[i] = 2;
+    }
 
-	var gl = this.gl;
-	gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+    var gl = this.gl;
+    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
 
 
-	this.setState(this.defaultState);
+    this.setState(this.defaultState);
 };
 
 module.exports = WebGLState;

--- a/src/core/renderers/webgl/managers/StencilManager.js
+++ b/src/core/renderers/webgl/managers/StencilManager.js
@@ -5,22 +5,22 @@ var WebGLManager = require('./WebGLManager');
  * @memberof PIXI
  * @param renderer {PIXI.WebGLRenderer} The renderer this manager works for.
  */
-function StencilMaskManager(renderer)
+function StencilManager(renderer)
 {
     WebGLManager.call(this, renderer);
     this.stencilMaskStack = null;
 }
 
-StencilMaskManager.prototype = Object.create(WebGLManager.prototype);
-StencilMaskManager.prototype.constructor = StencilMaskManager;
-module.exports = StencilMaskManager;
+StencilManager.prototype = Object.create(WebGLManager.prototype);
+StencilManager.prototype.constructor = StencilManager;
+module.exports = StencilManager;
 
 /**
  * Changes the mask stack that is used by this manager.
  *
  * @param stencilMaskStack {PIXI.Graphics[]} The mask stack
  */
-StencilMaskManager.prototype.setMaskStack = function ( stencilMaskStack )
+StencilManager.prototype.setMaskStack = function ( stencilMaskStack )
 {
     this.stencilMaskStack = stencilMaskStack;
 
@@ -41,7 +41,7 @@ StencilMaskManager.prototype.setMaskStack = function ( stencilMaskStack )
  *
  * @param graphics {PIXI.Graphics}
  */
-StencilMaskManager.prototype.pushStencil = function (graphics)
+StencilManager.prototype.pushStencil = function (graphics)
 {
     this.renderer.setObjectRenderer(this.renderer.plugins.graphics);
 
@@ -72,7 +72,7 @@ StencilMaskManager.prototype.pushStencil = function (graphics)
 /**
  * TODO @alvin
  */
-StencilMaskManager.prototype.popStencil = function ()
+StencilManager.prototype.popStencil = function ()
 {
     this.renderer.setObjectRenderer(this.renderer.plugins.graphics);
 
@@ -103,7 +103,7 @@ StencilMaskManager.prototype.popStencil = function ()
  * Destroys the mask stack.
  *
  */
-StencilMaskManager.prototype.destroy = function ()
+StencilManager.prototype.destroy = function ()
 {
     WebGLManager.prototype.destroy.call(this);
 

--- a/src/core/sprites/canvas/CanvasTinter.js
+++ b/src/core/sprites/canvas/CanvasTinter.js
@@ -1,250 +1,268 @@
 var utils = require('../../utils'),
-canUseNewCanvasBlendModes = require('../../renderers/canvas/utils/canUseNewCanvasBlendModes');
+    canUseNewCanvasBlendModes = require('../../renderers/canvas/utils/canUseNewCanvasBlendModes');
+
 /**
  * Utility methods for Sprite/Texture tinting.
+ *
  * @namespace PIXI.CanvasTinter
  */
-var CanvasTinter = {};
-module.exports = CanvasTinter;
-
-/**
- * Basically this method just needs a sprite and a color and tints the sprite with the given color.
- *
- * @memberof! PIXI.CanvasTinter#
- * @param sprite {PIXI.Sprite} the sprite to tint
- * @param color {number} the color to use to tint the sprite with
- * @return {HTMLCanvasElement} The tinted canvas
- */
-CanvasTinter.getTintedTexture = function (sprite, color)
-{
-    var texture = sprite.texture;
-
-    color = CanvasTinter.roundColor(color);
-
-    var stringColor = '#' + ('00000' + ( color | 0).toString(16)).substr(-6);
-
-    texture.tintCache = texture.tintCache || {};
-
-    if (texture.tintCache[stringColor])
+var CanvasTinter = module.exports = {
+    /**
+     * Basically this method just needs a sprite and a color and tints the sprite with the given color.
+     *
+     * @memberof PIXI.CanvasTinter
+     * @param sprite {PIXI.Sprite} the sprite to tint
+     * @param color {number} the color to use to tint the sprite with
+     * @return {HTMLCanvasElement} The tinted canvas
+     */
+    getTintedTexture: function (sprite, color)
     {
-        return texture.tintCache[stringColor];
-    }
+        var texture = sprite.texture;
 
-     // clone texture..
-    var canvas = CanvasTinter.canvas || document.createElement('canvas');
+        color = CanvasTinter.roundColor(color);
 
-    //CanvasTinter.tintWithPerPixel(texture, stringColor, canvas);
-    CanvasTinter.tintMethod(texture, color, canvas);
+        var stringColor = '#' + ('00000' + ( color | 0).toString(16)).substr(-6);
 
-    if (CanvasTinter.convertTintToImage)
+        texture.tintCache = texture.tintCache || {};
+
+        if (texture.tintCache[stringColor])
+        {
+            return texture.tintCache[stringColor];
+        }
+
+        // clone texture..
+        var canvas = CanvasTinter.canvas || document.createElement('canvas');
+
+        //CanvasTinter.tintWithPerPixel(texture, stringColor, canvas);
+        CanvasTinter.tintMethod(texture, color, canvas);
+
+        if (CanvasTinter.convertTintToImage)
+        {
+            // is this better?
+            var tintImage = new Image();
+            tintImage.src = canvas.toDataURL();
+
+            texture.tintCache[stringColor] = tintImage;
+        }
+        else
+        {
+            texture.tintCache[stringColor] = canvas;
+            // if we are not converting the texture to an image then we need to lose the reference to the canvas
+            CanvasTinter.canvas = null;
+        }
+
+        return canvas;
+    },
+
+    /**
+     * Tint a texture using the 'multiply' operation.
+     *
+     * @memberof PIXI.CanvasTinter
+     * @param texture {PIXI.Texture} the texture to tint
+     * @param color {number} the color to use to tint the sprite with
+     * @param canvas {HTMLCanvasElement} the current canvas
+     */
+    tintWithMultiply: function (texture, color, canvas)
     {
-        // is this better?
-        var tintImage = new Image();
-        tintImage.src = canvas.toDataURL();
+        var context = canvas.getContext( '2d' );
+        var crop = texture._frame.clone();
+        var resolution = texture.baseTexture.resolution;
 
-        texture.tintCache[stringColor] = tintImage;
-    }
-    else
+        crop.x *= resolution;
+        crop.y *= resolution;
+        crop.width *= resolution;
+        crop.height *= resolution;
+
+        canvas.width = crop.width;
+        canvas.height = crop.height;
+
+        context.fillStyle = '#' + ('00000' + ( color | 0).toString(16)).substr(-6);
+
+        context.fillRect(0, 0, crop.width, crop.height);
+
+        context.globalCompositeOperation = 'multiply';
+
+        context.drawImage(
+            texture.baseTexture.source,
+            crop.x,
+            crop.y,
+            crop.width,
+            crop.height,
+            0,
+            0,
+            crop.width,
+            crop.height
+        );
+
+        context.globalCompositeOperation = 'destination-atop';
+
+        context.drawImage(
+            texture.baseTexture.source,
+            crop.x,
+            crop.y,
+            crop.width,
+            crop.height,
+            0,
+            0,
+            crop.width,
+            crop.height
+        );
+    },
+
+    /**
+     * Tint a texture using the 'overlay' operation.
+     *
+     * @memberof PIXI.CanvasTinter
+     * @param texture {PIXI.Texture} the texture to tint
+     * @param color {number} the color to use to tint the sprite with
+     * @param canvas {HTMLCanvasElement} the current canvas
+     */
+    tintWithOverlay: function (texture, color, canvas)
     {
-        texture.tintCache[stringColor] = canvas;
-        // if we are not converting the texture to an image then we need to lose the reference to the canvas
-        CanvasTinter.canvas = null;
-    }
+        var context = canvas.getContext( '2d' );
+        var crop = texture._frame.clone();
+        var resolution = texture.baseTexture.resolution;
 
-    return canvas;
-};
+        crop.x *= resolution;
+        crop.y *= resolution;
+        crop.width *= resolution;
+        crop.height *= resolution;
 
-/**
- * Tint a texture using the 'multiply' operation.
- *
- * @memberof! PIXI.CanvasTinter#
- * @param texture {PIXI.Texture} the texture to tint
- * @param color {number} the color to use to tint the sprite with
- * @param canvas {HTMLCanvasElement} the current canvas
- */
-CanvasTinter.tintWithMultiply = function (texture, color, canvas)
-{
-    var context = canvas.getContext( '2d' );
-    var crop = texture._frame.clone();
-    var resolution = texture.baseTexture.resolution;
+        canvas.width = crop.width;
+        canvas.height = crop.height;
 
-    crop.x *= resolution;
-    crop.y *= resolution;
-    crop.width *= resolution;
-    crop.height *= resolution;
+        context.globalCompositeOperation = 'copy';
+        context.fillStyle = '#' + ('00000' + ( color | 0).toString(16)).substr(-6);
+        context.fillRect(0, 0, crop.width, crop.height);
 
-    canvas.width = crop.width;
-    canvas.height = crop.height;
+        context.globalCompositeOperation = 'destination-atop';
+        context.drawImage(
+            texture.baseTexture.source,
+            crop.x,
+            crop.y,
+            crop.width,
+            crop.height,
+            0,
+            0,
+            crop.width,
+            crop.height
+        );
 
-    context.fillStyle = '#' + ('00000' + ( color | 0).toString(16)).substr(-6);
+        // context.globalCompositeOperation = 'copy';
+    },
 
-    context.fillRect(0, 0, crop.width, crop.height);
-
-    context.globalCompositeOperation = 'multiply';
-
-    context.drawImage(
-        texture.baseTexture.source,
-        crop.x,
-        crop.y,
-        crop.width,
-        crop.height,
-        0,
-        0,
-        crop.width,
-        crop.height
-    );
-
-    context.globalCompositeOperation = 'destination-atop';
-
-    context.drawImage(
-        texture.baseTexture.source,
-        crop.x,
-        crop.y,
-        crop.width,
-        crop.height,
-        0,
-        0,
-        crop.width,
-        crop.height
-    );
-};
-
-/**
- * Tint a texture using the 'overlay' operation.
- *
- * @memberof! PIXI.CanvasTinter#
- * @param texture {PIXI.Texture} the texture to tint
- * @param color {number} the color to use to tint the sprite with
- * @param canvas {HTMLCanvasElement} the current canvas
- */
-CanvasTinter.tintWithOverlay = function (texture, color, canvas)
-{
-    var context = canvas.getContext( '2d' );
-    var crop = texture._frame.clone();
-    var resolution = texture.baseTexture.resolution;
-
-    crop.x *= resolution;
-    crop.y *= resolution;
-    crop.width *= resolution;
-    crop.height *= resolution;
-
-    canvas.width = crop.width;
-    canvas.height = crop.height;
-
-    context.globalCompositeOperation = 'copy';
-    context.fillStyle = '#' + ('00000' + ( color | 0).toString(16)).substr(-6);
-    context.fillRect(0, 0, crop.width, crop.height);
-
-    context.globalCompositeOperation = 'destination-atop';
-    context.drawImage(
-        texture.baseTexture.source,
-        crop.x,
-        crop.y,
-        crop.width,
-        crop.height,
-        0,
-        0,
-        crop.width,
-        crop.height
-    );
-
-    // context.globalCompositeOperation = 'copy';
-};
-
-/**
- * Tint a texture pixel per pixel.
- *
- * @memberof! PIXI.CanvasTinter#
- * @param texture {PIXI.Texture} the texture to tint
- * @param color {number} the color to use to tint the sprite with
- * @param canvas {HTMLCanvasElement} the current canvas
- */
-CanvasTinter.tintWithPerPixel = function (texture, color, canvas)
-{
-    var context = canvas.getContext( '2d' );
-    var crop = texture._frame.clone();
-    var resolution = texture.baseTexture.resolution;
-
-    crop.x *= resolution;
-    crop.y *= resolution;
-    crop.width *= resolution;
-    crop.height *= resolution;
-
-    canvas.width = crop.width;
-    canvas.height = crop.height;
-
-    context.globalCompositeOperation = 'copy';
-    context.drawImage(
-        texture.baseTexture.source,
-        crop.x,
-        crop.y,
-        crop.width,
-        crop.height,
-        0,
-        0,
-        crop.width,
-        crop.height
-    );
-
-    var rgbValues = utils.hex2rgb(color);
-    var r = rgbValues[0], g = rgbValues[1], b = rgbValues[2];
-
-    var pixelData = context.getImageData(0, 0, crop.width, crop.height);
-
-    var pixels = pixelData.data;
-
-    for (var i = 0; i < pixels.length; i += 4)
+    /**
+     * Tint a texture pixel per pixel.
+     *
+     * @memberof PIXI.CanvasTinter
+     * @param texture {PIXI.Texture} the texture to tint
+     * @param color {number} the color to use to tint the sprite with
+     * @param canvas {HTMLCanvasElement} the current canvas
+     */
+    tintWithPerPixel: function (texture, color, canvas)
     {
-        pixels[i+0] *= r;
-        pixels[i+1] *= g;
-        pixels[i+2] *= b;
-    }
+        var context = canvas.getContext( '2d' );
+        var crop = texture._frame.clone();
+        var resolution = texture.baseTexture.resolution;
 
-    context.putImageData(pixelData, 0, 0);
+        crop.x *= resolution;
+        crop.y *= resolution;
+        crop.width *= resolution;
+        crop.height *= resolution;
+
+        canvas.width = crop.width;
+        canvas.height = crop.height;
+
+        context.globalCompositeOperation = 'copy';
+        context.drawImage(
+            texture.baseTexture.source,
+            crop.x,
+            crop.y,
+            crop.width,
+            crop.height,
+            0,
+            0,
+            crop.width,
+            crop.height
+        );
+
+        var rgbValues = utils.hex2rgb(color);
+        var r = rgbValues[0], g = rgbValues[1], b = rgbValues[2];
+
+        var pixelData = context.getImageData(0, 0, crop.width, crop.height);
+
+        var pixels = pixelData.data;
+
+        for (var i = 0; i < pixels.length; i += 4)
+        {
+            pixels[i+0] *= r;
+            pixels[i+1] *= g;
+            pixels[i+2] *= b;
+        }
+
+        context.putImageData(pixelData, 0, 0);
+    },
+
+    /**
+     * Rounds the specified color according to the CanvasTinter.cacheStepsPerColorChannel.
+     *
+     * @memberof PIXI.CanvasTinter
+     * @param color {number} the color to round, should be a hex color
+     */
+    roundColor: function (color)
+    {
+        var step = CanvasTinter.cacheStepsPerColorChannel;
+
+        var rgbValues = utils.hex2rgb(color);
+
+        rgbValues[0] = Math.min(255, (rgbValues[0] / step) * step);
+        rgbValues[1] = Math.min(255, (rgbValues[1] / step) * step);
+        rgbValues[2] = Math.min(255, (rgbValues[2] / step) * step);
+
+        return utils.rgb2hex(rgbValues);
+    },
+
+    /**
+     * Number of steps which will be used as a cap when rounding colors.
+     *
+     * @memberof PIXI.CanvasTinter
+     * @type {number}
+     */
+    cacheStepsPerColorChannel: 8,
+
+    /**
+     * Tint cache boolean flag.
+     *
+     * @memberof PIXI.CanvasTinter
+     * @type {boolean}
+     */
+    convertTintToImage: false,
+
+    /**
+     * Whether or not the Canvas BlendModes are supported, consequently the ability to tint using the multiply method.
+     *
+     * @memberof PIXI.CanvasTinter
+     * @type {boolean}
+     */
+    canUseMultiply: canUseNewCanvasBlendModes(),
+
+    /**
+     * The tinting method that will be used.
+     *
+     * @memberof PIXI.CanvasTinter
+     * @type {tintMethodFunctionType}
+     */
+    tintMethod: 0
 };
 
-/**
- * Rounds the specified color according to the CanvasTinter.cacheStepsPerColorChannel.
- *
- * @memberof! PIXI.CanvasTinter#
- * @param color {number} the color to round, should be a hex color
- */
-CanvasTinter.roundColor = function (color)
-{
-    var step = CanvasTinter.cacheStepsPerColorChannel;
-
-    var rgbValues = utils.hex2rgb(color);
-
-    rgbValues[0] = Math.min(255, (rgbValues[0] / step) * step);
-    rgbValues[1] = Math.min(255, (rgbValues[1] / step) * step);
-    rgbValues[2] = Math.min(255, (rgbValues[2] / step) * step);
-
-    return utils.rgb2hex(rgbValues);
-};
-
-/**
- * Number of steps which will be used as a cap when rounding colors.
- *
- * @memberof! PIXI.CanvasTinter#
- */
-CanvasTinter.cacheStepsPerColorChannel = 8;
-
-/**
- * Tint cache boolean flag.
- *
- * @memberof! PIXI.CanvasTinter#
- */
-CanvasTinter.convertTintToImage = false;
-
-/**
- * Whether or not the Canvas BlendModes are supported, consequently the ability to tint using the multiply method.
- *
- * @memberof! PIXI.CanvasTinter#
- */
-CanvasTinter.canUseMultiply = canUseNewCanvasBlendModes();
-
-/**
- * The tinting method that will be used.
- *
- */
 CanvasTinter.tintMethod = CanvasTinter.canUseMultiply ? CanvasTinter.tintWithMultiply :  CanvasTinter.tintWithPerPixel;
+
+/**
+ * The tintMethod type.
+ *
+ * @memberof PIXI.CanvasTinter
+ * @callback tintMethodFunctionType
+ * @param texture {PIXI.Texture} the texture to tint
+ * @param color {number} the color to use to tint the sprite with
+ * @param canvas {HTMLCanvasElement} the current canvas
+ */

--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -9,7 +9,7 @@ var utils = require('../utils'),
  *
  * @class
  * @memberof PIXI
- * @param [source ]{Image|HTMLCanvasElement} the source object of the texture.
+ * @param [source ]{HTMLImageElement|HTMLCanvasElement} the source object of the texture.
  * @param [scaleMode=PIXI.SCALE_MODES.DEFAULT] {number} See {@link PIXI.SCALE_MODES} for possible values
  * @param [resolution=1] {number} The resolution / device pixel ratio of the texture
  */
@@ -98,7 +98,7 @@ function BaseTexture(source, scaleMode, resolution)
      *
      * TODO: Make this a setter that calls loadSource();
      *
-     * @member {Image|HTMLCanvasElement}
+     * @member {HTMLImageElement|HTMLCanvasElement}
      * @readonly
      */
     this.source = null; // set in loadSource, if at all
@@ -221,7 +221,7 @@ BaseTexture.prototype.update = function ()
  *     }
  *
  * @protected
- * @param source {Image|HTMLCanvasElement} the source object of the texture.
+ * @param source {HTMLImageElement|HTMLCanvasElement} the source object of the texture.
  */
 BaseTexture.prototype.loadSource = function (source)
 {

--- a/src/core/ticker/Ticker.js
+++ b/src/core/ticker/Ticker.js
@@ -90,7 +90,7 @@ function Ticker()
      * If the platform supports DOMHighResTimeStamp,
      * this value will have a precision of 1 µs.
      *
-     * @member {DOMHighResTimeStamp|number}
+     * @member {number}
      * @default 1 / TARGET_FPMS
      */
     this.elapsedMS = 1 / CONST.TARGET_FPMS; // default to target frame time
@@ -102,7 +102,7 @@ function Ticker()
      * If the platform supports DOMHighResTimeStamp,
      * this value will have a precision of 1 µs.
      *
-     * @member {DOMHighResTimeStamp|number}
+     * @member {number}
      * @default 0
      */
     this.lastTime = 0;
@@ -323,7 +323,7 @@ Ticker.prototype.stop = function stop()
  * frame callbacks if the ticker instance has been started
  * and listeners are added.
  *
- * @param [currentTime=performance.now()] {DOMHighResTimeStamp|number} the current time of execution
+ * @param [currentTime=performance.now()] {number} the current time of execution
  */
 Ticker.prototype.update = function update(currentTime)
 {

--- a/src/extract/canvas/CanvasExtract.js
+++ b/src/extract/canvas/CanvasExtract.js
@@ -21,7 +21,7 @@ module.exports = CanvasExtract;
  * Will return a HTML Image of the target
  *
  * @param target {PIXI.DisplayObject|PIXI.RenderTexture} A displayObject or renderTexture to convert. If left empty will use use the main renderer
- * @return {Image} HTML Image of the target
+ * @return {HTMLImageElement} HTML Image of the target
  */
 CanvasExtract.prototype.image = function ( target )
 {

--- a/src/extract/webgl/WebGLExtract.js
+++ b/src/extract/webgl/WebGLExtract.js
@@ -21,7 +21,7 @@ module.exports = WebGLExtract;
  * Will return a HTML Image of the target
  *
  * @param target {PIXI.DisplayObject|PIXI.RenderTexture} A displayObject or renderTexture to convert. If left empty will use use the main renderer
- * @return {Image} HTML Image of the target
+ * @return {HTMLImageElement} HTML Image of the target
  */
 WebGLExtract.prototype.image = function ( target )
 {

--- a/src/extras/MovieClip.js
+++ b/src/extras/MovieClip.js
@@ -1,7 +1,7 @@
 var core = require('../core');
 
 /**
- * @typedef PIXI.extras.MovieClip.FrameObject
+ * @typedef FrameObject
  * @type {object}
  * @property texture {PIXI.Texture} The {@link PIXI.Texture} of the frame
  * @property time {number} the duration of the frame in ms
@@ -27,7 +27,7 @@ var core = require('../core');
  * @class
  * @extends PIXI.Sprite
  * @memberof PIXI.extras
- * @param textures {PIXI.Texture[]|PIXI.extras.MovieClip.FrameObject[]} an array of {@link PIXI.Texture} or frame objects that make up the animation
+ * @param textures {PIXI.Texture[]|FrameObject[]} an array of {@link PIXI.Texture} or frame objects that make up the animation
  */
 function MovieClip(textures)
 {

--- a/src/mesh/Plane.js
+++ b/src/mesh/Plane.js
@@ -14,8 +14,8 @@ var Mesh = require('./Mesh');
  * @extends PIXI.mesh.Mesh
  * @memberof PIXI.mesh
  * @param {PIXI.Texture} texture - The texture to use on the Plane.
- * @param {int} segmentsX - The number ox x segments
- * @param {int} segmentsY - The number of y segments
+ * @param {number} segmentsX - The number ox x segments
+ * @param {number} segmentsY - The number of y segments
  *
  */
 function Plane(texture, segmentsX, segmentsY)
@@ -74,7 +74,7 @@ Plane.prototype.refresh = function()
         verts.push((x * sizeX),
                    (y * sizeY));
 
-        // this works for rectangular textures. 
+        // this works for rectangular textures.
         uvs.push(texture._uvs.x0 + (texture._uvs.x1 - texture._uvs.x0) * (x / (this.segmentsX-1)), texture._uvs.y0 + (texture._uvs.y3-texture._uvs.y0) * (y/ (this.segmentsY-1)));
       }
 


### PR DESCRIPTION
While working on a JSDoc3 theme meant to generate typescript definition files from JSDoc annotated JavaScript source (https://github.com/englercj/tsd-jsdoc) I found a few documentation errors throughout the source.

This PR is me fixing those, as well as replacing some tabs with spaces.