### PR TITLE
Fixes jshint error in WebGLState

### DIFF
--- a/src/core/renderers/webgl/WebGLState.js
+++ b/src/core/renderers/webgl/WebGLState.js
@@ -62,7 +62,7 @@ function WebGLState(gl)
       gl.getExtension('MOZ_OES_vertex_array_object') ||
       gl.getExtension('WEBKIT_OES_vertex_array_object')
     );
-};
+}
 
 /**
  * Pushes a new active state


### PR DESCRIPTION
Small fix to resolve build jshint error:
```
src/core/renderers/webgl/WebGLState.js
--------------------------------------
 W032  Line 65, Col 2  Unnecessary semicolon.
```