### PR TITLE
BaseTexture used for text now reports correct realWidth and realHeight

### DIFF
--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -409,6 +409,8 @@ Text.prototype.updateTexture = function ()
     texture.baseTexture.hasLoaded = true;
     texture.baseTexture.resolution = this.resolution;
 
+    texture.baseTexture.realWidth = this.canvas.width;
+    texture.baseTexture.realHeight = this.canvas.height;
     texture.baseTexture.width = this.canvas.width / this.resolution;
     texture.baseTexture.height = this.canvas.height / this.resolution;
     texture.trim.width = texture._frame.width = this.canvas.width / this.resolution;


### PR DESCRIPTION
Was trying to work out how much texture space I was taking up with Text, and noticed that measuring that with a resolution of 1 was the same as resolution of 2. Turns out that realWidth and realHeight weren't being updated, so were always reported the default canvas creation size.