### PR TITLE
cacheAsBitmap+mask fix, tested on tankwars.io

### DIFF
--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -968,7 +968,7 @@ Graphics.prototype.generateCanvasTexture = function(scaleMode, resolution)
 
     var bounds = this.getLocalBounds();
 
-    var canvasBuffer = new RenderTexture.create(bounds.width * resolution, bounds.height * resolution);
+    var canvasBuffer = RenderTexture.create(bounds.width | 0, bounds.height | 0, scaleMode, resolution);
 
     if(!canvasRenderer)
     {
@@ -978,7 +978,9 @@ Graphics.prototype.generateCanvasTexture = function(scaleMode, resolution)
     tempMatrix.tx = -bounds.x;
     tempMatrix.ty = -bounds.y;
 
-    canvasRenderer.render(this, canvasBuffer, false, tempMatrix);
+    this.beginTextureGeneration(tempMatrix);
+    canvasRenderer.render(this, canvasBuffer);
+    this.endTextureGeneration(false);
 
     var texture = Texture.fromCanvas(canvasBuffer.baseTexture._canvasRenderTarget.canvas, scaleMode);
     texture.baseTexture.resolution = resolution;

--- a/src/core/renderers/SystemRenderer.js
+++ b/src/core/renderers/SystemRenderer.js
@@ -242,7 +242,14 @@ SystemRenderer.prototype.generateTexture = function (displayObject, scaleMode, r
     tempMatrix.tx = -bounds.x;
     tempMatrix.ty = -bounds.y;
 
-    this.render(displayObject, renderTexture, false, tempMatrix, true);
+    renderTexture.generatedSpriteFrame = bounds.clone();
+    renderTexture.generatedSpriteAnchor = new math.Point(-bounds.x / bounds.width, -bounds.y / bounds.height);
+
+    displayObject.beginTextureGeneration(tempMatrix);
+
+    this.render(displayObject, renderTexture, false, null, true);
+
+    displayObject.endTextureGeneration(true);
 
     return renderTexture;
 };

--- a/src/core/renderers/SystemRenderer.js
+++ b/src/core/renderers/SystemRenderer.js
@@ -249,7 +249,7 @@ SystemRenderer.prototype.generateTexture = function (displayObject, scaleMode, r
 
     this.render(displayObject, renderTexture, false, null, true);
 
-    displayObject.endTextureGeneration(true);
+    displayObject.endTextureGeneration(false);
 
     return renderTexture;
 };

--- a/src/extras/cacheAsBitmap.js
+++ b/src/extras/cacheAsBitmap.js
@@ -101,13 +101,13 @@ DisplayObject.prototype.beginTextureGeneration = function(matrix) {
 /**
  * Finalizes texture generation, returns all previous values.
  * You can omit that for performance, nothing really bad will happen, just some side-effects
- * @param updateChildren {boolean} may update children again to return them in old state
+ * @param skipUpdate {boolean} do not update children to return them in old state
  */
-DisplayObject.prototype.endTextureGeneration = function(updateChildren) {
+DisplayObject.prototype.endTextureGeneration = function(skipUpdate) {
     this.transform.worldTransform = this._cacheWorldTransform;
     this.transform._worldID++;
     this.worldAlpha = this._cacheWorldAlpha;
-    if (updateChildren) {
+    if (!skipUpdate) {
         for (var i = 0, j = this.children.length; i < j; ++i) {
             this.children[i].updateTransform();
         }
@@ -190,7 +190,7 @@ DisplayObject.prototype._initCachedDisplayObject = function (renderer)
 
     renderer.render(this, renderTexture, true, null, true);
     // now restore the state be setting the new properties
-    this.endTextureGeneration(false);
+    this.endTextureGeneration(true);
 
     renderer.bindRenderTarget(cachedRenderTarget);
 

--- a/src/extras/cacheAsBitmap.js
+++ b/src/extras/cacheAsBitmap.js
@@ -72,6 +72,49 @@ Object.defineProperties(DisplayObject.prototype, {
         }
     }
 });
+
+/**
+ * This is old v3 implementation of getLocalBounds() which is required for cacheAsBitmap and generateTexture functions.
+ * Temporarily hijacks
+ *
+ * The calculation takes all visible children into consideration.
+ *
+ * The calculation can mess up with current transforms and bounds!
+ *
+ * @param matrix {PIXI.Matrix} required, take PIXI.Matrix.IDENTITY
+ */
+DisplayObject.prototype.beginTextureGeneration = function(matrix) {
+    this._cacheWorldTransform = this.transform.worldTransform;
+    this._cacheWorldAlpha = this.worldAlpha;
+
+    this.transform.worldTransform = matrix;
+    this.transform._worldID++;
+    this.worldAlpha = this.alpha;
+
+    for (var i = 0, j = this.children.length; i < j; ++i)
+    {
+        this.children[i].updateTransform();
+    }
+    this._currentBounds = null;
+};
+
+/**
+ * Finalizes texture generation, returns all previous values.
+ * You can omit that for performance, nothing really bad will happen, just some side-effects
+ * @param updateChildren {boolean} may update children again to return them in old state
+ */
+DisplayObject.prototype.endTextureGeneration = function(updateChildren) {
+    this.transform.worldTransform = this._cacheWorldTransform;
+    this.transform._worldID++;
+    this.worldAlpha = this._cacheWorldAlpha;
+    if (updateChildren) {
+        for (var i = 0, j = this.children.length; i < j; ++i) {
+            this.children[i].updateTransform();
+        }
+    }
+    this._currentBounds = null;
+};
+
 /**
 * Renders a cached version of the sprite with WebGL
 *
@@ -141,11 +184,13 @@ DisplayObject.prototype._initCachedDisplayObject = function (renderer)
     m.tx = -bounds.x;
     m.ty = -bounds.y;
 
+    this.beginTextureGeneration(_tempMatrix);
     // set all properties to there original so we can render to a texture
     this.renderWebGL = this._originalRenderWebGL;
 
-    renderer.render(this, renderTexture, true, m, true);
+    renderer.render(this, renderTexture, true, null, true);
     // now restore the state be setting the new properties
+    this.endTextureGeneration(false);
 
     renderer.bindRenderTarget(cachedRenderTarget);
 
@@ -204,7 +249,7 @@ DisplayObject.prototype._initCachedDisplayObjectCanvas = function (renderer)
     }
 
     //get bounds actually transforms the object for us already!
-    var bounds = this.getLocalBounds();
+    var bounds = this.getLegacyLocalBounds();
 
     var cachedRenderTarget = renderer.context;
 
@@ -253,7 +298,7 @@ DisplayObject.prototype._getCachedBounds = function ()
 {
     this._cachedSprite._currentBounds = null;
 
-    return this._cachedSprite.getBounds(core.Matrix.IDENTITY);
+    return this._cachedSprite.getBounds();
 };
 
 /**


### PR DESCRIPTION
subject.

This works regardless of how getLocalBounds() works, and regardless of "renderTarget.transform" which i think is evil spawn.

This fixes the following test (try to click on a sprite tp cache it):

```js
var renderer = PIXI.autoDetectRenderer(800, 600);
document.body.appendChild(renderer.view);

// create the root of the scene graph
var stage = new PIXI.Container();

// load resources
PIXI.loader
    .add('spritesheet','_assets/monsters.json')
    .load(onAssetsLoaded);

// holder to store aliens
var aliens = [];
var alienFrames = ['eggHead.png', 'flowerTop.png', 'helmlok.png', 'skully.png'];

var count = 0;

// create an empty container
var alienContainer = new PIXI.Container();
alienContainer.position.set(0);

var graphics = new PIXI.Graphics();
graphics.beginFill(0xFFFFFF);
graphics.drawRect(0, 0, 200, 200);
graphics.endFill();
graphics.position.set(100);
alienContainer.addChild(graphics);

var mask = PIXI.Sprite.fromImage('_assets/flowerTop.png');
alienContainer.mask = mask;
mask.position.set(200);
mask.anchor.set(0.5);
alienContainer.addChild(mask)

// make the stage interactive
stage.interactive = true;

stage.addChild(alienContainer);

function onAssetsLoaded()
{
    // start animating
    requestAnimationFrame(animate);
}

stage.on('click', onClick);
stage.on('tap', onClick);

function onClick()
{
    alienContainer.cacheAsBitmap = !alienContainer.cacheAsBitmap;

}

function animate() {
    // render the stage
    renderer.render(stage);

    requestAnimationFrame(animate);
}
```