### PR TITLE
Multitexturing DERP

### DIFF
--- a/src/core/sprites/webgl/generateMultiTextureShader.js
+++ b/src/core/sprites/webgl/generateMultiTextureShader.js
@@ -8,9 +8,10 @@ var fragTemplate = [
     'uniform sampler2D uSamplers[%count%];',
 
     'void main(void){',
-        'vec4 color;',
-        '%forloop%',
-        'gl_FragColor = color * vColor;',
+    'vec4 color;',
+    'float textureId = floor(vTextureId+0.01);',
+    '%forloop%',
+    'gl_FragColor = color * vColor;',
     '}'
 ].join('\n');
 
@@ -52,7 +53,7 @@ function generateSampleSrc(maxTextures)
 
         if(i < maxTextures-1)
         {
-            src += 'if(vTextureId == ' + i + '.0)';
+            src += 'if(textureId == ' + i + '.0)';
         }
 
         src += '\n{';

--- a/src/core/sprites/webgl/generateMultiTextureShader.js
+++ b/src/core/sprites/webgl/generateMultiTextureShader.js
@@ -9,7 +9,7 @@ var fragTemplate = [
 
     'void main(void){',
     'vec4 color;',
-    'float textureId = floor(vTextureId+0.01);',
+    'float textureId = floor(vTextureId+0.5);',
     '%forloop%',
     'gl_FragColor = color * vColor;',
     '}'


### PR DESCRIPTION
Precision errors can be very strange on some devices. Especially if you are rendering 3d transform. This is part of gameofbombs/pixi.js fork, I did not think that it will be needed in 2D scenes too.

Related to #2734, may be #2731 #2726 too.