### PR TITLE
extra conditions for bounds

### DIFF
--- a/src/core/display/BoundsBuilder.js
+++ b/src/core/display/BoundsBuilder.js
@@ -6,6 +6,9 @@ var math = require('../math'),
  * Axis-Aligned Bounding Box
  * It is not a shape! Its mutable thing, no 'EMPTY' or that kind of problems
  *
+ * Condition: Use it only as a temporary object per one calculation or per one module.
+ * If browser profiler shows more than 10 elements of that in memory, something is clearly wrong
+ *
  * @class
  * @memberof PIXI
  */

--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -447,7 +447,7 @@ Container.prototype.getBounds = function (skipUpdate)
                 child.updateTransform();
             }
 
-            childBounds = this.children[i].getBounds();
+            childBounds = this.children[i].getBounds(true);
             if (childBounds === math.Rectangle.EMPTY) {
                 continue;
             }

--- a/src/core/display/TransformBase.js
+++ b/src/core/display/TransformBase.js
@@ -17,15 +17,25 @@ function TransformBase()
     this.worldTransform = new math.Matrix();
     /**
      * The local matrix transform
-     * 
+     *
      * @member {PIXI.Matrix}
      */
     this.localTransform = new math.Matrix();
 
     this._worldID = 0;
+
+    this._parentID = -1;
 }
 
 TransformBase.prototype.constructor = TransformBase;
+
+/**
+ * Updates local transform, copies it to world. Used by elements which are roots and do not have parents
+ */
+TransformBase.prototype.updateRootTransform = function() {
+    this.updateLocalTransform();
+    this.updateTransform(TransformBase.IDENTITY);
+};
 
 /**
  * TransformBase does not have decomposition, so this function wont do anything

--- a/src/core/renderers/webgl/managers/MaskManager.js
+++ b/src/core/renderers/webgl/managers/MaskManager.js
@@ -108,7 +108,7 @@ MaskManager.prototype.pushSpriteMask = function (target, maskData)
     alphaMaskFilter[0].maskSprite = maskData;
 
     //TODO - may cause issues!
-    target.filterArea = maskData.getBounds();
+    target.filterArea = maskData.getBounds(true);
 
     this.renderer.filterManager.pushFilter(target, alphaMaskFilter);
 
@@ -158,7 +158,7 @@ MaskManager.prototype.pushScissorMask = function (target, maskData)
 
     var renderTarget = this.renderer._activeRenderTarget;
 
-    var bounds = maskData.getBounds();
+    var bounds = maskData.getBounds(true);
 
     bounds.fit(renderTarget.size);
     maskData.renderable = false;

--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -92,7 +92,17 @@ function Sprite(texture)
 
     // call texture setter
     this.texture = texture || Texture.EMPTY;
-    this.vertexData = new Float32Array(16);
+    /**
+     * Current vertex data
+     * @type {Float32Array}
+     */
+    this.vertexData = new Float32Array(8);
+    /**
+     * Current border data. Do you need it? please call callBorde
+     * @type {null}
+     */
+    this.borderData = null;
+
     this._transformID = -1;
     this._textureID = -1;
 }
@@ -266,31 +276,23 @@ Sprite.prototype.calculateVertices = function ()
 };
 
 /**
- * we need this method to be compatible with pixiv3. v3 does calculate bounds of original texture are, not trimmed one
+ * calculates worldTransform * border, store it in borderData. It is not trimmed!
+ * Utility function, is not used in PIXI renderer. It is here just for your own good.
  */
-Sprite.prototype.calculateBoundsVertices = function ()
+Sprite.prototype.calculateBorder = function ()
 {
     var texture = this._texture,
-        trim = texture.trim,
-        vertexData = this.vertexData,
+        wt = this.transform.worldTransform,
+        a = wt.a, b = wt.b, c = wt.c, d = wt.d, tx = wt.tx, ty = wt.ty,
+        borderData = this.borderData,
+        w0, w1, h0, h1,
         orig = texture.orig;
 
-    if (!trim || trim.width === orig.width && trim.height === orig.height) {
-        vertexData[8] = vertexData[0];
-        vertexData[9] = vertexData[1];
-        vertexData[10] = vertexData[2];
-        vertexData[11] = vertexData[3];
-        vertexData[12] = vertexData[4];
-        vertexData[13] = vertexData[5];
-        vertexData[14] = vertexData[6];
-        vertexData[15] = vertexData[7];
-        return;
+    if (!borderData)
+    {
+        borderData = new Float32Array(8);
+        this.borderData = borderData;
     }
-
-    var wt = this.transform.worldTransform,
-        a = wt.a, b = wt.b, c = wt.c, d = wt.d, tx = wt.tx, ty = wt.ty,
-        w0, w1, h0, h1;
-
 
     w0 = (orig.width ) * (1-this.anchor.x);
     w1 = (orig.width ) * -this.anchor.x;
@@ -299,20 +301,20 @@ Sprite.prototype.calculateBoundsVertices = function ()
     h1 = orig.height * -this.anchor.y;
 
     // xy
-    vertexData[8] = a * w1 + c * h1 + tx;
-    vertexData[9] = d * h1 + b * w1 + ty;
+    borderData[0] = a * w1 + c * h1 + tx;
+    borderData[1] = d * h1 + b * w1 + ty;
 
     // xy
-    vertexData[10] = a * w0 + c * h1 + tx;
-    vertexData[11] = d * h1 + b * w0 + ty;
+    borderData[2] = a * w0 + c * h1 + tx;
+    borderData[3] = d * h1 + b * w0 + ty;
 
     // xy
-    vertexData[12] = a * w0 + c * h0 + tx;
-    vertexData[13] = d * h0 + b * w0 + ty;
+    borderData[4] = a * w0 + c * h0 + tx;
+    borderData[5] = d * h0 + b * w0 + ty;
 
     // xy
-    vertexData[14] = a * w1 + c * h0 + tx;
-    vertexData[15] = d * h0 + b * w1 + ty;
+    borderData[6] = a * w1 + c * h0 + tx;
+    borderData[7] = d * h0 + b * w1 + ty;
 };
 
 /**
@@ -341,16 +343,42 @@ Sprite.prototype._renderCanvas = function (renderer)
     renderer.plugins.sprite.render(this);
 };
 
-Sprite.prototype._calculateBounds = function ()
+
+/**
+ * Passes sprite corners (without trimming) to bounds builder, takes passed transform into account.
+ *
+ * @param {PIXI.BoundsBuilder} builder
+ * @param {PIXI.TransformBase} transform
+ */
+Sprite.prototype._calculateBounds = function (builder, transform)
 {
-    this.calculateVertices();
-    // if we have already done this on THIS frame.
-    this._bounds_.addQuad(this.vertexData);
+    var texture = this._texture,
+        trim = texture.trim,
+        vertexData = this.vertexData,
+        orig = texture.orig;
+
+    if (transform === this.transform) {
+        this.calculateVertices();
+        if (!trim || trim.width === orig.width && trim.height === orig.height) {
+            builder.addQuad(vertexData);
+            return;
+        }
+    }
+
+    var w0, w1, h0, h1;
+
+    w0 = (orig.width ) * (1-this.anchor.x);
+    w1 = (orig.width ) * -this.anchor.x;
+
+    h0 = orig.height * (1-this.anchor.y);
+    h1 = orig.height * -this.anchor.y;
+
+    builder.addFrame(transform, w1, h1, w0, h0);
 };
 
 /**
  * Gets the local bounds of the sprite object.
- *
+ * Does not care about children. This is compliant with PIXI-v3
  */
 Sprite.prototype.getLocalBounds = function ()
 {

--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -634,14 +634,15 @@ Text.prototype.wordWrap = function (text)
 };
 
 /**
- * calculates the bounds of the Text as a rectangle. The bounds calculation takes the worldTransform into account.
+ * Passes corners of Text rectangle to bounds builder, takes passed transform into account.
+ *
+ * @param {PIXI.BoundsBuilder} builder
+ * @param {PIXI.TransformBase} transform
  */
-Text.prototype._calculateBounds = function ()
+Text.prototype._calculateBounds = function(builder, transform)
 {
     this.updateText(true);
-    this.calculateVertices();
-    // if we have already done this on THIS frame.
-    this._bounds_.addQuad(this.vertexData);
+    return Sprite.prototype._calculateBounds.call(this, builder, transform);
 };
 
 /**

--- a/src/extras/TilingSprite.js
+++ b/src/extras/TilingSprite.js
@@ -282,11 +282,12 @@ TilingSprite.prototype._renderCanvas = function (renderer)
 
 
 /**
- * Returns the framing rectangle of the sprite as a Rectangle object
-*
- * @return {PIXI.Rectangle} the framing rectangle
+ * Pass sprite corners to the builder.
+ *
+ * @param {PIXI.BoundsBuilder} builder
+ * @param {PIXI.TransformBase} transform
  */
-TilingSprite.prototype.getBounds = function ()
+TilingSprite.prototype._calculateBounds = function (builder, transform)
 {
     var width = this._width;
     var height = this._height;
@@ -297,64 +298,7 @@ TilingSprite.prototype.getBounds = function ()
     var h0 = height * (1-this.anchor.y);
     var h1 = height * -this.anchor.y;
 
-    var worldTransform = this.worldTransform;
-
-    var a = worldTransform.a;
-    var b = worldTransform.b;
-    var c = worldTransform.c;
-    var d = worldTransform.d;
-    var tx = worldTransform.tx;
-    var ty = worldTransform.ty;
-
-    var x1 = a * w1 + c * h1 + tx;
-    var y1 = d * h1 + b * w1 + ty;
-
-    var x2 = a * w0 + c * h1 + tx;
-    var y2 = d * h1 + b * w0 + ty;
-
-    var x3 = a * w0 + c * h0 + tx;
-    var y3 = d * h0 + b * w0 + ty;
-
-    var x4 =  a * w1 + c * h0 + tx;
-    var y4 =  d * h0 + b * w1 + ty;
-
-    var minX,
-        maxX,
-        minY,
-        maxY;
-
-    minX = x1;
-    minX = x2 < minX ? x2 : minX;
-    minX = x3 < minX ? x3 : minX;
-    minX = x4 < minX ? x4 : minX;
-
-    minY = y1;
-    minY = y2 < minY ? y2 : minY;
-    minY = y3 < minY ? y3 : minY;
-    minY = y4 < minY ? y4 : minY;
-
-    maxX = x1;
-    maxX = x2 > maxX ? x2 : maxX;
-    maxX = x3 > maxX ? x3 : maxX;
-    maxX = x4 > maxX ? x4 : maxX;
-
-    maxY = y1;
-    maxY = y2 > maxY ? y2 : maxY;
-    maxY = y3 > maxY ? y3 : maxY;
-    maxY = y4 > maxY ? y4 : maxY;
-
-    var bounds = this._bounds;
-
-    bounds.x = minX;
-    bounds.width = maxX - minX;
-
-    bounds.y = minY;
-    bounds.height = maxY - minY;
-
-    // store a reference so that if this function gets called again in the render cycle we do not have to recalculate
-    this._currentBounds = bounds;
-
-    return bounds;
+    builder.addFrame(transform, w0, h0, w1, h1);
 };
 
 /**

--- a/src/mesh/Mesh.js
+++ b/src/mesh/Mesh.js
@@ -440,15 +440,15 @@ Mesh.prototype._onTextureUpdate = function ()
 };
 
 /**
- * Returns the bounds of the mesh as a rectangle. The bounds calculation takes the worldTransform into account.
+ * Pass mesh vertices to the builder.
  *
- * @param [matrix=this.worldTransform] {PIXI.Matrix} the transformation matrix of the sprite
- * @return {PIXI.Rectangle} the framing rectangle
+ * @param {PIXI.BoundsBuilder} builder
+ * @param {PIXI.TransformBase} transform
  */
-Mesh.prototype._calculateBounds = function ()
+Mesh.prototype._calculateBounds = function (builder, transform)
 {
-    //TODO - we can cache local bounds and use them if they are dirty (like graphics)
-    this._bounds_.addVertices(this.transform, this.vertices, 0, this.vertices.length);
+    //TODO - we can cache local bounds and use them if they are dirty (like graphics). Though, only for our transform.
+    builder.addVertices(transform, this.vertices, 0, this.vertices.length);
 };
 
 /**


### PR DESCRIPTION
When I made previous boundsBuilder PR, I wanted these conditions to be met, but I didnt specify it. @GoodBoyDigital added many tests (THANK YOU! :+1:), introduced "skipUpdate" parameter, but he also sweeped all my conditions as a garbage.

In the future we will have to deal with one big performance problem: culling. I believe that it will require these conditions.

BoundsBuilder: Use it only as a temporary object per one calculation or per one module. If browser profiler shows more than 10 elements of that in memory, something is clearly wrong

DisplayObject.transform: transform shows global coordinates that were calculated after last updateTransform() pass. It may contain some local stuff only if a parent is cachedAsBitmap or inside generateTexture. getLocalBounds() does not use it.

DisplayObject.calculateBounds: does not affect anything except passed builder and may be some cached or pooled bounds for Mesh or Graphics.
