### PR TITLE
Add exception handling to `utils.canUseNewCanvasBlendModes`

### DIFF
--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -93,8 +93,15 @@ var utils = module.exports = {
         context.globalCompositeOperation = 'multiply';
         context.drawImage(magenta, 0, 0);
         context.drawImage(yellow, 2, 0);
-
-        var data = context.getImageData(2,0,1,1).data;
+        
+        try 
+        {
+            var data = context.getImageData(2, 0, 1, 1).data;
+        }
+        catch (e) 
+        {
+            return false;
+        }
 
         return (data[0] === 255 && data[1] === 0 && data[2] === 0);
     },

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -94,14 +94,14 @@ var utils = module.exports = {
         context.drawImage(magenta, 0, 0);
         context.drawImage(yellow, 2, 0);
         
-        try 
-        {
-            var data = context.getImageData(2, 0, 1, 1).data;
-        }
-        catch (e) 
+        var imageData = context.getImageData(2,0,1,1);
+        
+        if (!imageData)
         {
             return false;
         }
+        
+        var data = imageData.data;
 
         return (data[0] === 255 && data[1] === 0 && data[2] === 0);
     },


### PR DESCRIPTION
Multiple sites using pixi have been throwing the following error:
`Uncaught TypeError: Cannot read property 'data' of undefined`.

----

Chromium v53 x64 Linux  Kernel 4.6