### PR TITLE
Add exception handling to `canUseNewCanvasBlendModes`

### DIFF
--- a/src/core/renderers/canvas/utils/canUseNewCanvasBlendModes.js
+++ b/src/core/renderers/canvas/utils/canUseNewCanvasBlendModes.js
@@ -29,8 +29,15 @@ var canUseNewCanvasBlendModes = function ()
     context.drawImage(magenta, 0, 0);
     context.drawImage(yellow, 2, 0);
 
-    var data = context.getImageData(2,0,1,1).data;
-
+    var imageData = context.getImageData(2,0,1,1);
+    
+    if (!imageData)
+    {
+        return false;
+    }
+    
+    var data = imageData.data;
+    
     return (data[0] === 255 && data[1] === 0 && data[2] === 0);
 };
 


### PR DESCRIPTION
Multiple sites using pixi have been throwing the following error:
`Uncaught TypeError: Cannot read property 'data' of undefined.`

Additional context - I use a few extensions to prevent canvas fingerprinting and they seem to be the cause of my error.