### PR TITLE
Able to find out the real width and height of a base render texture

### DIFF
--- a/src/core/textures/BaseRenderTexture.js
+++ b/src/core/textures/BaseRenderTexture.js
@@ -52,6 +52,9 @@ function BaseRenderTexture(width, height, scaleMode, resolution)
     this.width = width || 100;
     this.height = height || 100;
 
+    this.realWidth = this.width * resolution;
+    this.realHeight = this.height * resolution;
+
     this.resolution = resolution || CONST.RESOLUTION;
     this.scaleMode = scaleMode || CONST.SCALE_MODES.DEFAULT;
     this.hasLoaded = true;
@@ -102,6 +105,9 @@ BaseRenderTexture.prototype.resize = function (width, height)
 
     this.width = width;
     this.height = height;
+
+    this.realWidth = this.width * this.resolution;
+    this.realHeight = this.height * this.resolution;
 
     if (!this.valid)
     {


### PR DESCRIPTION
Previously these weren't updated so reported back as 100/100