### PR TITLE
Removed unused Mesh include

### DIFF
--- a/src/mesh/NineSlicePlane.js
+++ b/src/mesh/NineSlicePlane.js
@@ -1,7 +1,6 @@
 var DEFAULT_BORDER_SIZE= 10;
 
 var Plane = require('./Plane');
-var Mesh = require('./Mesh');
 
 /**
  * The NineSlicePlane allows you to stretch a texture using 9-slice scaling. The corners will remain unscaled (useful


### PR DESCRIPTION
unused mesh include caused a jsHint error, line has been removed
following @staff0rd s comment in  #2715 