### PR TITLE
MaskManager - Sprite Mask Resolution

### DIFF
--- a/src/core/renderers/webgl/managers/MaskManager.js
+++ b/src/core/renderers/webgl/managers/MaskManager.js
@@ -105,6 +105,7 @@ MaskManager.prototype.pushSpriteMask = function (target, maskData)
         alphaMaskFilter = this.alphaMaskPool[this.alphaMaskIndex] = [new AlphaMaskFilter(maskData)];
     }
 
+    alphaMaskFilter[0].resolution = this.renderer.resolution;
     alphaMaskFilter[0].maskSprite = maskData;
 
     //TODO - may cause issues!


### PR DESCRIPTION
Currently when applying a mask to a -x2 Sprite, the Sprite resolution is lowered to that of the mask.