### PR TITLE
Adding performance caveat context option

### DIFF
--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -139,7 +139,7 @@ var utils = module.exports = {
      */
     isWebGLSupported: function ()
     {
-        var contextOptions = { stencil: true };
+        var contextOptions = { stencil: true, failIfMajorPerformanceCaveat: true };
         try
         {
             if (!window.WebGLRenderingContext)


### PR DESCRIPTION
http://www.html5gamedevs.com/topic/16425-ie11-software-rendering/#comment-92760
https://msdn.microsoft.com/en-us/library/dn798645(v=vs.85).aspx

If IE or Edge shows up the message "WEBGL11258: Temporarily switching to software rendering to display webGL content", WebGL detection should fail because the software rendering is slow as hell.