### PR TITLE
Adding CanvasRender worldAlpha

### DIFF
--- a/src/mesh/NineSlicePlane.js
+++ b/src/mesh/NineSlicePlane.js
@@ -249,6 +249,7 @@ NineSlicePlane.prototype.updateVerticalVertices = function() {
 NineSlicePlane.prototype._renderCanvas= function (renderer)
 {
     var context = renderer.context;
+    context.globalAlpha = this.worldAlpha;
 
     var transform = this.worldTransform;
     var res = renderer.resolution;


### PR DESCRIPTION
Got an issue of the alpha value of NineSlicePlane. Adding  worldAlpha value to context if rendered via CanvasRenderer.