### PR TITLE
Preprocess

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "mkdirp": "^0.5.1",
     "mocha": "^2.5.3",
     "parallelshell": "^2.0.0",
-    "pixify": "^1.0.0",
+    "pixify": "^1.2.0",
     "rimraf": "^2.5.3",
     "testem": "^1.8.1",
     "watchify": "^3.7.0"

--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -1,3 +1,4 @@
+// @if DEBUG
 /*global console */
 var core = require('./core'),
     mesh = require('./mesh'),
@@ -553,4 +554,4 @@ core.utils.canUseNewCanvasBlendModes = function() {
     warn('utils.canUseNewCanvasBlendModes() is deprecated, please use CanvasTinter.canUseMultiply from now on');
     return core.CanvasTinter.canUseMultiply;
 };
-
+// @endif

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ core.loaders        = require('./loaders');
 core.mesh           = require('./mesh');
 core.particles      = require('./particles');
 core.accessibility  = require('./accessibility');
-core.extract  		= require('./extract');
+core.extract        = require('./extract');
 core.prepare        = require('./prepare');
 
 // export a premade loader instance
@@ -24,8 +24,10 @@ core.prepare        = require('./prepare');
  */
 core.loader = new core.loaders.Loader();
 
+// @if DEBUG
 // mixin the deprecation features.
 Object.assign(core, require('./deprecation'));
+// @endif
 
 // Always export pixi globally.
 global.PIXI = core;


### PR DESCRIPTION
## Overview

Updates to [pixify@v1.2.0](https://github.com/pixijs/pixify/releases/tag/v1.2.0) which adds support for using preprocess to add comment blocks.  In the future, this feature could more broadly be used to provide better debugging features in the un-minified library (**bin/pixi.js**) and remove unnecessary code and logging from release library (**bin/pixi.min.js**). 

This PR utilizes this feature to remove the deprecations from the release build of the library.

### Debug Example
```js
// @if DEBUG
console.error('only show in debug mode');
// @endif
```
### Release Example
```js
// @if RELEASE
throw 'fail hard';
// @endif
```