### PR TITLE
Floor'ed all values passed to canvas.drawImage() as using non-integers

### DIFF
--- a/src/core/sprites/canvas/CanvasSpriteRenderer.js
+++ b/src/core/sprites/canvas/CanvasSpriteRenderer.js
@@ -129,12 +129,12 @@ CanvasSpriteRenderer.prototype.render = function (sprite)
                 sprite.tintedTexture,
                 0,
                 0,
-                width * resolution,
-                height * resolution,
-                dx * renderer.resolution,
-                dy * renderer.resolution,
-                width * renderer.resolution,
-                height * renderer.resolution
+                Math.floor( width * resolution ),
+                Math.floor( height * resolution ),
+                Math.floor( dx * renderer.resolution ),
+                Math.floor( dy * renderer.resolution ),
+                Math.floor( width * renderer.resolution ),
+                Math.floor( height * renderer.resolution )
             );
         }
         else
@@ -142,14 +142,14 @@ CanvasSpriteRenderer.prototype.render = function (sprite)
 
             renderer.context.drawImage(
                 texture.baseTexture.source,
-                texture._frame.x * resolution,
-                texture._frame.y * resolution,
-                width * resolution,
-                height * resolution,
-                dx  * renderer.resolution,
-                dy  * renderer.resolution,
-                width * renderer.resolution,
-                height * renderer.resolution
+                Math.floor( texture._frame.x * resolution ),
+                Math.floor( texture._frame.y * resolution ),
+                Math.floor( width * resolution ),
+                Math.floor( height * resolution ),
+                Math.floor( dx  * renderer.resolution ),
+                Math.floor( dy  * renderer.resolution ),
+                Math.floor( width * renderer.resolution ),
+                Math.floor( height * renderer.resolution )
             );
         }
     }


### PR DESCRIPTION
on IE and PhantomJS can cause INDEX_ERR errors to be thrown.

Especially prevalent if you are using a graphics resolution of <1
