### PR TITLE
initialize _localID

### DIFF
--- a/src/core/display/TransformStatic.js
+++ b/src/core/display/TransformStatic.js
@@ -47,7 +47,8 @@ function TransformStatic()
     this._sy  = Math.sin(0);//skewY);
     this._nsx = Math.sin(0);//skewX);
     this._cx  = Math.cos(0);//skewX);
-
+    
+    this._localID = 0;
     this._currentLocalID = 0;
 }
 


### PR DESCRIPTION
@ivanpopelyshev I think this is missing because the conditionals [here](https://github.com/staff0rd/pixi.js/blob/9aa8533338255c0cb9e038364045d0d763b8a778/src/core/display/TransformStatic.js#L78) and [here](https://github.com/staff0rd/pixi.js/blob/9aa8533338255c0cb9e038364045d0d763b8a778/src/core/display/TransformStatic.js#L113) eventually start comparing NaN because `_localID` is undefined.