### PR TITLE
fastRect problem, again

### DIFF
--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -735,10 +735,9 @@ Graphics.prototype._renderSpriteRect = function (renderer)
         }
 
         this._spriteRect = new Sprite(Graphics._SPRITE_TEXTURE);
-        this._spriteRect.tint = this.graphicsData[0].fillColor;
-        this._spriteRect.alpha = this.graphicsData[0].fillAlpha;
     }
-
+    this._spriteRect.tint = this.graphicsData[0].fillColor;
+    this._spriteRect.alpha = this.graphicsData[0].fillAlpha;
     this._spriteRect.worldAlpha = this.worldAlpha * this._spriteRect.alpha;
 
     Graphics._SPRITE_TEXTURE._frame.width = rect.width;


### PR DESCRIPTION
Compare results for rounded rect the fast one:

```js
var renderer = PIXI.autoDetectRenderer(800, 600, { antialias: true });
document.body.appendChild(renderer.view);

// create the root of the scene graph
var stage = new PIXI.Container();
var clr = [0xFF700B, 0x0000FF];
var step = 0;

stage.interactive = true;

var graphics = new PIXI.Graphics();

stage.addChild(graphics);

// run the render loop
animate();

function animate() {
    graphics.clear();
    graphics.beginFill(clr[Math.floor(step/5)], 1);
    //graphics.drawRoundedRect(50, 250, 120, 120, 5);
    graphics.drawRect(50, 250, 120, 120, 5);
    graphics.endFill();
    step = (step+1)%10;    

    renderer.render(stage);
    requestAnimationFrame( animate );
}

```