### PR TITLE
Dev2

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "README.md"
   ],
   "dependencies": {
-    "async": "^1.5.2",
     "bit-twiddle": "^1.0.2",
     "earcut": "^2.0.7",
     "eventemitter3": "^1.1.1",

--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -735,10 +735,9 @@ Graphics.prototype._renderSpriteRect = function (renderer)
         }
 
         this._spriteRect = new Sprite(Graphics._SPRITE_TEXTURE);
-        this._spriteRect.tint = this.graphicsData[0].fillColor;
-        this._spriteRect.alpha = this.graphicsData[0].fillAlpha;
     }
-
+    this._spriteRect.tint = this.graphicsData[0].fillColor;
+    this._spriteRect.alpha = this.graphicsData[0].fillAlpha;
     this._spriteRect.worldAlpha = this.worldAlpha * this._spriteRect.alpha;
 
     Graphics._SPRITE_TEXTURE._frame.width = rect.width;

--- a/src/loaders/spritesheetParser.js
+++ b/src/loaders/spritesheetParser.js
@@ -1,7 +1,6 @@
 var Resource = require('resource-loader').Resource,
     path = require('path'),
-    core = require('../core'),
-    async = require('async');
+    core = require('../core');
 
 var BATCH_SIZE = 1000;
 
@@ -25,11 +24,11 @@ module.exports = function ()
         };
 
         // Prepend url path unless the resource image is a data url
-        if (resource.isDataUrl) 
+        if (resource.isDataUrl)
         {
             resourcePath = resource.data.meta.image;
-        } 
-        else 
+        }
+        else
         {
             resourcePath = path.dirname(resource.url.replace(this.baseUrl, '')) + '/' + resource.data.meta.image;
         }
@@ -101,6 +100,16 @@ module.exports = function ()
                 setTimeout(done, 0);
             }
 
+            function iteration() {
+                processNextBatch(function() {
+                    if (shouldProcessNextBatch()) {
+                        iteration();
+                    } else {
+                        next();
+                    }
+                });
+            }
+
             if (frameKeys.length <= BATCH_SIZE)
             {
                 processFrames(0, BATCH_SIZE);
@@ -108,7 +117,7 @@ module.exports = function ()
             }
             else
             {
-                async.whilst(shouldProcessNextBatch, processNextBatch, next);
+                iteration();
             }
         });
     };


### PR DESCRIPTION
Reduces un-zipped size by 100kb.

This was the test for new code:

```js
//TEST
var test = {};
var frameKeys = [];
var BATCH_SIZE = 1000;
for (var i=0;i<100015;i++) {
	frameKeys.push(i);
}
var batchIndex = 0;

function next() {
   for (var i=0;i<100015;i++) {
      if (!test[i]) {
	     console.log("FAIL " +i);
		 return;
	  }
   }
   console.log("OK");
}

function processFrames(initialFrameIndex, maxFrames) {
	var frameIndex = initialFrameIndex;
	while (frameIndex - initialFrameIndex < maxFrames && frameIndex < frameKeys.length) {
	    test[frameIndex] = 1;
		frameIndex++;
	}
}

iteration();
//TESTING THIS PIECE OF CODE OF SPRITESHEET PARSER

function shouldProcessNextBatch()
{
	return batchIndex * BATCH_SIZE < frameKeys.length;
}

function processNextBatch(done)
{
	processFrames(batchIndex * BATCH_SIZE, BATCH_SIZE);
	batchIndex++;
	setTimeout(done, 0);
}

function iteration() {
	processNextBatch(function() {
		if (shouldProcessNextBatch()) {
			iteration();
		} else {
			next();
		}
	});
}
```