### PR TITLE
Supports linting while running `npm start`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,10 @@
   "scripts": {
     "clean": "rimraf bin && mkdirp bin",
     "prestart": "npm run clean",
-    "start": "parallelshell \"npm run watch:debug\" \"npm run watch:release\"",
+    "start": "parallelshell \"npm run watch:lint\" \"npm run watch:debug\" \"npm run watch:release\"",
     "watch:debug": "watchify src -s PIXI -o bin/pixi.js -dv",
     "watch:release": "watchify src -s PIXI -o bin/pixi.min.js -dv",
+    "watch:lint": "watch \"jshint --reporter=scripts/reporter.js scripts src test || exit 0\" src",
     "test": "floss --path test/index.js",
     "test:debug": "npm test -- --debug",
     "lint": "jshint --reporter=scripts/reporter.js scripts src test",
@@ -64,6 +65,7 @@
     "parallelshell": "^2.0.0",
     "pixify": "^1.3.0",
     "rimraf": "^2.5.3",
+    "watch": "^0.19.1",
     "watchify": "^3.7.0"
   },
   "browserify": {


### PR DESCRIPTION
Adds support for linting while running watch (via `npm start`).

cc: @GoodBoyDigital 