### PR TITLE
sprite bounds tweaks

### DIFF
--- a/src/core/display/TransformStatic.js
+++ b/src/core/display/TransformStatic.js
@@ -47,7 +47,7 @@ function TransformStatic()
     this._sy  = Math.sin(0);//skewY);
     this._nsx = Math.sin(0);//skewX);
     this._cx  = Math.cos(0);//skewX);
-    
+
     this._localID = 0;
     this._currentLocalID = 0;
 }
@@ -62,10 +62,10 @@ TransformStatic.prototype.onChange = function ()
 
 TransformStatic.prototype.updateSkew = function ()
 {
-    this._cy  = Math.cos(this.skew.y);
-    this._sy  = Math.sin(this.skew.y);
-    this._nsx = Math.sin(this.skew.x);
-    this._cx  = Math.cos(this.skew.x);
+    this._cy  = Math.cos(this.skew._y);
+    this._sy  = Math.sin(this.skew._y);
+    this._nsx = Math.sin(this.skew._x);
+    this._cx  = Math.cos(this.skew._x);
 
     this._localID ++;
 };
@@ -80,10 +80,10 @@ TransformStatic.prototype.updateLocalTransform = function() {
         // get the matrix values of the displayobject based on its transform properties..
         var a,b,c,d;
 
-        a  =  this._cr * this.scale.x;
-        b  =  this._sr * this.scale.x;
-        c  = -this._sr * this.scale.y;
-        d  =  this._cr * this.scale.y;
+        a  =  this._cr * this.scale._x;
+        b  =  this._sr * this.scale._x;
+        c  = -this._sr * this.scale._y;
+        d  =  this._cr * this.scale._y;
 
         lt.a  = this._cy * a + this._sy * c;
         lt.b  = this._cy * b + this._sy * d;
@@ -115,10 +115,10 @@ TransformStatic.prototype.updateTransform = function (parentTransform)
         // get the matrix values of the displayobject based on its transform properties..
         var a,b,c,d;
 
-        a  =  this._cr * this.scale.x;
-        b  =  this._sr * this.scale.x;
-        c  = -this._sr * this.scale.y;
-        d  =  this._cr * this.scale.y;
+        a  =  this._cr * this.scale._x;
+        b  =  this._sr * this.scale._x;
+        c  = -this._sr * this.scale._y;
+        d  =  this._cr * this.scale._y;
 
         lt.a  = this._cy * a + this._sy * c;
         lt.b  = this._cy * b + this._sy * d;

--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -63,6 +63,8 @@ function Sprite(texture)
      * @member {number}
      * @default 0xFFFFFF
      */
+    this._tint = null;
+    this._tintRGB = null;
     this.tint = 0xFFFFFF;
 
     /**
@@ -150,6 +152,18 @@ Object.defineProperties(Sprite.prototype, {
             var sign = utils.sign(this.scale.y) || 1;
             this.scale.y = sign * value / this.texture.orig.height;
             this._height = value;
+        }
+    },
+
+    tint: {
+        get: function ()
+        {
+            return  this._tint;
+        },
+        set: function (value)
+        {
+            this._tint = value;
+            this._tintRGB = (value >> 16) + (value & 0xff00) + ((value & 0xff) << 16);
         }
     },
 
@@ -244,20 +258,20 @@ Sprite.prototype.calculateVertices = function ()
     if (trim)
     {
         // if the sprite is trimmed and is not a tilingsprite then we need to add the extra space before transforming the sprite coords..
-        w1 = trim.x - this.anchor.x * orig.width;
+        w1 = trim.x - this.anchor._x * orig.width;
         w0 = w1 + trim.width;
 
-        h1 = trim.y - this.anchor.y * orig.height;
+        h1 = trim.y - this.anchor._y * orig.height;
         h0 = h1 + trim.height;
 
     }
     else
     {
-        w0 = (orig.width ) * (1-this.anchor.x);
-        w1 = (orig.width ) * -this.anchor.x;
+        w0 = orig.width * (1-this.anchor._x);
+        w1 = orig.width * -this.anchor._x;
 
-        h0 = orig.height * (1-this.anchor.y);
-        h1 = orig.height * -this.anchor.y;
+        h0 = orig.height * (1-this.anchor._y);
+        h1 = orig.height * -this.anchor._y;
     }
 
     // xy
@@ -298,11 +312,11 @@ Sprite.prototype.calculateTrimmedVertices = function ()
         a = wt.a, b = wt.b, c = wt.c, d = wt.d, tx = wt.tx, ty = wt.ty,
         w0, w1, h0, h1;
 
-    w0 = (orig.width ) * (1-this.anchor.x);
-    w1 = (orig.width ) * -this.anchor.x;
+    w0 = (orig.width ) * (1-this.anchor._x);
+    w1 = (orig.width ) * -this.anchor._x;
 
-    h0 = orig.height * (1-this.anchor.y);
-    h1 = orig.height * -this.anchor.y;
+    h0 = orig.height * (1-this.anchor._y);
+    h1 = orig.height * -this.anchor._y;
 
     // xy
     vertexData[0] = a * w1 + c * h1 + tx;
@@ -380,8 +394,8 @@ Sprite.prototype.getLocalBounds = function (rect)
     if(this.children.length === 0)
     {
 
-        this._bounds.minX = -this._texture.orig.width * this.anchor.x;
-        this._bounds.minY = -this._texture.orig.height * this.anchor.y;
+        this._bounds.minX = -this._texture.orig.width * this.anchor._x;
+        this._bounds.minY = -this._texture.orig.height * this.anchor._y;
         this._bounds.maxX = this._texture.orig.width;
         this._bounds.maxY = this._texture.orig.height;
 

--- a/src/core/sprites/webgl/SpriteRenderer.js
+++ b/src/core/sprites/webgl/SpriteRenderer.js
@@ -263,7 +263,7 @@ SpriteRenderer.prototype.flush = function ()
         vertexData = sprite.vertexData;
 
         //TODO this sum does not need to be set each frame..
-        tint = (sprite.tint >> 16) + (sprite.tint & 0xff00) + ((sprite.tint & 0xff) << 16) + (sprite.worldAlpha * 255 << 24);
+        tint = sprite._tintRGB + (sprite.worldAlpha * 255 << 24);
         uvs = sprite._texture._uvs.uvsUint32;
         textureId = nextTexture._id;
 

--- a/test/core/Bounds.js
+++ b/test/core/Bounds.js
@@ -360,4 +360,31 @@ describe('getBounds', function () {
         expect(bounds.width).to.equal(20);
         expect(bounds.height).to.equal(20);
     });
+
+    it('should ensure bounds respect the trim of a texture ', function() {
+
+        var parent = new PIXI.Container();
+        var baseTexture = new PIXI.BaseRenderTexture(100, 100);
+
+        var orig = new PIXI.Rectangle(0,0,100,50);
+        var frame = new PIXI.Rectangle(2,2,50,50);
+        var trim = new PIXI.Rectangle(25,0,50,50);
+
+        var trimmedTexture = new PIXI.Texture(baseTexture, frame, orig, trim);
+
+        var sprite = new PIXI.Sprite(trimmedTexture);
+
+        sprite.position.x = 20;
+        sprite.position.y = 20;
+
+        parent.addChild(sprite);
+
+        var bounds = sprite.getBounds();
+
+        expect(bounds.x).to.equal(20);
+        expect(bounds.y).to.equal(20);
+        expect(bounds.width).to.equal(100);
+        expect(bounds.height).to.equal(50);
+
+    });
 });


### PR DESCRIPTION
A variation of @ivanpopelyshev PR
This PR favours non trimmed Textures (As most will not be trimmed)

- It basically checked for trim, if its not then business as usual

- Renamed a few functions to make it easier to understand that we are calculating trimmed bounds

- Slight refactor that hopefully should make it easier to follow

- vertexTrimmedData only created when required 