### PR TITLE
InteractionManager: Add target and currentTarget to eventData

### DIFF
--- a/src/interaction/InteractionEvent.js
+++ b/src/interaction/InteractionEvent.js
@@ -1,0 +1,68 @@
+/**
+ * Event class that mimics native DOM events.
+ *
+ * @class
+ * @memberof PIXI.interaction
+ */
+class InteractionEvent
+{
+
+    constructor()
+    {
+        /**
+         * Which this event will continue propagating in the tree
+         *
+         * @member {boolean}
+         */
+        this.stopped = false;
+
+        /**
+         * The object to which event is dispatched.
+         *
+         * @member {PIXI.DisplayObject}
+         */
+        this.target = null;
+
+        /**
+         * The object whose event listener’s callback is currently being invoked.
+         *
+         * @member {PIXI.DisplayObject}
+         */
+        this.currentTarget = null;
+
+        /*
+         * Type of the event
+         *
+         * @member {string}
+         */
+        this.type = null;
+
+        /*
+         * InteractionData related to this event
+         *
+         * @member {PIXI.interaction.InteractionData}
+         */
+        this.data = null;
+    }
+
+    /**
+     * Prevents event from reaching any objects other than the current object.
+     */
+    stopPropagation()
+    {
+        this.stopped = true;
+    }
+
+    /**
+     * Prevents event from reaching any objects other than the current object.
+     */
+    _reset()
+    {
+        this.stopped = false;
+        this.currentTarget = null;
+        this.target = null;
+    }
+
+}
+
+export default InteractionEvent;

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -1,5 +1,6 @@
 import core from '../core';
 import InteractionData from './InteractionData';
+import InteractionEvent from './InteractionEvent';
 import EventEmitter from 'eventemitter3';
 import interactiveTarget from './interactiveTarget';
 
@@ -69,15 +70,7 @@ class InteractionManager extends EventEmitter
          *
          * @member {object}
          */
-        this.eventData = {
-            stopped: false,
-            target: null,
-            type: null,
-            data: this.mouse,
-            stopPropagation(){
-                this.stopped = true;
-            }
-        };
+        this.eventData = new InteractionEvent();
 
         /**
          * Tiny little interactiveData pool !
@@ -448,7 +441,7 @@ class InteractionManager extends EventEmitter
         // Resets the flag as set by a stopPropagation call. This flag is usually reset by a user interaction of any kind,
         // but there was a scenario of a display object moving under a static mouse cursor.
         // In this case, mouseover and mouseevents would not pass the flag test in dispatchEvent function
-        this.eventData.stopped = false;
+        this.eventData._reset();
 
         this.processInteractive(this.mouse.global, this.renderer._lastObjectRendered, this.processMouseOverOut, true );
 
@@ -473,7 +466,7 @@ class InteractionManager extends EventEmitter
     {
         if(!eventData.stopped)
         {
-            eventData.target = displayObject;
+            eventData.currentTarget = displayObject;
             eventData.type = eventString;
 
             displayObject.emit( eventString, eventData );
@@ -628,6 +621,12 @@ class InteractionManager extends EventEmitter
 
             if(displayObject.interactive)
             {
+                if (hit && !this.eventData.target)
+                {
+                    this.eventData.target = displayObject;
+                    this.mouse.target = displayObject;
+                }
+
                 func(displayObject, hit);
             }
         }
@@ -647,7 +646,7 @@ class InteractionManager extends EventEmitter
     {
         this.mouse.originalEvent = event;
         this.eventData.data = this.mouse;
-        this.eventData.stopped = false;
+        this.eventData._reset();
 
         // Update internal mouse reference
         this.mapPositionToPoint( this.mouse.global, event.clientX, event.clientY);
@@ -693,7 +692,7 @@ class InteractionManager extends EventEmitter
     {
         this.mouse.originalEvent = event;
         this.eventData.data = this.mouse;
-        this.eventData.stopped = false;
+        this.eventData._reset();
 
         // Update internal mouse reference
         this.mapPositionToPoint( this.mouse.global, event.clientX, event.clientY);
@@ -749,7 +748,7 @@ class InteractionManager extends EventEmitter
     {
         this.mouse.originalEvent = event;
         this.eventData.data = this.mouse;
-        this.eventData.stopped = false;
+        this.eventData._reset();
 
         this.mapPositionToPoint( this.mouse.global, event.clientX, event.clientY);
 
@@ -801,7 +800,7 @@ class InteractionManager extends EventEmitter
 
         this.mouse.originalEvent = event;
         this.eventData.data = this.mouse;
-        this.eventData.stopped = false;
+        this.eventData._reset();
 
         // Update internal mouse reference
         this.mapPositionToPoint( this.mouse.global, event.clientX, event.clientY);
@@ -860,7 +859,7 @@ class InteractionManager extends EventEmitter
 
         this.mouse.originalEvent = event;
         this.eventData.data = this.mouse;
-        this.eventData.stopped = false;
+        this.eventData._reset();
 
         this.emit('mouseover', this.eventData);
     }
@@ -891,7 +890,7 @@ class InteractionManager extends EventEmitter
             touchData.originalEvent = event;
 
             this.eventData.data = touchData;
-            this.eventData.stopped = false;
+            this.eventData._reset();
 
             this.processInteractive( touchData.global, this.renderer._lastObjectRendered, this.processTouchStart, true );
 
@@ -944,7 +943,7 @@ class InteractionManager extends EventEmitter
 
             //TODO this should be passed along.. no set
             this.eventData.data = touchData;
-            this.eventData.stopped = false;
+            this.eventData._reset();
 
 
             this.processInteractive( touchData.global, this.renderer._lastObjectRendered, this.processTouchEnd, true );
@@ -1009,7 +1008,7 @@ class InteractionManager extends EventEmitter
             touchData.originalEvent = event;
 
             this.eventData.data = touchData;
-            this.eventData.stopped = false;
+            this.eventData._reset();
 
             this.processInteractive( touchData.global, this.renderer._lastObjectRendered, this.processTouchMove, this.moveWhenInside );
 


### PR DESCRIPTION
I've extracted `eventData` into a new class called `InteractionEvent`. 

- what previously was  `event.target` is now `event.currentTarget` (object currently calling the callback handler)
- `event.target` now have the reference to the object that **triggered** the event

The idea here is to mimic the [DOM Event](https://developer.mozilla.org/en-US/docs/Web/API/Event/target) spec.

Is [InteractionData.target](https://github.com/pixijs/pixi.js/blob/0446c7829e9727439349d5dbbdd85f57dd54d5ea/src/interaction/InteractionData.js#L18-L23) being used right now? I guess somebody removed the usage of this at some point and it doesn't work anymore.

Cheers!