### PR TITLE
Fix for Text.width setter not updating if it's dirty before applying …

### DIFF
--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -115,6 +115,11 @@ Object.defineProperties(Text.prototype, {
         },
         set: function (value)
         {
+            if (this.dirty)
+            {
+                this.updateText();
+            }
+                        
             this.scale.x = value / this._texture._frame.width;
             this._width = value;
         }


### PR DESCRIPTION
Fix for Text not updating it's width when setting if teh Text is dirty. Cause the scaled value not be what was expected.