### PR TITLE
Tweak to realWidth / realHeight in base render texture

### DIFF
--- a/src/core/textures/BaseRenderTexture.js
+++ b/src/core/textures/BaseRenderTexture.js
@@ -49,13 +49,14 @@ function BaseRenderTexture(width, height, scaleMode, resolution)
 {
     BaseTexture.call(this, null, scaleMode);
 
+    this.resolution = resolution || CONST.RESOLUTION;
+
     this.width = width || 100;
     this.height = height || 100;
 
-    this.realWidth = this.width * resolution;
-    this.realHeight = this.height * resolution;
+    this.realWidth = this.width * this.resolution;
+    this.realHeight = this.height * this.resolution;
 
-    this.resolution = resolution || CONST.RESOLUTION;
     this.scaleMode = scaleMode || CONST.SCALE_MODES.DEFAULT;
     this.hasLoaded = true;
 


### PR DESCRIPTION
Making sure that the resolution used for realWidth & realHeight will work if nothing has been passed in as a constructor parameter