### PR TITLE
Removes link (breaks docs), updates year

### DIFF
--- a/scripts/jsdoc.conf.json
+++ b/scripts/jsdoc.conf.json
@@ -22,8 +22,8 @@
             "outputSourceFiles" : true
         },
         "applicationName": "PIXI",
-        "footer"        : "Made with ♥ by <a href='http://goodboydigital.com'>Goodboy Digital</a>",
-        "copyright"     : "PIXI Copyright © 2013-2015 Mat Groves.",
+        "footer"        : "Made with ♥ by Goodboy Digital (goodboydigital.com)",
+        "copyright"     : "PIXI Copyright © 2013-2016 Mat Groves.",
         "disqus": "",
         "googleAnalytics": "",
         "openGraph": {


### PR DESCRIPTION
### Fixed
* Resolves issue #2851
* The link was breaking the window config object in the JSdoc theme. 
* Updated the copyright year for documentation