### PR TITLE
Support for built, deployable documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
     - npm run docs
 
 deploy:
-    provider: s3
+  - provider: s3
     access_key_id: $S3_ACCESS_KEY_ID
     secret_access_key: $S3_SECRET_ACCESS_KEY
     bucket: "pixi.js"
@@ -40,8 +40,7 @@ deploy:
     region: eu-west-1
     on:
         all_branches: true
-deploy:
-    provider: s3
+  - provider: s3
     access_key_id: $S3_ACCESS_KEY_ID
     secret_access_key: $S3_SECRET_ACCESS_KEY
     bucket: "pixi.js"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_script:
 
 script:
     - xvfb-maybe npm run build
+    - npm run docs
 
 deploy:
     provider: s3
@@ -36,6 +37,18 @@ deploy:
     acl: public_read
     local_dir: bin
     upload-dir: "$TRAVIS_BRANCH"
+    region: eu-west-1
+    on:
+        all_branches: true
+deploy:
+    provider: s3
+    access_key_id: $S3_ACCESS_KEY_ID
+    secret_access_key: $S3_SECRET_ACCESS_KEY
+    bucket: "pixi.js"
+    skip_cleanup: true
+    acl: public_read
+    local_dir: docs
+    upload-dir: "$TRAVIS_BRANCH/docs"
     region: eu-west-1
     on:
         all_branches: true

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "del": "^2.2.0",
     "electron-prebuilt": "^1.3.2",
     "floss": "^0.7.1",
-    "jaguarjs-jsdoc": "^1.0.0",
+    "jaguarjs-jsdoc": "^1.0.1",
     "jsdoc": "^3.4.0",
     "jshint": "^2.9.2",
     "jshint-stylish": "^2.2.0",


### PR DESCRIPTION
## Overview

Supports building documentation to the S3 bucket. This can be useful for a couple of reasons:
- Always have a distributed up-to-date version of the documentation represented on a particular branch or release tag.
- Documentation is build and stored (archived) with each tag, so older versions of the docs are readily accessible. This makes the docs more future-forward, without having to so thoroughly capture old, deprecated APIs.

### Example 

Here's the documentation for this branch that was build by Travis:
http://s3-eu-west-1.amazonaws.com/pixi.js/cdn-docs/docs/index.html