### PR TITLE
Optimization: Less calls to gl.bindTexture() & gl.enable(gl.STENCIL_TEST)

### DIFF
--- a/src/core/const.js
+++ b/src/core/const.js
@@ -200,7 +200,7 @@ var CONST = {
     GC_MODES: {
         DEFAULT:        1,
         AUTO:           0,
-        MANUAL:         1,
+        MANUAL:         1
     },
 
     /**

--- a/src/core/renderers/webgl/managers/StencilManager.js
+++ b/src/core/renderers/webgl/managers/StencilManager.js
@@ -9,6 +9,7 @@ function StencilManager(renderer)
 {
     WebGLManager.call(this, renderer);
     this.stencilMaskStack = null;
+    this.currentStencilTest = false;
 }
 
 StencilManager.prototype = Object.create(WebGLManager.prototype);
@@ -28,11 +29,19 @@ StencilManager.prototype.setMaskStack = function ( stencilMaskStack )
 
     if (stencilMaskStack.length === 0)
     {
-        gl.disable(gl.STENCIL_TEST);
+        if (this.currentStencilTest)
+        {
+            gl.disable(gl.STENCIL_TEST);
+            this.currentStencilTest = false;
+        }
     }
     else
     {
-        gl.enable(gl.STENCIL_TEST);
+        if (!this.currentStencilTest)
+        {
+            gl.enable(gl.STENCIL_TEST);
+            this.currentStencilTest = true;
+        }
     }
 };
 

--- a/src/core/utils/maxRecommendedTextures.js
+++ b/src/core/utils/maxRecommendedTextures.js
@@ -5,16 +5,16 @@ var  Device = require('ismobilejs');
 var maxRecommendedTextures = function(max)
 {
 
-	if(Device.tablet || Device.phone)
-	{
+	// if(Device.tablet || Device.phone)
+	// {
 		// check if the res is iphone 6 or higher..
-		return 2;
-	}
-	else
-	{
+	// 	return 2;
+	// }
+	// else
+	// {
 		// desktop should be ok
 		return max;
-	}
+	// }
 };
 
 module.exports = maxRecommendedTextures;


### PR DESCRIPTION
Hello!

This PR requires this PR to be merged first: https://github.com/pixijs/pixi-gl-core/pull/17

I modified the bindTexture, bindRenderTexture and reset methods of WebGLRenderer to use the new GLTexture.isBound field added in the PR mentioned above!

I also cached the stencil test state to prevent calls to gl.enable/gl.disable when not needed.

P.S. I commented out the hardcoded maximum of two texture units for mobile devices. All the devices I tested on had a performance increase from the bigger batch sizes.