### PR TITLE
Small optimisation to Graphics class

### DIFF
--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -531,8 +531,8 @@ Graphics.prototype.arc = function(cx, cy, radius, startAngle, endAngle, anticloc
  * Specifies a simple one-color fill that subsequent calls to other Graphics methods
  * (such as lineTo() or drawCircle()) use when drawing.
  *
- * @param color {number} the color of the fill
- * @param alpha {number} the alpha of the fill
+ * @param [color=0] {number} the color of the fill
+ * @param [alpha=1] {number} the alpha of the fill
  * @return {PIXI.Graphics} This Graphics object. Good for chaining method calls
  */
 Graphics.prototype.beginFill = function (color, alpha)
@@ -676,13 +676,15 @@ Graphics.prototype.drawPolygon = function (path)
  */
 Graphics.prototype.clear = function ()
 {
-    this.lineWidth = 0;
-    this.filling = false;
+    if ( this.lineWidth || this.filling || this.graphicsData.length > 0 )
+    {
+        this.lineWidth = 0;
+        this.filling = false;
 
-    this.dirty++;
-    this.clearDirty++;
-    this.graphicsData = [];
-
+        this.dirty++;
+        this.clearDirty++;
+        this.graphicsData.length = 0;
+    }
     return this;
 };
 

--- a/src/core/graphics/webgl/GraphicsRenderer.js
+++ b/src/core/graphics/webgl/GraphicsRenderer.js
@@ -152,7 +152,7 @@ GraphicsRenderer.prototype.updateGraphics = function(graphics)
         }
 
         // clear the array and reset the index..
-        webGL.data = [];
+        webGL.data.length = 0;
         webGL.lastIndex = 0;
     }
 


### PR DESCRIPTION
clear function will only set the object as dirty if there has been something to clear
set array length = 0 instead of new array
tweak jsdocs as fillRect has valid defaults

Just means I can call clear on an array of Graphics objects rather than work out which ones were dirty to then clear