### PR TITLE
Fixes for PIXI + Cocoon

### DIFF
--- a/src/accessibility/AccessibilityManager.js
+++ b/src/accessibility/AccessibilityManager.js
@@ -18,7 +18,7 @@ Object.assign(
  */
 function AccessibilityManager(renderer)
 {
-	if(Device.tablet || Device.phone)
+	if((Device.tablet || Device.phone) && !navigator.isCocoonJS)
 	{
 		this.createTouchHook();
 	}

--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -691,6 +691,11 @@ Text.prototype._generateFillStyle = function (style, lines)
     }
     else
     {
+        // cocoon on canvas+ cannot generate textures, so use the first colour instead
+        if ( navigator.isCocoonJS ) {
+            return style.fill[0];
+        }
+
         // the gradient will be evenly spaced out according to how large the array is.
         // ['#FF0000', '#00FF00', '#0000FF'] would created stops at 0.25, 0.5 and 0.75
         var i;


### PR DESCRIPTION
Do not create touch hooks for accessibility - this stops cocoon from working - Fixes: https://github.com/pixijs/pixi.js/issues/2648
Do not use gradient text, just use the first colour listed in the array - cocoon displays text with gradients as black otherwise. I think this behaviour will be more like what developers would want as a fallback