### PR TITLE
Jsdoc fixes - marking relevant functions as @private

### DIFF
--- a/src/core/display/DisplayObject.js
+++ b/src/core/display/DisplayObject.js
@@ -355,6 +355,7 @@ DisplayObject.prototype.displayObjectUpdateTransform = DisplayObject.prototype.u
 /**
  * recursively updates transform of all objects from the root to this one
  * internal function for toLocal()
+ * @private
  */
 DisplayObject.prototype._recursivePostUpdateTransform = function()
 {
@@ -581,7 +582,7 @@ DisplayObject.prototype.setTransform = function(x, y, scaleX, scaleY, rotation, 
 /**
  * Base destroy method for generic display objects. This will automatically
  * remove the display object from its parent Container as well as remove
- * all current event listeners and internal references. Do not use a DisplayObject 
+ * all current event listeners and internal references. Do not use a DisplayObject
  * after calling `destroy`.
  */
 DisplayObject.prototype.destroy = function ()

--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -788,6 +788,7 @@ Graphics.prototype._renderCanvas = function (renderer)
  * @param [matrix] {PIXI.Matrix} The world transform matrix to use, defaults to this
  *  object's worldTransform.
  * @return {PIXI.Rectangle} the rectangular bounding area
+ * @private
  */
 Graphics.prototype._calculateBounds = function ()
 {

--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -148,6 +148,7 @@ function WebGLRenderer(width, height, options)
      * Holds the current shader
      *
      * @member {PIXI.Shader}
+     * @private
      */
     this._activeShader = null;
 

--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -57,6 +57,8 @@ function Sprite(texture)
      */
     this._height = 0;
 
+    this._tint = null;
+    this._tintRGB = null;
     /**
      * The tint applied to the sprite. This is a hex value. A value of 0xFFFFFF will remove any tint effect.
      *
@@ -64,8 +66,6 @@ function Sprite(texture)
      * @default 0xFFFFFF
      */
     this.tint = 0xFFFFFF;
-    this._tint = null;
-    this._tintRGB = null;
 
     /**
      * The blend mode to be applied to the sprite. Apply a value of `PIXI.BLEND_MODES.NORMAL` to reset the blend mode.

--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -63,9 +63,9 @@ function Sprite(texture)
      * @member {number}
      * @default 0xFFFFFF
      */
+    this.tint = 0xFFFFFF;
     this._tint = null;
     this._tintRGB = null;
-    this.tint = 0xFFFFFF;
 
     /**
      * The blend mode to be applied to the sprite. Apply a value of `PIXI.BLEND_MODES.NORMAL` to reset the blend mode.

--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -660,6 +660,7 @@ Text.prototype.wordWrap = function (text)
 
 /**
  * calculates the bounds of the Text as a rectangle. The bounds calculation takes the worldTransform into account.
+ * @private
  */
 Text.prototype._calculateBounds = function ()
 {

--- a/src/filters/colormatrix/ColorMatrixFilter.js
+++ b/src/filters/colormatrix/ColorMatrixFilter.js
@@ -45,6 +45,7 @@ module.exports = ColorMatrixFilter;
  *
  * @param matrix {number[]} (mat 5x4)
  * @param multiply {boolean} if true, current matrix and matrix are multiplied. If false, just set the current matrix with @param matrix
+ * @private
  */
 ColorMatrixFilter.prototype._loadMatrix = function (matrix, multiply)
 {
@@ -68,6 +69,7 @@ ColorMatrixFilter.prototype._loadMatrix = function (matrix, multiply)
  * @param a {number[]} (mat 5x4) the first operand
  * @param b {number[]} (mat 5x4) the second operand
  * @returns out {number[]} (mat 5x4)
+ * @private
  */
 ColorMatrixFilter.prototype._multiply = function (out, a, b)
 {
@@ -108,6 +110,7 @@ ColorMatrixFilter.prototype._multiply = function (out, a, b)
  *
  * @param matrix {number[]} (mat 5x4)
  * @return m {number[]} (mat 5x4) with all values between 0-1
+ * @private
  */
 ColorMatrixFilter.prototype._colorMatrix = function (matrix)
 {

--- a/src/mesh/Mesh.js
+++ b/src/mesh/Mesh.js
@@ -446,6 +446,7 @@ Mesh.prototype._onTextureUpdate = function ()
  *
  * @param [matrix=this.worldTransform] {PIXI.Matrix} the transformation matrix of the sprite
  * @return {PIXI.Rectangle} the framing rectangle
+ * @private
  */
 Mesh.prototype._calculateBounds = function ()
 {


### PR DESCRIPTION
As a side note, the property ._frame on Texture, and the property _activeRenderTarget on WebGLRenderer both have the leading underscore as if they are to be private, but are publicly accessed all over the shop.