### PR TITLE
Update Container.js

### DIFF
--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -213,6 +213,9 @@ class Container extends DisplayObject
         }
         else
         {
+            if(!this.children) return;
+            // If one is reusing Sprite's before removing them from their deceased parent, this is needed, as this.children will be null
+            
             let index = this.children.indexOf(child);
 
             if (index === -1)


### PR DESCRIPTION
If one is reusing Sprite's before removing them from their deceased parent, this modification is needed, as `this.children` will be null

Around the 4.0.1 release, I started getting exceptions with the same code that I was using, I don't know what caused it, but this fixes it