### PR TITLE
Always clear Text Canvas via clearRect

### DIFF
--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -165,14 +165,7 @@ class Text extends Sprite
 
         this.context.scale(this.resolution, this.resolution);
 
-        if (navigator.isCocoonJS)
-        {
-            this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);
-
-        }
-
-        //    this.context.fillStyle="#FF0000";
-        //    this.context.fillRect(0, 0, this.canvas.width, this.canvas.height);
+        this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);
 
         this.context.font = this._font;
         this.context.strokeStyle = style.stroke;


### PR DESCRIPTION
Don't rely on width & height clearing the canvas; both Cocoon and Safari require a proper clearRect

Resubmit of: https://github.com/pixijs/pixi.js/pull/2945
Fixes: https://github.com/pixijs/pixi.js/issues/2941