### PR TITLE
Fixed issue with delay-loaded BaseTexture objects 

### DIFF
--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -264,6 +264,8 @@ class BaseTexture extends EventEmitter
             this.source.onload = null;
             this.source.onerror = null;
         }
+		
+		const firstSourceLoaded = !this.source;
 
         this.source = source;
 
@@ -280,6 +282,11 @@ class BaseTexture extends EventEmitter
             {
                 this._sourceLoaded();
             }
+			if (firstSourceLoaded)
+			{
+				// send loaded event if previous source was null and we have been passed a pre-loaded IMG element
+				this.emit('loaded', this);
+			}
         }
         else if (!source.getContext)
         {


### PR DESCRIPTION
Fix issue when creating a BaseTexture with a 'null' source value, then using .loadSource() with an already-loaded IMG element. The 'loaded' event is never fired in that case and Texture objects are forever waiting for the 'loaded' event to be emitted.

I've added a check to see if source was valid before the loadSource() call, then emit the loaded event as necessary