### PR TITLE
Polyfills are included before any other code

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import './polyfill';
 import extras from './extras';
 import filters from './filters';
 import interaction from './interaction';
@@ -8,9 +9,6 @@ import accessibility from './accessibility';
 import extract from './extract';
 import prepare from './prepare';
 import core from './core';
-
-// run the polyfills
-require('./polyfill');
 
 /**
  * A premade instance of the loader that can be used to loader resources.


### PR DESCRIPTION
### Fixed

* Makes sure that polyfills are include before any other code runs. Object-assign was not working on IE 11.