### PR TITLE
Fix for "Cannot read property 'indexOf' of null #2882"

### DIFF
--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -202,6 +202,11 @@ class Container extends DisplayObject
     {
         const argumentsLength = arguments.length;
 
+        // break out if there are not children to remove
+        if (!this.children)
+        {
+            return child; 
+        }
         // if there is only one argument we can bypass looping through the them
         if(argumentsLength > 1)
         {


### PR DESCRIPTION
removeChild function checks if there is anything to remove first. #2882