### PR TITLE
Properly set resolution

### DIFF
--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -975,7 +975,7 @@ class Graphics extends Container
     {
         const bounds = this.getLocalBounds();
 
-        const canvasBuffer = RenderTexture.create(bounds.width * resolution, bounds.height * resolution);
+        const canvasBuffer = RenderTexture.create(bounds.width, bounds.height, scaleMode, resolution);
 
         if (!canvasRenderer)
         {
@@ -989,6 +989,7 @@ class Graphics extends Container
 
         const texture = Texture.fromCanvas(canvasBuffer.baseTexture._canvasRenderTarget.canvas, scaleMode);
         texture.baseTexture.resolution = resolution;
+        texture.baseTexture.update();
 
         return texture;
     }


### PR DESCRIPTION
Sets the generated texture's resolution properly and calls `texture.update()`.

Resolves the underlying issue that caused #2940.

I wonder if BaseTexture.resolution docs also need a comment noting that if you set it manually, you must call BaseTexture.update() for it to be effected?