### PR TITLE
Attach tint docs to correct property

### DIFF
--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -66,9 +66,9 @@ class Sprite extends Container
          * @member {number}
          * @default 0xFFFFFF
          */
+        this.tint = 0xFFFFFF;
         this._tint = null;
         this._tintRGB = null;
-        this.tint = 0xFFFFFF;
 
         /**
          * The blend mode to be applied to the sprite. Apply a value of `PIXI.BLEND_MODES.NORMAL` to reset the blend mode.


### PR DESCRIPTION
Will stop PIXI.Sprite generated docs from having a `_tint` member as the first entry, and rather a `tint` member instead.