### PR TITLE
clean up  to be specific

### DIFF
--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -1,4 +1,4 @@
-import * as utils from '../utils';
+import { removeItems } from '../utils';
 import DisplayObject from './DisplayObject';
 
 /**
@@ -166,7 +166,7 @@ export default class Container extends DisplayObject
 
         const currentIndex = this.getChildIndex(child);
 
-        utils.removeItems(this.children, currentIndex, 1); // remove from old position
+        removeItems(this.children, currentIndex, 1); // remove from old position
         this.children.splice(index, 0, child); // add at new position
         this.onChildrenChange(index);
     }
@@ -203,7 +203,7 @@ export default class Container extends DisplayObject
             if (index === -1) continue;
 
             child.parent = null;
-            utils.removeItems(this.children, index, 1);
+            removeItems(this.children, index, 1);
 
             // TODO - lets either do all callbacks or all events.. not both!
             this.onChildrenChange(index);
@@ -224,7 +224,7 @@ export default class Container extends DisplayObject
         const child = this.getChildAt(index);
 
         child.parent = null;
-        utils.removeItems(this.children, index, 1);
+        removeItems(this.children, index, 1);
 
         // TODO - lets either do all callbacks or all events.. not both!
         this.onChildrenChange(index);

--- a/src/core/display/DisplayObject.js
+++ b/src/core/display/DisplayObject.js
@@ -3,7 +3,7 @@ import { TRANSFORM_MODE } from '../const';
 import TransformStatic from './TransformStatic';
 import Transform from './Transform';
 import Bounds from './Bounds';
-import * as math from '../math';
+import { Rectangle } from '../math';
 // _tempDisplayObjectParent = new DisplayObject();
 
 /**
@@ -195,7 +195,7 @@ export default class DisplayObject extends EventEmitter
         {
             if (!this._boundsRect)
             {
-                this._boundsRect = new math.Rectangle();
+                this._boundsRect = new Rectangle();
             }
 
             rect = this._boundsRect;
@@ -222,7 +222,7 @@ export default class DisplayObject extends EventEmitter
         {
             if (!this._localBoundsRect)
             {
-                this._localBoundsRect = new math.Rectangle();
+                this._localBoundsRect = new Rectangle();
             }
 
             rect = this._localBoundsRect;

--- a/src/core/display/Transform.js
+++ b/src/core/display/Transform.js
@@ -1,4 +1,4 @@
-import * as math from '../math';
+import { Point, ObservablePoint } from '../math';
 import TransformBase from './TransformBase';
 
 /**
@@ -23,28 +23,28 @@ export default class Transform extends TransformBase
          *
          * @member {PIXI.Point}
          */
-        this.position = new math.Point(0, 0);
+        this.position = new Point(0, 0);
 
         /**
          * The scale factor of the object.
          *
          * @member {PIXI.Point}
          */
-        this.scale = new math.Point(1, 1);
+        this.scale = new Point(1, 1);
 
         /**
          * The skew amount, on the x and y axis.
          *
          * @member {PIXI.ObservablePoint}
          */
-        this.skew = new math.ObservablePoint(this.updateSkew, this, 0, 0);
+        this.skew = new ObservablePoint(this.updateSkew, this, 0, 0);
 
         /**
          * The pivot point of the displayObject that it rotates around
          *
          * @member {PIXI.Point}
          */
-        this.pivot = new math.Point(0, 0);
+        this.pivot = new Point(0, 0);
 
         /**
          * The rotation value of the object, in radians

--- a/src/core/display/TransformBase.js
+++ b/src/core/display/TransformBase.js
@@ -1,4 +1,4 @@
-import * as math from '../math';
+import { Matrix } from '../math';
 
 /**
  * Generic class to deal with traditional 2D matrix transforms
@@ -18,14 +18,14 @@ export default class TransformBase
          *
          * @member {PIXI.Matrix}
          */
-        this.worldTransform = new math.Matrix();
+        this.worldTransform = new Matrix();
 
         /**
          * The local matrix transform
          *
          * @member {PIXI.Matrix}
          */
-        this.localTransform = new math.Matrix();
+        this.localTransform = new Matrix();
 
         this._worldID = 0;
     }

--- a/src/core/display/TransformStatic.js
+++ b/src/core/display/TransformStatic.js
@@ -1,4 +1,4 @@
-import * as math from '../math';
+import { ObservablePoint } from '../math';
 import TransformBase from './TransformBase';
 
 /**
@@ -22,28 +22,28 @@ export default class TransformStatic extends TransformBase
          *
          * @member {PIXI.ObservablePoint}
          */
-        this.position = new math.ObservablePoint(this.onChange, this, 0, 0);
+        this.position = new ObservablePoint(this.onChange, this, 0, 0);
 
         /**
          * The scale factor of the object.
          *
          * @member {PIXI.ObservablePoint}
          */
-        this.scale = new math.ObservablePoint(this.onChange, this, 1, 1);
+        this.scale = new ObservablePoint(this.onChange, this, 1, 1);
 
         /**
          * The pivot point of the displayObject that it rotates around
          *
          * @member {PIXI.ObservablePoint}
          */
-        this.pivot = new math.ObservablePoint(this.onChange, this, 0, 0);
+        this.pivot = new ObservablePoint(this.onChange, this, 0, 0);
 
         /**
          * The skew amount, on the x and y axis.
          *
          * @member {PIXI.ObservablePoint}
          */
-        this.skew = new math.ObservablePoint(this.updateSkew, this, 0, 0);
+        this.skew = new ObservablePoint(this.updateSkew, this, 0, 0);
 
         this._rotation = 0;
 

--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -3,16 +3,16 @@ import RenderTexture from '../textures/RenderTexture';
 import Texture from '../textures/Texture';
 import GraphicsData from './GraphicsData';
 import Sprite from '../sprites/Sprite';
-import * as math from '../math';
-import * as utils from '../utils';
+import { Matrix, Point, Rectangle, RoundedRectangle, Ellipse, Polygon, Circle } from '../math';
+import { hex2rgb, rgb2hex } from '../utils';
 import { SHAPES, BLEND_MODES } from '../const';
 import Bounds from '../display/Bounds';
 import bezierCurveTo from './utils/bezierCurveTo';
 import CanvasRenderer from '../renderers/canvas/CanvasRenderer';
 
 let canvasRenderer;
-const tempMatrix = new math.Matrix();
-const tempPoint = new math.Point();
+const tempMatrix = new Matrix();
+const tempPoint = new Point();
 const tempColor1 = new Float32Array(4);
 const tempColor2 = new Float32Array(4);
 
@@ -239,7 +239,7 @@ export default class Graphics extends Container
             if (this.currentPath.shape.points.length)
             {
                 // halfway through a line? start a new one!
-                const shape = new math.Polygon(this.currentPath.shape.points.slice(-2));
+                const shape = new Polygon(this.currentPath.shape.points.slice(-2));
 
                 shape.closed = false;
 
@@ -266,7 +266,7 @@ export default class Graphics extends Container
      */
     moveTo(x, y)
     {
-        const shape = new math.Polygon([x, y]);
+        const shape = new Polygon([x, y]);
 
         shape.closed = false;
         this.drawShape(shape);
@@ -583,7 +583,7 @@ export default class Graphics extends Container
      */
     drawRect(x, y, width, height)
     {
-        this.drawShape(new math.Rectangle(x, y, width, height));
+        this.drawShape(new Rectangle(x, y, width, height));
 
         return this;
     }
@@ -599,7 +599,7 @@ export default class Graphics extends Container
      */
     drawRoundedRect(x, y, width, height, radius)
     {
-        this.drawShape(new math.RoundedRectangle(x, y, width, height, radius));
+        this.drawShape(new RoundedRectangle(x, y, width, height, radius));
 
         return this;
     }
@@ -614,7 +614,7 @@ export default class Graphics extends Container
      */
     drawCircle(x, y, radius)
     {
-        this.drawShape(new math.Circle(x, y, radius));
+        this.drawShape(new Circle(x, y, radius));
 
         return this;
     }
@@ -630,7 +630,7 @@ export default class Graphics extends Container
      */
     drawEllipse(x, y, width, height)
     {
-        this.drawShape(new math.Ellipse(x, y, width, height));
+        this.drawShape(new Ellipse(x, y, width, height));
 
         return this;
     }
@@ -649,7 +649,7 @@ export default class Graphics extends Container
 
         let closed = true;
 
-        if (points instanceof math.Polygon)
+        if (points instanceof Polygon)
         {
             closed = points.closed;
             points = points.points;
@@ -667,7 +667,7 @@ export default class Graphics extends Container
             }
         }
 
-        const shape = new math.Polygon(points);
+        const shape = new Polygon(points);
 
         shape.closed = closed;
 
@@ -776,14 +776,14 @@ export default class Graphics extends Container
             const t1 = tempColor1;
             const t2 = tempColor2;
 
-            utils.hex2rgb(this.graphicsData[0].fillColor, t1);
-            utils.hex2rgb(this.tint, t2);
+            hex2rgb(this.graphicsData[0].fillColor, t1);
+            hex2rgb(this.tint, t2);
 
             t1[0] *= t2[0];
             t1[1] *= t2[1];
             t1[2] *= t2[2];
 
-            this._spriteRect.tint = utils.rgb2hex(t1);
+            this._spriteRect.tint = rgb2hex(t1);
         }
         this._spriteRect.alpha = this.graphicsData[0].fillAlpha;
         this._spriteRect.worldAlpha = this.worldAlpha * this._spriteRect.alpha;

--- a/src/core/graphics/webgl/GraphicsRenderer.js
+++ b/src/core/graphics/webgl/GraphicsRenderer.js
@@ -1,4 +1,4 @@
-import * as utils from '../../utils';
+import { hex2rgb } from '../../utils';
 import { SHAPES } from '../../const';
 import ObjectRenderer from '../../renderers/webgl/utils/ObjectRenderer';
 import WebGLRenderer from '../../renderers/webgl/WebGLRenderer';
@@ -98,7 +98,7 @@ export default class GraphicsRenderer extends ObjectRenderer
 
             renderer.bindShader(shaderTemp);
             shaderTemp.uniforms.translationMatrix = graphics.transform.worldTransform.toArray(true);
-            shaderTemp.uniforms.tint = utils.hex2rgb(graphics.tint);
+            shaderTemp.uniforms.tint = hex2rgb(graphics.tint);
             shaderTemp.uniforms.alpha = graphics.worldAlpha;
 
             webGLData.vao.bind()

--- a/src/core/graphics/webgl/utils/buildCircle.js
+++ b/src/core/graphics/webgl/utils/buildCircle.js
@@ -1,6 +1,6 @@
 import buildLine from './buildLine';
 import { SHAPES } from '../../../const';
-import * as utils from '../../../utils';
+import { hex2rgb } from '../../../utils';
 
 /**
  * Builds a circle to draw
@@ -40,7 +40,7 @@ export default function buildCircle(graphicsData, webGLData)
 
     if (graphicsData.fill)
     {
-        const color = utils.hex2rgb(graphicsData.fillColor);
+        const color = hex2rgb(graphicsData.fillColor);
         const alpha = graphicsData.fillAlpha;
 
         const r = color[0] * alpha;

--- a/src/core/graphics/webgl/utils/buildComplexPoly.js
+++ b/src/core/graphics/webgl/utils/buildComplexPoly.js
@@ -1,4 +1,4 @@
-import * as utils from '../../../utils';
+import { hex2rgb } from '../../../utils';
 
 /**
  * Builds a complex polygon to draw
@@ -25,7 +25,7 @@ export default function buildComplexPoly(graphicsData, webGLData)
 
     webGLData.points = points;
     webGLData.alpha = graphicsData.fillAlpha;
-    webGLData.color = utils.hex2rgb(graphicsData.fillColor);
+    webGLData.color = hex2rgb(graphicsData.fillColor);
 
     // calclate the bounds..
     let minX = Infinity;

--- a/src/core/graphics/webgl/utils/buildLine.js
+++ b/src/core/graphics/webgl/utils/buildLine.js
@@ -1,5 +1,5 @@
-import * as math from '../../../math';
-import * as utils from '../../../utils';
+import { Point } from '../../../math';
+import { hex2rgb } from '../../../utils';
 
 /**
  * Builds a line to draw
@@ -31,8 +31,8 @@ export default function buildLine(graphicsData, webGLData)
     // }
 
     // get first and last point.. figure out the middle!
-    const firstPoint = new math.Point(points[0], points[1]);
-    let lastPoint = new math.Point(points[points.length - 2], points[points.length - 1]);
+    const firstPoint = new Point(points[0], points[1]);
+    let lastPoint = new Point(points[points.length - 2], points[points.length - 1]);
 
     // if the first point is the last point - gonna have issues :)
     if (firstPoint.x === lastPoint.x && firstPoint.y === lastPoint.y)
@@ -43,7 +43,7 @@ export default function buildLine(graphicsData, webGLData)
         points.pop();
         points.pop();
 
-        lastPoint = new math.Point(points[points.length - 2], points[points.length - 1]);
+        lastPoint = new Point(points[points.length - 2], points[points.length - 1]);
 
         const midPointX = lastPoint.x + ((firstPoint.x - lastPoint.x) * 0.5);
         const midPointY = lastPoint.y + ((firstPoint.y - lastPoint.y) * 0.5);
@@ -62,7 +62,7 @@ export default function buildLine(graphicsData, webGLData)
     const width = graphicsData.lineWidth / 2;
 
     // sort color
-    const color = utils.hex2rgb(graphicsData.lineColor);
+    const color = hex2rgb(graphicsData.lineColor);
     const alpha = graphicsData.lineAlpha;
     const r = color[0] * alpha;
     const g = color[1] * alpha;

--- a/src/core/graphics/webgl/utils/buildPoly.js
+++ b/src/core/graphics/webgl/utils/buildPoly.js
@@ -1,5 +1,5 @@
 import buildLine from './buildLine';
-import * as utils from '../../../utils';
+import { hex2rgb } from '../../../utils';
 import earcut from 'earcut';
 
 /**
@@ -40,7 +40,7 @@ export default function buildPoly(graphicsData, webGLData)
         const length = points.length / 2;
 
         // sort color
-        const color = utils.hex2rgb(graphicsData.fillColor);
+        const color = hex2rgb(graphicsData.fillColor);
         const alpha = graphicsData.fillAlpha;
         const r = color[0] * alpha;
         const g = color[1] * alpha;

--- a/src/core/graphics/webgl/utils/buildRectangle.js
+++ b/src/core/graphics/webgl/utils/buildRectangle.js
@@ -1,5 +1,5 @@
 import buildLine from './buildLine';
-import * as utils from '../../../utils';
+import { hex2rgb } from '../../../utils';
 
 /**
  * Builds a rectangle to draw
@@ -24,7 +24,7 @@ export default function buildRectangle(graphicsData, webGLData)
 
     if (graphicsData.fill)
     {
-        const color = utils.hex2rgb(graphicsData.fillColor);
+        const color = hex2rgb(graphicsData.fillColor);
         const alpha = graphicsData.fillAlpha;
 
         const r = color[0] * alpha;

--- a/src/core/graphics/webgl/utils/buildRoundedRectangle.js
+++ b/src/core/graphics/webgl/utils/buildRoundedRectangle.js
@@ -1,6 +1,6 @@
 import earcut from 'earcut';
 import buildLine from './buildLine';
-import * as utils from '../../../utils';
+import { hex2rgb } from '../../../utils';
 
 /**
  * Builds a rounded rectangle to draw
@@ -35,7 +35,7 @@ export default function buildRoundedRectangle(graphicsData, webGLData)
 
     if (graphicsData.fill)
     {
-        const color = utils.hex2rgb(graphicsData.fillColor);
+        const color = hex2rgb(graphicsData.fillColor);
         const alpha = graphicsData.fillAlpha;
 
         const r = color[0] * alpha;

--- a/src/core/renderers/SystemRenderer.js
+++ b/src/core/renderers/SystemRenderer.js
@@ -1,11 +1,11 @@
-import * as utils from '../utils';
-import * as math from '../math';
+import { sayHello, hex2string, hex2rgb } from '../utils';
+import { Matrix } from '../math';
 import { DEFAULT_RENDER_OPTIONS, RENDERER_TYPE } from '../const';
 import Container from '../display/Container';
 import RenderTexture from '../textures/RenderTexture';
 import EventEmitter from 'eventemitter3';
 
-const tempMatrix = new math.Matrix();
+const tempMatrix = new Matrix();
 
 /**
  * The SystemRenderer is the base for a Pixi Renderer. It is extended by the {@link PIXI.CanvasRenderer}
@@ -40,7 +40,7 @@ class SystemRenderer extends EventEmitter
     {
         super();
 
-        utils.sayHello(system);
+        sayHello(system);
 
         // prepare options
         if (options)
@@ -294,8 +294,8 @@ class SystemRenderer extends EventEmitter
     set backgroundColor(value)
     {
         this._backgroundColor = value;
-        this._backgroundColorString = utils.hex2string(value);
-        utils.hex2rgb(value, this._backgroundColorRgba);
+        this._backgroundColorString = hex2string(value);
+        hex2rgb(value, this._backgroundColorRgba);
     }
 }
 

--- a/src/core/renderers/canvas/CanvasRenderer.js
+++ b/src/core/renderers/canvas/CanvasRenderer.js
@@ -2,7 +2,7 @@ import SystemRenderer from '../SystemRenderer';
 import CanvasMaskManager from './utils/CanvasMaskManager';
 import CanvasRenderTarget from './utils/CanvasRenderTarget';
 import mapCanvasBlendModesToPixi from './utils/mapCanvasBlendModesToPixi';
-import * as utils from '../../utils';
+import { pluginTarget } from '../../utils';
 import { RENDERER_TYPE, SCALE_MODES, BLEND_MODES } from '../../const';
 
 /**
@@ -267,4 +267,4 @@ export default class CanvasRenderer extends SystemRenderer
     }
 }
 
-utils.pluginTarget.mixin(CanvasRenderer);
+pluginTarget.mixin(CanvasRenderer);

--- a/src/core/renderers/webgl/TextureManager.js
+++ b/src/core/renderers/webgl/TextureManager.js
@@ -1,7 +1,7 @@
 import { GLTexture } from 'pixi-gl-core';
 import { WRAP_MODES, SCALE_MODES } from '../../const';
 import RenderTarget from './utils/RenderTarget';
-import * as utils from '../../utils';
+import { removeItems } from '../../utils';
 
 /**
  * Helper class to create a webGL Texture
@@ -182,7 +182,7 @@ class TextureManager
 
                 if (i !== -1)
                 {
-                    utils.removeItems(this._managedTextures, i, 1);
+                    removeItems(this._managedTextures, i, 1);
                 }
             }
         }

--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -9,7 +9,7 @@ import TextureGarbageCollector from './TextureGarbageCollector';
 import WebGLState from './WebGLState';
 import mapWebGLDrawModesToPixi from './utils/mapWebGLDrawModesToPixi';
 import validateContext from './utils/validateContext';
-import * as utils from '../../utils';
+import { pluginTarget } from '../../utils';
 import glCore from 'pixi-gl-core';
 import { RENDERER_TYPE } from '../../const';
 
@@ -564,4 +564,4 @@ export default class WebGLRenderer extends SystemRenderer
     }
 }
 
-utils.pluginTarget.mixin(WebGLRenderer);
+pluginTarget.mixin(WebGLRenderer);

--- a/src/core/renderers/webgl/filters/Filter.js
+++ b/src/core/renderers/webgl/filters/Filter.js
@@ -1,5 +1,5 @@
 import extractUniformsFromSrc from './extractUniformsFromSrc';
-import * as utils from '../../../utils';
+import { uid } from '../../../utils';
 import { BLEND_MODES } from '../../../const';
 
 const SOURCE_KEY_MAP = {};
@@ -53,7 +53,7 @@ class Filter
         // used for cacheing.. sure there is a better way!
         if (!SOURCE_KEY_MAP[this.vertexSrc + this.fragmentSrc])
         {
-            SOURCE_KEY_MAP[this.vertexSrc + this.fragmentSrc] = utils.uid();
+            SOURCE_KEY_MAP[this.vertexSrc + this.fragmentSrc] = uid();
         }
 
         this.glShaderKey = SOURCE_KEY_MAP[this.vertexSrc + this.fragmentSrc];

--- a/src/core/renderers/webgl/filters/filterTransforms.js
+++ b/src/core/renderers/webgl/filters/filterTransforms.js
@@ -1,4 +1,4 @@
-import * as math from '../../../math';
+import { Matrix } from '../../../math';
 
 /*
  * Calculates the mapped matrix
@@ -10,7 +10,7 @@ import * as math from '../../../math';
 // thia returns a matrix that will normalise map filter cords in the filter to screen space
 export function calculateScreenSpaceMatrix(outputMatrix, filterArea, textureSize)
 {
-     // let worldTransform = sprite.worldTransform.copy(math.Matrix.TEMP_MATRIX),
+     // let worldTransform = sprite.worldTransform.copy(Matrix.TEMP_MATRIX),
     // let texture = {width:1136, height:700};//sprite._texture.baseTexture;
 
     // TODO unwrap?
@@ -40,7 +40,7 @@ export function calculateNormalizedScreenSpaceMatrix(outputMatrix, filterArea, t
 // this will map the filter coord so that a texture can be used based on the transform of a sprite
 export function calculateSpriteMatrix(outputMatrix, filterArea, textureSize, sprite)
 {
-    const worldTransform = sprite.worldTransform.copy(math.Matrix.TEMP_MATRIX);
+    const worldTransform = sprite.worldTransform.copy(Matrix.TEMP_MATRIX);
     const texture = sprite._texture.baseTexture;
 
     // TODO unwrap?

--- a/src/core/renderers/webgl/filters/spriteMask/SpriteMaskFilter.js
+++ b/src/core/renderers/webgl/filters/spriteMask/SpriteMaskFilter.js
@@ -1,5 +1,5 @@
 import Filter from '../Filter';
-import * as math from '../../../../math';
+import { Matrix } from '../../../../math';
 
 // @see https://github.com/substack/brfs/issues/25
 const glslify = require('glslify'); // eslint-disable-line no-undef
@@ -18,7 +18,7 @@ class SpriteMaskFilter extends Filter
      */
     constructor(sprite)
     {
-        const maskMatrix = new math.Matrix();
+        const maskMatrix = new Matrix();
 
         super(
             glslify('./spriteMaskFilter.vert'),

--- a/src/core/renderers/webgl/managers/FilterManager.js
+++ b/src/core/renderers/webgl/managers/FilterManager.js
@@ -1,7 +1,7 @@
 import WebGLManager from './WebGLManager';
 import RenderTarget from '../utils/RenderTarget';
 import Quad from '../utils/Quad';
-import * as math from '../../../math';
+import { Rectangle } from '../../../math';
 import Shader from '../../../Shader';
 import filterTransforms from '../filters/filterTransforms';
 import bitTwiddle from 'bit-twiddle';
@@ -18,8 +18,8 @@ class FilterState
     constructor()
     {
         this.renderTarget = null;
-        this.sourceFrame = new math.Rectangle();
-        this.destinationFrame = new math.Rectangle();
+        this.sourceFrame = new Rectangle();
+        this.destinationFrame = new Rectangle();
         this.filters = [];
         this.target = null;
         this.resolution = 1;

--- a/src/core/renderers/webgl/utils/RenderTarget.js
+++ b/src/core/renderers/webgl/utils/RenderTarget.js
@@ -1,4 +1,4 @@
-import * as math from '../../../math';
+import { Rectangle, Matrix } from '../../../math';
 import { RESOLUTION, SCALE_MODES } from '../../../const';
 import { GLFramebuffer } from 'pixi-gl-core';
 
@@ -55,7 +55,7 @@ export default class RenderTarget
          *
          * @member {PIXI.Rectangle}
          */
-        this.size = new math.Rectangle(0, 0, 1, 1);
+        this.size = new Rectangle(0, 0, 1, 1);
 
         /**
          * The current resolution / device pixel ratio
@@ -70,7 +70,7 @@ export default class RenderTarget
          *
          * @member {PIXI.Matrix}
          */
-        this.projectionMatrix = new math.Matrix();
+        this.projectionMatrix = new Matrix();
 
         /**
          * The object's transform
@@ -91,7 +91,7 @@ export default class RenderTarget
          *
          * @member {glCore.GLBuffer}
          */
-        this.defaultFrame = new math.Rectangle();
+        this.defaultFrame = new Rectangle();
         this.destinationFrame = null;
         this.sourceFrame = null;
 

--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -1,10 +1,10 @@
-import * as math from '../math';
+import { Point, ObservablePoint, Rectangle } from '../math';
+import { sign, TextureCache } from '../utils';
+import { BLEND_MODES } from '../const';
 import Texture from '../textures/Texture';
 import Container from '../display/Container';
-import * as utils from '../utils';
-import { BLEND_MODES } from '../const';
 
-const tempPoint = new math.Point();
+const tempPoint = new Point();
 
 /**
  * The Sprite object is the base for all textured objects that are rendered to the screen
@@ -37,7 +37,7 @@ export default class Sprite extends Container
          * @member {PIXI.ObservablePoint}
          * @private
          */
-        this._anchor = new math.ObservablePoint(this.onAnchorUpdate, this);
+        this._anchor = new ObservablePoint(this.onAnchorUpdate, this);
 
         /**
          * The texture that the sprite is using
@@ -134,12 +134,12 @@ export default class Sprite extends Container
         // so if _width is 0 then width was not set..
         if (this._width)
         {
-            this.scale.x = utils.sign(this.scale.x) * this._width / this.texture.orig.width;
+            this.scale.x = sign(this.scale.x) * this._width / this.texture.orig.width;
         }
 
         if (this._height)
         {
-            this.scale.y = utils.sign(this.scale.y) * this._height / this.texture.orig.height;
+            this.scale.y = sign(this.scale.y) * this._height / this.texture.orig.height;
         }
     }
 
@@ -339,7 +339,7 @@ export default class Sprite extends Container
             {
                 if (!this._localBoundsRect)
                 {
-                    this._localBoundsRect = new math.Rectangle();
+                    this._localBoundsRect = new Rectangle();
                 }
 
                 rect = this._localBoundsRect;
@@ -433,7 +433,7 @@ export default class Sprite extends Container
      */
     static fromFrame(frameId)
     {
-        const texture = utils.TextureCache[frameId];
+        const texture = TextureCache[frameId];
 
         if (!texture)
         {
@@ -477,9 +477,9 @@ export default class Sprite extends Container
      */
     set width(value)
     {
-        const sign = utils.sign(this.scale.x) || 1;
+        const s = sign(this.scale.x) || 1;
 
-        this.scale.x = sign * value / this.texture.orig.width;
+        this.scale.x = s * value / this.texture.orig.width;
         this._width = value;
     }
 
@@ -501,9 +501,9 @@ export default class Sprite extends Container
      */
     set height(value)
     {
-        const sign = utils.sign(this.scale.y) || 1;
+        const s = sign(this.scale.y) || 1;
 
-        this.scale.y = sign * value / this.texture.orig.height;
+        this.scale.y = s * value / this.texture.orig.height;
         this._height = value;
     }
 

--- a/src/core/sprites/canvas/CanvasSpriteRenderer.js
+++ b/src/core/sprites/canvas/CanvasSpriteRenderer.js
@@ -1,9 +1,9 @@
 import CanvasRenderer from '../../renderers/canvas/CanvasRenderer';
 import { SCALE_MODES } from '../../const';
-import * as math from '../../math';
+import { Matrix, GroupD8 } from '../../math';
 import CanvasTinter from './CanvasTinter';
 
-const canvasRenderWorldTransform = new math.Matrix();
+const canvasRenderWorldTransform = new Matrix();
 
 /**
  * @author Mat Groves
@@ -87,7 +87,7 @@ export default class CanvasSpriteRenderer
             {
                 wt.copy(canvasRenderWorldTransform);
                 wt = canvasRenderWorldTransform;
-                math.GroupD8.matrixAppendRotationInv(wt, texture.rotate, dx, dy);
+                GroupD8.matrixAppendRotationInv(wt, texture.rotate, dx, dy);
                 // the anchor has already been applied above, so lets set it to zero
                 dx = 0;
                 dy = 0;

--- a/src/core/sprites/canvas/CanvasTinter.js
+++ b/src/core/sprites/canvas/CanvasTinter.js
@@ -1,4 +1,4 @@
-import * as utils from '../../utils';
+import { hex2rgb, rgb2hex } from '../../utils';
 import canUseNewCanvasBlendModes from '../../renderers/canvas/utils/canUseNewCanvasBlendModes';
 
 /**
@@ -187,7 +187,7 @@ const CanvasTinter = {
             crop.height
         );
 
-        const rgbValues = utils.hex2rgb(color);
+        const rgbValues = hex2rgb(color);
         const r = rgbValues[0];
         const g = rgbValues[1];
         const b = rgbValues[2];
@@ -217,13 +217,13 @@ const CanvasTinter = {
     {
         const step = CanvasTinter.cacheStepsPerColorChannel;
 
-        const rgbValues = utils.hex2rgb(color);
+        const rgbValues = hex2rgb(color);
 
         rgbValues[0] = Math.min(255, (rgbValues[0] / step) * step);
         rgbValues[1] = Math.min(255, (rgbValues[1] / step) * step);
         rgbValues[2] = Math.min(255, (rgbValues[2] / step) * step);
 
-        return utils.rgb2hex(rgbValues);
+        return rgb2hex(rgbValues);
     },
 
     /**

--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -1,8 +1,8 @@
 /* eslint max-depth: [2, 8] */
 import Sprite from '../sprites/Sprite';
 import Texture from '../textures/Texture';
-import * as math from '../math';
-import * as utils from '../utils';
+import { Rectangle } from '../math';
+import { sign } from '../utils';
 import { TEXT_GRADIENT, RESOLUTION } from '../const';
 import TextStyle from './TextStyle';
 
@@ -37,8 +37,8 @@ export default class Text extends Sprite
         const canvas = document.createElement('canvas');
         const texture = Texture.fromCanvas(canvas);
 
-        texture.orig = new math.Rectangle();
-        texture.trim = new math.Rectangle();
+        texture.orig = new Rectangle();
+        texture.trim = new Rectangle();
 
         super(texture);
 
@@ -719,9 +719,9 @@ export default class Text extends Sprite
     {
         this.updateText(true);
 
-        const sign = utils.sign(this.scale.x) || 1;
+        const s = sign(this.scale.x) || 1;
 
-        this.scale.x = sign * value / this.texture.orig.width;
+        this.scale.x = s * value / this.texture.orig.width;
         this._width = value;
     }
 
@@ -747,9 +747,9 @@ export default class Text extends Sprite
     {
         this.updateText(true);
 
-        const sign = utils.sign(this.scale.y) || 1;
+        const s = sign(this.scale.y) || 1;
 
-        this.scale.y = sign * value / this.texture.orig.height;
+        this.scale.y = s * value / this.texture.orig.height;
         this._height = value;
     }
 

--- a/src/core/text/TextStyle.js
+++ b/src/core/text/TextStyle.js
@@ -2,7 +2,7 @@
 /* eslint-disable */
 
 import { TEXT_GRADIENT } from '../const';
-import * as utils from '../utils';
+import { hex2string } from '../utils';
 
 const defaultStyle = {
     align: 'left',
@@ -439,7 +439,7 @@ function getColor(color)
 {
     if (typeof color === 'number')
     {
-        return utils.hex2string(color);
+        return hex2string(color);
     }
     else if (Array.isArray(color))
     {
@@ -447,7 +447,7 @@ function getColor(color)
         {
             if (typeof color[i] === 'number')
             {
-                color[i] = utils.hex2string(color[i]);
+                color[i] = hex2string(color[i]);
             }
         }
     }

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -2,8 +2,8 @@ import BaseTexture from './BaseTexture';
 import VideoBaseTexture from './VideoBaseTexture';
 import TextureUvs from './TextureUvs';
 import EventEmitter from 'eventemitter3';
-import * as math from '../math';
-import * as utils from '../utils';
+import { Rectangle } from '../math';
+import { TextureCache, BaseTextureCache } from '../utils';
 
 /**
  * A texture stores the information that represents an image or part of an image. It cannot be added
@@ -45,7 +45,7 @@ class Texture extends EventEmitter
         if (!frame)
         {
             this.noFrame = true;
-            frame = new math.Rectangle(0, 0, 1, 1);
+            frame = new Rectangle(0, 0, 1, 1);
         }
 
         if (baseTexture instanceof Texture)
@@ -102,7 +102,7 @@ class Texture extends EventEmitter
          *
          * @member {PIXI.Rectangle}
          */
-        this.orig = orig || frame;// new math.Rectangle(0, 0, 1, 1);
+        this.orig = orig || frame;// new Rectangle(0, 0, 1, 1);
 
         this._rotate = Number(rotate || 0);
 
@@ -120,7 +120,7 @@ class Texture extends EventEmitter
         {
             if (this.noFrame)
             {
-                frame = new math.Rectangle(0, 0, baseTexture.width, baseTexture.height);
+                frame = new Rectangle(0, 0, baseTexture.width, baseTexture.height);
 
                 // if there is no frame we should monitor for any base texture changes..
                 baseTexture.on('update', this.onBaseTextureUpdated, this);
@@ -165,7 +165,7 @@ class Texture extends EventEmitter
         // TODO this code looks confusing.. boo to abusing getters and setterss!
         if (this.noFrame)
         {
-            this.frame = new math.Rectangle(0, 0, baseTexture.width, baseTexture.height);
+            this.frame = new Rectangle(0, 0, baseTexture.width, baseTexture.height);
         }
         else
         {
@@ -205,9 +205,9 @@ class Texture extends EventEmitter
             {
                 // delete the texture if it exists in the texture cache..
                 // this only needs to be removed if the base texture is actually destoryed too..
-                if (utils.TextureCache[this.baseTexture.imageUrl])
+                if (TextureCache[this.baseTexture.imageUrl])
                 {
-                    delete utils.TextureCache[this.baseTexture.imageUrl];
+                    delete TextureCache[this.baseTexture.imageUrl];
                 }
 
                 this.baseTexture.destroy();
@@ -270,12 +270,12 @@ class Texture extends EventEmitter
      */
     static fromImage(imageUrl, crossorigin, scaleMode, sourceScale)
     {
-        let texture = utils.TextureCache[imageUrl];
+        let texture = TextureCache[imageUrl];
 
         if (!texture)
         {
             texture = new Texture(BaseTexture.fromImage(imageUrl, crossorigin, scaleMode, sourceScale));
-            utils.TextureCache[imageUrl] = texture;
+            TextureCache[imageUrl] = texture;
         }
 
         return texture;
@@ -291,7 +291,7 @@ class Texture extends EventEmitter
      */
     static fromFrame(frameId)
     {
-        const texture = utils.TextureCache[frameId];
+        const texture = TextureCache[frameId];
 
         if (!texture)
         {
@@ -359,7 +359,7 @@ class Texture extends EventEmitter
         // TODO pass in scale mode?
         if (typeof source === 'string')
         {
-            const texture = utils.TextureCache[source];
+            const texture = TextureCache[source];
 
             if (!texture)
             {
@@ -394,7 +394,7 @@ class Texture extends EventEmitter
     }
 
     /**
-     * Adds a texture to the global utils.TextureCache. This cache is shared across the whole PIXI object.
+     * Adds a texture to the global TextureCache. This cache is shared across the whole PIXI object.
      *
      * @static
      * @param {PIXI.Texture} texture - The Texture to add to the cache.
@@ -402,11 +402,11 @@ class Texture extends EventEmitter
      */
     static addTextureToCache(texture, id)
     {
-        utils.TextureCache[id] = texture;
+        TextureCache[id] = texture;
     }
 
     /**
-     * Remove a texture from the global utils.TextureCache.
+     * Remove a texture from the global TextureCache.
      *
      * @static
      * @param {string} id - The id of the texture to be removed
@@ -414,10 +414,10 @@ class Texture extends EventEmitter
      */
     static removeTextureFromCache(id)
     {
-        const texture = utils.TextureCache[id];
+        const texture = TextureCache[id];
 
-        delete utils.TextureCache[id];
-        delete utils.BaseTextureCache[id];
+        delete TextureCache[id];
+        delete BaseTextureCache[id];
 
         return texture;
     }

--- a/src/core/textures/VideoBaseTexture.js
+++ b/src/core/textures/VideoBaseTexture.js
@@ -1,5 +1,5 @@
 import BaseTexture from './BaseTexture';
-import * as utils from '../utils';
+import { uid, BaseTextureCache } from '../utils';
 
 /**
  * A texture of a [playing] Video.
@@ -155,7 +155,7 @@ class VideoBaseTexture extends BaseTexture
     {
         if (this.source && this.source._pixiId)
         {
-            delete utils.BaseTextureCache[this.source._pixiId];
+            delete BaseTextureCache[this.source._pixiId];
             delete this.source._pixiId;
         }
 
@@ -174,15 +174,15 @@ class VideoBaseTexture extends BaseTexture
     {
         if (!video._pixiId)
         {
-            video._pixiId = `video_${utils.uid()}`;
+            video._pixiId = `video_${uid()}`;
         }
 
-        let baseTexture = utils.BaseTextureCache[video._pixiId];
+        let baseTexture = BaseTextureCache[video._pixiId];
 
         if (!baseTexture)
         {
             baseTexture = new VideoBaseTexture(video, scaleMode);
-            utils.BaseTextureCache[video._pixiId] = baseTexture;
+            BaseTextureCache[video._pixiId] = baseTexture;
         }
 
         return baseTexture;

--- a/src/loaders/bitmapFontParser.js
+++ b/src/loaders/bitmapFontParser.js
@@ -1,7 +1,7 @@
-import { Resource } from 'resource-loader';
-import * as core from '../core';
-import * as extras from '../extras';
 import * as path from 'path';
+import { Rectangle, Texture, utils } from '../core';
+import { Resource } from 'resource-loader';
+import { BitmapText } from '../extras';
 
 function parse(resource, texture)
 {
@@ -21,7 +21,7 @@ function parse(resource, texture)
     {
         const charCode = parseInt(letters[i].getAttribute('id'), 10);
 
-        const textureRect = new core.Rectangle(
+        const textureRect = new Rectangle(
             parseInt(letters[i].getAttribute('x'), 10) + texture.frame.x,
             parseInt(letters[i].getAttribute('y'), 10) + texture.frame.y,
             parseInt(letters[i].getAttribute('width'), 10),
@@ -33,7 +33,7 @@ function parse(resource, texture)
             yOffset: parseInt(letters[i].getAttribute('yoffset'), 10),
             xAdvance: parseInt(letters[i].getAttribute('xadvance'), 10),
             kerning: {},
-            texture: new core.Texture(texture.baseTexture, textureRect),
+            texture: new Texture(texture.baseTexture, textureRect),
 
         };
     }
@@ -57,7 +57,7 @@ function parse(resource, texture)
 
     // I'm leaving this as a temporary fix so we can test the bitmap fonts in v3
     // but it's very likely to change
-    extras.BitmapText.fonts[data.font] = data;
+    BitmapText.fonts[data.font] = data;
 }
 
 export default function ()
@@ -113,10 +113,10 @@ export default function ()
 
         const textureUrl = xmlUrl + resource.data.getElementsByTagName('page')[0].getAttribute('file');
 
-        if (core.utils.TextureCache[textureUrl])
+        if (utils.TextureCache[textureUrl])
         {
             // reuse existing texture
-            parse(resource, core.utils.TextureCache[textureUrl]);
+            parse(resource, utils.TextureCache[textureUrl]);
             next();
         }
         else


### PR DESCRIPTION
Cleans up `import * as ` declarations to be more specific to their imports, which should help with tree shaking down the road.

There are a few I intentionally left alone as they actually seemed appropriate uses of `import *`. Additionally I left alone the `import * as core` in plugins, at least for now.