### PR TITLE
Smaller default texture size for text

### DIFF
--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -35,6 +35,10 @@ export default class Text extends Sprite
     constructor(text, style)
     {
         const canvas = document.createElement('canvas');
+
+        canvas.width = 16;
+        canvas.height = 16;
+
         const texture = Texture.fromCanvas(canvas);
 
         texture.orig = new Rectangle();


### PR DESCRIPTION
I was measuring the total texture pixels being used by Text I created, and noticed that measurement went _down_ during gameplay.

Turns out it's because when Text is created, a canvas is created, and a texture created from it. However, the default canvas size is 150x300 (at least on Chrome) which is usually far larger than actually required. And that only gets updated the first time text gets rendered, which for some hidden away screens or menus, could be a fair while.

So I've changed this default size down to a super small 16x16, so no memory is wasted on unrendered text. Estimated texture memory usage of text went from 21mb to 3mb in my game.