### PR TITLE
Fixes a destroy error in Sprites with a shared texture

### DIFF
--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -397,7 +397,7 @@ export default class Sprite extends Container
 
         const destroyTexture = typeof options === 'boolean' ? options : options && options.texture;
 
-        if (destroyTexture)
+        if (destroyTexture && this._texture)
         {
             const destroyBaseTexture = typeof options === 'boolean' ? options : options && options.baseTexture;
 


### PR DESCRIPTION
If you have 2 sprites, with a shared texture, then try to destroy(true) both of them, the first one destroys correctly, but the second one will error because it's texture has already been destroyed. This PR adds a flag to fix that.