### PR TITLE
VideoBaseTexture fixes and changes

### DIFF
--- a/src/core/textures/VideoBaseTexture.js
+++ b/src/core/textures/VideoBaseTexture.js
@@ -1,5 +1,6 @@
 import BaseTexture from './BaseTexture';
 import { uid, BaseTextureCache } from '../utils';
+import * as ticker from '../ticker';
 
 /**
  * A texture of a [playing] Video.
@@ -54,13 +55,8 @@ export default class VideoBaseTexture extends BaseTexture
         this.width = source.videoWidth;
         this.height = source.videoHeight;
 
-        /**
-         * Should the base texture automatically update itself, set to true by default
-         *
-         * @member {boolean}
-         * @default true
-         */
-        this.autoUpdate = false;
+        this._autoUpdate = true;
+        this._isAutoUpdating = false;
 
         /**
          * When set to true will automatically play videos used by this texture once
@@ -71,7 +67,7 @@ export default class VideoBaseTexture extends BaseTexture
          */
         this.autoPlay = true;
 
-        this._onUpdate = this._onUpdate.bind(this);
+        this.update = this.update.bind(this);
         this._onCanPlay = this._onCanPlay.bind(this);
 
         source.addEventListener('play', this._onPlayStart.bind(this));
@@ -115,20 +111,6 @@ export default class VideoBaseTexture extends BaseTexture
     }
 
     /**
-     * The internal update loop of the video base texture, only runs when autoUpdate is set to true
-     *
-     * @private
-     */
-    _onUpdate()
-    {
-        if (this.autoUpdate)
-        {
-            window.requestAnimationFrame(this._onUpdate);
-            this.update();
-        }
-    }
-
-    /**
      * Runs the update loop when the video is ready to play
      *
      * @private
@@ -141,10 +123,10 @@ export default class VideoBaseTexture extends BaseTexture
             this._onCanPlay();
         }
 
-        if (!this.autoUpdate)
+        if (!this._isAutoUpdating && this.autoUpdate)
         {
-            window.requestAnimationFrame(this._onUpdate);
-            this.autoUpdate = true;
+            ticker.shared.add(this.update, this);
+            this._isAutoUpdating = true;
         }
     }
 
@@ -155,7 +137,11 @@ export default class VideoBaseTexture extends BaseTexture
      */
     _onPlayStop()
     {
-        this.autoUpdate = false;
+        if (this._isAutoUpdating)
+        {
+            ticker.shared.remove(this.update, this);
+            this._isAutoUpdating = false;
+        }
     }
 
     /**
@@ -199,6 +185,11 @@ export default class VideoBaseTexture extends BaseTexture
      */
     destroy()
     {
+        if (this._isAutoUpdating)
+        {
+            ticker.shared.remove(this.update, this);
+        }
+
         if (this.source && this.source._pixiId)
         {
             delete BaseTextureCache[this.source._pixiId];
@@ -268,9 +259,43 @@ export default class VideoBaseTexture extends BaseTexture
         }
 
         video.load();
-        video.play();
 
         return VideoBaseTexture.fromVideo(video, scaleMode);
+    }
+
+    /**
+     * Should the base texture automatically update itself, set to true by default
+     *
+     * @member {boolean}
+     * @memberof PIXI.VideoBaseTexture#
+     */
+    get autoUpdate()
+    {
+        return this._autoUpdate;
+    }
+
+    /**
+     * Sets autoUpdate property.
+     *
+     * @param {number} value - enable auto update or not
+     */
+    set autoUpdate(value)
+    {
+        if (value !== this._autoUpdate)
+        {
+            this._autoUpdate = value;
+
+            if (!this._autoUpdate && this._isAutoUpdating)
+            {
+                ticker.shared.remove(this.update, this);
+                this._isAutoUpdating = false;
+            }
+            else if (this._autoUpdate && !this._isAutoUpdating)
+            {
+                ticker.shared.add(this.update, this);
+                this._isAutoUpdating = true;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
- https://github.com/pixijs/pixi.js/commit/8d39e810c595b0afc48e542b2d4cad9c204cc7d2 didn't fully solve the video loading issues; the examples page for videos still doesn't work. I've tracked that down to the static 'fromUrl' function, which called video.play(). This was a tad early, resulting in width and height being 0. Removing the .play here doesn't matter, as it is still automatically called within _onCanPlay()

- autoUpdate changed to a getter/setter. It's doc states that it could be used to control when auto updating happened, but this wasn't true, it was actually just an internal variable to check whether it was currently auto updating or not. I've create a couple of private tracking variable for this state, whilst the public getter / setting now truly controls autoUpdate as per docs, and can be changed on the fly.

- moved this class to use the ticker. My expectation as a dev is that if I stop the shared ticker, PIXI would stop anything internal requiring timing, but VideoBaseTexture was an exception as it used rAF directly.