### PR TITLE
Allow Container.addChildAt when zero children

### DIFF
--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -87,7 +87,7 @@ export default class Container extends DisplayObject
      */
     addChildAt(child, index)
     {
-        if (index < 0 || index >= this.children.length)
+        if (index < 0 || (index > 0 && index >= this.children.length))
         {
             throw new Error(`${child}addChildAt: The index ${index} supplied is out of bounds ${this.children.length}`);
         }


### PR DESCRIPTION
Returns prior capability of `Container.addChildAt(something, 0)` when `Container.children.length === 0`.