### PR TITLE
Restore lost context before using it

### DIFF
--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -176,6 +176,12 @@ export default class WebGLRenderer extends SystemRenderer
     {
         const gl = this.gl;
 
+        // restore a context if it was previously lost
+        if (gl.isContextLost() && gl.getExtension('WEBGL_lose_context'))
+        {
+            gl.getExtension('WEBGL_lose_context').restoreContext();
+        }
+
         // create a texture manager...
         this.textureManager = new TextureManager(this);
         this.textureGC = new TextureGarbageCollector(this);

--- a/src/core/renderers/webgl/utils/checkMaxIfStatmentsInShader.js
+++ b/src/core/renderers/webgl/utils/checkMaxIfStatmentsInShader.js
@@ -13,6 +13,13 @@ export default function checkMaxIfStatmentsInShader(maxIfs, gl)
 {
     const createTempContext = !gl;
 
+    // @if DEBUG
+    if (maxIfs === 0)
+    {
+        throw new Error('Invalid value of `0` passed to `checkMaxIfStatementsInShader`');
+    }
+    // @endif
+
     if (createTempContext)
     {
         const tinyCanvas = document.createElement('canvas');


### PR DESCRIPTION
Looks like since we call loseContext() on `WebGLRenderer#destroy()` that
if you create another WebGLRenderer with the same canvas the browser will
recycle that lost context and return it.

This means when we try to use the context it is actually in a lost state.
This change tries to restore a lost context before we use it. It also adds
a debug assert at one location that will be invalid if the context is
invalid.