### PR TITLE
Renames S3 bucket from "pixi-builds" to "pixi.js"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ deploy:
   - provider: s3
     access_key_id: $S3_ACCESS_KEY_ID
     secret_access_key: $S3_SECRET_ACCESS_KEY
-    bucket: "pixi-builds"
+    bucket: "pixi.js"
     skip_cleanup: true
     acl: public_read
     region: eu-west-1
@@ -47,7 +47,7 @@ deploy:
   - provider: s3
     access_key_id: $S3_ACCESS_KEY_ID
     secret_access_key: $S3_SECRET_ACCESS_KEY
-    bucket: "pixi-builds"
+    bucket: "pixi.js"
     skip_cleanup: true
     acl: public_read
     region: eu-west-1
@@ -60,7 +60,7 @@ deploy:
   - provider: s3
     access_key_id: $S3_ACCESS_KEY_ID
     secret_access_key: $S3_SECRET_ACCESS_KEY
-    bucket: "pixi-builds"
+    bucket: "pixi.js"
     skip_cleanup: true
     acl: public_read
     region: eu-west-1
@@ -74,7 +74,7 @@ deploy:
   - provider: s3
     access_key_id: $S3_ACCESS_KEY_ID
     secret_access_key: $S3_SECRET_ACCESS_KEY
-    bucket: "pixi-builds"
+    bucket: "pixi.js"
     skip_cleanup: true
     acl: public_read
     region: eu-west-1
@@ -87,7 +87,7 @@ deploy:
   - provider: s3
     access_key_id: $S3_ACCESS_KEY_ID
     secret_access_key: $S3_SECRET_ACCESS_KEY
-    bucket: "pixi-builds"
+    bucket: "pixi.js"
     skip_cleanup: true
     acl: public_read
     region: eu-west-1
@@ -100,7 +100,7 @@ deploy:
   - provider: s3
     access_key_id: $S3_ACCESS_KEY_ID
     secret_access_key: $S3_SECRET_ACCESS_KEY
-    bucket: "pixi-builds"
+    bucket: "pixi.js"
     skip_cleanup: true
     acl: public_read
     region: eu-west-1


### PR DESCRIPTION
### Changed

* Renames the S3 bucket to be “pixi.js” instead of “pixi-builds”. This change makes it easier to remember, consistent with the name of the module and bucket names for other modules (like **pixi-gl-core** and **pixi-filters**).


_Note: links will need to be updated in the Wiki: https://s3-eu-west-1.amazonaws.com/pixi.js/dev/pixi.js_
