### PR TITLE
Custom deployment domain: pixi.download

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,39 +34,39 @@ deploy:
   - provider: s3
     access_key_id: $S3_ACCESS_KEY_ID
     secret_access_key: $S3_SECRET_ACCESS_KEY
-    bucket: "pixi.js"
+    bucket: "pixijs.download"
     skip_cleanup: true
     acl: public_read
     region: eu-west-1
     cache_control: "max-age=60"
     local_dir: bin
-    upload-dir: "$TRAVIS_BRANCH"
+    upload-dir: "pixi.js/$TRAVIS_BRANCH"
     on:
         all_branches: true
         condition: -z $TRAVIS_TAG
   - provider: s3
     access_key_id: $S3_ACCESS_KEY_ID
     secret_access_key: $S3_SECRET_ACCESS_KEY
-    bucket: "pixi.js"
+    bucket: "pixijs.download"
     skip_cleanup: true
     acl: public_read
     region: eu-west-1
     cache_control: "max-age=60"
     local_dir: docs
-    upload-dir: "$TRAVIS_BRANCH/docs"
+    upload-dir: "pixi.js/$TRAVIS_BRANCH/docs"
     on:
         all_branches: true
         condition: -z $TRAVIS_TAG
   - provider: s3
     access_key_id: $S3_ACCESS_KEY_ID
     secret_access_key: $S3_SECRET_ACCESS_KEY
-    bucket: "pixi.js"
+    bucket: "pixijs.download"
     skip_cleanup: true
     acl: public_read
     region: eu-west-1
     cache_control: "max-age=60"
     local_dir: coverage
-    upload-dir: "$TRAVIS_BRANCH/coverage"
+    upload-dir: "pixi.js/$TRAVIS_BRANCH/coverage"
     on:
         all_branches: true
         condition: -z $TRAVIS_TAG
@@ -74,39 +74,39 @@ deploy:
   - provider: s3
     access_key_id: $S3_ACCESS_KEY_ID
     secret_access_key: $S3_SECRET_ACCESS_KEY
-    bucket: "pixi.js"
+    bucket: "pixijs.download"
     skip_cleanup: true
     acl: public_read
     region: eu-west-1
     cache_control: "max-age=2592000"
     local_dir: bin
-    upload-dir: "$TRAVIS_BRANCH"
+    upload-dir: "pixi.js/$TRAVIS_BRANCH"
     on:
         all_branches: true
         condition: $TRAVIS_TAG
   - provider: s3
     access_key_id: $S3_ACCESS_KEY_ID
     secret_access_key: $S3_SECRET_ACCESS_KEY
-    bucket: "pixi.js"
+    bucket: "pixijs.download"
     skip_cleanup: true
     acl: public_read
     region: eu-west-1
     cache_control: "max-age=2592000"
     local_dir: docs
-    upload-dir: "$TRAVIS_BRANCH/docs"
+    upload-dir: "pixi.js/$TRAVIS_BRANCH/docs"
     on:
         all_branches: true
         condition: $TRAVIS_TAG
   - provider: s3
     access_key_id: $S3_ACCESS_KEY_ID
     secret_access_key: $S3_SECRET_ACCESS_KEY
-    bucket: "pixi.js"
+    bucket: "pixijs.download"
     skip_cleanup: true
     acl: public_read
     region: eu-west-1
     cache_control: "max-age=2592000"
     local_dir: coverage
-    upload-dir: "$TRAVIS_BRANCH/coverage"
+    upload-dir: "pixi.js/$TRAVIS_BRANCH/coverage"
     on:
         all_branches: true
         condition: $TRAVIS_TAG


### PR DESCRIPTION
### Changed

* Modified the S3 deployment to make it accessible from a custom domain (http://pixijs.download). This is easier to remember for devs and more portable if we ever want to use another deployment option over AWS. 

Example: http://pixijs.download/pixi.js/s3-bucket/pixi.js

All the files and release from the old bucket have been moved over.