### PR TITLE
TilingSprite BaseTexture resolution

### DIFF
--- a/src/extras/TilingSprite.js
+++ b/src/extras/TilingSprite.js
@@ -181,6 +181,7 @@ export default class TilingSprite extends core.Sprite
         const transform = this.worldTransform;
         const resolution = renderer.resolution;
         const baseTexture = texture.baseTexture;
+        const baseTextureResolution = texture.baseTexture.resolution;
         const modX = (this.tilePosition.x / this.tileScale.x) % texture._frame.width;
         const modY = (this.tilePosition.y / this.tileScale.y) % texture._frame.height;
 
@@ -189,7 +190,7 @@ export default class TilingSprite extends core.Sprite
         if (!this._canvasPattern)
         {
             // cut an object from a spritesheet..
-            const tempCanvas = new core.CanvasRenderTarget(texture._frame.width, texture._frame.height, texture.baseTexture.resolution);
+            const tempCanvas = new core.CanvasRenderTarget(texture._frame.width, texture._frame.height, baseTextureResolution);
 
             // Tint the tiling sprite
             if (this.tint !== 0xFFFFFF)
@@ -219,7 +220,7 @@ export default class TilingSprite extends core.Sprite
                            transform.ty * resolution);
 
         // TODO - this should be rolled into the setTransform above..
-        context.scale(this.tileScale.x / texture.baseTexture.resolution, this.tileScale.y / texture.baseTexture.resolution);
+        context.scale(this.tileScale.x / baseTextureResolution, this.tileScale.y / baseTextureResolution);
 
         context.translate(modX + (this.anchor.x * -this._width),
                           modY + (this.anchor.y * -this._height));
@@ -236,8 +237,8 @@ export default class TilingSprite extends core.Sprite
         context.fillStyle = this._canvasPattern;
         context.fillRect(-modX,
                          -modY,
-                         this._width / this.tileScale.x * texture.baseTexture.resolution,
-                         this._height / this.tileScale.y * texture.baseTexture.resolution);
+                         this._width / this.tileScale.x * baseTextureResolution,
+                         this._height / this.tileScale.y * baseTextureResolution);
     }
 
     /**

--- a/src/extras/TilingSprite.js
+++ b/src/extras/TilingSprite.js
@@ -189,7 +189,7 @@ export default class TilingSprite extends core.Sprite
         if (!this._canvasPattern)
         {
             // cut an object from a spritesheet..
-            const tempCanvas = new core.CanvasRenderTarget(texture._frame.width, texture._frame.height);
+            const tempCanvas = new core.CanvasRenderTarget(texture._frame.width, texture._frame.height, texture.baseTexture.resolution);
 
             // Tint the tiling sprite
             if (this.tint !== 0xFFFFFF)
@@ -219,7 +219,7 @@ export default class TilingSprite extends core.Sprite
                            transform.ty * resolution);
 
         // TODO - this should be rolled into the setTransform above..
-        context.scale(this.tileScale.x, this.tileScale.y);
+        context.scale(this.tileScale.x / texture.baseTexture.resolution, this.tileScale.y / texture.baseTexture.resolution);
 
         context.translate(modX + (this.anchor.x * -this._width),
                           modY + (this.anchor.y * -this._height));
@@ -236,8 +236,8 @@ export default class TilingSprite extends core.Sprite
         context.fillStyle = this._canvasPattern;
         context.fillRect(-modX,
                          -modY,
-                         this._width / this.tileScale.x,
-                         this._height / this.tileScale.y);
+                         this._width / this.tileScale.x * texture.baseTexture.resolution,
+                         this._height / this.tileScale.y * texture.baseTexture.resolution);
     }
 
     /**


### PR DESCRIPTION
I ran into a problem if the base texture resolution is not 1 and the renderer is not WebGL. The resolution auf the base texture is nowhere considered. This is how i solved it. The solution is probably not the best...