### PR TITLE
Fix for tilingsprite destroy

### DIFF
--- a/src/extras/TilingSprite.js
+++ b/src/extras/TilingSprite.js
@@ -325,8 +325,8 @@ export default class TilingSprite extends core.Sprite
     {
         super.destroy();
 
-        this.tileScale = null;
-        this.tilePosition = null;
+        this.tileTransform = null;
+        this.uvTransform = null;
     }
 
     /**


### PR DESCRIPTION
When a tiling sprite was destroyed the setter was called, which would
set the point value to null. This gave an error while Point.copy does
not like null values.

My fix is to bypass the setters and set the object properties to null.
I’ve added the uvTransform also.