### PR TITLE
Document skipHello, deprecates _saidHello

### DIFF
--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -173,6 +173,7 @@ export function getSvgSize(svgString)
 /**
  * Skips the hello message of renderers that are created after this is run.
  *
+ * @memberof PIXI.utils
  */
 export function skipHello()
 {

--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -622,8 +622,8 @@ core.utils.canUseNewCanvasBlendModes = () =>
 let saidHello = true;
 
 /**
- * @method
  * @name PIXI.utils._saidHello
+ * @type {boolean}
  * @see PIXI.utils.skipHello
  * @deprecated since 4.1.0
  */

--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -624,7 +624,7 @@ let saidHello = true;
 /**
  * @method
  * @name PIXI.utils._saidHello
- * @see PIXI.utils.sayHello
+ * @see PIXI.utils.skipHello
  * @deprecated since 4.1.0
  */
 Object.defineProperty(core.utils, '_saidHello', {

--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -618,3 +618,27 @@ core.utils.canUseNewCanvasBlendModes = () =>
 
     return core.CanvasTinter.canUseMultiply;
 };
+
+let saidHello = true;
+
+/**
+ * @method
+ * @name PIXI.utils._saidHello
+ * @see PIXI.utils.sayHello
+ * @deprecated since 4.1.0
+ */
+Object.defineProperty(core.utils, '_saidHello', {
+    set(bool)
+    {
+        if (bool)
+        {
+            warn('PIXI.utils._saidHello is deprecated, please use PIXI.utils.skipHello()');
+            this.skipHello();
+        }
+        saidHello = bool;
+    },
+    get()
+    {
+        return saidHello;
+    },
+});


### PR DESCRIPTION
### Overview

In v4.1.0, `PIXI.utils._saidHello = true` was removed in favor of `PIXI.utils.skipHello()`. This PR provides the backward compatibility. It also documents skipHello.