### PR TITLE
Update MovieClip frame immediately with gotoAndPlay #3180

### DIFF
--- a/src/extras/MovieClip.js
+++ b/src/extras/MovieClip.js
@@ -143,13 +143,7 @@ export default class MovieClip extends core.Sprite
 
         if (previousFrame !== this.currentFrame)
         {
-            this._texture = this._textures[this.currentFrame];
-            this._textureID = -1;
-
-            if (this.onFrameChange)
-            {
-                this.onFrameChange(this.currentFrame);
-            }
+            this.updateTexture();
         }
     }
 
@@ -166,13 +160,7 @@ export default class MovieClip extends core.Sprite
 
         if (previousFrame !== this.currentFrame)
         {
-            this._texture = this._textures[this.currentFrame];
-            this._textureID = -1;
-
-            if (this.onFrameChange)
-            {
-                this.onFrameChange(this.currentFrame);
-            }
+            this.updateTexture();
         }
 
         this.play();
@@ -238,13 +226,23 @@ export default class MovieClip extends core.Sprite
         }
         else if (previousFrame !== this.currentFrame)
         {
-            this._texture = this._textures[this.currentFrame];
-            this._textureID = -1;
+            this.updateTexture();
+        }
+    }
 
-            if (this.onFrameChange)
-            {
-                this.onFrameChange(this.currentFrame);
-            }
+    /**
+     * Updates the displayed texture to match the current frame index
+     *
+     * @private
+     */
+    updateTexture()
+    {
+        this._texture = this._textures[this.currentFrame];
+        this._textureID = -1;
+
+        if (this.onFrameChange)
+        {
+            this.onFrameChange(this.currentFrame);
         }
     }
 

--- a/src/extras/MovieClip.js
+++ b/src/extras/MovieClip.js
@@ -160,7 +160,20 @@ export default class MovieClip extends core.Sprite
      */
     gotoAndPlay(frameNumber)
     {
+        const previousFrame = this.currentFrame;
+
         this._currentTime = frameNumber;
+
+        if (previousFrame !== this.currentFrame)
+        {
+            this._texture = this._textures[this.currentFrame];
+            this._textureID = -1;
+
+            if (this.onFrameChange)
+            {
+                this.onFrameChange(this.currentFrame);
+            }
+        }
 
         this.play();
     }


### PR DESCRIPTION
Employs the same approach for updating the current frame and invoking the `onFrameChange` callback as `gotoAndStop()`