### PR TITLE
Allow extension-less image urls

### DIFF
--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -412,7 +412,7 @@ export default class BaseTexture extends EventEmitter
 
             if (!imageType)
             {
-                throw new Error('Invalid image type in URL.');
+                imageType = 'png';
             }
         }
 

--- a/test/core/BaseTexture.js
+++ b/test/core/BaseTexture.js
@@ -1,0 +1,17 @@
+'use strict';
+
+describe('BaseTexture', () =>
+{
+    describe('updateImageType', () =>
+    {
+        it('should allow no extension', () =>
+        {
+            const baseTexture = new PIXI.BaseTexture();
+
+            baseTexture.imageUrl = 'http://some.domain.org/100/100';
+            baseTexture._updateImageType();
+
+            expect(baseTexture.imageType).to.be.equals('png');
+        });
+    });
+});

--- a/test/core/index.js
+++ b/test/core/index.js
@@ -18,3 +18,4 @@ require('./Rectangle');
 require('./RoundedRectangle');
 require('./Circle');
 require('./Graphics');
+require('./BaseTexture');


### PR DESCRIPTION
The adding of SVG support added a requirement of `imageType`, which is determined by the file extension, and was throwing were no extension available. There doesn't seem to be a way to determine an `HTMLImageElement`'s image type, so this PR just allows non-svg images to be extension-less as per prior functionality.

The caveat is that svg image types cannot be loaded without an extension.  A couple of options to enable it would be;

1) Extend `*.fromImage()` to allow a user to specify an `imageType` override (easy)
2) xhr images as byte arrays instead of Image, determine type from data, convert to image (hard) 
