### PR TITLE
Adjust SVG_SIZE regex to support finding either format of quotes

### DIFF
--- a/src/core/const.js
+++ b/src/core/const.js
@@ -318,7 +318,7 @@ export const DATA_URI = /^\s*data:(?:([\w-]+)\/([\w+.-]+))?(?:;(charset=[\w-]+|b
  * @type {RegExp|string}
  * @example `<svg width="100" height="100"></svg>`
  */
-export const SVG_SIZE = /<svg[^>]*(?:\s(width|height)="(\d*(?:\.\d+)?)(?:px)?")[^>]*(?:\s(width|height)="(\d*(?:\.\d+)?)(?:px)?")[^>]*>/i; // eslint-disable-line max-len
+export const SVG_SIZE = /<svg[^>]*(?:\s(width|height)=('|")(\d*(?:\.\d+)?)(?:px)?('|"))[^>]*(?:\s(width|height)=('|")(\d*(?:\.\d+)?)(?:px)?('|"))[^>]*>/i; // eslint-disable-line max-len
 
 /**
  * Constants that identify shapes, mainly to prevent `instanceof` calls.

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -163,8 +163,8 @@ export function getSvgSize(svgString)
 
     if (sizeMatch)
     {
-        size[sizeMatch[1]] = Math.round(parseFloat(sizeMatch[2]));
-        size[sizeMatch[3]] = Math.round(parseFloat(sizeMatch[4]));
+        size[sizeMatch[1]] = Math.round(parseFloat(sizeMatch[3]));
+        size[sizeMatch[5]] = Math.round(parseFloat(sizeMatch[7]));
     }
 
     return size;

--- a/test/core/util.js
+++ b/test/core/util.js
@@ -195,6 +195,18 @@ describe('PIXI.utils', function ()
                 .to.equal(32);
         });
 
+        it('should return a size object from an SVG string with inverted quotes', function ()
+        {
+            var svgSize = PIXI.utils.getSvgSize("<svg height='32' width='64'></svg>"); // eslint-disable-line quotes
+
+            expect(svgSize)
+                .to.be.an('object');
+            expect(svgSize.width)
+                .to.equal(64);
+            expect(svgSize.height)
+                .to.equal(32);
+        });
+
         it('should work with px values', function ()
         {
             var svgSize = PIXI.utils.getSvgSize('<svg height="32px" width="64px"></svg>');


### PR DESCRIPTION
Was unable to create textures from SVGs when optimized according to https://codepen.io/tigt/post/optimizing-svgs-in-data-uris due to the regex only excepting one set of quotes.
