### PR TITLE
Update package.json main prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pixi.js",
-  "version": "4.1.1",
+  "version": "4.1.0",
   "description": "Pixi.js is a fast lightweight 2D library that works across all devices.",
   "author": "Mat Groves",
   "contributors": [
@@ -9,7 +9,7 @@
     "Chad Engler <chad@pantherdev.com>",
     "Richard Davey <rdavey@gmail.com>"
   ],
-  "main": "./bin/pixi.min.js",
+  "main": "./src/index.js",
   "homepage": "http://goodboydigital.com/",
   "bugs": "https://github.com/pixijs/pixi.js/issues",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pixi.js",
-  "version": "4.1.2",
+  "version": "4.1.1",
   "description": "Pixi.js is a fast lightweight 2D library that works across all devices.",
   "author": "Mat Groves",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pixi.js",
-  "version": "4.1.0",
+  "version": "4.1.2",
   "description": "Pixi.js is a fast lightweight 2D library that works across all devices.",
   "author": "Mat Groves",
   "contributors": [


### PR DESCRIPTION
It would be nice if, while developing, it imports the source code, instead the minified one. For example, this code:

```js
import { Container } from 'pixi.js';
```
Using atom and js-hyperclick, you can Ctrl+click `pixi.js` and go into the code. Right now, it opens the minified. With this change, it opens the `src/index.js`.

But the main problem will occur when something goes wrong. Error stacks will be easier to read and trace when using the source code.