### PR TITLE
Renames MovieClip to AnimatedSprite

### DIFF
--- a/src/core/ticker/index.js
+++ b/src/core/ticker/index.js
@@ -1,7 +1,7 @@
 import Ticker from './Ticker';
 
 /**
- * The shared ticker instance used by {@link PIXI.extras.MovieClip}.
+ * The shared ticker instance used by {@link PIXI.extras.AnimatedSprite}.
  * and by {@link PIXI.interaction.InteractionManager}.
  * The property {@link PIXI.ticker.Ticker#autoStart} is set to `true`
  * for this instance. Please follow the examples for usage, including

--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -177,9 +177,9 @@ Object.defineProperties(core, {
         enumerable: true,
         get()
         {
-            warn('The MovieClip class has been moved to extras.MovieClip, please use extras.MovieClip from now on.');
+            warn('The MovieClip class has been moved to extras.AnimatedSprite, please use extras.AnimatedSprite.');
 
-            return extras.MovieClip;
+            return extras.AnimatedSprite;
         },
     },
 
@@ -344,6 +344,26 @@ Object.defineProperties(core, {
             warn('TransformManual has been renamed to TransformBase, please update your pixi-spine');
 
             return core.TransformBase;
+        },
+    },
+});
+
+Object.defineProperties(extras, {
+
+    /**
+     * @class
+     * @name MovieClip
+     * @memberof PIXI.extras
+     * @see PIXI.extras.AnimatedSprite
+     * @deprecated since version 4.2.0
+     */
+    MovieClip: {
+        enumerable: true,
+        get()
+        {
+            warn('The MovieClip class has been renamed to AnimatedSprite, please use AnimatedSprite from now on.');
+
+            return extras.AnimatedSprite;
         },
     },
 });

--- a/src/extras/AnimatedSprite.js
+++ b/src/extras/AnimatedSprite.js
@@ -8,7 +8,7 @@ import * as core from '../core';
  */
 
 /**
- * A MovieClip is a simple way to display an animation depicted by a list of textures.
+ * A AnimatedSprite is a simple way to display an animation depicted by a list of textures.
  *
  * ```js
  * let alienImages = ["image_sequence_01.png","image_sequence_02.png","image_sequence_03.png","image_sequence_04.png"];
@@ -20,14 +20,14 @@ import * as core from '../core';
  *      textureArray.push(texture);
  * };
  *
- * let mc = new PIXI.MovieClip(textureArray);
+ * let mc = new PIXI.AnimatedSprite(textureArray);
  * ```
  *
  * @class
  * @extends PIXI.Sprite
  * @memberof PIXI.extras
  */
-export default class MovieClip extends core.Sprite
+export default class AnimatedSprite extends core.Sprite
 {
     /**
      * @param {PIXI.Texture[]|FrameObject[]} textures - an array of {@link PIXI.Texture} or frame
@@ -50,7 +50,7 @@ export default class MovieClip extends core.Sprite
         this.textures = textures;
 
         /**
-         * The speed that the MovieClip will play at. Higher is faster, lower is slower
+         * The speed that the AnimatedSprite will play at. Higher is faster, lower is slower
          *
          * @member {number}
          * @default 1
@@ -66,18 +66,18 @@ export default class MovieClip extends core.Sprite
         this.loop = true;
 
         /**
-         * Function to call when a MovieClip finishes playing
+         * Function to call when a AnimatedSprite finishes playing
          *
          * @method
-         * @memberof PIXI.extras.MovieClip#
+         * @memberof PIXI.extras.AnimatedSprite#
          */
         this.onComplete = null;
 
         /**
-         * Function to call when a MovieClip changes which texture is being rendered
+         * Function to call when a AnimatedSprite changes which texture is being rendered
          *
          * @method
-         * @memberof PIXI.extras.MovieClip#
+         * @memberof PIXI.extras.AnimatedSprite#
          */
         this.onFrameChange = null;
 
@@ -90,7 +90,7 @@ export default class MovieClip extends core.Sprite
         this._currentTime = 0;
 
         /**
-         * Indicates if the MovieClip is currently playing
+         * Indicates if the AnimatedSprite is currently playing
          *
          * @member {boolean}
          * @readonly
@@ -99,7 +99,7 @@ export default class MovieClip extends core.Sprite
     }
 
     /**
-     * Stops the MovieClip
+     * Stops the AnimatedSprite
      *
      */
     stop()
@@ -114,7 +114,7 @@ export default class MovieClip extends core.Sprite
     }
 
     /**
-     * Plays the MovieClip
+     * Plays the AnimatedSprite
      *
      */
     play()
@@ -129,7 +129,7 @@ export default class MovieClip extends core.Sprite
     }
 
     /**
-     * Stops the MovieClip and goes to a specific frame
+     * Stops the AnimatedSprite and goes to a specific frame
      *
      * @param {number} frameNumber - frame index to stop at
      */
@@ -148,7 +148,7 @@ export default class MovieClip extends core.Sprite
     }
 
     /**
-     * Goes to a specific frame and begins playing the MovieClip
+     * Goes to a specific frame and begins playing the AnimatedSprite
      *
      * @param {number} frameNumber - frame index to start at
      */
@@ -247,7 +247,7 @@ export default class MovieClip extends core.Sprite
     }
 
     /**
-     * Stops the MovieClip and destroys it
+     * Stops the AnimatedSprite and destroys it
      *
      */
     destroy()
@@ -261,7 +261,7 @@ export default class MovieClip extends core.Sprite
      *
      * @static
      * @param {string[]} frames - The array of frames ids the movieclip will use as its texture frames
-     * @return {MovieClip} The new movie clip with the specified frames.
+     * @return {AnimatedSprite} The new movie clip with the specified frames.
      */
     static fromFrames(frames)
     {
@@ -272,7 +272,7 @@ export default class MovieClip extends core.Sprite
             textures.push(core.Texture.fromFrame(frames[i]));
         }
 
-        return new MovieClip(textures);
+        return new AnimatedSprite(textures);
     }
 
     /**
@@ -280,7 +280,7 @@ export default class MovieClip extends core.Sprite
      *
      * @static
      * @param {string[]} images - the array of image urls the movieclip will use as its texture frames
-     * @return {MovieClip} The new movie clip with the specified images as frames.
+     * @return {AnimatedSprite} The new movie clip with the specified images as frames.
      */
     static fromImages(images)
     {
@@ -291,16 +291,16 @@ export default class MovieClip extends core.Sprite
             textures.push(core.Texture.fromImage(images[i]));
         }
 
-        return new MovieClip(textures);
+        return new AnimatedSprite(textures);
     }
 
     /**
-     * totalFrames is the total number of frames in the MovieClip. This is the same as number of textures
-     * assigned to the MovieClip.
+     * totalFrames is the total number of frames in the AnimatedSprite. This is the same as number of textures
+     * assigned to the AnimatedSprite.
      *
      * @readonly
      * @member {number}
-     * @memberof PIXI.extras.MovieClip#
+     * @memberof PIXI.extras.AnimatedSprite#
      * @default 0
      */
     get totalFrames()
@@ -309,10 +309,10 @@ export default class MovieClip extends core.Sprite
     }
 
     /**
-     * The array of textures used for this MovieClip
+     * The array of textures used for this AnimatedSprite
      *
      * @member {PIXI.Texture[]}
-     * @memberof PIXI.extras.MovieClip#
+     * @memberof PIXI.extras.AnimatedSprite#
      */
     get textures()
     {
@@ -345,10 +345,10 @@ export default class MovieClip extends core.Sprite
     }
 
     /**
-    * The MovieClips current frame index
+    * The AnimatedSprites current frame index
     *
     * @member {number}
-    * @memberof PIXI.extras.MovieClip#
+    * @memberof PIXI.extras.AnimatedSprite#
     * @readonly
     */
     get currentFrame()

--- a/src/extras/AnimatedSprite.js
+++ b/src/extras/AnimatedSprite.js
@@ -8,7 +8,7 @@ import * as core from '../core';
  */
 
 /**
- * A AnimatedSprite is a simple way to display an animation depicted by a list of textures.
+ * An AnimatedSprite is a simple way to display an animation depicted by a list of textures.
  *
  * ```js
  * let alienImages = ["image_sequence_01.png","image_sequence_02.png","image_sequence_03.png","image_sequence_04.png"];
@@ -58,7 +58,7 @@ export default class AnimatedSprite extends core.Sprite
         this.animationSpeed = 1;
 
         /**
-         * Whether or not the movie clip repeats after playing.
+         * Whether or not the animate sprite repeats after playing.
          *
          * @member {boolean}
          * @default true
@@ -261,7 +261,7 @@ export default class AnimatedSprite extends core.Sprite
      *
      * @static
      * @param {string[]} frames - The array of frames ids the movieclip will use as its texture frames
-     * @return {AnimatedSprite} The new movie clip with the specified frames.
+     * @return {AnimatedSprite} The new animated sprite with the specified frames.
      */
     static fromFrames(frames)
     {
@@ -280,7 +280,7 @@ export default class AnimatedSprite extends core.Sprite
      *
      * @static
      * @param {string[]} images - the array of image urls the movieclip will use as its texture frames
-     * @return {AnimatedSprite} The new movie clip with the specified images as frames.
+     * @return {AnimatedSprite} The new animate sprite with the specified images as frames.
      */
     static fromImages(images)
     {

--- a/src/extras/index.js
+++ b/src/extras/index.js
@@ -2,7 +2,7 @@
  * @namespace PIXI.extras
  */
 export { default as TextureTransform } from './TextureTransform';
-export { default as MovieClip } from './MovieClip';
+export { default as AnimatedSprite } from './AnimatedSprite';
 export { default as TilingSprite } from './TilingSprite';
 export { default as TilingSpriteRenderer } from './webgl/TilingSpriteRenderer';
 export { default as BitmapText } from './BitmapText';


### PR DESCRIPTION
### Changed

Renames `PIXI.extras.MovieClip` to `PIXI.extras.AnimatedSprite` for these reasons:
- The name "MovieClip" does not accurately reflect the nature of the class.
- Preventatively, do not want to confuse this class with a new forthcoming MovieClip API