### PR TITLE
Fix the Polygon contains method

### DIFF
--- a/src/core/math/shapes/Polygon.js
+++ b/src/core/math/shapes/Polygon.js
@@ -94,7 +94,7 @@ export default class Polygon
         // https://github.com/substack/point-in-polygon/blob/master/index.js
         const length = this.points.length / 2;
 
-        for (let i = 0, j = length - 1; i < length; j = ++i)
+        for (let i = 0, j = length - 1; i < length; j = i++)
         {
             const xi = this.points[i * 2];
             const yi = this.points[(i * 2) + 1];


### PR DESCRIPTION
We couldn't click on things. This change (to align with the mentioned algorithm from substack) fixed it for us.