### PR TITLE
More flexible preparation limits

### DIFF
--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -455,12 +455,16 @@ core.Text.prototype.setStyle = function setStyle(style)
  * @method
  * @name PIXI.Text#determineFontProperties
  * @see PIXI.Text#calculateFontProperties
+ * @deprecated since version 4.2.0
  * @private
  * @param {string} fontStyle - String representing the style of the font
  * @return {Object} Font properties object
  */
 core.Text.prototype.determineFontProperties = function determineFontProperties(fontStyle)
 {
+    warn('determineFontProperties is now deprecated, please use the static calculateFontProperties method, '
+        + 'e.g : Text.calculateFontProperties(fontStyle);');
+
     return Text.calculateFontProperties(fontStyle);
 };
 
@@ -676,7 +680,10 @@ Object.defineProperty(prepare.canvas, 'UPLOADS_PER_FRAME', {
     },
     get()
     {
-        return 4;
+        warn('PIXI.CanvasPrepare.UPLOADS_PER_FRAME has been removed. Please use '
+            + 'renderer.plugins.prepare.limiter');
+
+        return NaN;
     },
 });
 
@@ -692,13 +699,16 @@ Object.defineProperty(prepare.canvas, 'UPLOADS_PER_FRAME', {
 Object.defineProperty(prepare.webgl, 'UPLOADS_PER_FRAME', {
     set()
     {
-        warn('PIXI.CanvasPrepare.UPLOADS_PER_FRAME has been removed. Please set '
+        warn('PIXI.WebGLPrepare.UPLOADS_PER_FRAME has been removed. Please set '
             + 'renderer.plugins.prepare.limiter.maxItemsPerFrame on your renderer');
         // because we don't have a reference to the renderer, we can't actually set
         // the uploads per frame, so we'll have to stick with the warning.
     },
     get()
     {
-        return 4;
+        warn('PIXI.WebGLPrepare.UPLOADS_PER_FRAME has been removed. Please use '
+            + 'renderer.plugins.prepare.limiter');
+
+        return NaN;
     },
 });

--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -451,6 +451,19 @@ core.Text.prototype.setStyle = function setStyle(style)
     warn('setStyle is now deprecated, please use the style property, e.g : myText.style = style;');
 };
 
+/**
+ * @method
+ * @name PIXI.Text#determineFontProperties
+ * @see PIXI.Text#calculateFontProperties
+ * @private
+ * @param {string} fontStyle - String representing the style of the font
+ * @return {Object} Font properties object
+ */
+core.Text.prototype.determineFontProperties = function determineFontProperties(fontStyle)
+{
+    return Text.calculateFontProperties(fontStyle);
+};
+
 Object.defineProperties(core.TextStyle.prototype, {
     /**
      * Set all properties of a font as a single string

--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -3,6 +3,7 @@ import * as mesh from './mesh';
 import * as particles from './particles';
 import * as extras from './extras';
 import * as filters from './filters';
+import * as prepare from './prepare';
 
 // provide method to give a stack track for warnings
 // useful for tracking-down where deprecated methods/properties/classes
@@ -640,5 +641,51 @@ Object.defineProperty(core.utils, '_saidHello', {
     get()
     {
         return saidHello;
+    },
+});
+
+/**
+ * The number of graphics or textures to upload to the GPU.
+ *
+ * @name PIXI.prepare.canvas.UPLOADS_PER_FRAME
+ * @static
+ * @type {number}
+ * @see PIXI.prepare.BasePrepare.limiter
+ * @deprecated since 4.2.0
+ */
+Object.defineProperty(prepare.canvas, 'UPLOADS_PER_FRAME', {
+    set()
+    {
+        warn('PIXI.CanvasPrepare.UPLOADS_PER_FRAME has been removed. Please set '
+            + 'renderer.plugins.prepare.limiter.maxItemsPerFrame on your renderer');
+        // because we don't have a reference to the renderer, we can't actually set
+        // the uploads per frame, so we'll have to stick with the warning.
+    },
+    get()
+    {
+        return 4;
+    },
+});
+
+/**
+ * The number of graphics or textures to upload to the GPU.
+ *
+ * @name PIXI.prepare.webgl.UPLOADS_PER_FRAME
+ * @static
+ * @type {number}
+ * @see PIXI.prepare.BasePrepare.limiter
+ * @deprecated since 4.2.0
+ */
+Object.defineProperty(prepare.webgl, 'UPLOADS_PER_FRAME', {
+    set()
+    {
+        warn('PIXI.CanvasPrepare.UPLOADS_PER_FRAME has been removed. Please set '
+            + 'renderer.plugins.prepare.limiter.maxItemsPerFrame on your renderer');
+        // because we don't have a reference to the renderer, we can't actually set
+        // the uploads per frame, so we'll have to stick with the warning.
+    },
+    get()
+    {
+        return 4;
     },
 });

--- a/src/prepare/BasePrepare.js
+++ b/src/prepare/BasePrepare.js
@@ -1,0 +1,245 @@
+import * as core from '../core';
+import CountLimiter from './limiters/CountLimiter';
+const SharedTicker = core.ticker.shared;
+
+const DEFAULT_UPLOADS_PER_FRAME = 4;
+
+/**
+ * The prepare manager provides functionality to upload content to the GPU. BasePrepare handles
+ * basic queuing functionality and is extended by {@link PIXI.prepare.WebGLPrepare} and {@link PIXI.prepare.CanvasPrepare}
+ * to provide preparation capabilities specific to their respective renderers.
+ *
+ * @abstract
+ * @class
+ * @memberof PIXI
+ */
+export default class BasePrepare
+{
+    /**
+     * @param {PIXI.SystemRenderer} renderer - A reference to the current renderer
+     */
+    constructor(renderer)
+    {
+        /**
+         * The limiter to be used to control how quickly items are prepared.
+         * @type {PIXI.prepare.CountLimiter|PIXI.prepare.TimeLimiter}
+         */
+        this.limiter = new CountLimiter(DEFAULT_UPLOADS_PER_FRAME);
+
+        /**
+         * Reference to the renderer.
+         * @type {PIXI.SystemRenderer}
+         * @protected
+         */
+        this.renderer = renderer;
+
+        /**
+         * The only real difference between CanvasPrepare and WebGLPrepare is what they pass
+         * to upload hooks. That different parameter is stored here.
+         * @type {PIXI.prepare.CanvasPrepare|PIXI.WebGLRenderer}
+         * @protected
+         */
+        this.uploadHookSource = null;
+
+        /**
+         * Collection of items to uploads at once.
+         * @type {Array<*>}
+         * @private
+         */
+        this.queue = [];
+
+        /**
+         * Collection of additional hooks for finding assets.
+         * @type {Array<Function>}
+         * @private
+         */
+        this.addHooks = [];
+
+        /**
+         * Collection of additional hooks for processing assets.
+         * @type {Array<Function>}
+         * @private
+         */
+        this.uploadHooks = [];
+
+        /**
+         * Callback to call after completed.
+         * @type {Array<Function>}
+         * @private
+         */
+        this.completes = [];
+
+        /**
+         * If prepare is ticking (running).
+         * @type {boolean}
+         * @private
+         */
+        this.ticking = false;
+    }
+
+    /**
+     * Upload all the textures and graphics to the GPU.
+     *
+     * @param {Function|PIXI.DisplayObject|PIXI.Container} item - Either
+     *        the container or display object to search for items to upload or
+     *        the callback function, if items have been added using `prepare.add`.
+     * @param {Function} [done] - Optional callback when all queued uploads have completed
+     */
+    upload(item, done)
+    {
+        if (typeof item === 'function')
+        {
+            done = item;
+            item = null;
+        }
+
+        // If a display object, search for items
+        // that we could upload
+        if (item)
+        {
+            this.add(item);
+        }
+
+        // Get the items for upload from the display
+        if (this.queue.length)
+        {
+            if (done)
+            {
+                this.completes.push(done);
+            }
+
+            if (!this.ticking)
+            {
+                this.ticking = true;
+                SharedTicker.add(this.tick, this);
+            }
+        }
+        else if (done)
+        {
+            done();
+        }
+    }
+
+    /**
+     * Handle tick update
+     *
+     * @private
+     */
+    tick()
+    {
+        this.limiter.beginFrame();
+        // Upload the graphics
+        while (this.queue.length && this.limiter.allowedToUpload())
+        {
+            const item = this.queue[0];
+            let uploaded = false;
+
+            for (let i = 0, len = this.uploadHooks.length; i < len; i++)
+            {
+                if (this.uploadHooks[i](this.uploadHookSource, item))
+                {
+                    this.queue.shift();
+                    uploaded = true;
+                    break;
+                }
+            }
+
+            if (!uploaded)
+            {
+                this.queue.shift();
+            }
+        }
+
+        // We're finished
+        if (!this.queue.length)
+        {
+            this.ticking = false;
+
+            SharedTicker.remove(this.tick, this);
+
+            const completes = this.completes.slice(0);
+
+            this.completes.length = 0;
+
+            for (let i = 0, len = completes.length; i < len; i++)
+            {
+                completes[i]();
+            }
+        }
+    }
+
+    /**
+     * Adds hooks for finding and uploading items.
+     *
+     * @param {Function} [addHook] - Function call that takes two parameters: `item:*, queue:Array`
+              function must return `true` if it was able to add item to the queue.
+     * @param {Function} [uploadHook] - Function call that takes two parameters: `prepare:CanvasPrepare, item:*` and
+     *        function must return `true` if it was able to handle upload of item.
+     * @return {PIXI.CanvasPrepare} Instance of plugin for chaining.
+     */
+    register(addHook, uploadHook)
+    {
+        if (addHook)
+        {
+            this.addHooks.push(addHook);
+        }
+
+        if (uploadHook)
+        {
+            this.uploadHooks.push(uploadHook);
+        }
+
+        return this;
+    }
+
+    /**
+     * Manually add an item to the uploading queue.
+     *
+     * @param {PIXI.DisplayObject|PIXI.Container|*} item - Object to add to the queue
+     * @return {PIXI.CanvasPrepare} Instance of plugin for chaining.
+     */
+    add(item)
+    {
+        // Add additional hooks for finding elements on special
+        // types of objects that
+        for (let i = 0, len = this.addHooks.length; i < len; i++)
+        {
+            if (this.addHooks[i](item, this.queue))
+            {
+                break;
+            }
+        }
+
+        // Get childen recursively
+        if (item instanceof core.Container)
+        {
+            for (let i = item.children.length - 1; i >= 0; i--)
+            {
+                this.add(item.children[i]);
+            }
+        }
+
+        return this;
+    }
+
+    /**
+     * Destroys the plugin, don't use after this.
+     *
+     */
+    destroy()
+    {
+        if (this.ticking)
+        {
+            SharedTicker.remove(this.tick, this);
+        }
+        this.ticking = false;
+        this.addHooks = null;
+        this.uploadHooks = null;
+        this.renderer = null;
+        this.completes = null;
+        this.queue = null;
+        this.limiter = null;
+        this.uploadHookSource = null;
+    }
+
+}

--- a/src/prepare/BasePrepare.js
+++ b/src/prepare/BasePrepare.js
@@ -314,7 +314,7 @@ function calculateTextStyle(helper, item)
 
         if (!core.Text.fontPropertiesCache[font])
         {
-            core.Text.calculateTextStyle(font);
+            core.Text.calculateFontProperties(font);
 
             return true;
         }

--- a/src/prepare/BasePrepare.js
+++ b/src/prepare/BasePrepare.js
@@ -288,8 +288,7 @@ function drawText(helper, item)
 {
     if (item instanceof core.Text)
     {
-        // updating text will return early if it is not dirty, but we won't know
-        // so a non-dirty Text will count against the max number of items per frame.
+        // updating text will return early if it is not dirty
         item.updateText(true);
 
         return true;
@@ -315,13 +314,9 @@ function calculateTextStyle(helper, item)
         if (!core.Text.fontPropertiesCache[font])
         {
             core.Text.calculateFontProperties(font);
-
-            return true;
         }
-        // return false here - if it was already prepared it shouldn't count against the maximum
-        // number of uploads per frame
 
-        return false;
+        return true;
     }
 
     return false;

--- a/src/prepare/BasePrepare.js
+++ b/src/prepare/BasePrepare.js
@@ -39,7 +39,7 @@ export default class BasePrepare
          * @type {PIXI.prepare.CanvasPrepare|PIXI.WebGLRenderer}
          * @protected
          */
-        this.uploadHookSource = null;
+        this.uploadHookHelper = null;
 
         /**
          * Collection of items to uploads at once.
@@ -136,7 +136,7 @@ export default class BasePrepare
 
             for (let i = 0, len = this.uploadHooks.length; i < len; i++)
             {
-                if (this.uploadHooks[i](this.uploadHookSource, item))
+                if (this.uploadHooks[i](this.uploadHookHelper, item))
                 {
                     this.queue.shift();
                     uploaded = true;
@@ -239,7 +239,7 @@ export default class BasePrepare
         this.completes = null;
         this.queue = null;
         this.limiter = null;
-        this.uploadHookSource = null;
+        this.uploadHookHelper = null;
     }
 
 }

--- a/src/prepare/canvas/CanvasPrepare.js
+++ b/src/prepare/canvas/CanvasPrepare.js
@@ -1,8 +1,7 @@
 import * as core from '../../core';
-const SharedTicker = core.ticker.shared;
+import BasePrepare from '../BasePrepare';
 
 const CANVAS_START_SIZE = 16;
-const DEFAULT_UPLOADS_PER_FRAME = 4;
 
 /**
  * The prepare manager provides functionality to upload content to the GPU
@@ -13,19 +12,16 @@ const DEFAULT_UPLOADS_PER_FRAME = 4;
  * @class
  * @memberof PIXI
  */
-export default class CanvasPrepare
+export default class CanvasPrepare extends BasePrepare
 {
     /**
      * @param {PIXI.CanvasRenderer} renderer - A reference to the current renderer
      */
     constructor(renderer)
     {
-        /**
-         * Reference to the renderer.
-         * @type {PIXI.CanvasRenderer}
-         * @private
-         */
-        this.renderer = renderer;
+        super(renderer);
+
+        this.uploadHookSource = this;
 
         /**
         * An offline canvas to render textures to
@@ -43,194 +39,8 @@ export default class CanvasPrepare
         */
         this.ctx = this.canvas.getContext('2d');
 
-        /**
-         * Collection of items to uploads at once.
-         * @type {Array<*>}
-         * @private
-         */
-        this.queue = [];
-
-        /**
-         * Collection of additional hooks for finding assets.
-         * @type {Array<Function>}
-         * @private
-         */
-        this.addHooks = [];
-
-        /**
-         * Collection of additional hooks for processing assets.
-         * @type {Array<Function>}
-         * @private
-         */
-        this.uploadHooks = [];
-
-        /**
-         * Callback to call after completed.
-         * @type {Array<Function>}
-         * @private
-         */
-        this.completes = [];
-
-        /**
-         * If prepare is ticking (running).
-         * @type {boolean}
-         * @private
-         */
-        this.ticking = false;
-
         // Add textures to upload
         this.register(findBaseTextures, uploadBaseTextures);
-    }
-
-    /**
-     * Upload all the textures and graphics to the GPU.
-     *
-     * @param {Function|PIXI.DisplayObject|PIXI.Container} item - Either
-     *        the container or display object to search for items to upload or
-     *        the callback function, if items have been added using `prepare.add`.
-     * @param {Function} [done] - Optional callback when all queued uploads have completed
-     */
-    upload(item, done)
-    {
-        if (typeof item === 'function')
-        {
-            done = item;
-            item = null;
-        }
-
-        // If a display object, search for items
-        // that we could upload
-        if (item)
-        {
-            this.add(item);
-        }
-
-        // Get the items for upload from the display
-        if (this.queue.length)
-        {
-            this.numLeft = CanvasPrepare.UPLOADS_PER_FRAME;
-
-            if (done)
-            {
-                this.completes.push(done);
-            }
-
-            if (!this.ticking)
-            {
-                this.ticking = true;
-                SharedTicker.add(this.tick, this);
-            }
-        }
-        else if (done)
-        {
-            done();
-        }
-    }
-
-    /**
-     * Handle tick update
-     *
-     * @private
-     */
-    tick()
-    {
-        // Upload the graphics
-        while (this.queue.length && this.numLeft > 0)
-        {
-            const item = this.queue[0];
-            let uploaded = false;
-
-            for (let i = 0, len = this.uploadHooks.length; i < len; i++)
-            {
-                if (this.uploadHooks[i](this, item))
-                {
-                    this.numLeft--;
-                    this.queue.shift();
-                    uploaded = true;
-                    break;
-                }
-            }
-
-            if (!uploaded)
-            {
-                this.queue.shift();
-            }
-        }
-
-        // We're finished
-        if (this.queue.length)
-        {
-            this.numLeft = CanvasPrepare.UPLOADS_PER_FRAME;
-        }
-        else
-        {
-            this.ticking = false;
-
-            SharedTicker.remove(this.tick, this);
-
-            const completes = this.completes.slice(0);
-
-            this.completes.length = 0;
-
-            for (let i = 0, len = completes.length; i < len; i++)
-            {
-                completes[i]();
-            }
-        }
-    }
-
-    /**
-     * Adds hooks for finding and uploading items.
-     *
-     * @param {Function} [addHook] - Function call that takes two parameters: `item:*, queue:Array`
-              function must return `true` if it was able to add item to the queue.
-     * @param {Function} [uploadHook] - Function call that takes two parameters: `prepare:CanvasPrepare, item:*` and
-     *        function must return `true` if it was able to handle upload of item.
-     * @return {PIXI.CanvasPrepare} Instance of plugin for chaining.
-     */
-    register(addHook, uploadHook)
-    {
-        if (addHook)
-        {
-            this.addHooks.push(addHook);
-        }
-
-        if (uploadHook)
-        {
-            this.uploadHooks.push(uploadHook);
-        }
-
-        return this;
-    }
-
-    /**
-     * Manually add an item to the uploading queue.
-     *
-     * @param {PIXI.DisplayObject|PIXI.Container|*} item - Object to add to the queue
-     * @return {PIXI.CanvasPrepare} Instance of plugin for chaining.
-     */
-    add(item)
-    {
-        // Add additional hooks for finding elements on special
-        // types of objects that
-        for (let i = 0, len = this.addHooks.length; i < len; i++)
-        {
-            if (this.addHooks[i](item, this.queue))
-            {
-                break;
-            }
-        }
-
-        // Get childen recursively
-        if (item instanceof core.Container)
-        {
-            for (let i = item.children.length - 1; i >= 0; i--)
-            {
-                this.add(item.children[i]);
-            }
-        }
-
-        return this;
     }
 
     /**
@@ -239,30 +49,12 @@ export default class CanvasPrepare
      */
     destroy()
     {
-        if (this.ticking)
-        {
-            SharedTicker.remove(this.tick, this);
-        }
-        this.ticking = false;
-        this.addHooks = null;
-        this.uploadHooks = null;
-        this.renderer = null;
-        this.completes = null;
-        this.queue = null;
+        super.destroy();
         this.ctx = null;
         this.canvas = null;
     }
 
 }
-
-/**
- * The number of graphics or textures to upload to the GPU.
- *
- * @static
- * @type {number}
- * @default 4
- */
-CanvasPrepare.UPLOADS_PER_FRAME = DEFAULT_UPLOADS_PER_FRAME;
 
 /**
  * Built-in hook to upload PIXI.Texture objects to the GPU.

--- a/src/prepare/canvas/CanvasPrepare.js
+++ b/src/prepare/canvas/CanvasPrepare.js
@@ -21,7 +21,7 @@ export default class CanvasPrepare extends BasePrepare
     {
         super(renderer);
 
-        this.uploadHookSource = this;
+        this.uploadHookHelper = this;
 
         /**
         * An offline canvas to render textures to

--- a/src/prepare/index.js
+++ b/src/prepare/index.js
@@ -3,3 +3,6 @@
  */
 export { default as webgl } from './webgl/WebGLPrepare';
 export { default as canvas } from './canvas/CanvasPrepare';
+export { default as BasePrepare } from './BasePrepare';
+export { default as CountLimiter } from './limiters/CountLimiter';
+export { default as TimeLimiter } from './limiters/TimeLimiter';

--- a/src/prepare/limiters/CountLimiter.js
+++ b/src/prepare/limiters/CountLimiter.js
@@ -1,0 +1,43 @@
+/**
+ * CountLimiter limits the number of items handled by a {@link PIXI.prepare.BasePrepare} to a specified
+ * number of items per frame.
+ *
+ * @class
+ * @memberof PIXI
+ */
+export default class CountLimiter {
+    /**
+     * @param {number} maxItemsPerFrame - The maximum number of items that can be prepared each frame.
+     */
+    constructor(maxItemsPerFrame)
+    {
+        /**
+         * The maximum number of items that can be prepared each frame.
+         * @private
+         */
+        this.maxItemsPerFrame = maxItemsPerFrame;
+        /**
+         * The number of items that can be prepared in the current frame.
+         * @type {number}
+         * @private
+         */
+        this.itemsLeft = 0;
+    }
+
+    /**
+     * Resets any counting properties to start fresh on a new frame.
+     */
+    beginFrame()
+    {
+        this.itemsLeft = this.maxItemsPerFrame;
+    }
+
+    /**
+     * Checks to see if another item can be uploaded. This should only be called once per item.
+     * @return {boolean} If the item is allowed to be uploaded.
+     */
+    allowedToUpload()
+    {
+        return this.itemsLeft-- > 0;
+    }
+}

--- a/src/prepare/limiters/TimeLimiter.js
+++ b/src/prepare/limiters/TimeLimiter.js
@@ -1,0 +1,43 @@
+/**
+ * TimeLimiter limits the number of items handled by a {@link PIXI.BasePrepare} to a specified
+ * number of milliseconds per frame.
+ *
+ * @class
+ * @memberof PIXI
+ */
+export default class TimeLimiter {
+    /**
+     * @param {number} maxMilliseconds - The maximum milliseconds that can be spent preparing items each frame.
+     */
+    constructor(maxMilliseconds)
+    {
+        /**
+         * The maximum milliseconds that can be spent preparing items each frame.
+         * @private
+         */
+        this.maxMilliseconds = maxMilliseconds;
+        /**
+         * The start time of the current frame.
+         * @type {number}
+         * @private
+         */
+        this.frameStart = 0;
+    }
+
+    /**
+     * Resets any counting properties to start fresh on a new frame.
+     */
+    beginFrame()
+    {
+        this.frameStart = Date.now();
+    }
+
+    /**
+     * Checks to see if another item can be uploaded. This should only be called once per item.
+     * @return {boolean} If the item is allowed to be uploaded.
+     */
+    allowedToUpload()
+    {
+        return Date.now() - this.frameStart < this.maxMilliseconds;
+    }
+}

--- a/src/prepare/webgl/WebGLPrepare.js
+++ b/src/prepare/webgl/WebGLPrepare.js
@@ -16,7 +16,7 @@ export default class WebGLPrepare extends BasePrepare
     {
         super(renderer);
 
-        this.uploadHookSource = this.renderer;
+        this.uploadHookHelper = this.renderer;
 
         // Add textures and graphics to upload
         this.register(findBaseTextures, uploadBaseTextures)

--- a/src/prepare/webgl/WebGLPrepare.js
+++ b/src/prepare/webgl/WebGLPrepare.js
@@ -43,13 +43,9 @@ function uploadBaseTextures(renderer, item)
         if (!item._glTextures[renderer.CONTEXT_UID])
         {
             renderer.textureManager.updateTexture(item);
-
-            return true;
         }
-        // return false here - if it was already prepared it shouldn't count against the maximum
-        // number of uploads per frame
 
-        return false;
+        return true;
     }
 
     return false;
@@ -72,13 +68,9 @@ function uploadGraphics(renderer, item)
         if (item.dirty || item.clearDirty || !item._webGL[renderer.plugins.graphics.CONTEXT_UID])
         {
             renderer.plugins.graphics.updateGraphics(item);
-
-            return true;
         }
-        // return false here - if it was already prepared it shouldn't count against the maximum
-        // number of uploads per frame
 
-        return false;
+        return true;
     }
 
     return false;

--- a/src/prepare/webgl/WebGLPrepare.js
+++ b/src/prepare/webgl/WebGLPrepare.js
@@ -1,7 +1,5 @@
 import * as core from '../../core';
-
-const SharedTicker = core.ticker.shared;
-const DEFAULT_UPLOADS_PER_FRAME = 4;
+import BasePrepare from '../BasePrepare';
 
 /**
  * The prepare manager provides functionality to upload content to the GPU.
@@ -9,239 +7,23 @@ const DEFAULT_UPLOADS_PER_FRAME = 4;
  * @class
  * @memberof PIXI
  */
-export default class WebGLPrepare
+export default class WebGLPrepare extends BasePrepare
 {
     /**
      * @param {PIXI.WebGLRenderer} renderer - A reference to the current renderer
      */
     constructor(renderer)
     {
-        /**
-         * Reference to the renderer.
-         * @type {PIXI.WebGLRenderer}
-         * @private
-         */
-        this.renderer = renderer;
+        super(renderer);
 
-        /**
-         * Collection of items to uploads at once.
-         * @type {Array<*>}
-         * @private
-         */
-        this.queue = [];
-
-        /**
-         * Collection of additional hooks for finding assets.
-         * @type {Array<Function>}
-         * @private
-         */
-        this.addHooks = [];
-
-        /**
-         * Collection of additional hooks for processing assets.
-         * @type {Array<Function>}
-         * @private
-         */
-        this.uploadHooks = [];
-
-        /**
-         * Callback to call after completed.
-         * @type {Array<Function>}
-         * @private
-         */
-        this.completes = [];
-
-        /**
-         * If prepare is ticking (running).
-         * @type {boolean}
-         * @private
-         */
-        this.ticking = false;
+        this.uploadHookSource = this.renderer;
 
         // Add textures and graphics to upload
         this.register(findBaseTextures, uploadBaseTextures)
             .register(findGraphics, uploadGraphics);
     }
 
-    /**
-     * Upload all the textures and graphics to the GPU.
-     *
-     * @param {Function|PIXI.DisplayObject|PIXI.Container} item - Either
-     *        the container or display object to search for items to upload or
-     *        the callback function, if items have been added using `prepare.add`.
-     * @param {Function} [done] - Optional callback when all queued uploads have completed
-     */
-    upload(item, done)
-    {
-        if (typeof item === 'function')
-        {
-            done = item;
-            item = null;
-        }
-
-        // If a display object, search for items
-        // that we could upload
-        if (item)
-        {
-            this.add(item);
-        }
-
-        // Get the items for upload from the display
-        if (this.queue.length)
-        {
-            this.numLeft = WebGLPrepare.UPLOADS_PER_FRAME;
-
-            if (done)
-            {
-                this.completes.push(done);
-            }
-
-            if (!this.ticking)
-            {
-                this.ticking = true;
-                SharedTicker.add(this.tick, this);
-            }
-        }
-        else if (done)
-        {
-            done();
-        }
-    }
-
-    /**
-     * Handle tick update.
-     *
-     * @private
-     */
-    tick()
-    {
-        // Upload the graphics
-        while (this.queue.length && this.numLeft > 0)
-        {
-            const item = this.queue[0];
-            let uploaded = false;
-
-            for (let i = 0, len = this.uploadHooks.length; i < len; i++)
-            {
-                if (this.uploadHooks[i](this.renderer, item))
-                {
-                    this.numLeft--;
-                    this.queue.shift();
-                    uploaded = true;
-                    break;
-                }
-            }
-
-            if (!uploaded)
-            {
-                this.queue.shift();
-            }
-        }
-
-        // We're finished
-        if (this.queue.length)
-        {
-            this.numLeft = WebGLPrepare.UPLOADS_PER_FRAME;
-        }
-        else
-        {
-            this.ticking = false;
-
-            SharedTicker.remove(this.tick, this);
-
-            const completes = this.completes.slice(0);
-
-            this.completes.length = 0;
-
-            for (let i = 0, len = completes.length; i < len; i++)
-            {
-                completes[i]();
-            }
-        }
-    }
-
-    /**
-     * Adds hooks for finding and uploading items.
-     *
-     * @param {Function} [addHook] - Function call that takes two parameters: `item:*, queue:Array`
-              function must return `true` if it was able to add item to the queue.
-     * @param {Function} [uploadHook] - Function call that takes two parameters: `renderer:WebGLRenderer, item:*` and
-     *        function must return `true` if it was able to handle upload of item.
-     * @return {PIXI.WebGLPrepare} Instance of plugin for chaining.
-     */
-    register(addHook, uploadHook)
-    {
-        if (addHook)
-        {
-            this.addHooks.push(addHook);
-        }
-
-        if (uploadHook)
-        {
-            this.uploadHooks.push(uploadHook);
-        }
-
-        return this;
-    }
-
-    /**
-     * Manually add an item to the uploading queue.
-     *
-     * @param {PIXI.DisplayObject|PIXI.Container|*} item - Object to add to the queue
-     * @return {PIXI.WebGLPrepare} Instance of plugin for chaining.
-     */
-    add(item)
-    {
-        // Add additional hooks for finding elements on special
-        // types of objects that
-        for (let i = 0, len = this.addHooks.length; i < len; i++)
-        {
-            if (this.addHooks[i](item, this.queue))
-            {
-                break;
-            }
-        }
-
-        // Get childen recursively
-        if (item instanceof core.Container)
-        {
-            for (let i = item.children.length - 1; i >= 0; i--)
-            {
-                this.add(item.children[i]);
-            }
-        }
-
-        return this;
-    }
-
-    /**
-     * Destroys the plugin, don't use after this.
-     *
-     */
-    destroy()
-    {
-        if (this.ticking)
-        {
-            SharedTicker.remove(this.tick, this);
-        }
-        this.ticking = false;
-        this.addHooks = null;
-        this.uploadHooks = null;
-        this.renderer = null;
-        this.completes = null;
-        this.queue = null;
-    }
-
 }
-
-/**
- * The number of graphics or textures to upload to the GPU
- *
- * @static
- * @type {number}
- * @default 4
- */
-WebGLPrepare.UPLOADS_PER_FRAME = DEFAULT_UPLOADS_PER_FRAME;
 
 /**
  * Built-in hook to upload PIXI.Texture objects to the GPU.

--- a/test/index.js
+++ b/test/index.js
@@ -14,4 +14,5 @@ describe('PIXI', function ()
     require('./core');
     require('./interaction');
     require('./renders');
+    require('./prepare');
 });

--- a/test/prepare/BasePrepare.js
+++ b/test/prepare/BasePrepare.js
@@ -63,7 +63,7 @@ describe('PIXI.prepare.BasePrepare', function ()
 
         expect(prep.queue).to.contain(uploadItem);
 
-        prep.tick();
+        prep.prepareItems();
 
         expect(addHook.calledOnce).to.be.true;
         expect(uploadHook.calledOnce).to.be.true;
@@ -111,7 +111,7 @@ describe('PIXI.prepare.BasePrepare', function ()
 
         expect(prep.queue).to.have.lengthOf(1);
 
-        prep.tick();
+        prep.prepareItems();
 
         expect(prep.queue).to.be.empty;
         expect(addHook.calledOnce).to.be.true;

--- a/test/prepare/BasePrepare.js
+++ b/test/prepare/BasePrepare.js
@@ -1,0 +1,158 @@
+'use strict';
+
+describe('PIXI.prepare.BasePrepare', function ()
+{
+    it('should create a new, empty, BasePrepare', function ()
+    {
+        const renderer = {};
+        const prep = new PIXI.prepare.BasePrepare(renderer);
+
+        expect(prep.renderer).to.equal(renderer);
+        expect(prep.uploadHookHelper).to.be.null;
+        expect(prep.queue).to.be.empty;
+        expect(prep.addHooks).to.be.empty;
+        expect(prep.uploadHooks).to.be.empty;
+        expect(prep.completes).to.be.empty;
+
+        prep.destroy();
+    });
+
+    it('should add hooks', function ()
+    {
+        function addHook() { /* empty */ }
+        function uploadHook() { /* empty */ }
+        const prep = new PIXI.prepare.BasePrepare();
+
+        prep.register(addHook, uploadHook);
+
+        expect(prep.addHooks).to.contain(addHook);
+        expect(prep.addHooks).to.have.lengthOf(1);
+        expect(prep.uploadHooks).to.contain(uploadHook);
+        expect(prep.uploadHooks).to.have.lengthOf(1);
+
+        prep.destroy();
+    });
+
+    it('should call hooks and complete', function ()
+    {
+        const prep = new PIXI.prepare.BasePrepare();
+        const uploadItem = {};
+        const uploadHelper = {};
+
+        prep.uploadHookHelper = uploadHelper;
+
+        const addHook = sinon.spy(function (item, queue)
+        {
+            expect(item).to.equal(uploadItem);
+            expect(queue).to.equal(prep.queue);
+            queue.push(item);
+
+            return true;
+        });
+        const uploadHook = sinon.spy(function (helper, item)
+        {
+            expect(helper).to.equal(uploadHelper);
+            expect(item).to.equal(uploadItem);
+
+            return true;
+        });
+        const complete = sinon.spy(function () { /* empty */ });
+
+        prep.register(addHook, uploadHook);
+        prep.upload(uploadItem, complete);
+
+        expect(prep.queue).to.contain(uploadItem);
+
+        prep.tick();
+
+        expect(addHook.calledOnce).to.be.true;
+        expect(uploadHook.calledOnce).to.be.true;
+        expect(complete.calledOnce).to.be.true;
+
+        prep.destroy();
+    });
+
+    it('should call complete if no queue', function ()
+    {
+        const prep = new PIXI.prepare.BasePrepare();
+
+        function addHook()
+        {
+            return false;
+        }
+        const complete = sinon.spy(function () { /* empty */ });
+
+        prep.register(addHook);
+        prep.upload({}, complete);
+
+        expect(complete.calledOnce).to.be.true;
+
+        prep.destroy();
+    });
+
+    it('should remove un-preparable items from queue', function ()
+    {
+        const prep = new PIXI.prepare.BasePrepare();
+
+        const addHook = sinon.spy(function (item, queue)
+        {
+            queue.push(item);
+
+            return true;
+        });
+        const uploadHook = sinon.spy(function ()
+        {
+            return false;
+        });
+        const complete = sinon.spy(function () { /* empty */ });
+
+        prep.register(addHook, uploadHook);
+        prep.upload({}, complete);
+
+        expect(prep.queue).to.have.lengthOf(1);
+
+        prep.tick();
+
+        expect(prep.queue).to.be.empty;
+        expect(addHook.calledOnce).to.be.true;
+        expect(uploadHook.calledOnce).to.be.true;
+        expect(complete.calledOnce).to.be.true;
+
+        prep.destroy();
+    });
+
+    it('should attach to SharedTicker', function (done)
+    {
+        const prep = new PIXI.prepare.BasePrepare();
+
+        const addHook = sinon.spy(function (item, queue)
+        {
+            queue.push(item);
+
+            return true;
+        });
+        const uploadHook = sinon.spy(function ()
+        {
+            return true;
+        });
+
+        function complete()
+        {
+            expect(prep.queue).to.be.empty;
+            expect(addHook.calledOnce).to.be.true;
+            expect(uploadHook.calledOnce).to.be.true;
+
+            prep.destroy();
+
+            done();
+        }
+
+        prep.register(addHook, uploadHook);
+        prep.upload({}, complete);
+
+        expect(prep.queue).to.have.lengthOf(1);
+        expect(addHook.called).to.be.true;
+        expect(uploadHook.called).to.be.false;
+        expect(complete.called).to.not.be.ok;
+    });
+});

--- a/test/prepare/BasePrepare.js
+++ b/test/prepare/BasePrepare.js
@@ -10,8 +10,8 @@ describe('PIXI.prepare.BasePrepare', function ()
         expect(prep.renderer).to.equal(renderer);
         expect(prep.uploadHookHelper).to.be.null;
         expect(prep.queue).to.be.empty;
-        expect(prep.addHooks).to.be.empty;
-        expect(prep.uploadHooks).to.be.empty;
+        expect(prep.addHooks).to.have.lengthOf(2);
+        expect(prep.uploadHooks).to.have.lengthOf(2);
         expect(prep.completes).to.be.empty;
 
         prep.destroy();
@@ -26,9 +26,9 @@ describe('PIXI.prepare.BasePrepare', function ()
         prep.register(addHook, uploadHook);
 
         expect(prep.addHooks).to.contain(addHook);
-        expect(prep.addHooks).to.have.lengthOf(1);
+        expect(prep.addHooks).to.have.lengthOf(3);
         expect(prep.uploadHooks).to.contain(uploadHook);
-        expect(prep.uploadHooks).to.have.lengthOf(1);
+        expect(prep.uploadHooks).to.have.lengthOf(3);
 
         prep.destroy();
     });

--- a/test/prepare/CountLimiter.js
+++ b/test/prepare/CountLimiter.js
@@ -1,0 +1,21 @@
+'use strict';
+
+describe('PIXI.prepare.CountLimiter', function ()
+{
+    it('should limit to specified number per beginFrame()', function ()
+    {
+        const limit = new PIXI.prepare.CountLimiter(3);
+
+        limit.beginFrame();
+        expect(limit.allowedToUpload()).to.be.true;
+        expect(limit.allowedToUpload()).to.be.true;
+        expect(limit.allowedToUpload()).to.be.true;
+        expect(limit.allowedToUpload()).to.be.false;
+
+        limit.beginFrame();
+        expect(limit.allowedToUpload()).to.be.true;
+        expect(limit.allowedToUpload()).to.be.true;
+        expect(limit.allowedToUpload()).to.be.true;
+        expect(limit.allowedToUpload()).to.be.false;
+    });
+});

--- a/test/prepare/TimeLimiter.js
+++ b/test/prepare/TimeLimiter.js
@@ -1,0 +1,26 @@
+'use strict';
+
+describe('PIXI.prepare.TimeLimiter', function ()
+{
+    it('should limit to stop after time from beginFrame()', function (done)
+    {
+        const limit = new PIXI.prepare.TimeLimiter(3);
+
+        limit.beginFrame();
+        for (let i = 0; i < 20; ++i)
+        {
+            expect(limit.allowedToUpload()).to.be.true;
+        }
+
+        setTimeout(function ()
+        {
+            expect(limit.allowedToUpload()).to.be.false;
+
+            limit.beginFrame();
+
+            expect(limit.allowedToUpload()).to.be.true;
+
+            done();
+        }, 4);
+    });
+});

--- a/test/prepare/index.js
+++ b/test/prepare/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+require('./CountLimiter');
+require('./TimeLimiter');
+require('./BasePrepare');


### PR DESCRIPTION
* Combines the shared code of WebGLPrepare and CanvasPrepare into one BasePrepare class.
* Makes the rate limiting functionality more configurable by changing it to be class based and adding a class for limiting based on time spent preparing.
* Adds hooks for both WebGL and Canvas for preparing PIXI.Text and PIXI.TextStyle objects.
* Adds unit tests for the rate limiting and basic functionality of BasePrepare.

I did some testing of GPU upload times on a mobile device and found that texture upload time was quite variable and generally expensive, so I wanted to be able to limit preparation to a specified amount of time to attempt to preserve the framerate instead of loading as quickly as possible.
I also found that calculating the font properties was generally worse than uploading any single texture to the GPU, so added the hooks to prepare that stuff ahead of time using the same system.