### PR TITLE
Add jsdocs for renderer.extract property

### DIFF
--- a/src/extract/canvas/CanvasExtract.js
+++ b/src/extract/canvas/CanvasExtract.js
@@ -16,6 +16,13 @@ export default class CanvasExtract
     constructor(renderer)
     {
         this.renderer = renderer;
+        /**
+         * Collection of methods for extracting data (image, pixels, etc.) from a display object or render texture
+         *
+         * @member {PIXI.CanvasExtract} extract
+         * @memberof PIXI.CanvasRenderer#
+         * @see PIXI.CanvasExtract
+         */
         renderer.extract = this;
     }
 

--- a/src/extract/webgl/WebGLExtract.js
+++ b/src/extract/webgl/WebGLExtract.js
@@ -17,6 +17,13 @@ export default class WebGLExtract
     constructor(renderer)
     {
         this.renderer = renderer;
+        /**
+         * Collection of methods for extracting data (image, pixels, etc.) from a display object or render texture
+         *
+         * @member {PIXI.WebGLExtract} extract
+         * @memberof PIXI.WebGLRenderer#
+         * @see PIXI.WebGLExtract
+         */
         renderer.extract = this;
     }
 


### PR DESCRIPTION
The position of the doc block is a bit awkward, but I'm not sure there's really a better place for it.

Declaring it where the plugin is registered [(here)](https://github.com/pixijs/pixi.js/blob/master/src/extract/webgl/WebGLExtract.js#L223) would clarify why the property is being set for the renderer, but obscure what's being set in the first place.