### PR TITLE
Spritesheet Scale

### DIFF
--- a/src/loaders/spritesheetParser.js
+++ b/src/loaders/spritesheetParser.js
@@ -42,7 +42,17 @@ export default function ()
 
             const frames = resource.data.frames;
             const frameKeys = Object.keys(frames);
-            const resolution = core.utils.getResolutionOfUrl(resource.url);
+            const baseTexture = res.texture.baseTexture;
+            let resolution = core.utils.getResolutionOfUrl(resource.url);
+            const scale = resource.data.meta.scale;
+
+            // Support scale field on spritesheet
+            if (scale !== undefined && scale !== 1)
+            {
+                baseTexture.resolution = resolution = scale;
+                baseTexture.update();
+            }
+
             let batchIndex = 0;
 
             function processFrames(initialFrameIndex, maxFrames)
@@ -96,7 +106,7 @@ export default function ()
                         }
 
                         resource.textures[i] = new core.Texture(
-                            res.texture.baseTexture,
+                            baseTexture,
                             frame,
                             orig,
                             trim,


### PR DESCRIPTION
### Added

* Adds support for using the `meta.scale` property of spritesheet format to determine the resolution rather than relying on the filename (e.g., `@2x.png`), for conditions when renaming the file might not be appropriate. 

_Note: this is also needed to support an optimization feature in PixiAnimate_