### PR TITLE
Fixes a bug on SpriteRenderer's destroy

### DIFF
--- a/src/core/sprites/webgl/SpriteRenderer.js
+++ b/src/core/sprites/webgl/SpriteRenderer.js
@@ -452,12 +452,10 @@ export default class SpriteRenderer extends ObjectRenderer
 
         super.destroy();
 
-        for (let i = 0; i < this.shaders.length; i++)
+        if (this.shader)
         {
-            if (this.shaders[i])
-            {
-                this.shaders[i].destroy();
-            }
+            this.shader.destroy();
+            this.shader = null;
         }
 
         this.vertexBuffers = null;


### PR DESCRIPTION
### Overview

Resolves a bug when trying to destroy the  SpriteRenderer. Found when running `npm test` locally.

cc @GoodBoyDigital 