### PR TITLE
Build System, Babel and ES6 src

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+  presets: [
+    ["es2015", { "loose": true }]
+  ]
+}

--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,7 @@
     ["es2015", { "loose": true }],
   ],
   plugins: [
-    "static-fs"
+    "static-fs",
+    "version-inline"
   ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,8 @@
 {
   presets: [
-    ["es2015", { "loose": true }]
+    ["es2015", { "loose": true }],
+  ],
+  plugins: [
+    "static-fs"
   ]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,8 @@
 {
     "env": {
         "es6": true,
-        "browser": true
+        "browser": true,
+        "node": true
     },
     "globals": {
         "global": false

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,8 @@
         "node": true
     },
     "globals": {
-        "global": false
+        "global": false,
+        "__VERSION__": false
     },
     "parserOptions": {
         "ecmaVersion": 6,

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ docs/
 examples_old/
 bin/
 coverage/
+lib/
+dist/
 
 # jetBrains IDE ignores
 .idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ deploy:
     acl: public_read
     region: eu-west-1
     cache_control: "max-age=60"
-    local_dir: bin
+    local_dir: dist
     upload-dir: "$TRAVIS_BRANCH"
     on:
         all_branches: true
@@ -79,7 +79,7 @@ deploy:
     acl: public_read
     region: eu-west-1
     cache_control: "max-age=2592000"
-    local_dir: bin
+    local_dir: dist
     upload-dir: "$TRAVIS_BRANCH"
     on:
         all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_script:
 script:
   - xvfb-maybe npm run coverage
   - npm run build
+  - npm run bundle
   - npm run docs
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ before_script:
 
 script:
   - xvfb-maybe npm run coverage
-  - npm run build
   - npm run bundle
   - npm run docs
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint": "eslint scripts src test --max-warnings 0",
     "lintfix": "npm run lint --fix",
     "prebuild": "npm run lint",
-    "build": "babel src --out-dir lib",
+    "build": "babel src --out-dir lib -s",
     "bundle": "pixify -d dist -n PIXI -o pixi",
     "docs": "jsdoc -c scripts/jsdoc.conf.json -R README.md",
     "publish:patch": "npm version patch --no-git-tag-version && npm publish",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "Chad Engler <chad@pantherdev.com>",
     "Richard Davey <rdavey@gmail.com>"
   ],
-  "main": "./bin/pixi.min.js",
+  "main": "./lib/index.js",
   "homepage": "http://goodboydigital.com/",
   "bugs": "https://github.com/pixijs/pixi.js/issues",
   "license": "MIT",
@@ -18,31 +18,33 @@
     "url": "https://github.com/pixijs/pixi.js.git"
   },
   "scripts": {
-    "clean": "rimraf bin && mkdirp bin",
+    "clean": "rimraf dist lib && mkdirp dist && mkdir lib",
     "prestart": "npm run clean",
     "start": "parallelshell \"npm run watch:lint\" \"npm run watch\"",
-    "watch": "pixify -n PIXI -o pixi -w",
+    "watch": "npm run build -- --watch",
     "watch:lint": "watch \"eslint scripts src test || exit 0\" src",
+    "watch:bundle": "npm run bundle -- -w",
     "test": "floss --path test/index.js",
     "test:debug": "npm test -- --debug",
     "prerenders": "npm --prefix scripts/renders i scripts/renders",
     "renders": "electron scripts/renders",
     "precoverage": "rimraf coverage && npm run build -- --noExternal",
-    "coverage": "npm test -- -c bin/pixi.js -s -h",
+    "coverage": "npm test -- -c dist/pixi.js -s -h",
     "lint": "eslint scripts src test --max-warnings 0",
     "lintfix": "npm run lint --fix",
-    "prebuild": "npm run lint && npm run clean",
-    "build": "pixify -n PIXI -o pixi",
+    "prebuild": "npm run lint",
+    "build": "babel src --out-dir lib",
+    "bundle": "pixify -d dist -n PIXI -o pixi",
     "docs": "jsdoc -c scripts/jsdoc.conf.json -R README.md",
     "publish:patch": "npm version patch --no-git-tag-version && npm publish",
     "publish:minor": "npm version minor --no-git-tag-version && npm publish",
     "publish:major": "npm version major --no-git-tag-version && npm publish",
-    "postversion": "npm run build && npm test",
+    "postversion": "npm run clean && npm run build && npm run bundle && npm test",
     "postpublish": "node scripts/release.js"
   },
   "files": [
-    "bin/",
-    "src/",
+    "dist/",
+    "lib/",
     "CONTRIBUTING.md",
     "LICENSE",
     "package.json",
@@ -79,19 +81,7 @@
   },
   "browserify": {
     "transform": [
-      [
-        "babelify",
-        {
-          "presets": [
-            [
-              "es2015",
-              {
-                "loose": true
-              }
-            ]
-          ]
-        }
-      ],
+      "babelify",
       "glslify",
       "browserify-versionify"
     ]

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "bit-twiddle": "^1.0.2",
     "earcut": "^2.0.7",
     "eventemitter3": "^2.0.0",
-    "glslify": "^5.0.2",
     "ismobilejs": "^0.4.0",
     "object-assign": "^4.0.1",
     "pixi-gl-core": "^1.0.3",
@@ -63,6 +62,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",
+    "babel-plugin-static-fs": "^1.1.0",
     "babel-preset-es2015": "^6.14.0",
     "babelify": "^7.3.0",
     "del": "^2.2.0",
@@ -83,7 +83,6 @@
   "browserify": {
     "transform": [
       "babelify",
-      "glslify",
       "browserify-versionify"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -57,12 +57,12 @@
     "ismobilejs": "^0.4.0",
     "object-assign": "^4.0.1",
     "pixi-gl-core": "^1.0.3",
-    "resource-loader": "^1.8.0",
-    "browserify-versionify": "^1.0.6"
+    "resource-loader": "^1.8.0"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-plugin-static-fs": "^1.1.0",
+    "babel-plugin-version-inline": "^1.0.0",
     "babel-preset-es2015": "^6.14.0",
     "babelify": "^7.3.0",
     "del": "^2.2.0",
@@ -82,8 +82,7 @@
   },
   "browserify": {
     "transform": [
-      "babelify",
-      "browserify-versionify"
+      "babelify"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "browserify-versionify": "^1.0.6"
   },
   "devDependencies": {
+    "babel-cli": "^6.18.0",
     "babel-preset-es2015": "^6.14.0",
     "babelify": "^7.3.0",
     "del": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:debug": "npm test -- --debug",
     "prerenders": "npm --prefix scripts/renders i scripts/renders",
     "renders": "electron scripts/renders",
-    "precoverage": "rimraf coverage && npm run build -- --noExternal",
+    "precoverage": "rimraf coverage && npm run build",
     "coverage": "npm test -- -c dist/pixi.js -s -h",
     "lint": "eslint scripts src test --max-warnings 0",
     "lintfix": "npm run lint --fix",

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -9,9 +9,9 @@ const packageInfo = require(path.join(__dirname, '..', 'package.json'));
 
 const options = {
     src: [
-        'bin/**/*',
+        'dist/**/*',
+        'lib/**/*',
         'scripts/**/*',
-        'src/**/*',
         'test/**/*',
         '*.json',
         '*.md',

--- a/src/core/const.js
+++ b/src/core/const.js
@@ -8,7 +8,7 @@ import maxRecommendedTextures from './utils/maxRecommendedTextures';
  * @memberof PIXI
  * @type {string}
  */
-export const VERSION = '__VERSION__';
+export const VERSION = __VERSION__;
 
 /**
  * Two Pi.

--- a/src/core/renderers/webgl/filters/spriteMask/SpriteMaskFilter.js
+++ b/src/core/renderers/webgl/filters/spriteMask/SpriteMaskFilter.js
@@ -1,8 +1,7 @@
 import Filter from '../Filter';
 import { Matrix } from '../../../../math';
-
-// @see https://github.com/substack/brfs/issues/25
-const glslify = require('glslify'); // eslint-disable-line no-undef
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 /**
  * The SpriteMaskFilter class
@@ -21,8 +20,8 @@ export default class SpriteMaskFilter extends Filter
         const maskMatrix = new Matrix();
 
         super(
-            glslify('./spriteMaskFilter.vert'),
-            glslify('./spriteMaskFilter.frag')
+            readFileSync(join(__dirname, './spriteMaskFilter.vert'), 'utf8'),
+            readFileSync(join(__dirname, './spriteMaskFilter.frag'), 'utf8')
         );
 
         sprite.renderable = false;

--- a/src/core/sprites/webgl/generateMultiTextureShader.js
+++ b/src/core/sprites/webgl/generateMultiTextureShader.js
@@ -1,5 +1,6 @@
 import Shader from '../../Shader';
-const glslify = require('glslify'); // eslint-disable-line no-undef
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 const fragTemplate = [
     'varying vec2 vTextureCoord;',
@@ -17,7 +18,7 @@ const fragTemplate = [
 
 export default function generateMultiTextureShader(gl, maxTextures)
 {
-    const vertexSrc = glslify('./texture.vert');
+    const vertexSrc = readFileSync(join(__dirname, './texture.vert'), 'utf8');
     let fragmentSrc = fragTemplate;
 
     fragmentSrc = fragmentSrc.replace(/%count%/gi, maxTextures);

--- a/src/extras/webgl/TilingSpriteRenderer.js
+++ b/src/extras/webgl/TilingSpriteRenderer.js
@@ -1,7 +1,7 @@
 import * as core from '../../core';
 import { WRAP_MODES } from '../../core/const';
-
-const glslify = require('glslify'); // eslint-disable-line no-undef
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 const tempMat = new core.Matrix();
 const tempArray = new Float32Array(4);
@@ -35,11 +35,11 @@ export default class TilingSpriteRenderer extends core.ObjectRenderer {
         const gl = this.renderer.gl;
 
         this.shader = new core.Shader(gl,
-            glslify('./tilingSprite.vert'),
-            glslify('./tilingSprite.frag'));
+            readFileSync(join(__dirname, './tilingSprite.vert'), 'utf8'),
+            readFileSync(join(__dirname, './tilingSprite.frag'), 'utf8'));
         this.simpleShader = new core.Shader(gl,
-            glslify('./tilingSprite.vert'),
-            glslify('./tilingSprite_simple.frag'));
+            readFileSync(join(__dirname, './tilingSprite.vert'), 'utf8'),
+            readFileSync(join(__dirname, './tilingSprite_simple.frag'), 'utf8'));
 
         this.quad = new core.Quad(gl, this.renderer.state.attribState);
         this.quad.initVao(this.shader);

--- a/src/filters/colormatrix/ColorMatrixFilter.js
+++ b/src/filters/colormatrix/ColorMatrixFilter.js
@@ -1,5 +1,6 @@
 import * as core from '../../core';
-const glslify = require('glslify'); // eslint-disable-line no-undef
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 /**
  * The ColorMatrixFilter class lets you apply a 5x4 matrix transformation on the RGBA
@@ -25,9 +26,9 @@ export default class ColorMatrixFilter extends core.Filter
     {
         super(
             // vertex shader
-            glslify('../fragments/default.vert'),
+            readFileSync(join(__dirname, '../fragments/default.vert'), 'utf8'),
             // fragment shader
-            glslify('./colorMatrix.frag')
+            readFileSync(join(__dirname, './colorMatrix.frag'), 'utf8')
         );
 
         this.uniforms.m = [

--- a/src/filters/displacement/DisplacementFilter.js
+++ b/src/filters/displacement/DisplacementFilter.js
@@ -1,5 +1,6 @@
 import * as core from '../../core';
-const glslify = require('glslify'); // eslint-disable-line no-undef
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 /**
  * The DisplacementFilter class uses the pixel values from the specified texture
@@ -26,9 +27,9 @@ export default class DisplacementFilter extends core.Filter
 
         super(
             // vertex shader
-            glslify('../fragments/default-filter-matrix.vert'),
+            readFileSync(join(__dirname, '../fragments/default-filter-matrix.vert'), 'utf8'),
             // fragment shader
-            glslify('./displacement.frag')
+            readFileSync(join(__dirname, './displacement.frag'), 'utf8')
         );
 
         this.maskSprite = sprite;

--- a/src/filters/fxaa/FXAAFilter.js
+++ b/src/filters/fxaa/FXAAFilter.js
@@ -1,5 +1,6 @@
 import * as core from '../../core';
-const glslify = require('glslify'); // eslint-disable-line no-undef
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 /**
  *
@@ -24,9 +25,9 @@ export default class FXAAFilter extends core.Filter
         // TODO - needs work
         super(
             // vertex shader
-            glslify('./fxaa.vert'),
+            readFileSync(join(__dirname, './fxaa.vert'), 'utf8'),
             // fragment shader
-            glslify('./fxaa.frag')
+            readFileSync(join(__dirname, './fxaa.frag'), 'utf8')
         );
     }
 }

--- a/src/filters/noise/NoiseFilter.js
+++ b/src/filters/noise/NoiseFilter.js
@@ -1,5 +1,6 @@
 import * as core from '../../core';
-const glslify = require('glslify'); // eslint-disable-line no-undef
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 /**
  * @author Vico @vicocotea
@@ -22,9 +23,9 @@ export default class NoiseFilter extends core.Filter
     {
         super(
             // vertex shader
-            glslify('../fragments/default.vert'),
+            readFileSync(join(__dirname, '../fragments/default.vert'), 'utf8'),
             // fragment shader
-            glslify('./noise.frag')
+            readFileSync(join(__dirname, './noise.frag'), 'utf8')
         );
 
         this.noise = 0.5;

--- a/src/filters/void/VoidFilter.js
+++ b/src/filters/void/VoidFilter.js
@@ -1,7 +1,6 @@
 import * as core from '../../core';
-
-// @see https://github.com/substack/brfs/issues/25
-const glslify = require('glslify'); // eslint-disable-line no-undef
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 /**
  * Does nothing. Very handy.
@@ -19,9 +18,9 @@ export default class VoidFilter extends core.Filter
     {
         super(
             // vertex shader
-            glslify('../fragments/default.vert'),
+            readFileSync(join(__dirname, '../fragments/default.vert'), 'utf8'),
             // fragment shader
-            glslify('./void.frag')
+            readFileSync(join(__dirname, './void.frag'), 'utf8')
         );
 
         this.glShaderKey = 'void';

--- a/src/mesh/webgl/MeshRenderer.js
+++ b/src/mesh/webgl/MeshRenderer.js
@@ -1,8 +1,8 @@
 import * as core from '../../core';
 import glCore from 'pixi-gl-core';
 import { default as Mesh } from '../Mesh';
-
-const glslify = require('glslify'); // eslint-disable-line no-undef
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 /**
  * WebGL renderer plugin for tiling sprites
@@ -31,8 +31,8 @@ export default class MeshRenderer extends core.ObjectRenderer {
         const gl = this.renderer.gl;
 
         this.shader = new core.Shader(gl,
-            glslify('./mesh.vert'),
-            glslify('./mesh.frag'));
+            readFileSync(join(__dirname, './mesh.vert'), 'utf8'),
+            readFileSync(join(__dirname, './mesh.frag'), 'utf8'));
     }
 
     /**

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /* eslint-disable global-require */
-require('../bin/pixi');
+require('../lib/');
 
 PIXI.utils.skipHello(); // hide banner
 


### PR DESCRIPTION
## Overview

Removes the ES6 src directory from npm and replaces with a lib folder, which is now the main point for the package.json's `main` field. Creates bundled files in the "dist" folder and individual files in the "lib" folder. 

This should help resolve issues with devs using webpack and other build systems that are more friendly with unbundled modules.