### PR TITLE
Moves constants that are actually settings

### DIFF
--- a/src/core/Shader.js
+++ b/src/core/Shader.js
@@ -1,5 +1,7 @@
 import { GLShader } from 'pixi-gl-core';
-import { PRECISION } from './const';
+import settings from './settings';
+
+const { PRECISION } = settings;
 
 function checkPrecision(src)
 {
@@ -9,14 +11,14 @@ function checkPrecision(src)
         {
             const copy = src.slice(0);
 
-            copy.unshift(`precision ${PRECISION.DEFAULT} float;`);
+            copy.unshift(`precision ${PRECISION} float;`);
 
             return copy;
         }
     }
     else if (src.substring(0, 9) !== 'precision')
     {
-        return `precision ${PRECISION.DEFAULT} float;\n${src}`;
+        return `precision ${PRECISION} float;\n${src}`;
     }
 
     return src;

--- a/src/core/const.js
+++ b/src/core/const.js
@@ -1,4 +1,3 @@
-import maxRecommendedTextures from './utils/maxRecommendedTextures';
 import canUploadSameBuffer from './utils/canUploadSameBuffer';
 
 /**
@@ -40,17 +39,6 @@ export const RAD_TO_DEG = 180 / Math.PI;
  * @type {number}
  */
 export const DEG_TO_RAD = Math.PI / 180;
-
-/**
- * Target frames per millisecond.
- *
- * @static
- * @constant
- * @memberof PIXI
- * @type {number}
- * @default 0.06
- */
-export const TARGET_FPMS = 0.06;
 
 /**
  * Constant to identify the Renderer Type.
@@ -216,17 +204,6 @@ export const GC_MODES = {
 };
 
 /**
- * If set to true WebGL will attempt make textures mimpaped by default.
- * Mipmapping will only succeed if the base texture uploaded has power of two dimensions.
- *
- * @static
- * @constant
- * @memberof PIXI
- * @type {boolean}
- */
-export const MIPMAP_TEXTURES = true;
-
-/**
  * The prefix that denotes a URL is for a retina asset.
  *
  * @static
@@ -236,25 +213,6 @@ export const MIPMAP_TEXTURES = true;
  * @example `@2x`
  */
 export const RETINA_PREFIX = /@(.+)x/;
-
-/**
- * Default resolution / device pixel ratio of the renderer.
- *
- * @static
- * @constant
- * @memberof PIXI
- * @type {number}
- */
-export const RESOLUTION = 1;
-
-/**
- * Default filter resolution.
- *
- * @static
- * @constant
- * @type {number}
- */
-export const FILTER_RESOLUTION = 1;
 
 /**
  * The default render options if none are supplied to {@link PIXI.WebGLRenderer}
@@ -395,29 +353,6 @@ export const TEXT_GRADIENT = {
 
 // TODO: maybe change to SPRITE.BATCH_SIZE: 2000
 // TODO: maybe add PARTICLE.BATCH_SIZE: 15000
-
-/**
- * The default sprite batch size.
- *
- * The default aims to balance desktop and mobile devices.
- *
- * @static
- * @constant
- * @memberof PIXI
- * @type {number}
- * @default 4096
- */
-export const SPRITE_BATCH_SIZE = 4096;
-
-/**
- * The maximum textures that this device supports.
- *
- * @static
- * @constant
- * @memberof PIXI
- * @type {number}
- */
-export const SPRITE_MAX_TEXTURES = maxRecommendedTextures(32);
 
 /**
  * Can we upload the same buffer in a single frame?

--- a/src/core/const.js
+++ b/src/core/const.js
@@ -134,19 +134,17 @@ export const DRAW_MODES = {
 /**
  * The scale modes that are supported by pixi.
  *
- * The DEFAULT scale mode affects the default scaling mode of future operations.
+ * The PIXI.settings.SCALE_MODE scale mode affects the default scaling mode of future operations.
  * It can be re-assigned to either LINEAR or NEAREST, depending upon suitability.
  *
  * @static
  * @constant
  * @memberof PIXI
  * @type {object}
- * @property {number} DEFAULT=LINEAR
  * @property {number} LINEAR Smooth scaling
  * @property {number} NEAREST Pixelating scaling
  */
 export const SCALE_MODES = {
-    DEFAULT:    0,
     LINEAR:     0,
     NEAREST:    1,
 };
@@ -154,7 +152,7 @@ export const SCALE_MODES = {
 /**
  * The wrap modes that are supported by pixi.
  *
- * The DEFAULT wrap mode affects the default wraping mode of future operations.
+ * The PIXI.settings.WRAP_MODE wrap mode affects the default wraping mode of future operations.
  * It can be re-assigned to either CLAMP or REPEAT, depending upon suitability.
  * If the texture is non power of two then clamp will be used regardless as webGL can
  * only use REPEAT if the texture is po2.
@@ -165,13 +163,11 @@ export const SCALE_MODES = {
  * @constant
  * @memberof PIXI
  * @type {object}
- * @property {number} DEFAULT=CLAMP
  * @property {number} CLAMP - The textures uvs are clamped
  * @property {number} REPEAT - The texture uvs tile and repeat
  * @property {number} MIRRORED_REPEAT - The texture uvs tile and repeat with mirroring
  */
 export const WRAP_MODES = {
-    DEFAULT:        0,
     CLAMP:          0,
     REPEAT:         1,
     MIRRORED_REPEAT: 2,
@@ -180,8 +176,8 @@ export const WRAP_MODES = {
 /**
  * The gc modes that are supported by pixi.
  *
- * The DEFAULT Garbage Collection mode for pixi textures is MANUAL
- * If set to DEFAULT, the renderer will occasianally check textures usage. If they are not
+ * The PIXI.settings.GC_MODE Garbage Collection mode for pixi textures is AUTO
+ * If set to GC_MODE, the renderer will occasianally check textures usage. If they are not
  * used for a specified period of time they will be removed from the GPU. They will of course
  * be uploaded again when they are required. This is a silent behind the scenes process that
  * should ensure that the GPU does not  get filled up.
@@ -193,56 +189,12 @@ export const WRAP_MODES = {
  * @constant
  * @memberof PIXI
  * @type {object}
- * @property {number} DEFAULT=MANUAL
  * @property {number} AUTO - Garbage collection will happen periodically automatically
  * @property {number} MANUAL - Garbage collection will need to be called manually
  */
 export const GC_MODES = {
-    DEFAULT:        0,
     AUTO:           0,
     MANUAL:         1,
-};
-
-/**
- * The prefix that denotes a URL is for a retina asset.
- *
- * @static
- * @constant
- * @memberof PIXI
- * @type {RegExp|string}
- * @example `@2x`
- */
-export const RETINA_PREFIX = /@(.+)x/;
-
-/**
- * The default render options if none are supplied to {@link PIXI.WebGLRenderer}
- * or {@link PIXI.CanvasRenderer}.
- *
- * @static
- * @constant
- * @memberof PIXI
- * @type {object}
- * @property {HTMLCanvasElement} view=null
- * @property {number} resolution=1
- * @property {boolean} antialias=false
- * @property {boolean} forceFXAA=false
- * @property {boolean} autoResize=false
- * @property {boolean} transparent=false
- * @property {number} backgroundColor=0x000000
- * @property {boolean} clearBeforeRender=true
- * @property {boolean} preserveDrawingBuffer=false
- * @property {boolean} roundPixels=false
- */
-export const DEFAULT_RENDER_OPTIONS = {
-    view: null,
-    antialias: false,
-    forceFXAA: false,
-    autoResize: false,
-    transparent: false,
-    backgroundColor: 0x000000,
-    clearBeforeRender: true,
-    preserveDrawingBuffer: false,
-    roundPixels: false,
 };
 
 /**
@@ -307,13 +259,11 @@ export const SHAPES = {
  * @constant
  * @memberof PIXI
  * @type {object}
- * @property {number} DEFAULT='mediump'
- * @property {number} LOW='lowp'
- * @property {number} MEDIUM='mediump'
- * @property {number} HIGH='highp'
+ * @property {string} LOW='lowp'
+ * @property {string} MEDIUM='mediump'
+ * @property {string} HIGH='highp'
  */
 export const PRECISION = {
-    DEFAULT: 'mediump',
     LOW: 'lowp',
     MEDIUM: 'mediump',
     HIGH: 'highp',
@@ -326,12 +276,10 @@ export const PRECISION = {
  * @constant
  * @memberof PIXI
  * @type {object}
- * @property {number} DEFAULT=STATIC
  * @property {number} STATIC
  * @property {number} DYNAMIC
  */
 export const TRANSFORM_MODE = {
-    DEFAULT:    0,
     STATIC:     0,
     DYNAMIC:    1,
 };

--- a/src/core/display/DisplayObject.js
+++ b/src/core/display/DisplayObject.js
@@ -1,5 +1,6 @@
 import EventEmitter from 'eventemitter3';
 import { TRANSFORM_MODE } from '../const';
+import settings from '../settings';
 import TransformStatic from './TransformStatic';
 import Transform from './Transform';
 import Bounds from './Bounds';
@@ -24,7 +25,7 @@ export default class DisplayObject extends EventEmitter
     {
         super();
 
-        const TransformClass = TRANSFORM_MODE.DEFAULT === TRANSFORM_MODE.STATIC ? TransformStatic : Transform;
+        const TransformClass = settings.TRANSFORM_MODE === TRANSFORM_MODE.STATIC ? TransformStatic : Transform;
 
         this.tempDisplayObjectParent = null;
 

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -6,10 +6,11 @@ export * from './math';
 
 import * as utils from './utils';
 import * as ticker from './ticker';
+import settings from './settings';
 import CanvasRenderer from './renderers/canvas/CanvasRenderer';
 import WebGLRenderer from './renderers/webgl/WebGLRenderer';
 
-export { utils, ticker, CanvasRenderer, WebGLRenderer };
+export { settings, utils, ticker, CanvasRenderer, WebGLRenderer };
 
 export { default as glCore } from 'pixi-gl-core';
 

--- a/src/core/renderers/SystemRenderer.js
+++ b/src/core/renderers/SystemRenderer.js
@@ -1,13 +1,13 @@
 import { sayHello, hex2string, hex2rgb } from '../utils';
 import { Matrix } from '../math';
-import { DEFAULT_RENDER_OPTIONS, RENDERER_TYPE } from '../const';
+import { RENDERER_TYPE } from '../const';
 import settings from '../settings';
 import Container from '../display/Container';
 import RenderTexture from '../textures/RenderTexture';
 import EventEmitter from 'eventemitter3';
 
 const tempMatrix = new Matrix();
-const { RESOLUTION } = settings;
+const { RESOLUTION, RENDER_OPTIONS } = settings;
 
 /**
  * The SystemRenderer is the base for a Pixi Renderer. It is extended by the {@link PIXI.CanvasRenderer}
@@ -47,17 +47,17 @@ export default class SystemRenderer extends EventEmitter
         // prepare options
         if (options)
         {
-            for (const i in DEFAULT_RENDER_OPTIONS)
+            for (const i in RENDER_OPTIONS)
             {
                 if (typeof options[i] === 'undefined')
                 {
-                    options[i] = DEFAULT_RENDER_OPTIONS[i];
+                    options[i] = RENDER_OPTIONS[i];
                 }
             }
         }
         else
         {
-            options = DEFAULT_RENDER_OPTIONS;
+            options = RENDER_OPTIONS;
         }
 
         /**

--- a/src/core/renderers/SystemRenderer.js
+++ b/src/core/renderers/SystemRenderer.js
@@ -1,11 +1,13 @@
 import { sayHello, hex2string, hex2rgb } from '../utils';
 import { Matrix } from '../math';
-import { DEFAULT_RENDER_OPTIONS, RENDERER_TYPE, RESOLUTION } from '../const';
+import { DEFAULT_RENDER_OPTIONS, RENDERER_TYPE } from '../const';
+import settings from '../settings';
 import Container from '../display/Container';
 import RenderTexture from '../textures/RenderTexture';
 import EventEmitter from 'eventemitter3';
 
 const tempMatrix = new Matrix();
+const { RESOLUTION } = settings;
 
 /**
  * The SystemRenderer is the base for a Pixi Renderer. It is extended by the {@link PIXI.CanvasRenderer}

--- a/src/core/renderers/canvas/CanvasRenderer.js
+++ b/src/core/renderers/canvas/CanvasRenderer.js
@@ -4,6 +4,7 @@ import CanvasRenderTarget from './utils/CanvasRenderTarget';
 import mapCanvasBlendModesToPixi from './utils/mapCanvasBlendModesToPixi';
 import { pluginTarget } from '../../utils';
 import { RENDERER_TYPE, SCALE_MODES, BLEND_MODES } from '../../const';
+import settings from '../../settings';
 
 /**
  * The CanvasRenderer draws the scene and all its content onto a 2d canvas. This renderer should
@@ -263,7 +264,7 @@ export default class CanvasRenderer extends SystemRenderer
         // surely a browser bug?? Let pixi fix that for you..
         if (this.smoothProperty)
         {
-            this.rootContext[this.smoothProperty] = (SCALE_MODES.DEFAULT === SCALE_MODES.LINEAR);
+            this.rootContext[this.smoothProperty] = (settings.SCALE_MODE === SCALE_MODES.LINEAR);
         }
     }
 }

--- a/src/core/renderers/canvas/utils/CanvasRenderTarget.js
+++ b/src/core/renderers/canvas/utils/CanvasRenderTarget.js
@@ -1,4 +1,5 @@
-import { RESOLUTION } from '../../../const';
+import settings from '../../../settings';
+const { RESOLUTION } = settings;
 
 /**
  * Creates a Canvas element of the given size.

--- a/src/core/renderers/webgl/TextureGarbageCollector.js
+++ b/src/core/renderers/webgl/TextureGarbageCollector.js
@@ -1,4 +1,5 @@
 import { GC_MODES } from '../../const';
+import settings from '../../settings';
 
 /**
  * TextureGarbageCollector. This class manages the GPU and ensures that it does not get clogged
@@ -21,7 +22,7 @@ export default class TextureGarbageCollector
         this.maxIdle = 60 * 60;
         this.checkCountMax = 60 * 10;
 
-        this.mode = GC_MODES.DEFAULT;
+        this.mode = settings.GC_MODE;
     }
 
     /**

--- a/src/core/renderers/webgl/utils/RenderTarget.js
+++ b/src/core/renderers/webgl/utils/RenderTarget.js
@@ -1,6 +1,9 @@
 import { Rectangle, Matrix } from '../../../math';
-import { RESOLUTION, SCALE_MODES } from '../../../const';
+import { SCALE_MODES } from '../../../const';
+import settings from '../../../settings';
 import { GLFramebuffer } from 'pixi-gl-core';
+
+const { RESOLUTION } = settings;
 
 /**
  * @class

--- a/src/core/renderers/webgl/utils/RenderTarget.js
+++ b/src/core/renderers/webgl/utils/RenderTarget.js
@@ -3,7 +3,7 @@ import { SCALE_MODES } from '../../../const';
 import settings from '../../../settings';
 import { GLFramebuffer } from 'pixi-gl-core';
 
-const { RESOLUTION } = settings;
+const { RESOLUTION, SCALE_MODE } = settings;
 
 /**
  * @class
@@ -15,7 +15,7 @@ export default class RenderTarget
      * @param {WebGLRenderingContext} gl - The current WebGL drawing context
      * @param {number} [width=0] - the horizontal range of the filter
      * @param {number} [height=0] - the vertical range of the filter
-     * @param {number} [scaleMode=PIXI.SCALE_MODES.DEFAULT] - See {@link PIXI.SCALE_MODES} for possible values
+     * @param {number} [scaleMode=PIXI.settings.SCALE_MODE] - See {@link PIXI.SCALE_MODES} for possible values
      * @param {number} [resolution=1] - The current resolution / device pixel ratio
      * @param {boolean} [root=false] - Whether this object is the root element or not
      */
@@ -123,10 +123,10 @@ export default class RenderTarget
          * The scale mode.
          *
          * @member {number}
-         * @default PIXI.SCALE_MODES.DEFAULT
+         * @default PIXI.settings.SCALE_MODE
          * @see PIXI.SCALE_MODES
          */
-        this.scaleMode = scaleMode || SCALE_MODES.DEFAULT;
+        this.scaleMode = scaleMode || SCALE_MODE;
 
         /**
          * Whether this object is the root element or not

--- a/src/core/settings.js
+++ b/src/core/settings.js
@@ -67,4 +67,97 @@ export default {
      * @default 4096
      */
     SPRITE_BATCH_SIZE: 4096,
+
+    /**
+     * The prefix that denotes a URL is for a retina asset.
+     *
+     * @static
+     * @memberof PIXI.settings
+     * @type {RegExp|string}
+     * @example `@2x`
+     * @default /@(.+)x/
+     */
+    RETINA_PREFIX: /@(.+)x/,
+
+    /**
+     * The default render options if none are supplied to {@link PIXI.WebGLRenderer}
+     * or {@link PIXI.CanvasRenderer}.
+     *
+     * @static
+     * @constant
+     * @memberof PIXI.settings
+     * @type {object}
+     * @property {HTMLCanvasElement} view=null
+     * @property {number} resolution=1
+     * @property {boolean} antialias=false
+     * @property {boolean} forceFXAA=false
+     * @property {boolean} autoResize=false
+     * @property {boolean} transparent=false
+     * @property {number} backgroundColor=0x000000
+     * @property {boolean} clearBeforeRender=true
+     * @property {boolean} preserveDrawingBuffer=false
+     * @property {boolean} roundPixels=false
+     */
+    RENDER_OPTIONS: {
+        view: null,
+        antialias: false,
+        forceFXAA: false,
+        autoResize: false,
+        transparent: false,
+        backgroundColor: 0x000000,
+        clearBeforeRender: true,
+        preserveDrawingBuffer: false,
+        roundPixels: false,
+    },
+
+    /**
+     * Default transform type.
+     *
+     * @static
+     * @memberof PIXI.settings
+     * @type {number}
+     * @default PIXI.TRANSFORM_MODE.STATIC
+     */
+    TRANSFORM_MODE: 0,
+
+    /**
+     * Default Garbage Collection mode.
+     *
+     * @static
+     * @memberof PIXI.settings
+     * @type {number}
+     * @default PIXI.GC_MODES.AUTO
+     */
+    GC_MODE: 0,
+
+    /**
+     * Default wrap modes that are supported by pixi.
+     *
+     * @static
+     * @memberof PIXI.settings
+     * @type {number}
+     * @default PIXI.WRAP_MODES.CLAMP
+     */
+    WRAP_MODE: 0,
+
+    /**
+     * The scale modes that are supported by pixi.
+     *
+     * @static
+     * @memberof PIXI.settings
+     * @type {number}
+     * @default PIXI.SCALE_MODES.LINEAR
+     */
+    SCALE_MODE: 0,
+
+    /**
+     * Default specify float precision in shaders.
+     *
+     * @static
+     * @memberof PIXI.settings
+     * @type {string}
+     * @default PIXI.PRECISION.MEDIUM
+     */
+    PRECISION: 'mediump',
+
 };

--- a/src/core/settings.js
+++ b/src/core/settings.js
@@ -1,0 +1,70 @@
+import maxRecommendedTextures from './utils/maxRecommendedTextures';
+
+/**
+ * @namespace PIXI.settings
+ */
+export default {
+
+    /**
+     * Target frames per millisecond.
+     *
+     * @static
+     * @memberof PIXI.settings
+     * @type {number}
+     * @default 0.06
+     */
+    TARGET_FPMS: 0.06,
+
+    /**
+     * If set to true WebGL will attempt make textures mimpaped by default.
+     * Mipmapping will only succeed if the base texture uploaded has power of two dimensions.
+     *
+     * @static
+     * @memberof PIXI.settings
+     * @type {boolean}
+     * @default true
+     */
+    MIPMAP_TEXTURES: true,
+
+    /**
+     * Default resolution / device pixel ratio of the renderer.
+     *
+     * @static
+     * @memberof PIXI.settings
+     * @type {number}
+     * @default 1
+     */
+    RESOLUTION: 1,
+
+    /**
+     * Default filter resolution.
+     *
+     * @static
+     * @memberof PIXI.settings
+     * @type {number}
+     * @default 1
+     */
+    FILTER_RESOLUTION: 1,
+
+    /**
+     * The maximum textures that this device supports.
+     *
+     * @static
+     * @memberof PIXI.settings
+     * @type {number}
+     * @default 32
+     */
+    SPRITE_MAX_TEXTURES: maxRecommendedTextures(32),
+
+    /**
+     * The default sprite batch size.
+     *
+     * The default aims to balance desktop and mobile devices.
+     *
+     * @static
+     * @memberof PIXI.settings
+     * @type {number}
+     * @default 4096
+     */
+    SPRITE_BATCH_SIZE: 4096,
+};

--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -453,7 +453,7 @@ export default class Sprite extends Container
      * @static
      * @param {string} imageId - The image url of the texture
      * @param {boolean} [crossorigin=(auto)] - if you want to specify the cross-origin parameter
-     * @param {number} [scaleMode=PIXI.SCALE_MODES.DEFAULT] - if you want to specify the scale mode,
+     * @param {number} [scaleMode=PIXI.settings.SCALE_MODE] - if you want to specify the scale mode,
      *  see {@link PIXI.SCALE_MODES} for possible values
      * @return {PIXI.Sprite} A new Sprite using a texture from the texture cache matching the image id
      */

--- a/src/core/sprites/webgl/SpriteRenderer.js
+++ b/src/core/sprites/webgl/SpriteRenderer.js
@@ -4,9 +4,12 @@ import createIndicesForQuads from '../../utils/createIndicesForQuads';
 import generateMultiTextureShader from './generateMultiTextureShader';
 import checkMaxIfStatmentsInShader from '../../renderers/webgl/utils/checkMaxIfStatmentsInShader';
 import Buffer from './BatchBuffer';
-import { SPRITE_BATCH_SIZE, SPRITE_MAX_TEXTURES, CAN_UPLOAD_SAME_BUFFER } from '../../const';
+import { CAN_UPLOAD_SAME_BUFFER } from '../../const';
+import settings from '../../settings';
 import glCore from 'pixi-gl-core';
 import bitTwiddle from 'bit-twiddle';
+
+const { SPRITE_BATCH_SIZE, SPRITE_MAX_TEXTURES } = settings;
 
 let TICK = 0;
 let TEXTURE_TICK = 0;

--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -3,8 +3,11 @@ import Sprite from '../sprites/Sprite';
 import Texture from '../textures/Texture';
 import { Rectangle } from '../math';
 import { sign } from '../utils';
-import { TEXT_GRADIENT, RESOLUTION } from '../const';
+import { TEXT_GRADIENT } from '../const';
+import settings from '../settings';
 import TextStyle from './TextStyle';
+
+const { RESOLUTION } = settings;
 
 const defaultDestroyOptions = {
     texture: true,

--- a/src/core/textures/BaseRenderTexture.js
+++ b/src/core/textures/BaseRenderTexture.js
@@ -1,8 +1,7 @@
 import BaseTexture from './BaseTexture';
-import { SCALE_MODES } from '../const';
 import settings from '../settings';
 
-const { RESOLUTION } = settings;
+const { RESOLUTION, SCALE_MODE } = settings;
 
 /**
  * A BaseRenderTexture is a special texture that allows any Pixi display object to be rendered to it.
@@ -49,7 +48,7 @@ export default class BaseRenderTexture extends BaseTexture
     /**
      * @param {number} [width=100] - The width of the base render texture
      * @param {number} [height=100] - The height of the base render texture
-     * @param {number} [scaleMode=PIXI.SCALE_MODES.DEFAULT] - See {@link PIXI.SCALE_MODES} for possible values
+     * @param {number} [scaleMode=PIXI.settings.SCALE_MODE] - See {@link PIXI.SCALE_MODES} for possible values
      * @param {number} [resolution=1] - The resolution / device pixel ratio of the texture being generated
      */
     constructor(width = 100, height = 100, scaleMode, resolution)
@@ -64,7 +63,7 @@ export default class BaseRenderTexture extends BaseTexture
         this.realWidth = this.width * this.resolution;
         this.realHeight = this.height * this.resolution;
 
-        this.scaleMode = scaleMode || SCALE_MODES.DEFAULT;
+        this.scaleMode = scaleMode || SCALE_MODE;
         this.hasLoaded = true;
 
         /**

--- a/src/core/textures/BaseRenderTexture.js
+++ b/src/core/textures/BaseRenderTexture.js
@@ -1,5 +1,8 @@
 import BaseTexture from './BaseTexture';
-import { RESOLUTION, SCALE_MODES } from '../const';
+import { SCALE_MODES } from '../const';
+import settings from '../settings';
+
+const { RESOLUTION } = settings;
 
 /**
  * A BaseRenderTexture is a special texture that allows any Pixi display object to be rendered to it.

--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -2,13 +2,12 @@ import {
     uid, getUrlFileExtension, decomposeDataUri, getSvgSize,
     getResolutionOfUrl, BaseTextureCache, TextureCache,
 } from '../utils';
-import { SCALE_MODES, WRAP_MODES } from '../const';
 import settings from '../settings';
 import EventEmitter from 'eventemitter3';
 import determineCrossOrigin from '../utils/determineCrossOrigin';
 import bitTwiddle from 'bit-twiddle';
 
-const { RESOLUTION, MIPMAP_TEXTURES } = settings;
+const { RESOLUTION, MIPMAP_TEXTURES, SCALE_MODE, WRAP_MODE } = settings;
 
 /**
  * A texture stores the information that represents an image. All textures have a base texture.
@@ -21,7 +20,7 @@ export default class BaseTexture extends EventEmitter
 {
     /**
      * @param {HTMLImageElement|HTMLCanvasElement} [source] - the source object of the texture.
-     * @param {number} [scaleMode=PIXI.SCALE_MODES.DEFAULT] - See {@link PIXI.SCALE_MODES} for possible values
+     * @param {number} [scaleMode=PIXI.settings.SCALE_MODE] - See {@link PIXI.SCALE_MODES} for possible values
      * @param {number} [resolution=1] - The resolution / device pixel ratio of the texture
      */
     constructor(source, scaleMode, resolution)
@@ -77,10 +76,10 @@ export default class BaseTexture extends EventEmitter
          * The scale mode to apply when scaling this texture
          *
          * @member {number}
-         * @default PIXI.SCALE_MODES.DEFAULT
+         * @default PIXI.settings.SCALE_MODE
          * @see PIXI.SCALE_MODES
          */
-        this.scaleMode = scaleMode || SCALE_MODES.DEFAULT;
+        this.scaleMode = scaleMode || SCALE_MODE;
 
         /**
          * Set to true once the base texture has successfully loaded.
@@ -186,7 +185,7 @@ export default class BaseTexture extends EventEmitter
          * @member {number}
          * @see PIXI.WRAP_MODES
          */
-        this.wrapMode = WRAP_MODES.DEFAULT;
+        this.wrapMode = WRAP_MODE;
 
         /**
          * A map of renderer IDs to webgl textures
@@ -630,7 +629,7 @@ export default class BaseTexture extends EventEmitter
      * @static
      * @param {string} imageUrl - The image url of the texture
      * @param {boolean} [crossorigin=(auto)] - Should use anonymous CORS? Defaults to true if the URL is not a data-URI.
-     * @param {number} [scaleMode=PIXI.SCALE_MODES.DEFAULT] - See {@link PIXI.SCALE_MODES} for possible values
+     * @param {number} [scaleMode=PIXI.settings.SCALE_MODE] - See {@link PIXI.SCALE_MODES} for possible values
      * @param {number} [sourceScale=(auto)] - Scale for the original image, used with Svg images.
      * @return {PIXI.BaseTexture} The new base texture.
      */

--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -2,10 +2,13 @@ import {
     uid, getUrlFileExtension, decomposeDataUri, getSvgSize,
     getResolutionOfUrl, BaseTextureCache, TextureCache,
 } from '../utils';
-import { RESOLUTION, SCALE_MODES, MIPMAP_TEXTURES, WRAP_MODES } from '../const';
+import { SCALE_MODES, WRAP_MODES } from '../const';
+import settings from '../settings';
 import EventEmitter from 'eventemitter3';
 import determineCrossOrigin from '../utils/determineCrossOrigin';
 import bitTwiddle from 'bit-twiddle';
+
+const { RESOLUTION, MIPMAP_TEXTURES } = settings;
 
 /**
  * A texture stores the information that represents an image. All textures have a base texture.

--- a/src/core/textures/RenderTexture.js
+++ b/src/core/textures/RenderTexture.js
@@ -116,7 +116,7 @@ export default class RenderTexture extends Texture
      *
      * @param {number} [width=100] - The width of the render texture
      * @param {number} [height=100] - The height of the render texture
-     * @param {number} [scaleMode=PIXI.SCALE_MODES.DEFAULT] - See {@link PIXI.SCALE_MODES} for possible values
+     * @param {number} [scaleMode=PIXI.settings.SCALE_MODE] - See {@link PIXI.SCALE_MODES} for possible values
      * @param {number} [resolution=1] - The resolution / device pixel ratio of the texture being generated
      * @return {PIXI.RenderTexture} The new render texture
      */

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -279,7 +279,7 @@ export default class Texture extends EventEmitter
      * @static
      * @param {string} imageUrl - The image url of the texture
      * @param {boolean} [crossorigin] - Whether requests should be treated as crossorigin
-     * @param {number} [scaleMode=PIXI.SCALE_MODES.DEFAULT] - See {@link PIXI.SCALE_MODES} for possible values
+     * @param {number} [scaleMode=PIXI.settings.SCALE_MODE] - See {@link PIXI.SCALE_MODES} for possible values
      * @param {number} [sourceScale=(auto)] - Scale for the original image, used with SVG images.
      * @return {PIXI.Texture} The newly created texture
      */
@@ -321,7 +321,7 @@ export default class Texture extends EventEmitter
      *
      * @static
      * @param {HTMLCanvasElement} canvas - The canvas element source of the texture
-     * @param {number} [scaleMode=PIXI.SCALE_MODES.DEFAULT] - See {@link PIXI.SCALE_MODES} for possible values
+     * @param {number} [scaleMode=PIXI.settings.SCALE_MODE] - See {@link PIXI.SCALE_MODES} for possible values
      * @return {PIXI.Texture} The newly created texture
      */
     static fromCanvas(canvas, scaleMode)
@@ -334,7 +334,7 @@ export default class Texture extends EventEmitter
      *
      * @static
      * @param {HTMLVideoElement|string} video - The URL or actual element of the video
-     * @param {number} [scaleMode=PIXI.SCALE_MODES.DEFAULT] - See {@link PIXI.SCALE_MODES} for possible values
+     * @param {number} [scaleMode=PIXI.settings.SCALE_MODE] - See {@link PIXI.SCALE_MODES} for possible values
      * @return {PIXI.Texture} The newly created texture
      */
     static fromVideo(video, scaleMode)
@@ -352,7 +352,7 @@ export default class Texture extends EventEmitter
      *
      * @static
      * @param {string} videoUrl - URL of the video
-     * @param {number} [scaleMode=PIXI.SCALE_MODES.DEFAULT] - See {@link PIXI.SCALE_MODES} for possible values
+     * @param {number} [scaleMode=PIXI.settings.SCALE_MODE] - See {@link PIXI.SCALE_MODES} for possible values
      * @return {PIXI.Texture} The newly created texture
      */
     static fromVideoUrl(videoUrl, scaleMode)

--- a/src/core/textures/VideoBaseTexture.js
+++ b/src/core/textures/VideoBaseTexture.js
@@ -32,7 +32,7 @@ export default class VideoBaseTexture extends BaseTexture
 {
     /**
      * @param {HTMLVideoElement} source - Video source
-     * @param {number} [scaleMode=PIXI.SCALE_MODES.DEFAULT] - See {@link PIXI.SCALE_MODES} for possible values
+     * @param {number} [scaleMode=PIXI.settings.SCALE_MODE] - See {@link PIXI.SCALE_MODES} for possible values
      */
     constructor(source, scaleMode)
     {
@@ -204,7 +204,7 @@ export default class VideoBaseTexture extends BaseTexture
      *
      * @static
      * @param {HTMLVideoElement} video - Video to create texture from
-     * @param {number} [scaleMode=PIXI.SCALE_MODES.DEFAULT] - See {@link PIXI.SCALE_MODES} for possible values
+     * @param {number} [scaleMode=PIXI.settings.SCALE_MODE] - See {@link PIXI.SCALE_MODES} for possible values
      * @return {PIXI.VideoBaseTexture} Newly created VideoBaseTexture
      */
     static fromVideo(video, scaleMode)

--- a/src/core/ticker/Ticker.js
+++ b/src/core/ticker/Ticker.js
@@ -1,8 +1,10 @@
-import { TARGET_FPMS } from '../const';
+import settings from '../settings';
 import EventEmitter from 'eventemitter3';
 
 // Internal event used by composed emitter
 const TICK = 'tick';
+
+const { TARGET_FPMS } = settings;
 
 /**
  * A Ticker class that runs an update loop that other objects listen to.
@@ -351,7 +353,7 @@ export default class Ticker
      * This value is used to cap {@link PIXI.ticker.Ticker#deltaTime},
      * but does not effect the measured value of {@link PIXI.ticker.Ticker#FPS}.
      * When setting this property it is clamped to a value between
-     * `0` and `PIXI.TARGET_FPMS * 1000`.
+     * `0` and `PIXI.settings.TARGET_FPMS * 1000`.
      *
      * @memberof PIXI.ticker.Ticker#
      * @default 10

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -1,4 +1,5 @@
-import { RETINA_PREFIX, DATA_URI, URL_FILE_EXTENSION, SVG_SIZE, VERSION } from '../const';
+import { DATA_URI, URL_FILE_EXTENSION, SVG_SIZE, VERSION } from '../const';
+import settings from '../settings';
 import EventEmitter from 'eventemitter3';
 import pluginTarget from './pluginTarget';
 import * as isMobile from 'ismobilejs';
@@ -98,7 +99,7 @@ export function rgb2hex(rgb)
  */
 export function getResolutionOfUrl(url)
 {
-    const resolution = RETINA_PREFIX.exec(url);
+    const resolution = settings.RETINA_PREFIX.exec(url);
 
     if (resolution)
     {

--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -485,7 +485,77 @@ Object.defineProperties(core, {
             core.settings.SPRITE_MAX_TEXTURES = value;
         },
     },
+
+    /**
+     * @static
+     * @constant
+     * @name PIXI.RETINA_PREFIX
+     * @see PIXI.settings.RETINA_PREFIX
+     * @deprecated since version 4.2.0
+     */
+    RETINA_PREFIX: {
+        enumerable: true,
+        get()
+        {
+            warn('PIXI.RETINA_PREFIX has been deprecated, please use PIXI.settings.RETINA_PREFIX');
+
+            return core.settings.RETINA_PREFIX;
+        },
+        set(value)
+        {
+            warn('PIXI.RETINA_PREFIX has been deprecated, please use PIXI.settings.RETINA_PREFIX');
+
+            core.settings.RETINA_PREFIX = value;
+        },
+    },
+
+    /**
+     * @static
+     * @constant
+     * @name PIXI.DEFAULT_RENDER_OPTIONS
+     * @see PIXI.settings.RENDER_OPTIONS
+     * @deprecated since version 4.2.0
+     */
+    DEFAULT_RENDER_OPTIONS: {
+        enumerable: true,
+        get()
+        {
+            warn('PIXI.DEFAULT_RENDER_OPTIONS has been deprecated, please use PIXI.settings.DEFAULT_RENDER_OPTIONS');
+
+            return core.settings.RENDER_OPTIONS;
+        },
+    },
 });
+
+// Move the default properties to settings
+const defaults = [
+    { parent: 'TRANSFORM_MODE', target: 'TRANSFORM_MODE' },
+    { parent: 'GC_MODES', target: 'GC_MODE' },
+    { parent: 'WRAP_MODES', target: 'WRAP_MODE' },
+    { parent: 'SCALE_MODES', target: 'SCALE_MODE' },
+    { parent: 'PRECISION', target: 'PRECISION' },
+];
+
+for (let i = 0; i < defaults.length; i++)
+{
+    const deprecation = defaults[i];
+
+    Object.defineProperty(core[deprecation.parent], 'DEFAULT', {
+        enumerable: true,
+        get()
+        {
+            warn(`PIXI.${deprecation.parent}.DEFAULT has been deprecated, please use PIXI.settings.${deprecation.target}`);
+
+            return core.settings[deprecation.target];
+        },
+        set(value)
+        {
+            warn(`PIXI.${deprecation.parent}.DEFAULT has been deprecated, please use PIXI.settings.${deprecation.target}`);
+
+            core.settings[deprecation.target] = value;
+        },
+    });
+}
 
 Object.defineProperties(extras, {
 

--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -347,6 +347,144 @@ Object.defineProperties(core, {
             return core.TransformBase;
         },
     },
+
+    /**
+     * @static
+     * @constant
+     * @name PIXI.TARGET_FPMS
+     * @see PIXI.settings.TARGET_FPMS
+     * @deprecated since version 4.2.0
+     */
+    TARGET_FPMS: {
+        enumerable: true,
+        get()
+        {
+            warn('PIXI.TARGET_FPMS has been deprecated, please use PIXI.settings.TARGET_FPMS');
+
+            return core.settings.TARGET_FPMS;
+        },
+        set(value)
+        {
+            warn('PIXI.TARGET_FPMS has been deprecated, please use PIXI.settings.TARGET_FPMS');
+
+            core.settings.TARGET_FPMS = value;
+        },
+    },
+
+    /**
+     * @static
+     * @constant
+     * @name PIXI.FILTER_RESOLUTION
+     * @see PIXI.settings.FILTER_RESOLUTION
+     * @deprecated since version 4.2.0
+     */
+    FILTER_RESOLUTION: {
+        enumerable: true,
+        get()
+        {
+            warn('PIXI.FILTER_RESOLUTION has been deprecated, please use PIXI.settings.FILTER_RESOLUTION');
+
+            return core.settings.FILTER_RESOLUTION;
+        },
+        set(value)
+        {
+            warn('PIXI.FILTER_RESOLUTION has been deprecated, please use PIXI.settings.FILTER_RESOLUTION');
+
+            core.settings.FILTER_RESOLUTION = value;
+        },
+    },
+
+    /**
+     * @static
+     * @constant
+     * @name PIXI.RESOLUTION
+     * @see PIXI.settings.RESOLUTION
+     * @deprecated since version 4.2.0
+     */
+    RESOLUTION: {
+        enumerable: true,
+        get()
+        {
+            warn('PIXI.RESOLUTION has been deprecated, please use PIXI.settings.RESOLUTION');
+
+            return core.settings.RESOLUTION;
+        },
+        set(value)
+        {
+            warn('PIXI.RESOLUTION has been deprecated, please use PIXI.settings.RESOLUTION');
+
+            core.settings.RESOLUTION = value;
+        },
+    },
+
+    /**
+     * @static
+     * @constant
+     * @name PIXI.MIPMAP_TEXTURES
+     * @see PIXI.settings.MIPMAP_TEXTURES
+     * @deprecated since version 4.2.0
+     */
+    MIPMAP_TEXTURES: {
+        enumerable: true,
+        get()
+        {
+            warn('PIXI.MIPMAP_TEXTURES has been deprecated, please use PIXI.settings.MIPMAP_TEXTURES');
+
+            return core.settings.MIPMAP_TEXTURES;
+        },
+        set(value)
+        {
+            warn('PIXI.MIPMAP_TEXTURES has been deprecated, please use PIXI.settings.MIPMAP_TEXTURES');
+
+            core.settings.MIPMAP_TEXTURES = value;
+        },
+    },
+
+    /**
+     * @static
+     * @constant
+     * @name PIXI.SPRITE_BATCH_SIZE
+     * @see PIXI.settings.SPRITE_BATCH_SIZE
+     * @deprecated since version 4.2.0
+     */
+    SPRITE_BATCH_SIZE: {
+        enumerable: true,
+        get()
+        {
+            warn('PIXI.SPRITE_BATCH_SIZE has been deprecated, please use PIXI.settings.SPRITE_BATCH_SIZE');
+
+            return core.settings.SPRITE_BATCH_SIZE;
+        },
+        set(value)
+        {
+            warn('PIXI.SPRITE_BATCH_SIZE has been deprecated, please use PIXI.settings.SPRITE_BATCH_SIZE');
+
+            core.settings.SPRITE_BATCH_SIZE = value;
+        },
+    },
+
+    /**
+     * @static
+     * @constant
+     * @name PIXI.SPRITE_MAX_TEXTURES
+     * @see PIXI.settings.SPRITE_MAX_TEXTURES
+     * @deprecated since version 4.2.0
+     */
+    SPRITE_MAX_TEXTURES: {
+        enumerable: true,
+        get()
+        {
+            warn('PIXI.SPRITE_MAX_TEXTURES has been deprecated, please use PIXI.settings.SPRITE_MAX_TEXTURES');
+
+            return core.settings.SPRITE_MAX_TEXTURES;
+        },
+        set(value)
+        {
+            warn('PIXI.SPRITE_MAX_TEXTURES has been deprecated, please use PIXI.settings.SPRITE_MAX_TEXTURES');
+
+            core.settings.SPRITE_MAX_TEXTURES = value;
+        },
+    },
 });
 
 Object.defineProperties(extras, {

--- a/src/extras/TilingSprite.js
+++ b/src/extras/TilingSprite.js
@@ -369,7 +369,7 @@ export default class TilingSprite extends core.Sprite
      * @param {number} width - the width of the tiling sprite
      * @param {number} height - the height of the tiling sprite
      * @param {boolean} [crossorigin] - if you want to specify the cross-origin parameter
-     * @param {number} [scaleMode=PIXI.SCALE_MODES.DEFAULT] - if you want to specify the scale mode,
+     * @param {number} [scaleMode=PIXI.settings.SCALE_MODE] - if you want to specify the scale mode,
      *  see {@link PIXI.SCALE_MODES} for possible values
      * @return {PIXI.extras.TilingSprite} A new TilingSprite using a texture from the texture cache matching the image id
      */

--- a/test/core/DisplayObject.js
+++ b/test/core/DisplayObject.js
@@ -16,13 +16,13 @@ describe('PIXI.DisplayObject', () =>
 
         it('should set the correct Transform', () =>
         {
-            PIXI.TRANSFORM_MODE.DEFAULT = PIXI.TRANSFORM_MODE.DYNAMIC;
+            PIXI.settings.TRANSFORM_MODE = PIXI.TRANSFORM_MODE.DYNAMIC;
 
             const dynamicTransform = new PIXI.DisplayObject();
 
             expect(dynamicTransform.transform).to.be.instanceof(PIXI.Transform);
 
-            PIXI.TRANSFORM_MODE.DEFAULT = PIXI.TRANSFORM_MODE.STATIC;
+            PIXI.settings.TRANSFORM_MODE = PIXI.TRANSFORM_MODE.STATIC;
 
             const staticTransform = new PIXI.DisplayObject();
 

--- a/test/core/TilingSprite.js
+++ b/test/core/TilingSprite.js
@@ -8,7 +8,7 @@ describe('PIXI.TilingSprite', function ()
         {
             const parent = new PIXI.Container();
             const texture = new PIXI.Texture(new PIXI.BaseTexture());
-            const tilingSprite = new PIXI.TilingSprite(texture, 200, 300);
+            const tilingSprite = new PIXI.extras.TilingSprite(texture, 200, 300);
 
             parent.addChild(tilingSprite);
 


### PR DESCRIPTION
There are a handful of settings in **src/core/const.js** that are actually intended to be writable. Because these are exported, they cannot be changed. This PR deprecates the high-level properties and moves them to a `PIXI.settings` namespace object, which can be edited. _This restores functionality that was lost when converting to ES6._

### Deprecations
* `PIXI.RESOLUTION` => `PIXI.settings.RESOLUTION`
* `PIXI.FILTER_RESOLUTION` => `PIXI.settings.FILTER_RESOLUTION`
* `PIXI.TARGET_FPMS` => `PIXI.settings.TARGET_FPMS`
* `PIXI.MIPMAP_TEXTURES ` => `PIXI.settings.MIPMAP_TEXTURES `
* `PIXI.SPRITE_BATCH_SIZE ` => `PIXI.settings.SPRITE_BATCH_SIZE `
* `PIXI.SPRITE_MAX_TEXTURES` => `PIXI.settings.SPRITE_MAX_TEXTURES`

Preview the [docs here](http://pixijs.download/dev-settings/docs/PIXI.settings.html).

Fix for #3170

### Updated - Additional Deprecations
* `PIXI.DEFAULT_RENDER_OPTIONS` => `PIXI.settings.RENDER_OPTIONS`
* `PIXI.GC_MODES.DEFAULT` => `PIXI.settings.GC_MODE`
* `PIXI.TRANSFORM_MODE.DEFAULT` => `PIXI.settings.TRANSFORM_MODE`
* `PIXI.SCALE_MODES.DEFAULT` => `PIXI.settings.SCALE_MODE`
* `PIXI.RETINA_PREFIX` => `PIXI.settings.RETINA_PREFIX`
* `PIXI.WRAP_MODES.DEFAULT` => `PIXI.settings.WRAP_MODE`
* `PIXI.PRECISION.DEFAULT` => `PIXI.settings.PRECISION`

