### PR TITLE
Fixes jsdoc issues with exports and module.exports

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -49,6 +49,7 @@ export { default as Filter } from './renderers/webgl/filters/Filter';
  * the browser then this function will return a canvas renderer
  *
  * @memberof PIXI
+ * @function autoDetectRenderer
  * @param {number} [width=800] - the width of the renderers view
  * @param {number} [height=600] - the height of the renderers view
  * @param {object} [options] - The optional renderer parameters

--- a/src/core/renderers/canvas/utils/mapCanvasBlendModesToPixi.js
+++ b/src/core/renderers/canvas/utils/mapCanvasBlendModesToPixi.js
@@ -5,6 +5,8 @@ import canUseNewCanvasBlendModes from './canUseNewCanvasBlendModes';
  * Maps blend combinations to Canvas.
  *
  * @memberof PIXI
+ * @function mapCanvasBlendModesToPixi
+ * @private
  * @param {string[]} [array=[]] - The array to output into.
  * @return {string[]} Mapped modes.
  */

--- a/src/core/renderers/webgl/utils/mapWebGLBlendModesToPixi.js
+++ b/src/core/renderers/webgl/utils/mapWebGLBlendModesToPixi.js
@@ -4,6 +4,8 @@ import { BLEND_MODES } from '../../../const';
  * Maps gl blend combinations to WebGL.
  *
  * @memberof PIXI
+ * @function mapWebGLBlendModesToPixi
+ * @private
  * @param {WebGLRenderingContext} gl - The rendering context.
  * @param {string[]} [array=[]] - The array to output into.
  * @return {string[]} Mapped modes.

--- a/src/core/renderers/webgl/utils/mapWebGLDrawModesToPixi.js
+++ b/src/core/renderers/webgl/utils/mapWebGLDrawModesToPixi.js
@@ -3,8 +3,9 @@ import { DRAW_MODES } from '../../../const';
 /**
  * Generic Mask Stack data structure.
  *
- * @class
  * @memberof PIXI
+ * @function mapWebGLDrawModesToPixi
+ * @private
  * @param {WebGLRenderingContext} gl - The current WebGL drawing context
  * @param {object} [object={}] - The object to map into
  * @return {object} The mapped draw modes.

--- a/src/core/utils/createIndicesForQuads.js
+++ b/src/core/utils/createIndicesForQuads.js
@@ -1,8 +1,9 @@
 /**
  * Generic Mask Stack data structure
  *
- * @class
  * @memberof PIXI
+ * @function createIndicesForQuads
+ * @private
  * @param {number} size - Number of quads
  * @return {Uint16Array} indices
  */

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -14,6 +14,7 @@ export {
      * @see {@link https://github.com/kaimallea/isMobile}
      *
      * @memberof PIXI.utils
+     * @function isMobile
      * @type {Object}
      */
     isMobile,
@@ -21,11 +22,13 @@ export {
      * @see {@link https://github.com/primus/eventemitter3}
      *
      * @memberof PIXI.utils
+     * @class EventEmitter
      * @type {EventEmitter}
      */
     EventEmitter,
     /**
      * @memberof PIXI.utils
+     * @function pluginTarget
      * @type {mixin}
      */
     pluginTarget,
@@ -35,6 +38,7 @@ export {
  * Gets the next unique identifier
  *
  * @memberof PIXI.utils
+ * @function uid
  * @return {number} The next unique identifier to use.
  */
 export function uid()
@@ -46,6 +50,7 @@ export function uid()
  * Converts a hex color number to an [R, G, B] array
  *
  * @memberof PIXI.utils
+ * @function hex2rgb
  * @param {number} hex - The number to convert
  * @param  {number[]} [out=[]] If supplied, this array will be used rather than returning a new one
  * @return {number[]} An array representing the [R, G, B] of the color.
@@ -65,6 +70,7 @@ export function hex2rgb(hex, out)
  * Converts a hex color number to a string.
  *
  * @memberof PIXI.utils
+ * @function hex2string
  * @param {number} hex - Number in hex
  * @return {string} The string color.
  */
@@ -80,6 +86,7 @@ export function hex2string(hex)
  * Converts a color as an [R, G, B] array to a hex number
  *
  * @memberof PIXI.utils
+ * @function rgb2hex
  * @param {number[]} rgb - rgb array
  * @return {number} The color number
  */
@@ -93,6 +100,7 @@ export function rgb2hex(rgb)
  * used by spritesheets and image urls
  *
  * @memberof PIXI.utils
+ * @function getResolutionOfUrl
  * @param {string} url - the image path
  * @return {number} resolution / device pixel ratio of an asset
  */
@@ -123,6 +131,7 @@ export function getResolutionOfUrl(url)
  * parameter `dataUri` is not a valid data URI.
  *
  * @memberof PIXI.utils
+ * @function decomposeDataUri
  * @param {string} dataUri - the data URI to check
  * @return {DecomposedDataUri|undefined} The decomposed data uri or undefined
  */
@@ -147,6 +156,7 @@ export function decomposeDataUri(dataUri)
  * Get type of the image by regexp for extension. Returns undefined for unknown extensions.
  *
  * @memberof PIXI.utils
+ * @function getUrlFileExtension
  * @param {string} url - the image path
  * @return {string|undefined} image extension
  */
@@ -174,6 +184,7 @@ export function getUrlFileExtension(url)
  * Get size from an svg string using regexp.
  *
  * @memberof PIXI.utils
+ * @function getSvgSize
  * @param {string} svgString - a serialized svg element
  * @return {Size|undefined} image extension
  */
@@ -194,6 +205,7 @@ export function getSvgSize(svgString)
 /**
  * Skips the hello message of renderers that are created after this is run.
  *
+ * @function skipHello
  * @memberof PIXI.utils
  */
 export function skipHello()
@@ -207,6 +219,7 @@ export function skipHello()
  * creating your renderer. Keep in mind that doing that will forever makes you a jerk face.
  *
  * @static
+ * @function sayHello
  * @memberof PIXI.utils
  * @param {string} type - The string renderer type to log.
  */
@@ -246,6 +259,7 @@ export function sayHello(type)
  * Helper for checking for webgl support
  *
  * @memberof PIXI.utils
+ * @function isWebGLSupported
  * @return {boolean} is webgl supported
  */
 export function isWebGLSupported()
@@ -288,6 +302,7 @@ export function isWebGLSupported()
  * Returns sign of number
  *
  * @memberof PIXI.utils
+ * @function sign
  * @param {number} n - the number to check the sign of
  * @returns {number} 0 if `n` is 0, -1 if `n` is negative, 1 if `n` is positive
  */
@@ -302,6 +317,7 @@ export function sign(n)
  * Remove a range of items from an array
  *
  * @memberof PIXI.utils
+ * @function removeItems
  * @param {Array<*>} arr The target array
  * @param {number} startIdx The index to begin removing from (inclusive)
  * @param {number} removeCount How many items to remove


### PR DESCRIPTION
Currently the doc contain a few references to exports and module.export. See [here](http://pixijs.download/dev/docs/PIXI.utils.html). Makes these explicit for JSdoc, which seems to be having trouble with the exports.

See updated docs [here](http://pixijs.download/fix-jsdocs/docs/PIXI.utils.html)