### PR TITLE
Fixes the readme for bundle building excludes

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,22 +187,22 @@ $> npm install
 Then, to build the source, run:
 
 ```
-$> npm run build
+$> npm run dist
 ```
 
-This will create a minified version at `bin/pixi.min.js` and a non-minified version at `bin/pixi.js`
+This will create a minified version at `dist/pixi.min.js` and a non-minified version at `dist/pixi.js`
 with all the plugins in the pixi.js project.
 
 If there are specific plugins you don't want, say "interaction" or "extras", you can exclude those:
 
 ```
-$> npm run build -- --exclude extras --exclude interaction
+$> npm run dist -- --exclude extras --exclude interaction
 ```
 
 You can also use the short-form `-e`:
 
 ```
-$> npm run build -- -e extras -e interaction -e filters
+$> npm run dist -- -e extras -e interaction -e filters
 ```
 
 ### How to generate the documentation ###


### PR DESCRIPTION
Updates the build instructions to match the latest build process in v4.2.x

Fixes #3322 (thanks @Friksel for pointing this out)