### PR TITLE
Reworked cursor handling to expand cursor options.

### DIFF
--- a/src/accessibility/AccessibilityManager.js
+++ b/src/accessibility/AccessibilityManager.js
@@ -3,7 +3,7 @@ import Device from 'ismobilejs';
 import accessibleTarget from './accessibleTarget';
 
 // add some extra variables to the container..
-Object.assign(
+core.utils.mixins.delayMixin(
     core.DisplayObject.prototype,
     accessibleTarget
 );

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -2,6 +2,7 @@ import { DATA_URI, URL_FILE_EXTENSION, SVG_SIZE, VERSION } from '../const';
 import settings from '../settings';
 import EventEmitter from 'eventemitter3';
 import pluginTarget from './pluginTarget';
+import * as mixins from './mixin';
 import * as isMobile from 'ismobilejs';
 
 let nextUid = 0;
@@ -33,6 +34,7 @@ export {
      * @type {mixin}
      */
     pluginTarget,
+    mixins,
 };
 
 /**

--- a/src/core/utils/mixin.js
+++ b/src/core/utils/mixin.js
@@ -1,0 +1,59 @@
+/**
+ * Mixes all enumerable properties and methods from a source object to a target object.
+ *
+ * @memberof PIXI.utils.mixins
+ * @function mixin
+ * @param {object} target The prototype or instance that properties and methods should be added to.
+ * @param {object} source The source of properties and methods to mix in.
+ */
+export function mixin(target, source)
+{
+    if (!target || !source) return;
+    // in ES8/ES2017, this would be really easy:
+    // Object.defineProperties(target, Object.getOwnPropertyDescriptors(source));
+
+    // get all the enumerable property keys
+    const keys = Object.keys(source);
+
+    // loop through properties
+    for (let i = 0; i < keys.length; ++i)
+    {
+        const propertyName = keys[i];
+
+        // Set the property using the property descriptor - this works for accessors and normal value properties
+        Object.defineProperty(target, propertyName, Object.getOwnPropertyDescriptor(source, propertyName));
+    }
+}
+
+const mixins = [];
+
+/**
+ * Queues a mixin to be handled towards the end of the initialization of PIXI, so that deprecation
+ * can take effect.
+ *
+ * @memberof PIXI.utils.mixins
+ * @function delayMixin
+ * @private
+ * @param {object} target The prototype or instance that properties and methods should be added to.
+ * @param {object} source The source of properties and methods to mix in.
+ */
+export function delayMixin(target, source)
+{
+    mixins.push(target, source);
+}
+
+/**
+ * Handles all mixins queued via delayMixin().
+ *
+ * @memberof PIXI.utils.mixins
+ * @function performMixins
+ * @private
+ */
+export function performMixins()
+{
+    for (let i = 0; i < mixins.length; i += 2)
+    {
+        mixin(mixins[i], mixins[i + 1]);
+    }
+    mixins.length = 0;
+}

--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -5,6 +5,7 @@ import * as extras from './extras';
 import * as filters from './filters';
 import * as prepare from './prepare';
 import * as loaders from './loaders';
+import * as interaction from './interaction';
 
 // provide method to give a stack track for warnings
 // useful for tracking-down where deprecated methods/properties/classes
@@ -1001,5 +1002,71 @@ Object.defineProperties(loaders.Loader.prototype, {
 
             return this.use;
         },
+    },
+});
+
+/**
+ * @name PIXI.interaction.interactiveTarget#defaultCursor
+ * @static
+ * @type {number}
+ * @see PIXI.interaction.interactiveTarget#cursor
+ * @deprecated since 4.3.0
+ */
+Object.defineProperty(interaction.interactiveTarget, 'defaultCursor', {
+    set(value)
+    {
+        warn('Property defaultCursor has been replaced with \'cursor\'. ');
+        this.cursor = value;
+    },
+    get()
+    {
+        warn('Property defaultCursor has been replaced with \'cursor\'. ');
+
+        return this.cursor;
+    },
+    enumerable: true,
+});
+
+/**
+ * @name PIXI.interaction.InteractionManager#defaultCursorStyle
+ * @static
+ * @type {string}
+ * @see PIXI.interaction.InteractionManager#cursorStyles
+ * @deprecated since 4.3.0
+ */
+Object.defineProperty(interaction.InteractionManager, 'defaultCursorStyle', {
+    set(value)
+    {
+        warn('Property defaultCursorStyle has been replaced with \'cursorStyles.default\'. ');
+        this.cursorStyles.default = value;
+    },
+    get()
+    {
+        warn('Property defaultCursorStyle has been replaced with \'cursorStyles.default\'. ');
+
+        return this.cursorStyles.default;
+    },
+});
+
+/**
+ * @name PIXI.interaction.InteractionManager#currentCursorStyle
+ * @static
+ * @type {string}
+ * @see PIXI.interaction.InteractionManager#cursorStyles
+ * @deprecated since 4.3.0
+ */
+Object.defineProperty(interaction.InteractionManager, 'currentCursorStyle', {
+    set(value)
+    {
+        warn('Property currentCursorStyle has been removed.'
+        + 'See the currentCursorMode property, which works differently.');
+        this.currentCursorMode = value;
+    },
+    get()
+    {
+        warn('Property currentCursorStyle has been removed.'
+        + 'See the currentCursorMode property, which works differently.');
+
+        return this.currentCursorMode;
     },
 });

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,10 @@ import * as mesh from './mesh';
 import * as particles from './particles';
 import * as prepare from './prepare';
 
+// handle mixins now, after all code has been added, including deprecation
+import { utils } from './core';
+utils.mixins.performMixins();
+
 export {
     accessibility,
     extract,

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -4,7 +4,6 @@ import InteractionEvent from './InteractionEvent';
 import InteractionTrackingData from './InteractionTrackingData';
 import EventEmitter from 'eventemitter3';
 import interactiveTarget from './interactiveTarget';
-import MobileDevice from 'ismobilejs';
 
 // Mix interactiveTarget into core.DisplayObject.prototype, after deprecation has been handled
 core.utils.mixins.delayMixin(
@@ -155,26 +154,6 @@ export default class InteractionManager extends EventEmitter
          * @member {boolean}
          */
         this.supportsPointerEvents = !!window.PointerEvent;
-
-        /**
-         * Are touch events being 'normalized' and converted into pointer events if pointer events are not supported
-         * For example, on a touch screen mobile device, a touchstart would also be emitted as a pointerdown
-         *
-         * @private
-         * @readonly
-         * @member {boolean}
-         */
-        this.normalizeTouchEvents = !this.supportsPointerEvents && this.supportsTouchEvents;
-
-        /**
-         * Are mouse events being 'normalized' and converted into pointer events if pointer events are not supported
-         * For example, on a desktop pc, a mousedown would also be emitted as a pointerdown
-         *
-         * @private
-         * @readonly
-         * @member {boolean}
-         */
-        this.normalizeMouseEvents = !this.supportsPointerEvents && !MobileDevice.any;
 
         // this will make it so that you don't have to call bind all the time
 

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -876,7 +876,7 @@ export default class InteractionManager extends EventEmitter
 
         // Guaranteed that there will be at least one event in events, and all events must have the same pointer type
 
-        if (this.autoPreventDefault && (events[0].pointerType === 'touch' || events[0].pointerType === 'mouse'))
+        if (this.autoPreventDefault && events[0].isNormalized)
         {
             originalEvent.preventDefault();
         }
@@ -1449,10 +1449,14 @@ export default class InteractionManager extends EventEmitter
                 if (typeof touch.layerX === 'undefined') touch.layerX = touch.offsetX = touch.clientX;
                 if (typeof touch.layerY === 'undefined') touch.layerY = touch.offsetY = touch.clientY;
 
+                // mark the touch as normalized, just so that we know we did it
+                touch.isNormalized = true;
+
                 normalizedEvents.push(touch);
             }
         }
-        else if (event instanceof MouseEvent)
+        // apparently PointerEvent subclasses MouseEvent, so yay
+        else if (event instanceof MouseEvent && (!this.supportsPointerEvents || !(event instanceof window.PointerEvent)))
         {
             if (typeof event.isPrimary === 'undefined') event.isPrimary = true;
             if (typeof event.width === 'undefined') event.width = 1;
@@ -1463,6 +1467,9 @@ export default class InteractionManager extends EventEmitter
             if (typeof event.pointerId === 'undefined') event.pointerId = MOUSE_POINTER_ID;
             if (typeof event.pressure === 'undefined') event.pressure = 0.5;
             if (typeof event.rotation === 'undefined') event.rotation = 0;
+
+            // mark the mouse event as normalized, just so that we know we did it
+            event.isNormalized = true;
 
             normalizedEvents.push(event);
         }

--- a/src/interaction/InteractionTrackingData.js
+++ b/src/interaction/InteractionTrackingData.js
@@ -65,6 +65,17 @@ export default class InteractionTrackingData
     }
 
     /**
+     * Is the tracked event inactive (not over or down)?
+     *
+     * @member {number}
+     * @memberof PIXI.interaction.InteractionTrackingData#
+     */
+    get none()
+    {
+        return this._flags === this.constructor.FLAGS.NONE;
+    }
+
+    /**
      * Is the tracked event over the DisplayObject?
      *
      * @member {boolean}

--- a/src/interaction/InteractionTrackingData.js
+++ b/src/interaction/InteractionTrackingData.js
@@ -83,7 +83,7 @@ export default class InteractionTrackingData
      */
     get over()
     {
-        return (this._flags | this.constructor.FLAGS.OVER) !== 0;
+        return (this._flags & this.constructor.FLAGS.OVER) !== 0;
     }
 
     /**
@@ -104,7 +104,7 @@ export default class InteractionTrackingData
      */
     get rightDown()
     {
-        return (this._flags | this.constructor.FLAGS.RIGHT_DOWN) !== 0;
+        return (this._flags & this.constructor.FLAGS.RIGHT_DOWN) !== 0;
     }
 
     /**
@@ -125,7 +125,7 @@ export default class InteractionTrackingData
      */
     get leftDown()
     {
-        return (this._flags | this.constructor.FLAGS.LEFT_DOWN) !== 0;
+        return (this._flags & this.constructor.FLAGS.LEFT_DOWN) !== 0;
     }
 
     /**

--- a/src/interaction/interactiveTarget.js
+++ b/src/interaction/interactiveTarget.js
@@ -38,21 +38,37 @@ export default {
     hitArea: null,
 
     /**
-     * If enabled, the mouse cursor will change when hovered over the displayObject if it is interactive
+     * If enabled, the mouse cursor use the pointer behavior when hovered over the displayObject if it is interactive
+     * Setting this changes the 'cursor' property to `'pointer'`.
      *
-     * @inner {boolean}
+     * @member {boolean}
+     * @memberof PIXI.interaction.interactiveTarget#
      */
-    buttonMode: false,
+    get buttonMode()
+    {
+        return this.cursor === 'pointer';
+    },
+    set buttonMode(value)
+    {
+        if (value)
+        {
+            this.cursor = 'pointer';
+        }
+        else if (this.cursor === 'pointer')
+        {
+            this.cursor = null;
+        }
+    },
 
     /**
-     * If buttonMode is enabled, this defines what CSS cursor property is used when the mouse cursor
-     * is hovered over the displayObject
+     * This defines what cursor mode is used when the mouse cursor
+     * is hovered over the displayObject.
      *
      * @see https://developer.mozilla.org/en/docs/Web/CSS/cursor
      *
      * @inner {string}
      */
-    defaultCursor: 'pointer',
+    cursor: null,
 
     /**
      * Internal set of all active pointers, by identifier
@@ -60,7 +76,7 @@ export default {
      * @returns {Map<number, InteractionTrackingData>} Map of all tracked pointers, by identifier
      * @private
      */
-    getTrackedPointers: function getTrackedPointers()
+    get trackedPointers()
     {
         if (this._trackedPointers === undefined) this._trackedPointers = {};
 

--- a/src/interaction/interactiveTarget.js
+++ b/src/interaction/interactiveTarget.js
@@ -73,7 +73,8 @@ export default {
     /**
      * Internal set of all active pointers, by identifier
      *
-     * @returns {Map<number, InteractionTrackingData>} Map of all tracked pointers, by identifier
+     * @member {Map<number, InteractionTrackingData>}
+     * @memberof PIXI.interaction.interactiveTarget#
      * @private
      */
     get trackedPointers()
@@ -82,4 +83,11 @@ export default {
 
         return this._trackedPointers;
     },
+
+    /**
+     * Map of all tracked pointers, by identifier. Use trackedPointers to access.
+     *
+     * @private {Map<number, InteractionTrackingData>}
+     */
+    _trackedPointers: undefined,
 };

--- a/test/interaction/InteractionManager.js
+++ b/test/interaction/InteractionManager.js
@@ -4,6 +4,101 @@ const MockPointer = require('./MockPointer');
 
 describe('PIXI.interaction.InteractionManager', function ()
 {
+    describe('event basics', function ()
+    {
+        it('should call mousedown handler', function ()
+        {
+            const stage = new PIXI.Container();
+            const graphics = new PIXI.Graphics();
+            const eventSpy = sinon.spy();
+            const pointer = new MockPointer(stage);
+
+            stage.addChild(graphics);
+            graphics.beginFill(0xFFFFFF);
+            graphics.drawRect(0, 0, 50, 50);
+            graphics.interactive = true;
+            graphics.on('mousedown', eventSpy);
+
+            pointer.mousedown(10, 10);
+
+            expect(eventSpy).to.have.been.calledOnce;
+        });
+
+        it('should call mouseup handler', function ()
+        {
+            const stage = new PIXI.Container();
+            const graphics = new PIXI.Graphics();
+            const eventSpy = sinon.spy();
+            const pointer = new MockPointer(stage);
+
+            stage.addChild(graphics);
+            graphics.beginFill(0xFFFFFF);
+            graphics.drawRect(0, 0, 50, 50);
+            graphics.interactive = true;
+            graphics.on('mouseup', eventSpy);
+
+            pointer.click(10, 10);
+
+            expect(eventSpy).to.have.been.called;
+        });
+
+        it('should call mouseupoutside handler', function ()
+        {
+            const stage = new PIXI.Container();
+            const graphics = new PIXI.Graphics();
+            const eventSpy = sinon.spy();
+            const pointer = new MockPointer(stage);
+
+            stage.addChild(graphics);
+            graphics.beginFill(0xFFFFFF);
+            graphics.drawRect(0, 0, 50, 50);
+            graphics.interactive = true;
+            graphics.on('mouseupoutside', eventSpy);
+
+            pointer.mousedown(10, 10);
+            pointer.mouseup(60, 60);
+
+            expect(eventSpy).to.have.been.called;
+        });
+
+        it('should call mouseover handler', function ()
+        {
+            const stage = new PIXI.Container();
+            const graphics = new PIXI.Graphics();
+            const eventSpy = sinon.spy();
+            const pointer = new MockPointer(stage);
+
+            stage.addChild(graphics);
+            graphics.beginFill(0xFFFFFF);
+            graphics.drawRect(0, 0, 50, 50);
+            graphics.interactive = true;
+            graphics.on('mouseover', eventSpy);
+
+            pointer.mousemove(10, 10);
+
+            expect(eventSpy).to.have.been.called;
+        });
+
+        it('should call mouseout handler', function ()
+        {
+            const stage = new PIXI.Container();
+            const graphics = new PIXI.Graphics();
+            const eventSpy = sinon.spy();
+            const pointer = new MockPointer(stage);
+
+            stage.addChild(graphics);
+            graphics.beginFill(0xFFFFFF);
+            graphics.drawRect(0, 0, 50, 50);
+            graphics.interactive = true;
+            graphics.on('mouseout', eventSpy);
+
+            pointer.mousemove(10, 10);
+            pointer.mousemove(60, 60);
+
+            expect(eventSpy).to.have.been.called;
+        });
+    });
+
     describe('onClick', function ()
     {
         it('should call handler when inside', function ()
@@ -459,6 +554,150 @@ describe('PIXI.interaction.InteractionManager', function ()
                     expect(scene.parentCallback).to.have.been.calledOnce;
                 });
             });
+        });
+    });
+
+    describe('cursor changes', function ()
+    {
+        it('cursor should be the cursor of interactive item', function ()
+        {
+            const stage = new PIXI.Container();
+            const graphics = new PIXI.Graphics();
+            const pointer = new MockPointer(stage);
+
+            stage.addChild(graphics);
+            graphics.beginFill(0xFFFFFF);
+            graphics.drawRect(0, 0, 50, 50);
+            graphics.interactive = true;
+            graphics.cursor = 'help';
+            pointer.interaction.cursorStyles.help = 'help';
+
+            pointer.mousemove(10, 10);
+
+            expect(pointer.renderer.view.style.cursor).to.equal('help');
+        });
+
+        it('should return cursor to default on mouseout', function ()
+        {
+            const stage = new PIXI.Container();
+            const graphics = new PIXI.Graphics();
+            const pointer = new MockPointer(stage);
+
+            stage.addChild(graphics);
+            graphics.beginFill(0xFFFFFF);
+            graphics.drawRect(0, 0, 50, 50);
+            graphics.interactive = true;
+            graphics.cursor = 'help';
+            pointer.interaction.cursorStyles.help = 'help';
+
+            pointer.mousemove(10, 10);
+            pointer.mousemove(60, 60);
+
+            expect(pointer.renderer.view.style.cursor).to.equal(pointer.interaction.cursorStyles.default);
+        });
+
+        it('should still be the over cursor after a click', function ()
+        {
+            const stage = new PIXI.Container();
+            const graphics = new PIXI.Graphics();
+            const pointer = new MockPointer(stage);
+
+            stage.addChild(graphics);
+            graphics.beginFill(0xFFFFFF);
+            graphics.drawRect(0, 0, 50, 50);
+            graphics.interactive = true;
+            graphics.cursor = 'help';
+            pointer.interaction.cursorStyles.help = 'help';
+
+            pointer.mousemove(10, 10);
+            pointer.click(10, 10);
+
+            expect(pointer.renderer.view.style.cursor).to.equal('help');
+        });
+
+        it('should return cursor to default when mouse leaves renderer', function ()
+        {
+            const stage = new PIXI.Container();
+            const graphics = new PIXI.Graphics();
+            const pointer = new MockPointer(stage);
+
+            stage.addChild(graphics);
+            graphics.beginFill(0xFFFFFF);
+            graphics.drawRect(0, 0, 50, 50);
+            graphics.interactive = true;
+            graphics.cursor = 'help';
+            pointer.interaction.cursorStyles.help = 'help';
+
+            pointer.mousemove(10, 10);
+            pointer.mousemove(-10, 60);
+
+            expect(pointer.renderer.view.style.cursor).to.equal(pointer.interaction.cursorStyles.default);
+        });
+
+        it('cursor callback should be called', function ()
+        {
+            const stage = new PIXI.Container();
+            const graphics = new PIXI.Graphics();
+            const overSpy = sinon.spy();
+            const defaultSpy = sinon.spy();
+            const pointer = new MockPointer(stage);
+
+            stage.addChild(graphics);
+            graphics.beginFill(0xFFFFFF);
+            graphics.drawRect(0, 0, 50, 50);
+            graphics.interactive = true;
+            graphics.cursor = 'help';
+            pointer.interaction.cursorStyles.help = overSpy;
+            pointer.interaction.cursorStyles.default = defaultSpy;
+
+            pointer.mousemove(10, 10);
+            pointer.mousemove(60, 60);
+
+            expect(overSpy).to.have.been.called;
+            expect(defaultSpy).to.have.been.called;
+        });
+
+        it('cursor style object should be fully applied', function ()
+        {
+            const stage = new PIXI.Container();
+            const graphics = new PIXI.Graphics();
+            const pointer = new MockPointer(stage);
+
+            stage.addChild(graphics);
+            graphics.beginFill(0xFFFFFF);
+            graphics.drawRect(0, 0, 50, 50);
+            graphics.interactive = true;
+            graphics.cursor = 'help';
+            pointer.interaction.cursorStyles.help = {
+                cursor: 'none',
+                display: 'none',
+            };
+
+            pointer.mousemove(10, 10);
+
+            expect(pointer.renderer.view.style.cursor).to.equal('none');
+            expect(pointer.renderer.view.style.display).to.equal('none');
+        });
+
+        it('should not change cursor style if no cursor style provided', function ()
+        {
+            const stage = new PIXI.Container();
+            const graphics = new PIXI.Graphics();
+            const pointer = new MockPointer(stage);
+
+            stage.addChild(graphics);
+            graphics.beginFill(0xFFFFFF);
+            graphics.drawRect(0, 0, 50, 50);
+            graphics.interactive = true;
+            graphics.cursor = 'pointer';
+            pointer.interaction.cursorStyles.pointer = null;
+            pointer.interaction.cursorStyles.default = null;
+
+            pointer.mousemove(10, 10);
+            expect(pointer.renderer.view.style.cursor).to.equal('');
+
+            pointer.mousemove(60, 60);
+            expect(pointer.renderer.view.style.cursor).to.equal('');
         });
     });
 });

--- a/test/interaction/MockPointer.js
+++ b/test/interaction/MockPointer.js
@@ -46,6 +46,45 @@ class MockPointer
      * @param {number} x - pointer x position
      * @param {number} y - pointer y position
      */
+    mousemove(x, y)
+    {
+        const mouseEvent = new MouseEvent('mousemove', {
+            clientX: x,
+            clientY: y,
+            preventDefault: sinon.stub(),
+        });
+
+        this.setPosition(x, y);
+        this.render();
+        // mouseOverRenderer state should be correct, so mouse position to view rect
+        const rect = new PIXI.Rectangle(0, 0, this.renderer.width, this.renderer.height);
+
+        if (rect.contains(x, y))
+        {
+            if (!this.interaction.mouseOverRenderer)
+            {
+                this.interaction.onPointerOver(new MouseEvent('mouseover', {
+                    clientX: x,
+                    clientY: y,
+                    preventDefault: sinon.stub(),
+                }));
+            }
+            this.interaction.onPointerMove(mouseEvent);
+        }
+        else
+        {
+            this.interaction.onPointerOut(new MouseEvent('mouseout', {
+                clientX: x,
+                clientY: y,
+                preventDefault: sinon.stub(),
+            }));
+        }
+    }
+
+    /**
+     * @param {number} x - pointer x position
+     * @param {number} y - pointer y position
+     */
     click(x, y)
     {
         this.mousedown(x, y);


### PR DESCRIPTION
Changed how cursors are handled:
* `InteractionManager` has a `cursorStyles` dictionary, which is a number of CSS cursor styles, callbacks upon cursor change, or dictionaries of CSS properties.
* `InteractionManager` tracks the cursor mode, and then handles it according to its `cursorStyles` dictionary.
* `interactiveTarget.cursor` is the cursor mode to be used when moused over. It is not limited to just 'default' and 'pointer'.
* `interactiveTarget.buttonMode` now just sets cursor to 'pointer'.

Also, added some mixin utilities so that the Accessibility and Interaction mixins can use accessors and can be affected by deprecations.

This does not directly fix #3301, but allows users to specify callbacks for cursor changes _instead_ of changing CSS, so that their callbacks can change CSS classes.

Additionally, fixed bugs in the InteractionManager where I found them, related to mouseover/out handling, and #3662.