### PR TITLE
Bower main fix, "bin" renamed "dist"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "pixi.js",
-    "main": "bin/pixi.min.js",
+    "main": "dist/pixi.min.js",
     "ignore": [
         "**/.*",
         "docs",


### PR DESCRIPTION
Resolves #3327, changes the name from "bin" to "dist" in **bower.json**.