### PR TITLE
Expose the PIXI.Bounds class again

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -14,6 +14,7 @@ export { settings, utils, ticker, CanvasRenderer, WebGLRenderer };
 
 export { default as glCore } from 'pixi-gl-core';
 
+export { default as Bounds } from './display/Bounds';
 export { default as DisplayObject } from './display/DisplayObject';
 export { default as Container } from './display/Container';
 export { default as Transform } from './display/Transform';


### PR DESCRIPTION
Resolves #3329 by publicly exposing the Bounds class to the PIXI namespace.