### PR TITLE
Allow '0x' notation of colours via strings to work in Text class

### DIFF
--- a/src/core/text/TextStyle.js
+++ b/src/core/text/TextStyle.js
@@ -443,7 +443,7 @@ function getSingleColor(color)
     }
     else if ( typeof color === 'string' )
     {
-        if ( color.includes('0x') )
+        if ( color.indexOf('0x') === 0 )
         {
             color = color.replace('0x', '#');
         }

--- a/src/core/text/TextStyle.js
+++ b/src/core/text/TextStyle.js
@@ -435,22 +435,43 @@ export default class TextStyle
  * @param {number|number[]} color
  * @return {string} The color as a string.
  */
-function getColor(color)
+function getSingleColor(color)
 {
     if (typeof color === 'number')
     {
         return hex2string(color);
     }
-    else if (Array.isArray(color))
+    else if ( typeof color === 'string' )
     {
-        for (let i = 0; i < color.length; ++i)
+        if ( color.includes('0x') )
         {
-            if (typeof color[i] === 'number')
-            {
-                color[i] = hex2string(color[i]);
-            }
+            color = color.replace('0x', '#');
         }
     }
 
     return color;
+}
+
+/**
+ * Utility function to convert hexadecimal colors to strings, and simply return the color if it's a string.
+ * This version can also convert array of colors
+ *
+ * @param {number|number[]} color
+ * @return {string} The color as a string.
+ */
+function getColor(color)
+{
+    if (!Array.isArray(color))
+    {
+        return getSingleColor(color);
+    }
+    else
+    {
+        for (let i = 0; i < color.length; ++i)
+        {
+            color[i] = getSingleColor(color[i]);
+        }
+
+        return color;
+    }
 }


### PR DESCRIPTION
I know internally, canvas likes "#FF0000" for setting colours, but I find it easier to have all values as "0xFF0000" in my settings json. "0x" notation already works in places such as tinting, so I like being able to have this consistency into TextStyle