### PR TITLE
Fix for the texture garbage collector

### DIFF
--- a/src/core/renderers/webgl/TextureGarbageCollector.js
+++ b/src/core/renderers/webgl/TextureGarbageCollector.js
@@ -95,7 +95,8 @@ export default class TextureGarbageCollector
     {
         const tm = this.renderer.textureManager;
 
-        if (displayObject._texture)
+        // only destroy non generated textures
+        if (displayObject._texture && displayObject._texture._glRenderTargets)
         {
             tm.destroyTexture(displayObject._texture, true);
         }


### PR DESCRIPTION
Do not unload generated textures when manually running the texture garbage collector. This check is already in place for when it is run automatically. The check is there, as otherwsie the texture to not be able to be renderered again.

Fixes: https://github.com/pixijs/pixi.js/issues/3215