### PR TITLE
Fix for Text's fontFamily

### DIFF
--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -735,7 +735,7 @@ export default class Text extends Sprite
         // build canvas api font setting from individual components. Convert a numeric style.fontSize to px
         const fontSizeString = (typeof style.fontSize === 'number') ? `${style.fontSize}px` : style.fontSize;
 
-        return `${style.fontStyle} ${style.fontVariant} ${style.fontWeight} ${fontSizeString} ${style.fontFamily}`;
+        return `${style.fontStyle} ${style.fontVariant} ${style.fontWeight} ${fontSizeString} "${style.fontFamily}"`;
     }
 
     /**


### PR DESCRIPTION
### Fixed

* Fixes issue #3349 by putting quotes around fontFamiy when setting the font style.