### PR TITLE
use high precision float instead of medium in texture shader

### DIFF
--- a/src/core/sprites/webgl/texture.vert
+++ b/src/core/sprites/webgl/texture.vert
@@ -1,3 +1,4 @@
+precision highp float;
 attribute vec2 aVertexPosition;
 attribute vec2 aTextureCoord;
 attribute vec4 aColor;


### PR DESCRIPTION
Fiddle: https://jsfiddle.net/Icemic/wmdruwLc/show/light/

Device: MEIZU MX5 ( Android 5.1 )
Browser: Chromium
CPU: MTK Helio X10 Turbo (MTK6795)
GPU: PowerVR G6200

Detail: Draw a 800\*600 image to a 800\*600 canvas, there will be a 1px width line at right. After some test, I find that the image is scaled to 799\*600. It must be to do with precision, maybe a GPU bug.

![image](https://cloud.githubusercontent.com/assets/837432/20592302/abb06078-b267-11e6-8c82-de35955fec04.png)


Solution: add `precision highp float;` to `pixi.js/src/core/sprites/webgl/texture.vert` (default is `mediump`)

Note: Need more test for detecting how many CPUs/GPUs effected by this bug.