### PR TITLE
Adds tintRgbFloat property to Sprite (fixes #3229)

### DIFF
--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -1,5 +1,5 @@
 import { Point, ObservablePoint, Rectangle } from '../math';
-import { sign, TextureCache } from '../utils';
+import { sign, TextureCache, hex2rgb, rgb2hex } from '../utils';
 import { BLEND_MODES } from '../const';
 import Texture from '../textures/Texture';
 import Container from '../display/Container';
@@ -89,6 +89,15 @@ export default class Sprite extends Container
          * @member {PIXI.Filter|PIXI.Shader}
          */
         this.shader = null;
+
+        /**
+         * The tint applied to the mesh. This is a [r,g,b] value. A value of [1,1,1] will remove any
+         * tint effect.
+         *
+         * @member {number}
+         * @memberof PIXI.mesh.Mesh#
+         */
+        this._tintRgbFloat = new Float32Array([1, 1, 1]);
 
         /**
          * An internal cached value of the tint.
@@ -556,6 +565,32 @@ export default class Sprite extends Container
     {
         this._tint = value;
         this._tintRGB = (value >> 16) + (value & 0xff00) + ((value & 0xff) << 16);
+        this._tintRgbFloat = hex2rgb(value, this._tintRgbFloat);
+    }
+
+    /**
+     * The tint applied to the sprite. This is a rgb value. A value of
+     * [1,1,1] will remove any tint effect.
+     *
+     * @member {Float32Array}
+     * @memberof PIXI.Sprite#
+     * @default [1.0,1.0,1.0]
+     */
+    get tintRgbFloat()
+    {
+        return this._tintRgbFloat;
+    }
+
+    /**
+     * Sets the tintRgb of the sprite.
+     *
+     * @param {number[]} value - The rgb array to set to.
+     */
+    set tintRgbFloat(value)
+    {
+        this._tint = rgb2hex(value);
+        this._tintRGB = (this._tint >> 16) + (this._tint & 0xff00) + ((this._tint & 0xff) << 16);
+        this._tintRgbFloat = value;
     }
 
     /**

--- a/test/core/Sprite.js
+++ b/test/core/Sprite.js
@@ -109,4 +109,27 @@ describe('PIXI.Sprite', function ()
             expect(sprite.containsPoint(point)).to.be.false;
         });
     });
+
+    describe('tintRgbFloat', function ()
+    {
+        it('should return array[3] of floats', function ()
+        {
+            const texture = new PIXI.RenderTexture.create(20, 30);
+            const sprite = new PIXI.Sprite(texture);
+
+            sprite.tint = 0x012345;
+
+            const tintRgbFloat = sprite.tintRgbFloat;
+
+            expect(tintRgbFloat.length === 3).to.be.true;
+
+            expect(typeof tintRgbFloat[0] === 'number').to.be.true;
+            expect(typeof tintRgbFloat[1] === 'number').to.be.true;
+            expect(typeof tintRgbFloat[2] === 'number').to.be.true;
+            // check that the array elements are of type float
+            expect(tintRgbFloat[0] % 1 === 0).to.be.false;
+            expect(tintRgbFloat[1] % 1 === 0).to.be.false;
+            expect(tintRgbFloat[2] % 1 === 0).to.be.false;
+        });
+    });
 });


### PR DESCRIPTION
Compute hex2rgb of Sprite when set tint

Currently setter for tint in Sprite class sets variable _tintRGB, which is integer. As requested in #3229, this commit adds a getter and a setter for tintRgbFloat, which is an array of three floats representing the rgb value of tint. This corresponds the tintRgb value in Mesh class.