### PR TITLE
Fix Issue #3356 

### DIFF
--- a/src/extras/cacheAsBitmap.js
+++ b/src/extras/cacheAsBitmap.js
@@ -283,8 +283,8 @@ DisplayObject.prototype._initCachedDisplayObjectCanvas = function _initCachedDis
     this.transform.worldTransform.copy(m);
     m.invert();
 
-    m.tx -= bounds.x;
-    m.ty -= bounds.y;
+    m.tx = -bounds.x;
+    m.ty = -bounds.y;
 
     // m.append(this.transform.worldTransform.)
      // set all properties to there original so we can render to a texture


### PR DESCRIPTION
Pixi 4.2.2 cacheAsBitmap shifts container in Canvas renderer.

- Transform Matrix elements should be overwritten

Fixes issue: #3356