### PR TITLE
Change the code lines order in  updateTransform

### DIFF
--- a/src/core/display/Transform.js
+++ b/src/core/display/Transform.js
@@ -109,6 +109,7 @@ export default class Transform extends TransformBase
         // concat the parent matrix with the objects transform.
         const pt = parentTransform.worldTransform;
         const wt = this.worldTransform;
+
         wt.a = (lt.a * pt.a) + (lt.b * pt.c);
         wt.b = (lt.a * pt.b) + (lt.b * pt.d);
         wt.c = (lt.c * pt.a) + (lt.d * pt.c);

--- a/src/core/display/Transform.js
+++ b/src/core/display/Transform.js
@@ -96,8 +96,6 @@ export default class Transform extends TransformBase
      */
     updateTransform(parentTransform)
     {
-        const pt = parentTransform.worldTransform;
-        const wt = this.worldTransform;
         const lt = this.localTransform;
 
         lt.a = this._cx * this.scale._x;
@@ -109,6 +107,8 @@ export default class Transform extends TransformBase
         lt.ty = this.position.y - ((this.pivot.x * lt.b) + (this.pivot.y * lt.d));
 
         // concat the parent matrix with the objects transform.
+        const pt = parentTransform.worldTransform;
+        const wt = this.worldTransform;
         wt.a = (lt.a * pt.a) + (lt.b * pt.c);
         wt.b = (lt.a * pt.b) + (lt.b * pt.d);
         wt.c = (lt.c * pt.a) + (lt.d * pt.c);


### PR DESCRIPTION
This PR doesn't change any logic in this function , it's just change the code lines order.
the reason:
*  let the codes that do one thing be together. ( please forgive me for my terrible english）
*  let the "update local transform" be ```the first part``` , others be the second part.  if the logic of  ```updateLocalTransform``` changed ,  We just could copy the code in ```updateLocalTransform``` , and paste them to override the ```the first part```. Don't need to think about other codes.
* I have obsessive-compulsive disorder  ;)