### PR TITLE
cocoonJS interaction position fix

### DIFF
--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -735,8 +735,16 @@ export default class InteractionManager extends EventEmitter
             rect = this.interactionDOMElement.getBoundingClientRect();
         }
 
-        point.x = ((x - rect.left) * (this.interactionDOMElement.width / rect.width)) / this.resolution;
-        point.y = ((y - rect.top) * (this.interactionDOMElement.height / rect.height)) / this.resolution;
+        if (navigator.isCocoonJS)
+        {
+            point.x = ((x - rect.left) * (this.interactionDOMElement.width / rect.width)) * this.resolution;
+            point.y = ((y - rect.top) * (this.interactionDOMElement.height / rect.height)) * this.resolution;
+        }
+        else
+        {
+            point.x = ((x - rect.left) * (this.interactionDOMElement.width / rect.width)) / this.resolution;
+            point.y = ((y - rect.top) * (this.interactionDOMElement.height / rect.height)) / this.resolution;
+        }
     }
 
     /**

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -735,16 +735,10 @@ export default class InteractionManager extends EventEmitter
             rect = this.interactionDOMElement.getBoundingClientRect();
         }
 
-        if (navigator.isCocoonJS)
-        {
-            point.x = ((x - rect.left) * (this.interactionDOMElement.width / rect.width)) * this.resolution;
-            point.y = ((y - rect.top) * (this.interactionDOMElement.height / rect.height)) * this.resolution;
-        }
-        else
-        {
-            point.x = ((x - rect.left) * (this.interactionDOMElement.width / rect.width)) / this.resolution;
-            point.y = ((y - rect.top) * (this.interactionDOMElement.height / rect.height)) / this.resolution;
-        }
+        const resolutionMultiplier = navigator.isCocoonJS ? this.resolution : (1.0 / this.resolution);
+
+        point.x = ((x - rect.left) * (this.interactionDOMElement.width / rect.width)) * resolutionMultiplier;
+        point.y = ((y - rect.top) * (this.interactionDOMElement.height / rect.height)) * resolutionMultiplier;
     }
 
     /**


### PR DESCRIPTION
Suggested by @bqvle. Tested on iphone,

getClientBoundingRect and coords are screwed, that's why its different by "resolution^2"