### PR TITLE
#3350 Fixed createColoredCanvas() documentation

### DIFF
--- a/src/core/renderers/canvas/utils/canUseNewCanvasBlendModes.js
+++ b/src/core/renderers/canvas/utils/canUseNewCanvasBlendModes.js
@@ -2,7 +2,7 @@
  * Creates a little colored canvas
  *
  * @ignore
- * @param {number} color - The color to make the canvas
+ * @param {string} color - The color to make the canvas
  * @return {canvas} a small canvas element
  */
 function createColoredCanvas(color)


### PR DESCRIPTION
createColoredCanvas() was documented as taking a number, but should have
said it takes a string. issue #3350 
