### PR TITLE
Change the code lines order in updateTransform in TransformStatic.js

### DIFF
--- a/src/core/display/TransformStatic.js
+++ b/src/core/display/TransformStatic.js
@@ -112,8 +112,6 @@ export default class TransformStatic extends TransformBase
      */
     updateTransform(parentTransform)
     {
-        const pt = parentTransform.worldTransform;
-        const wt = this.worldTransform;
         const lt = this.localTransform;
 
         if (this._localID !== this._currentLocalID)
@@ -135,6 +133,9 @@ export default class TransformStatic extends TransformBase
         if (this._parentID !== parentTransform._worldID)
         {
             // concat the parent matrix with the objects transform.
+            const pt = parentTransform.worldTransform;
+            const wt = this.worldTransform;
+            
             wt.a = (lt.a * pt.a) + (lt.b * pt.c);
             wt.b = (lt.a * pt.b) + (lt.b * pt.d);
             wt.c = (lt.c * pt.a) + (lt.d * pt.c);

--- a/src/core/display/TransformStatic.js
+++ b/src/core/display/TransformStatic.js
@@ -135,7 +135,7 @@ export default class TransformStatic extends TransformBase
             // concat the parent matrix with the objects transform.
             const pt = parentTransform.worldTransform;
             const wt = this.worldTransform;
-            
+
             wt.a = (lt.a * pt.a) + (lt.b * pt.c);
             wt.b = (lt.a * pt.b) + (lt.b * pt.d);
             wt.c = (lt.c * pt.a) + (lt.d * pt.c);


### PR DESCRIPTION
```
            const pt = parentTransform.worldTransform;
            const wt = this.worldTransform;
```
the code above in updateTransform  is not needed always.

And another reason is like  https://github.com/pixijs/pixi.js/pull/3391