### PR TITLE
Text style fixes

### DIFF
--- a/src/core/text/TextStyle.js
+++ b/src/core/text/TextStyle.js
@@ -97,7 +97,7 @@ export default class TextStyle
     {
         const clonedProperties = {};
 
-        for (const key in this._defaults)
+        for (const key in defaultStyle)
         {
             clonedProperties[key] = this[key];
         }
@@ -110,7 +110,7 @@ export default class TextStyle
      */
     reset()
     {
-        Object.assign(this, this._defaults);
+        Object.assign(this, defaultStyle);
     }
 
     get align()

--- a/test/core/TextStyle.js
+++ b/test/core/TextStyle.js
@@ -1,0 +1,26 @@
+'use strict';
+
+describe('PIXI.TextStyle', function ()
+{
+    it('reset reverts style to default', function ()
+    {
+        const textStyle = new PIXI.TextStyle();
+        const defaultFontSize = textStyle.fontSize;
+
+        textStyle.fontSize = 1000;
+
+        expect(textStyle.fontSize).to.equal(1000);
+        textStyle.reset();
+        expect(textStyle.fontSize).to.equal(defaultFontSize);
+    });
+
+    it('should clone correctly', function ()
+    {
+        const textStyle = new PIXI.TextStyle({ fontSize: 1000 });
+
+        const clonedTextStyle = textStyle.clone();
+
+        expect(textStyle.fontSize).to.equal(1000);
+        expect(clonedTextStyle.fontSize).to.equal(textStyle.fontSize);
+    });
+});

--- a/test/core/index.js
+++ b/test/core/index.js
@@ -7,6 +7,7 @@ require('./DisplayObject');
 require('./getLocalBounds');
 require('./Sprite');
 require('./TilingSprite');
+require('./TextStyle');
 require('./Text');
 require('./toGlobal');
 require('./toLocal');


### PR DESCRIPTION
defaultText had been moved, but there were references to the old location when cloning or resettings.

Unit tests for these added too