### PR TITLE
Add parameter kernelSize for blur filters.

### DIFF
--- a/src/filters/blur/BlurFilter.js
+++ b/src/filters/blur/BlurFilter.js
@@ -16,13 +16,14 @@ export default class BlurFilter extends core.Filter
      * @param {number} strength - The strength of the blur filter.
      * @param {number} quality - The quality of the blur filter.
      * @param {number} resolution - The reoslution of the blur filter.
+     * @param {number} kernelSize - The kernelSize of the blur filter.Options: 3, 5, 7, 9, 11, 13, 15.
      */
-    constructor(strength, quality, resolution)
+    constructor(strength, quality, resolution, kernelSize)
     {
         super();
 
-        this.blurXFilter = new BlurXFilter();
-        this.blurYFilter = new BlurYFilter();
+        this.blurXFilter = new BlurXFilter(strength, quality, resolution, kernelSize);
+        this.blurYFilter = new BlurYFilter(strength, quality, resolution, kernelSize);
         this.resolution = 1;
 
         this.padding = 0;

--- a/src/filters/blur/BlurFilter.js
+++ b/src/filters/blur/BlurFilter.js
@@ -15,7 +15,7 @@ export default class BlurFilter extends core.Filter
     /**
      * @param {number} strength - The strength of the blur filter.
      * @param {number} quality - The quality of the blur filter.
-     * @param {number} resolution - The reoslution of the blur filter.
+     * @param {number} resolution - The resolution of the blur filter.
      * @param {number} kernelSize - The kernelSize of the blur filter.Options: 5, 7, 9, 11, 13, 15.
      */
     constructor(strength, quality, resolution, kernelSize)

--- a/src/filters/blur/BlurFilter.js
+++ b/src/filters/blur/BlurFilter.js
@@ -16,7 +16,7 @@ export default class BlurFilter extends core.Filter
      * @param {number} strength - The strength of the blur filter.
      * @param {number} quality - The quality of the blur filter.
      * @param {number} resolution - The reoslution of the blur filter.
-     * @param {number} kernelSize - The kernelSize of the blur filter.Options: 3, 5, 7, 9, 11, 13, 15.
+     * @param {number} kernelSize - The kernelSize of the blur filter.Options: 5, 7, 9, 11, 13, 15.
      */
     constructor(strength, quality, resolution, kernelSize)
     {

--- a/src/filters/blur/BlurFilter.js
+++ b/src/filters/blur/BlurFilter.js
@@ -16,7 +16,7 @@ export default class BlurFilter extends core.Filter
      * @param {number} strength - The strength of the blur filter.
      * @param {number} quality - The quality of the blur filter.
      * @param {number} resolution - The resolution of the blur filter.
-     * @param {number} kernelSize - The kernelSize of the blur filter.Options: 5, 7, 9, 11, 13, 15.
+     * @param {number} [kernelSize=5] - The kernelSize of the blur filter.Options: 5, 7, 9, 11, 13, 15.
      */
     constructor(strength, quality, resolution, kernelSize)
     {

--- a/src/filters/blur/BlurXFilter.js
+++ b/src/filters/blur/BlurXFilter.js
@@ -16,7 +16,7 @@ export default class BlurXFilter extends core.Filter
      * @param {number} strength - The strength of the blur filter.
      * @param {number} quality - The quality of the blur filter.
      * @param {number} resolution - The reoslution of the blur filter.
-     * @param {number} kernelSize - The kernelSize of the blur filter.Options: 3, 5, 7, 9, 11, 13, 15.
+     * @param {number} kernelSize - The kernelSize of the blur filter.Options: 5, 7, 9, 11, 13, 15.
      */
     constructor(strength, quality, resolution, kernelSize)
     {

--- a/src/filters/blur/BlurXFilter.js
+++ b/src/filters/blur/BlurXFilter.js
@@ -16,7 +16,7 @@ export default class BlurXFilter extends core.Filter
      * @param {number} strength - The strength of the blur filter.
      * @param {number} quality - The quality of the blur filter.
      * @param {number} resolution - The resolution of the blur filter.
-     * @param {number} kernelSize - The kernelSize of the blur filter.Options: 5, 7, 9, 11, 13, 15.
+     * @param {number} [kernelSize=5] - The kernelSize of the blur filter.Options: 5, 7, 9, 11, 13, 15.
      */
     constructor(strength, quality, resolution, kernelSize)
     {

--- a/src/filters/blur/BlurXFilter.js
+++ b/src/filters/blur/BlurXFilter.js
@@ -16,11 +16,13 @@ export default class BlurXFilter extends core.Filter
      * @param {number} strength - The strength of the blur filter.
      * @param {number} quality - The quality of the blur filter.
      * @param {number} resolution - The reoslution of the blur filter.
+     * @param {number} kernelSize - The kernelSize of the blur filter.Options: 3, 5, 7, 9, 11, 13, 15.
      */
-    constructor(strength, quality, resolution)
+    constructor(strength, quality, resolution, kernelSize)
     {
-        const vertSrc = generateBlurVertSource(5, true);
-        const fragSrc = generateBlurFragSource(5);
+        kernelSize = kernelSize || 5;
+        const vertSrc = generateBlurVertSource(kernelSize, true);
+        const fragSrc = generateBlurFragSource(kernelSize);
 
         super(
             // vertex shader

--- a/src/filters/blur/BlurXFilter.js
+++ b/src/filters/blur/BlurXFilter.js
@@ -15,7 +15,7 @@ export default class BlurXFilter extends core.Filter
     /**
      * @param {number} strength - The strength of the blur filter.
      * @param {number} quality - The quality of the blur filter.
-     * @param {number} resolution - The reoslution of the blur filter.
+     * @param {number} resolution - The resolution of the blur filter.
      * @param {number} kernelSize - The kernelSize of the blur filter.Options: 5, 7, 9, 11, 13, 15.
      */
     constructor(strength, quality, resolution, kernelSize)

--- a/src/filters/blur/BlurYFilter.js
+++ b/src/filters/blur/BlurYFilter.js
@@ -15,7 +15,7 @@ export default class BlurYFilter extends core.Filter
     /**
      * @param {number} strength - The strength of the blur filter.
      * @param {number} quality - The quality of the blur filter.
-     * @param {number} resolution - The reoslution of the blur filter.
+     * @param {number} resolution - The resolution of the blur filter.
      * @param {number} kernelSize - The kernelSize of the blur filter.Options: 5, 7, 9, 11, 13, 15.
      */
     constructor(strength, quality, resolution, kernelSize)

--- a/src/filters/blur/BlurYFilter.js
+++ b/src/filters/blur/BlurYFilter.js
@@ -16,7 +16,7 @@ export default class BlurYFilter extends core.Filter
      * @param {number} strength - The strength of the blur filter.
      * @param {number} quality - The quality of the blur filter.
      * @param {number} resolution - The resolution of the blur filter.
-     * @param {number} kernelSize - The kernelSize of the blur filter.Options: 5, 7, 9, 11, 13, 15.
+     * @param {number} [kernelSize=5] - The kernelSize of the blur filter.Options: 5, 7, 9, 11, 13, 15.
      */
     constructor(strength, quality, resolution, kernelSize)
     {

--- a/src/filters/blur/BlurYFilter.js
+++ b/src/filters/blur/BlurYFilter.js
@@ -16,7 +16,7 @@ export default class BlurYFilter extends core.Filter
      * @param {number} strength - The strength of the blur filter.
      * @param {number} quality - The quality of the blur filter.
      * @param {number} resolution - The reoslution of the blur filter.
-     * @param {number} kernelSize - The kernelSize of the blur filter.Options: 3, 5, 7, 9, 11, 13, 15.
+     * @param {number} kernelSize - The kernelSize of the blur filter.Options: 5, 7, 9, 11, 13, 15.
      */
     constructor(strength, quality, resolution, kernelSize)
     {

--- a/src/filters/blur/BlurYFilter.js
+++ b/src/filters/blur/BlurYFilter.js
@@ -16,11 +16,13 @@ export default class BlurYFilter extends core.Filter
      * @param {number} strength - The strength of the blur filter.
      * @param {number} quality - The quality of the blur filter.
      * @param {number} resolution - The reoslution of the blur filter.
+     * @param {number} kernelSize - The kernelSize of the blur filter.Options: 3, 5, 7, 9, 11, 13, 15.
      */
-    constructor(strength, quality, resolution)
+    constructor(strength, quality, resolution, kernelSize)
     {
-        const vertSrc = generateBlurVertSource(5, false);
-        const fragSrc = generateBlurFragSource(5);
+        kernelSize = kernelSize || 5;
+        const vertSrc = generateBlurVertSource(kernelSize, false);
+        const fragSrc = generateBlurFragSource(kernelSize);
 
         super(
             // vertex shader


### PR DESCRIPTION
Add parameter kernelSize for blur filters.
```
    /**
     * ......
     * @param {number} kernelSize - The kernelSize of the blur filter.Options: 5, 7, 9, 11, 13, 15.
     */
    constructor(strength, quality, resolution, kernelSize)
    {
        kernelSize = kernelSize || 5;
        // ......
    }
```

related issue : https://github.com/pixijs/pixi.js/issues/3242

