### PR TITLE
Add "predist" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lintfix": "npm run lint --fix",
     "prebuild": "npm run lint",
     "build": "npm run dist",
-    "predist": "rimraf dist/pixi*.js dist/pixi*.map",
+    "predist": "rimraf dist/pixi.*js dist/pixi.*.map",
     "dist": "pixify -d dist -n PIXI -o pixi -t babelify",
     "lib": "babel src --out-dir lib -s",
     "docs": "jsdoc -c scripts/jsdoc.conf.json -R README.md",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lintfix": "npm run lint --fix",
     "prebuild": "npm run lint",
     "build": "npm run dist",
-    "predist": "rimraf dist/pixi.*js dist/pixi.*.map",
+    "predist": "rimraf dist/*.*",
     "dist": "pixify -d dist -n PIXI -o pixi -t babelify",
     "lib": "babel src --out-dir lib -s",
     "docs": "jsdoc -c scripts/jsdoc.conf.json -R README.md",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lintfix": "npm run lint --fix",
     "prebuild": "npm run lint",
     "build": "npm run dist",
+    "predist": "rimraf dist/pixi*.js dist/pixi*.map",
     "dist": "pixify -d dist -n PIXI -o pixi -t babelify",
     "lib": "babel src --out-dir lib -s",
     "docs": "jsdoc -c scripts/jsdoc.conf.json -R README.md",


### PR DESCRIPTION
Remove the previous version output files before run dist.
Because maybe there are other files in the dist folder, so  we shouldn't remove the folder.

Related issues : 
https://github.com/pixijs/pixi.js/issues/3403
https://github.com/pixijs/pixify/pull/8

.