### PR TITLE
Add Feature: update transform as orphan

### DIFF
--- a/src/core/display/Transform.js
+++ b/src/core/display/Transform.js
@@ -96,8 +96,6 @@ export default class Transform extends TransformBase
      */
     updateTransform(parentTransform)
     {
-        const pt = parentTransform.worldTransform;
-        const wt = this.worldTransform;
         const lt = this.localTransform;
 
         lt.a = this._cx * this.scale._x;
@@ -109,6 +107,9 @@ export default class Transform extends TransformBase
         lt.ty = this.position.y - ((this.pivot.x * lt.b) + (this.pivot.y * lt.d));
 
         // concat the parent matrix with the objects transform.
+        const pt = parentTransform.worldTransform;
+        const wt = this.worldTransform;
+
         wt.a = (lt.a * pt.a) + (lt.b * pt.c);
         wt.b = (lt.a * pt.b) + (lt.b * pt.d);
         wt.c = (lt.c * pt.a) + (lt.d * pt.c);

--- a/src/core/display/Transform.js
+++ b/src/core/display/Transform.js
@@ -120,6 +120,33 @@ export default class Transform extends TransformBase
     }
 
     /**
+     * Updates local matrix & world matrix without parent
+     */
+    updateTransformAsOrphan()
+    {
+        const lt = this.localTransform;
+
+        lt.a = this._cx * this.scale._x;
+        lt.b = this._sx * this.scale._x;
+        lt.c = this._cy * this.scale._y;
+        lt.d = this._sy * this.scale._y;
+
+        lt.tx = this.position._x - ((this.pivot._x * lt.a) + (this.pivot._y * lt.c));
+        lt.ty = this.position._y - ((this.pivot._x * lt.b) + (this.pivot._y * lt.d));
+
+        const wt = this.worldTransform;
+
+        wt.a = lt.a;
+        wt.b = lt.b;
+        wt.c = lt.c;
+        wt.d = lt.d;
+        wt.tx = lt.tx;
+        wt.ty = lt.ty;
+
+        this._worldID ++;
+    }
+
+    /**
      * Decomposes a matrix and sets the transforms properties based on it.
      *
      * @param {PIXI.Matrix} matrix - The matrix to decompose

--- a/src/core/display/TransformStatic.js
+++ b/src/core/display/TransformStatic.js
@@ -98,6 +98,7 @@ export default class TransformStatic extends TransformBase
 
             lt.tx = this.position._x - ((this.pivot._x * lt.a) + (this.pivot._y * lt.c));
             lt.ty = this.position._y - ((this.pivot._x * lt.b) + (this.pivot._y * lt.d));
+
             this._currentLocalID = this._localID;
 
             // force an update..
@@ -124,6 +125,7 @@ export default class TransformStatic extends TransformBase
 
             lt.tx = this.position._x - ((this.pivot._x * lt.a) + (this.pivot._y * lt.c));
             lt.ty = this.position._y - ((this.pivot._x * lt.b) + (this.pivot._y * lt.d));
+
             this._currentLocalID = this._localID;
 
             // force an update..
@@ -148,6 +150,39 @@ export default class TransformStatic extends TransformBase
             // update the id of the transform..
             this._worldID ++;
         }
+    }
+
+    /**
+     * Updates local matrix & world matrix without parent
+     */
+    updateTransformAsOrphan()
+    {
+        const lt = this.localTransform;
+
+        if (this._localID !== this._currentLocalID)
+        {
+            // get the matrix values of the displayobject based on its transform properties..
+            lt.a = this._cx * this.scale._x;
+            lt.b = this._sx * this.scale._x;
+            lt.c = this._cy * this.scale._y;
+            lt.d = this._sy * this.scale._y;
+
+            lt.tx = this.position._x - ((this.pivot._x * lt.a) + (this.pivot._y * lt.c));
+            lt.ty = this.position._y - ((this.pivot._x * lt.b) + (this.pivot._y * lt.d));
+
+            this._currentLocalID = this._localID;
+        }
+
+        const wt = this.worldTransform;
+
+        wt.a = lt.a;
+        wt.b = lt.b;
+        wt.c = lt.c;
+        wt.d = lt.d;
+        wt.tx = lt.tx;
+        wt.ty = lt.ty;
+
+        this._worldID ++;
     }
 
     /**


### PR DESCRIPTION
I've told many things  about  "updateTransform" , at 
https://github.com/pixijs/pixi.js/issues/3370
https://github.com/pixijs/pixi.js/issues/3389
https://github.com/pixijs/pixi.js/issues/3388

My english is too weak to explain it  in further detail.

There are just few things to add ： 

### Why named the function as ```updateTransformAsOrphan``` ？
Maybe It's not the best name , I named it just by  convention of web development.
In web development, We call a no-parent DOM node ```orphan node```(in China).

### Why don't check parent in ```updateTransform``` , but add a new function ?
I want do it. But I'm afraid that if I do it , you wouldn't accept it for stability of current version.

### When we need this feature  ？
Many times , we can't ensure any display object & transform object has a parent. 
When we need update  orphan object manually ， if no the function like this , there will be an error.

~

I think we could solve the problem about no-parent transform first.
Solving the same problem about no-parent display object  would be the next step.

