### PR TITLE
Add pluginName to  Plugin

### DIFF
--- a/src/core/utils/pluginTarget.js
+++ b/src/core/utils/pluginTarget.js
@@ -23,6 +23,7 @@ function pluginTarget(obj)
     obj.registerPlugin = function registerPlugin(pluginName, ctor)
     {
         obj.__plugins[pluginName] = ctor;
+        ctor.prototype.pluginName = pluginName;
     };
 
     /**


### PR DESCRIPTION
A Plugin should know its own name.

If use
```
ctor.prototype.name = pluginName;
```
The ```name``` is too common , there may be conflict in Plugin. So I used pluginName.