### PR TITLE
Add clear method to CanvasRenderer

### DIFF
--- a/src/core/renderers/canvas/CanvasRenderer.js
+++ b/src/core/renderers/canvas/CanvasRenderer.js
@@ -211,6 +211,27 @@ export default class CanvasRenderer extends SystemRenderer
     }
 
     /**
+     * Clear the canvas of renderer.
+     *
+     * @param {string} [clearColor] - Clear the canvas with this color, except the canvas is transparent.
+     */
+    clear(clearColor)
+    {
+        const context = this.context;
+
+        clearColor = clearColor || this._backgroundColorString;
+
+        if (!this.transparent && clearColor) {
+            context.fillStyle = clearColor;
+            context.fillRect(0, 0, this.width, this.height);
+        }
+        else
+        {
+            context.clearRect(0, 0, this.width, this.height);
+        }
+    }
+
+    /**
      * Sets the blend mode of the renderer.
      *
      * @param {number} blendMode - See {@link PIXI.BLEND_MODES} for valid values.

--- a/src/core/renderers/canvas/CanvasRenderer.js
+++ b/src/core/renderers/canvas/CanvasRenderer.js
@@ -221,7 +221,8 @@ export default class CanvasRenderer extends SystemRenderer
 
         clearColor = clearColor || this._backgroundColorString;
 
-        if (!this.transparent && clearColor) {
+        if (!this.transparent && clearColor)
+        {
             context.fillStyle = clearColor;
             context.fillRect(0, 0, this.width, this.height);
         }


### PR DESCRIPTION
WebGLRenderer has the ```clear``` method , I think CanvasRenderer should has it too.

Sometimes, maybe we want to clear the canvas manually via ``` game.renderer.clear()``` .

If  CanvasRenderer doesn't  has this method ,  there will be an error.