### PR TITLE
Control whether use core.ticker.shared to update

### DIFF
--- a/src/extras/AnimatedSprite.js
+++ b/src/extras/AnimatedSprite.js
@@ -32,18 +32,11 @@ export default class AnimatedSprite extends core.Sprite
     /**
      * @param {PIXI.Texture[]|FrameObject[]} textures - an array of {@link PIXI.Texture} or frame
      *  objects that make up the animation
-     * @param {boolean} [selfUpdate=true] - Whether use PIXI.ticker.shared to self-update animation time.
+     * @param {boolean} [autoUpdate=true] - Whether use PIXI.ticker.shared to auto update animation time.
      */
-    constructor(textures, selfUpdate)
+    constructor(textures, autoUpdate)
     {
         super(textures[0] instanceof core.Texture ? textures[0] : textures[0].texture);
-
-        /**
-         * `true` uses PIXI.ticker.shared to self-update animation time.
-         * @type {boolean}
-         * @default true
-         */
-        this.selfUpdate = selfUpdate !== false;
 
         /**
          * @private
@@ -56,6 +49,13 @@ export default class AnimatedSprite extends core.Sprite
         this._durations = null;
 
         this.textures = textures;
+
+        /**
+         * `true` uses PIXI.ticker.shared to auto update animation time.
+         * @type {boolean}
+         * @default true
+         */
+        this.autoUpdate = autoUpdate !== false;
 
         /**
          * The speed that the AnimatedSprite will play at. Higher is faster, lower is slower
@@ -118,7 +118,7 @@ export default class AnimatedSprite extends core.Sprite
         }
 
         this.playing = false;
-        if (this.selfUpdate)
+        if (this.autoUpdate)
         {
             core.ticker.shared.remove(this.update, this);
         }
@@ -136,7 +136,7 @@ export default class AnimatedSprite extends core.Sprite
         }
 
         this.playing = true;
-        if (this.selfUpdate)
+        if (this.autoUpdate)
         {
             core.ticker.shared.add(this.update, this);
         }

--- a/src/extras/AnimatedSprite.js
+++ b/src/extras/AnimatedSprite.js
@@ -54,6 +54,7 @@ export default class AnimatedSprite extends core.Sprite
          * `true` uses PIXI.ticker.shared to auto update animation time.
          * @type {boolean}
          * @default true
+         * @private
          */
         this.autoUpdate = autoUpdate !== false;
 

--- a/src/extras/AnimatedSprite.js
+++ b/src/extras/AnimatedSprite.js
@@ -137,7 +137,7 @@ export default class AnimatedSprite extends core.Sprite
         }
 
         this.playing = true;
-        if (this.autoUpdate)
+        if (this._autoUpdate)
         {
             core.ticker.shared.add(this.update, this);
         }

--- a/src/extras/AnimatedSprite.js
+++ b/src/extras/AnimatedSprite.js
@@ -32,10 +32,13 @@ export default class AnimatedSprite extends core.Sprite
     /**
      * @param {PIXI.Texture[]|FrameObject[]} textures - an array of {@link PIXI.Texture} or frame
      *  objects that make up the animation
+     * @param {boolean} [autoUpdate=true] - Whether use core.ticker.shared to update animation.
      */
-    constructor(textures)
+    constructor(textures, autoUpdate)
     {
         super(textures[0] instanceof core.Texture ? textures[0] : textures[0].texture);
+
+        this.autoUpdate = autoUpdate !== false;
 
         /**
          * @private
@@ -110,7 +113,10 @@ export default class AnimatedSprite extends core.Sprite
         }
 
         this.playing = false;
-        core.ticker.shared.remove(this.update, this);
+        if (this.autoUpdate)
+        {
+            core.ticker.shared.remove(this.update, this);
+        }
     }
 
     /**
@@ -125,7 +131,10 @@ export default class AnimatedSprite extends core.Sprite
         }
 
         this.playing = true;
-        core.ticker.shared.add(this.update, this);
+        if (this.autoUpdate)
+        {
+            core.ticker.shared.add(this.update, this);
+        }
     }
 
     /**

--- a/src/extras/AnimatedSprite.js
+++ b/src/extras/AnimatedSprite.js
@@ -32,13 +32,18 @@ export default class AnimatedSprite extends core.Sprite
     /**
      * @param {PIXI.Texture[]|FrameObject[]} textures - an array of {@link PIXI.Texture} or frame
      *  objects that make up the animation
-     * @param {boolean} [autoUpdate=true] - Whether use core.ticker.shared to update animation.
+     * @param {boolean} [selfUpdate=true] - Whether use PIXI.ticker.shared to self-update animation time.
      */
-    constructor(textures, autoUpdate)
+    constructor(textures, selfUpdate)
     {
         super(textures[0] instanceof core.Texture ? textures[0] : textures[0].texture);
 
-        this.autoUpdate = autoUpdate !== false;
+        /**
+         * `true` uses PIXI.ticker.shared to self-update animation time.
+         * @type {boolean}
+         * @default true
+         */
+        this.selfUpdate = selfUpdate !== false;
 
         /**
          * @private
@@ -113,7 +118,7 @@ export default class AnimatedSprite extends core.Sprite
         }
 
         this.playing = false;
-        if (this.autoUpdate)
+        if (this.selfUpdate)
         {
             core.ticker.shared.remove(this.update, this);
         }
@@ -131,7 +136,7 @@ export default class AnimatedSprite extends core.Sprite
         }
 
         this.playing = true;
-        if (this.autoUpdate)
+        if (this.selfUpdate)
         {
             core.ticker.shared.add(this.update, this);
         }

--- a/src/extras/AnimatedSprite.js
+++ b/src/extras/AnimatedSprite.js
@@ -56,7 +56,7 @@ export default class AnimatedSprite extends core.Sprite
          * @default true
          * @private
          */
-        this.autoUpdate = autoUpdate !== false;
+        this._autoUpdate = autoUpdate !== false;
 
         /**
          * The speed that the AnimatedSprite will play at. Higher is faster, lower is slower
@@ -119,7 +119,7 @@ export default class AnimatedSprite extends core.Sprite
         }
 
         this.playing = false;
-        if (this.autoUpdate)
+        if (this._autoUpdate)
         {
             core.ticker.shared.remove(this.update, this);
         }


### PR DESCRIPTION
Add a argument to control whether use core.ticker.shared to update animation.

Related Issue :  https://github.com/pixijs/pixi.js/issues/3428

Default value is true.
```
new AnimatedSprite(textures)  ---> use core.ticker.shared to update, as same as current version.

new AnimatedSprite(textures, false)   ---> don't use core.ticker.shared to update.
```