### PR TITLE
Do `flush()` after `_renderSpriteRect()`

### DIFF
--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -731,6 +731,7 @@ export default class Graphics extends Container
         if (this._fastRect)
         {
             this._renderSpriteRect(renderer);
+            renderer.flush();
         }
         else
         {


### PR DESCRIPTION
Fixed https://github.com/pixijs/pixi.js/issues/3439 

Why don't I put ```renderer.flush();``` into  ```_renderSpriteRect``` ?
`_renderSpriteRect`  just do something for  `rendering sprite rect` , the "flush" is another thing.
And maybe sometimes we need _renderSpriteRect but flush.