### PR TITLE
Protect the initial state  of `this._activeRenderTarget` in _indexContext

### DIFF
--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -162,6 +162,7 @@ export default class WebGLRenderer extends SystemRenderer
         this._activeRenderTarget = null;
 
         this._initContext();
+
         /**
          * Manages the filters.
          *

--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -145,16 +145,6 @@ export default class WebGLRenderer extends SystemRenderer
          */
         this.boundTextures = null;
 
-        this._initContext();
-        /**
-         * Manages the filters.
-         *
-         * @member {PIXI.FilterManager}
-         */
-        this.filterManager = new FilterManager(this);
-        // map some webGL blend and drawmodes..
-        this.drawModes = mapWebGLDrawModesToPixi(this.gl);
-
         /**
          * Holds the current shader
          *
@@ -170,6 +160,16 @@ export default class WebGLRenderer extends SystemRenderer
          * @member {PIXI.RenderTarget}
          */
         this._activeRenderTarget = null;
+
+        this._initContext();
+        /**
+         * Manages the filters.
+         *
+         * @member {PIXI.FilterManager}
+         */
+        this.filterManager = new FilterManager(this);
+        // map some webGL blend and drawmodes..
+        this.drawModes = mapWebGLDrawModesToPixi(this.gl);
 
         this._nextTextureLocation = 0;
 


### PR DESCRIPTION
```
    this._activeRenderTarget = null;
    this._activeTextureLocation = 999;
    this._activeTexture = null;
````
must before `this._indexContext()` , otherwise  the _activeRenderTarget & _activeTexture init in  _indexContext will back to `null`.