### PR TITLE
Test case & fix for Graphics._calculateBounds calling updateLocalBounds every time

### DIFF
--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -833,7 +833,6 @@ export default class Graphics extends Container
             this.boundsDirty = this.dirty;
             this.updateLocalBounds();
 
-            this.dirty++;
             this.cachedSpriteDirty = true;
         }
 

--- a/test/core/Graphics.js
+++ b/test/core/Graphics.js
@@ -191,4 +191,21 @@ describe('PIXI.Graphics', () =>
             expect(graphics.currentPath).to.be.null;
         });
     });
+
+    describe('_calculateBounds', () =>
+    {
+        it('should only call updateLocalBounds once', () =>
+        {
+            const graphics = new PIXI.Graphics();
+            const spy = sinon.spy(graphics, 'updateLocalBounds');
+
+            graphics._calculateBounds();
+
+            expect(spy).to.have.been.calledOnce;
+
+            graphics._calculateBounds();
+
+            expect(spy).to.not.have.been.called;
+        });
+    });
 });

--- a/test/core/Graphics.js
+++ b/test/core/Graphics.js
@@ -205,7 +205,7 @@ describe('PIXI.Graphics', () =>
 
             graphics._calculateBounds();
 
-            expect(spy).to.not.have.been.called;
+            expect(spy).to.have.been.calledOnce;
         });
     });
 });


### PR DESCRIPTION
Test case for #3414, plus a potential fix.

@GoodBoyDigital, I'm presuming [this line](https://github.com/pixijs/pixi.js/commit/46b063f501410de6420c4f441e48d23cae33c666#diff-ffbed917ef49b1b44e503c3e91f37be1R790) is a mistake?
