### PR TITLE
Update `clear` for a more thorough cleaning

### DIFF
--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -696,6 +696,9 @@ export default class Graphics extends Container
             this.graphicsData.length = 0;
         }
 
+        this.currentPath = null;
+        this._spriteRect = null;
+        
         return this;
     }
 

--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -698,7 +698,7 @@ export default class Graphics extends Container
 
         this.currentPath = null;
         this._spriteRect = null;
-        
+
         return this;
     }
 


### PR DESCRIPTION
Clear something that should be cleared.
```js
        this.currentPath = null;
        this._spriteRect = null;
```
if no this patch , some test cases will be failed.

## Test Case Base
There are some common codes of test cases :
```js
var renderer = new PIXI.WebGLRenderer(900, 600, {
    clearBeforeRender: false,
    backgroundColor: 0xFFFFFF
});
document.body.appendChild(renderer.view);

// the root container.
var stage = new PIXI.Container();

// a shared graphics for drawing multi shapes
var graphics = new PIXI.Graphics();
stage.addChild(graphics);

```

## TEST 1
If no  ```currentPath = null ``` ,  the second arc can't be rendered, and there is no error on browser's console.

```js
    // clear manually
    renderer.clear();

    graphics.clear();
    graphics.beginFill(0xFF0000);
    graphics.arc(150, 160, 100, 0, Math.PI * 2, false);
    graphics.endFill();

   // draw the first shape
    renderer.render(stage);

    graphics.clear();
    graphics.beginFill(0x0000FF);
    graphics.arc(150+50, 160+50, 100, 0, Math.PI * 2, false);
    graphics.endFill();

   // draw the second shape
    renderer.render(stage);

```

## TEST 2
If no  ```_spriteRect = null ``` ,  the first rect can't be rendered, and there is no error on browser's console.

```js
    // clear manually
    renderer.clear();

    graphics.clear();
    graphics.beginFill(0xFF0000);
    graphics.drawRect(150, 160, 100, 60);
    graphics.endFill();

    // draw the first shape
    graphics.updateTransform();
    graphics.renderWebGL(renderer);

    graphics.clear();
    graphics.beginFill(0x0000FF);
    graphics.drawRect(150+50, 160+50, 100, 60);
    graphics.endFill();

    // draw the second shape
    graphics.updateTransform();
    graphics.renderWebGL(renderer);

    // flush manually
    renderer.flush();

```

## Summary

If don't call  `graphics.clear();` before draw the second shape , there will be another error : 
> In the TestCase 1 ,  two arc shapes will with the same color as the first one.
> In the TestCase 2, if there is another non-fill-rect shape before it , will cause confusions.


If add 
```js
        this.currentPath = null;
        this._spriteRect = null;
```
in `clear()` everything will be OK, and I test many other examples, this patch doesn't break anything else, it's safe.

The only  side-effect is , after `this._spriteRect = null` , when we draw a new `fill rect`, the Graphics has to create a new sprite object. but the constructor of Sprite Class is not  performance hotspot.

I know when we want to draw multi shapes , we could use multi graphics objects.
But we shouldn't prevent users to use one shared graphics to draw multi shapes.