### PR TITLE
Fixing graphic = new PIXI.Graphic(); graphic.generateTexture(); throwing errors when using webgl renderer

### DIFF
--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -10,7 +10,6 @@ import Bounds from '../display/Bounds';
 import bezierCurveTo from './utils/bezierCurveTo';
 import CanvasRenderer from '../renderers/canvas/CanvasRenderer';
 
-let canvasRenderer;
 const tempMatrix = new Matrix();
 const tempPoint = new Point();
 const tempColor1 = new Float32Array(4);
@@ -1058,12 +1057,7 @@ export default class Graphics extends Container
 
         const canvasBuffer = RenderTexture.create(bounds.width, bounds.height, scaleMode, resolution);
 
-        if(!canvasRenderer)
-        {
-            canvasRenderer = new CanvasRenderer(bounds.width, bounds.height);
-        }
-
-        canvasRenderer.resize(bounds.width, bounds.height);
+        const canvasRenderer = new CanvasRenderer(bounds.width, bounds.height);
 
         tempMatrix.tx = -bounds.x;
         tempMatrix.ty = -bounds.y;

--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -10,7 +10,6 @@ import Bounds from '../display/Bounds';
 import bezierCurveTo from './utils/bezierCurveTo';
 import CanvasRenderer from '../renderers/canvas/CanvasRenderer';
 
-let canvasRenderer;
 const tempMatrix = new Matrix();
 const tempPoint = new Point();
 const tempColor1 = new Float32Array(4);

--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -1058,17 +1058,14 @@ export default class Graphics extends Container
 
         const canvasBuffer = RenderTexture.create(bounds.width, bounds.height, scaleMode, resolution);
 
-        if (!canvasRenderer)
-        {
-            canvasRenderer = new CanvasRenderer();
-        }
+        const canvasRenderer = new CanvasRenderer(bounds.width, bounds.height);
 
         tempMatrix.tx = -bounds.x;
         tempMatrix.ty = -bounds.y;
 
         canvasRenderer.render(this, canvasBuffer, false, tempMatrix);
 
-        const texture = Texture.fromCanvas(canvasBuffer.baseTexture._canvasRenderTarget.canvas, scaleMode);
+        const texture = Texture.fromCanvas(canvasRenderer.view, scaleMode);
 
         texture.baseTexture.resolution = resolution;
         texture.baseTexture.update();

--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -10,6 +10,7 @@ import Bounds from '../display/Bounds';
 import bezierCurveTo from './utils/bezierCurveTo';
 import CanvasRenderer from '../renderers/canvas/CanvasRenderer';
 
+let canvasRenderer;
 const tempMatrix = new Matrix();
 const tempPoint = new Point();
 const tempColor1 = new Float32Array(4);
@@ -1057,7 +1058,12 @@ export default class Graphics extends Container
 
         const canvasBuffer = RenderTexture.create(bounds.width, bounds.height, scaleMode, resolution);
 
-        const canvasRenderer = new CanvasRenderer(bounds.width, bounds.height);
+        if(!canvasRenderer)
+        {
+            canvasRenderer = new CanvasRenderer(bounds.width, bounds.height);
+        }
+
+        canvasRenderer.resize(bounds.width, bounds.height);
 
         tempMatrix.tx = -bounds.x;
         tempMatrix.ty = -bounds.y;


### PR DESCRIPTION
Was having a nightmare migrating a v3 codebase to v4 until I made this change. Perhaps not the most elegant, but hopefully enough to prompt someone with a better understanding into fixing the generateCanvasTexture function on an un-rendered instance of Graphics while using a WebGL renderer?