### PR TITLE
Adds tintRgb property to Sprite (#3229)

### DIFF
--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -1,5 +1,5 @@
 import { Point, ObservablePoint, Rectangle } from '../math';
-import { sign, TextureCache } from '../utils';
+import { sign, TextureCache, hex2rgb } from '../utils';
 import { BLEND_MODES } from '../const';
 import Texture from '../textures/Texture';
 import Container from '../display/Container';
@@ -70,9 +70,26 @@ export default class Sprite extends Container
          * @member {number}
          * @default 0xFFFFFF
          */
-        this._tint = null;
-        this._tintRGB = null;
-        this.tint = 0xFFFFFF;
+        this._tint = 0xFFFFFF;
+
+        /**
+         * The tint applied to the sprite. This is a [r,g,b] value.
+         *
+         * @member {number}
+         * @memberof PIXI.sprites.Sprite#
+         * @default [1,1,1]
+         */
+        this._tintRgb = new Float32Array([1, 1, 1]);
+
+        /**
+         * The tint applied to the sprite. This is an integer value
+         * which corresponds to the hex value of tint.
+         *
+         * @private
+         * @member {number}
+         * @default 16777215
+         */
+        this._tintRgbInt = 16777215;
 
         /**
          * The blend mode to be applied to the sprite. Apply a value of `PIXI.BLEND_MODES.NORMAL` to reset the blend mode.
@@ -540,7 +557,34 @@ export default class Sprite extends Container
     set tint(value) // eslint-disable-line require-jsdoc
     {
         this._tint = value;
-        this._tintRGB = (value >> 16) + (value & 0xff00) + ((value & 0xff) << 16);
+        this._tintRgb = Object.freeze(hex2rgb(this._tint));
+        this._tintRgbInt = (this._tint >> 16) + (this._tint & 0xff00) + ((this._tint & 0xff) << 16);
+    }
+
+    /**
+     * The immutable rgb value of tint applied to the sprite.
+     * This is a float array of a size of three. A value of
+     * [1,1,1] will remove any tint effect.
+     *
+     * @member {Float32Array}
+     * @memberof PIXI.Sprite#
+     * @default [1.0,1.0,1.0]
+     */
+    get tintRgb()
+    {
+        return this._tintRgb;
+    }
+
+    /**
+     * The int value of tint applied to the sprite.
+     *
+     * @member {int}
+     * @memberof PIXI.Sprite#
+     * @default 16777215
+     */
+    get tintRgbInt()
+    {
+        return this._tintRgbInt;
     }
 
     /**

--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -557,8 +557,8 @@ export default class Sprite extends Container
     set tint(value) // eslint-disable-line require-jsdoc
     {
         this._tint = value;
-        this._tintRgb = Object.freeze(hex2rgb(this._tint));
-        this._tintRgbInt = (this._tint >> 16) + (this._tint & 0xff00) + ((this._tint & 0xff) << 16);
+        this._tintRgb = Object.freeze(hex2rgb(value));
+        this._tintRgbInt = (value >> 16) + (value & 0xff00) + ((value & 0xff) << 16);
     }
 
     /**

--- a/src/mesh/Mesh.js
+++ b/src/mesh/Mesh.js
@@ -114,7 +114,7 @@ export default class Mesh extends core.Container
          *
          * @member {number}
          */
-        this.tintRgb = new Float32Array([1, 1, 1]);
+        this._tintRgb = new Float32Array([1, 1, 1]);
 
         /**
          * A map of renderer IDs to webgl render data
@@ -261,12 +261,12 @@ export default class Mesh extends core.Container
      */
     get tint()
     {
-        return core.utils.rgb2hex(this.tintRgb);
+        return core.utils.rgb2hex(this._tintRgb);
     }
 
     set tint(value) // eslint-disable-line require-jsdoc
     {
-        this.tintRgb = core.utils.hex2rgb(value, this.tintRgb);
+        this._tintRgb = core.utils.hex2rgb(value, this._tintRgb);
     }
 }
 

--- a/test/core/Sprite.js
+++ b/test/core/Sprite.js
@@ -109,4 +109,29 @@ describe('PIXI.Sprite', function ()
             expect(sprite.containsPoint(point)).to.be.false;
         });
     });
+
+    describe('tintRgb', function ()
+    {
+        it('should return array[3] of floats', function ()
+        {
+            const texture = new PIXI.RenderTexture.create(20, 30);
+            const sprite = new PIXI.Sprite(texture);
+
+            sprite.tint = 0x012345;
+
+            const tintRgb = sprite.tintRgb;
+
+            expect(tintRgb.length === 3).to.be.true;
+
+            expect(typeof tintRgb[0] === 'number').to.be.true;
+            expect(typeof tintRgb[1] === 'number').to.be.true;
+            expect(typeof tintRgb[2] === 'number').to.be.true;
+            // check that the array values are as expected
+            expect(tintRgb[0] === 0x01 / 255).to.be.true;
+            expect(tintRgb[1] === 0x23 / 255).to.be.true;
+            expect(tintRgb[2] === 0x45 / 255).to.be.true;
+
+            expect(sprite.tintRgbInt === 0x452301).to.be.true;
+        });
+    });
 });


### PR DESCRIPTION
Compute hex2rgb of Sprite when set tint

Currently setter for tint in Sprite class sets variable _tintRGB, which is an integer. As requested in #3229, this commit adds a getter for _tintRgb, which is an array of three floats representing the rgb value of tint. This corresponds the _tintRgb value in Mesh class.

The tint can only be set through _tint, which has setter and getter. _tintRgbInt has only getter which returns an integer by value (not by reference!). Also only getter for _tintRgb is provided, which returns an immutable array of three floats. The reasoning for this is as follows. If for example tintRgb returned a reference to the array, the contents of the array could be changed by assigning a new value to an individual element of the array (e.g. tintRgb()[2] = 0.5). But changing the contents of _tintRgb array should in that case require that the values of _tint and _tintRgbInt are also updated in order to keep the tint values consistent. Implementing that would be tricky and made the implementation of the class difficult.