### PR TITLE
Fixes logic for spritesheet resolution

### DIFF
--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -115,7 +115,7 @@ export function getResolutionOfUrl(url, defaultValue)
         return parseFloat(resolution[1]);
     }
 
-    return defaultValue || 1;
+    return defaultValue !== undefined ? defaultValue : 1;
 }
 
 /**

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -103,9 +103,10 @@ export function rgb2hex(rgb)
  * @memberof PIXI.utils
  * @function getResolutionOfUrl
  * @param {string} url - the image path
+ * @param {number} [defaultValue=1] - the defaultValue if not filename prefix is set.
  * @return {number} resolution / device pixel ratio of an asset
  */
-export function getResolutionOfUrl(url)
+export function getResolutionOfUrl(url, defaultValue)
 {
     const resolution = settings.RETINA_PREFIX.exec(url);
 
@@ -114,7 +115,7 @@ export function getResolutionOfUrl(url)
         return parseFloat(resolution[1]);
     }
 
-    return 1;
+    return defaultValue || 1;
 }
 
 /**

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -103,7 +103,7 @@ export function rgb2hex(rgb)
  * @memberof PIXI.utils
  * @function getResolutionOfUrl
  * @param {string} url - the image path
- * @param {number} [defaultValue=1] - the defaultValue if not filename prefix is set.
+ * @param {number} [defaultValue=1] - the defaultValue if no filename prefix is set.
  * @return {number} resolution / device pixel ratio of an asset
  */
 export function getResolutionOfUrl(url, defaultValue)

--- a/src/loaders/spritesheetParser.js
+++ b/src/loaders/spritesheetParser.js
@@ -43,14 +43,20 @@ export default function ()
             const frames = resource.data.frames;
             const frameKeys = Object.keys(frames);
             const baseTexture = res.texture.baseTexture;
-            let resolution = core.utils.getResolutionOfUrl(resource.url);
+            let resolution = core.utils.getResolutionOfUrl(resource.url, null);
             const scale = resource.data.meta.scale;
 
-            // for now (to keep things compatible) resolution overrides scale
-            // Support scale field on spritesheet
-            if (resolution === 1 && scale !== undefined && scale !== 1)
+            // No resolution found via URL
+            if (resolution === null)
             {
-                baseTexture.resolution = resolution = scale;
+                // Use the scale value or default to 1
+                resolution = scale !== undefined ? scale : 1;
+            }
+
+            // For non-1 resolutions, update baseTexture
+            if (resolution !== 1)
+            {
+                baseTexture.resolution = resolution;
                 baseTexture.update();
             }
 

--- a/src/loaders/spritesheetParser.js
+++ b/src/loaders/spritesheetParser.js
@@ -43,8 +43,10 @@ export default function ()
             const frames = resource.data.frames;
             const frameKeys = Object.keys(frames);
             const baseTexture = res.texture.baseTexture;
-            let resolution = core.utils.getResolutionOfUrl(resource.url, null);
             const scale = resource.data.meta.scale;
+
+            // Use a defaultValue of `null` to check if a url-based resolution is set
+            let resolution = core.utils.getResolutionOfUrl(resource.url, null);
 
             // No resolution found via URL
             if (resolution === null)


### PR DESCRIPTION
Addresses #3458

This PR tweaks the logic for when to respect a spritesheet's internal `scale`.

The current implementation reads the filename but defaults to `1` and then overrides with the JSON scale if it's defined and not `1`.

This change prioritizes the filename resolution (e.g. @2x). If that isn't set, it falls back to the `scale` value set in the JSON. Otherwise, resolution of `1`. 

For example, now if a file is named `atlas@1x.png` with a corresponding scale value of `0.5` in the JSON data, the resolution will be `1` instead of `0.5`. 

### Added

* Adds an additional argument for `PIXI.utils.getResolutionOfUrl` to define the default value.