### PR TITLE
InteractionEvent.target clarification

### DIFF
--- a/src/interaction/InteractionEvent.js
+++ b/src/interaction/InteractionEvent.js
@@ -12,14 +12,15 @@ export default class InteractionEvent
     constructor()
     {
         /**
-         * Which this event will continue propagating in the tree
+         * Whether this event will continue propagating in the tree
          *
          * @member {boolean}
          */
         this.stopped = false;
 
         /**
-         * The object to which event is dispatched.
+         * The object which caused this event to be dispatched.
+         * For listener callback see {@link PIXI.interaction.InteractionEvent.currentTarget}.
          *
          * @member {PIXI.DisplayObject}
          */


### PR DESCRIPTION
An attempt to clarify issues like #3450 with respect to accesing `target` rather than `currentTarget`.

Property name change would probably greatly benefit here, but would  be breaking.