### PR TITLE
Remove  the needless checking for `orig`

### DIFF
--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -517,7 +517,7 @@ export default class Texture extends EventEmitter
      */
     get width()
     {
-        return this.orig ? this.orig.width : 0;
+        return this.orig.width;
     }
 
     /**
@@ -527,7 +527,7 @@ export default class Texture extends EventEmitter
      */
     get height()
     {
-        return this.orig ? this.orig.height : 0;
+        return this.orig.height;
     }
 }
 


### PR DESCRIPTION
In Texture , the `orig` is always exist after new Texture object . 

 If `orig` is not accessible , there will be a bug in the App.
The developers must fix it , not ignore and return `0`.