### PR TITLE
Bugfix for #3356 and #3485

### DIFF
--- a/src/extras/cacheAsBitmap.js
+++ b/src/extras/cacheAsBitmap.js
@@ -280,7 +280,7 @@ DisplayObject.prototype._initCachedDisplayObjectCanvas = function _initCachedDis
     // need to set //
     const m = _tempMatrix;
 
-    this.transform.worldTransform.copy(m);
+    this.transform.localTransform.copy(m);
     m.invert();
 
     m.tx -= bounds.x;


### PR DESCRIPTION
https://github.com/pixijs/pixi.js/pull/3366
^ This PR is wrong, it takes into the account only one of the two situations (breaks half of the use cases while fixing the other half)

After changing from worldTransform to localTransform, caching is proper for all cases.