### PR TITLE
The canvas could be passed into Text

### DIFF
--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -32,10 +32,11 @@ export default class Text extends Sprite
     /**
      * @param {string} text - The string that you would like the text to display
      * @param {object|PIXI.TextStyle} [style] - The style parameters
+     * @param {HTMLCanvasElement} [canvas] - The canvas element for drawing text
      */
-    constructor(text, style)
+    constructor(text, style, canvas)
     {
-        const canvas = document.createElement('canvas');
+        canvas = canvas || document.createElement('canvas');
 
         canvas.width = 3;
         canvas.height = 3;


### PR DESCRIPTION
This feature could help users to  share canvas among two or more  Text  objects （ like Graphics._SPRITE_TEXTURE in Graphics).

In the game ,normally  we need rebuild stage/scene when stage/scene changed ,  If Text supports passing canvas , we could avoid create and destroy HTMLCanvasElement often when game running. 

e.g. create a canvas-pool  cache some canvas for Text.