### PR TITLE
Use `*._texture.*`to instead of`*.texture.*`

### DIFF
--- a/src/core/sprites/webgl/SpriteRenderer.js
+++ b/src/core/sprites/webgl/SpriteRenderer.js
@@ -168,7 +168,7 @@ export default class SpriteRenderer extends ObjectRenderer
         // get the uvs for the texture
 
         // if the uvs have not updated then no point rendering just yet!
-        if (!sprite.texture._uvs)
+        if (!sprite._texture._uvs)
         {
             return;
         }


### PR DESCRIPTION
it could offer a bit little performance gains.