### PR TITLE
Update to Resource loader v2; fixes #2876

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "ismobilejs": "^0.4.0",
     "object-assign": "^4.0.1",
     "pixi-gl-core": "^1.0.3",
-    "resource-loader": "^1.8.0"
+    "resource-loader": "^2.0.3"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",

--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -4,6 +4,7 @@ import * as particles from './particles';
 import * as extras from './extras';
 import * as filters from './filters';
 import * as prepare from './prepare';
+import * as loaders from './loaders';
 
 // provide method to give a stack track for warnings
 // useful for tracking-down where deprecated methods/properties/classes
@@ -938,5 +939,67 @@ Object.defineProperty(prepare.webgl, 'UPLOADS_PER_FRAME', {
             + 'renderer.plugins.prepare.limiter');
 
         return NaN;
+    },
+});
+
+Object.defineProperties(loaders.Resource.prototype, {
+    isJson: {
+        get()
+        {
+            warn('The isJson property is deprecated, please use `resource.type === Resource.TYPE.JSON`.');
+
+            return this.type === loaders.Loader.Resource.TYPE.JSON;
+        },
+    },
+    isXml: {
+        get()
+        {
+            warn('The isXml property is deprecated, please use `resource.type === Resource.TYPE.XML`.');
+
+            return this.type === loaders.Loader.Resource.TYPE.XML;
+        },
+    },
+    isImage: {
+        get()
+        {
+            warn('The isImage property is deprecated, please use `resource.type === Resource.TYPE.IMAGE`.');
+
+            return this.type === loaders.Loader.Resource.TYPE.IMAGE;
+        },
+    },
+    isAudio: {
+        get()
+        {
+            warn('The isAudio property is deprecated, please use `resource.type === Resource.TYPE.AUDIO`.');
+
+            return this.type === loaders.Loader.Resource.TYPE.AUDIO;
+        },
+    },
+    isVideo: {
+        get()
+        {
+            warn('The isVideo property is deprecated, please use `resource.type === Resource.TYPE.VIDEO`.');
+
+            return this.type === loaders.Loader.Resource.TYPE.VIDEO;
+        },
+    },
+});
+
+Object.defineProperties(loaders.Loader.prototype, {
+    before: {
+        get()
+        {
+            warn('The before() method is deprecated, please use pre().');
+
+            return this.pre;
+        },
+    },
+    after: {
+        get()
+        {
+            warn('The after() method is deprecated, please use use().');
+
+            return this.use;
+        },
     },
 });

--- a/src/loaders/bitmapFontParser.js
+++ b/src/loaders/bitmapFontParser.js
@@ -65,7 +65,7 @@ export default function ()
     return function bitmapFontParser(resource, next)
     {
         // skip if no data or not xml data
-        if (!resource.data || !resource.isXml)
+        if (!resource.data || resource.type !== Resource.TYPE.XML)
         {
             next();
 
@@ -125,6 +125,7 @@ export default function ()
                 crossOrigin: resource.crossOrigin,
                 loadType: Resource.LOAD_TYPE.IMAGE,
                 metadata: resource.metadata.imageMetadata,
+                parentResource: resource,
             };
 
             // load the texture for the font

--- a/src/loaders/loader.js
+++ b/src/loaders/loader.js
@@ -1,4 +1,5 @@
 import ResourceLoader from 'resource-loader';
+import { blobMiddlewareFactory } from 'resource-loader/lib/middlewares/parsing/blob';
 import EventEmitter from 'eventemitter3';
 import textureParser from './textureParser';
 import spritesheetParser from './spritesheetParser';
@@ -72,7 +73,7 @@ for (const k in EventEmitter.prototype)
 
 Loader._pixiMiddleware = [
     // parse any blob into more usable objects (e.g. Image)
-    ResourceLoader.middleware.parsing.blob,
+    blobMiddlewareFactory,
     // parse any Image objects into textures
     textureParser,
     // parse any spritesheet data into multiple textures

--- a/src/loaders/spritesheetParser.js
+++ b/src/loaders/spritesheetParser.js
@@ -12,7 +12,11 @@ export default function ()
         const imageResourceName = `${resource.name}_image`;
 
         // skip if no data, its not json, it isn't spritesheet data, or the image resource already exists
-        if (!resource.data || !resource.isJson || !resource.data.frames || this.resources[imageResourceName])
+        if (!resource.data
+            || resource.type !== Resource.TYPE.JSON
+            || !resource.data.frames
+            || this.resources[imageResourceName]
+        )
         {
             next();
 
@@ -23,6 +27,7 @@ export default function ()
             crossOrigin: resource.crossOrigin,
             loadType: Resource.LOAD_TYPE.IMAGE,
             metadata: resource.metadata.imageMetadata,
+            parentResource: resource,
         };
 
         // Prepend url path unless the resource image is a data url

--- a/src/loaders/textureParser.js
+++ b/src/loaders/textureParser.js
@@ -1,11 +1,12 @@
 import * as core from '../core';
+import { Resource } from 'resource-loader';
 
 export default function ()
 {
     return function textureParser(resource, next)
     {
         // create a new texture if the data is an Image object
-        if (resource.data && resource.isImage)
+        if (resource.data && resource.type === Resource.TYPE.IMAGE)
         {
             const baseTexture = new core.BaseTexture(resource.data, null, core.utils.getResolutionOfUrl(resource.url));
 

--- a/test/index.js
+++ b/test/index.js
@@ -13,6 +13,7 @@ describe('PIXI', function ()
     });
     require('./core');
     require('./interaction');
+    require('./loaders');
     require('./renders');
     require('./prepare');
 });

--- a/test/loaders/bitmapFontParser.js
+++ b/test/loaders/bitmapFontParser.js
@@ -1,0 +1,46 @@
+'use strict';
+
+describe('PIXI.loaders.bitmapFontParser', function ()
+{
+    it('should exist and return a function', function ()
+    {
+        expect(PIXI.loaders.bitmapFontParser).to.be.a('function');
+        expect(PIXI.loaders.bitmapFontParser()).to.be.a('function');
+    });
+
+    it('should do nothing if the resource is not XML', function ()
+    {
+        const spy = sinon.spy();
+        const res = {};
+
+        PIXI.loaders.bitmapFontParser()(res, spy);
+
+        expect(spy).to.have.been.calledOnce;
+        expect(res.textures).to.be.undefined;
+    });
+
+    it('should do nothing if the resource is not properly formatted XML', function ()
+    {
+        const spy = sinon.spy();
+        const res = { data: document.createDocumentFragment() };
+
+        PIXI.loaders.bitmapFontParser()(res, spy);
+
+        expect(spy).to.have.been.calledOnce;
+        expect(res.textures).to.be.undefined;
+    });
+
+    // TODO: Test the texture cache code path.
+    // TODO: Test the loading texture code path.
+    // TODO: Test data-url code paths.
+});
+
+describe('PIXI.loaders.parseBitmapFontData', function ()
+{
+    it('should exist', function ()
+    {
+        expect(PIXI.loaders.parseBitmapFontData).to.be.a('function');
+    });
+
+    // TODO: Test the parser code.
+});

--- a/test/loaders/index.js
+++ b/test/loaders/index.js
@@ -1,0 +1,6 @@
+'use strict';
+
+require('./bitmapFontParser');
+require('./loader');
+require('./spritesheetParser');
+require('./textureParser');

--- a/test/loaders/loader.js
+++ b/test/loaders/loader.js
@@ -1,0 +1,9 @@
+'use strict';
+
+describe('PIXI.loaders.Loader', function ()
+{
+    it('should exist', function ()
+    {
+        expect(PIXI.loaders.Loader).to.be.a('function');
+    });
+});

--- a/test/loaders/spritesheetParser.js
+++ b/test/loaders/spritesheetParser.js
@@ -1,0 +1,178 @@
+'use strict';
+
+const path = require('path');
+
+describe('PIXI.loaders.spritesheetParser', function ()
+{
+    it('should exist and return a function', function ()
+    {
+        expect(PIXI.loaders.spritesheetParser).to.be.a('function');
+        expect(PIXI.loaders.spritesheetParser()).to.be.a('function');
+    });
+
+    it('should do nothing if the resource is not JSON', function ()
+    {
+        const spy = sinon.spy();
+        const res = {};
+
+        PIXI.loaders.spritesheetParser()(res, spy);
+
+        expect(spy).to.have.been.calledOnce;
+        expect(res.textures).to.be.undefined;
+    });
+
+    it('should do nothing if the resource is JSON, but improper format', function ()
+    {
+        const spy = sinon.spy();
+        const res = createMockResource(PIXI.loaders.Resource.TYPE.JSON, {});
+
+        PIXI.loaders.spritesheetParser()(res, spy);
+
+        expect(spy).to.have.been.calledOnce;
+        expect(res.textures).to.be.undefined;
+    });
+
+    it('should load the image & create textures if json is properly formatted', function ()
+    {
+        const spy = sinon.spy();
+        const res = createMockResource(PIXI.loaders.Resource.TYPE.JSON, getJsonSpritesheet());
+        const loader = new PIXI.loaders.Loader();
+        const addStub = sinon.stub(loader, 'add');
+        const imgRes = createMockResource(PIXI.loaders.Resource.TYPE.IMAGE, new Image());
+
+        imgRes.texture = new PIXI.Texture(new PIXI.BaseTexture(imgRes.data));
+
+        addStub.yields(imgRes);
+
+        PIXI.loaders.spritesheetParser().call(loader, res, spy);
+
+        addStub.restore();
+
+        expect(spy).to.have.been.calledOnce;
+        expect(addStub).to.have.been.calledWith(
+            `${res.name}_image`,
+            `${path.dirname(res.url)}/${res.data.meta.image}`
+        );
+        expect(res).to.have.property('textures')
+            .that.is.an('object')
+            .with.keys(Object.keys(getJsonSpritesheet().frames))
+            .and.has.property('0.png')
+                .that.is.an.instanceof(PIXI.Texture);
+    });
+
+    // TODO: Test that rectangles are created correctly.
+    // TODO: Test that bathc processing works correctly.
+    // TODO: Test that resolution processing works correctly.
+    // TODO: Test that metadata is honored.
+    // TODO: Test data-url code paths.
+});
+
+function createMockResource(type, data)
+{
+    const name = `${Math.floor(Date.now() * Math.random())}`;
+
+    return {
+        url: `http://localhost/doesnt_exist/${name}`,
+        name,
+        type,
+        data,
+        metadata: {},
+    };
+}
+
+function getJsonSpritesheet()
+{
+    /* eslint-disable */
+    return {"frames": {
+    "0.png":
+    {
+        "frame": {"x":14,"y":28,"w":14,"h":14},
+        "rotated": false,
+        "trimmed": false,
+        "spriteSourceSize": {"x":0,"y":0,"w":14,"h":14},
+        "sourceSize": {"w":14,"h":14}
+    },
+    "1.png":
+    {
+        "frame": {"x":14,"y":42,"w":12,"h":14},
+        "rotated": false,
+        "trimmed": false,
+        "spriteSourceSize": {"x":0,"y":0,"w":12,"h":14},
+        "sourceSize": {"w":12,"h":14}
+    },
+    "2.png":
+    {
+        "frame": {"x":14,"y":14,"w":14,"h":14},
+        "rotated": false,
+        "trimmed": false,
+        "spriteSourceSize": {"x":0,"y":0,"w":14,"h":14},
+        "sourceSize": {"w":14,"h":14}
+    },
+    "3.png":
+    {
+        "frame": {"x":42,"y":0,"w":14,"h":14},
+        "rotated": false,
+        "trimmed": false,
+        "spriteSourceSize": {"x":0,"y":0,"w":14,"h":14},
+        "sourceSize": {"w":14,"h":14}
+    },
+    "4.png":
+    {
+        "frame": {"x":28,"y":0,"w":14,"h":14},
+        "rotated": false,
+        "trimmed": false,
+        "spriteSourceSize": {"x":0,"y":0,"w":14,"h":14},
+        "sourceSize": {"w":14,"h":14}
+    },
+    "5.png":
+    {
+        "frame": {"x":14,"y":0,"w":14,"h":14},
+        "rotated": false,
+        "trimmed": false,
+        "spriteSourceSize": {"x":0,"y":0,"w":14,"h":14},
+        "sourceSize": {"w":14,"h":14}
+    },
+    "6.png":
+    {
+        "frame": {"x":0,"y":42,"w":14,"h":14},
+        "rotated": false,
+        "trimmed": false,
+        "spriteSourceSize": {"x":0,"y":0,"w":14,"h":14},
+        "sourceSize": {"w":14,"h":14}
+    },
+    "7.png":
+    {
+        "frame": {"x":0,"y":28,"w":14,"h":14},
+        "rotated": false,
+        "trimmed": false,
+        "spriteSourceSize": {"x":0,"y":0,"w":14,"h":14},
+        "sourceSize": {"w":14,"h":14}
+    },
+    "8.png":
+    {
+        "frame": {"x":0,"y":14,"w":14,"h":14},
+        "rotated": false,
+        "trimmed": false,
+        "spriteSourceSize": {"x":0,"y":0,"w":14,"h":14},
+        "sourceSize": {"w":14,"h":14}
+    },
+    "9.png":
+    {
+        "frame": {"x":0,"y":0,"w":14,"h":14},
+        "rotated": false,
+        "trimmed": false,
+        "spriteSourceSize": {"x":0,"y":0,"w":14,"h":14},
+        "sourceSize": {"w":14,"h":14}
+    }},
+    "meta": {
+        "app": "http://www.texturepacker.com",
+        "version": "1.0",
+        "image": "hud.png",
+        "format": "RGBA8888",
+        "size": {"w":64,"h":64},
+        "scale": "1",
+        "smartupdate": "$TexturePacker:SmartUpdate:47025c98c8b10634b75172d4ed7e7edc$"
+    }
+    };
+    /* eslint-enable */
+}

--- a/test/loaders/textureParser.js
+++ b/test/loaders/textureParser.js
@@ -1,0 +1,50 @@
+'use strict';
+
+describe('PIXI.loaders.textureParser', function ()
+{
+    it('should exist and return a function', function ()
+    {
+        expect(PIXI.loaders.textureParser).to.be.a('function');
+        expect(PIXI.loaders.textureParser()).to.be.a('function');
+    });
+
+    it('should do nothing if the resource is not an image', function ()
+    {
+        const spy = sinon.spy();
+        const res = {};
+
+        PIXI.loaders.textureParser()(res, spy);
+
+        expect(spy).to.have.been.calledOnce;
+        expect(res.texture).to.be.undefined;
+    });
+
+    it('should create a texture if resource is an image', function ()
+    {
+        const spy = sinon.spy();
+        const res = createMockResource(PIXI.loaders.Resource.TYPE.IMAGE, new Image());
+
+        PIXI.loaders.textureParser()(res, spy);
+
+        expect(spy).to.have.been.calledOnce;
+        expect(res.texture).to.be.an.instanceof(PIXI.Texture);
+
+        expect(PIXI.utils.BaseTextureCache).to.have.property(res.name, res.texture.baseTexture);
+        expect(PIXI.utils.BaseTextureCache).to.have.property(res.url, res.texture.baseTexture);
+
+        expect(PIXI.utils.TextureCache).to.have.property(res.name, res.texture);
+        expect(PIXI.utils.TextureCache).to.have.property(res.url, res.texture);
+    });
+});
+
+function createMockResource(type, data)
+{
+    const name = `${Math.floor(Date.now() * Math.random())}`;
+
+    return {
+        url: `http://localhost/doesnt_exist/${name}`,
+        name,
+        type,
+        data,
+    };
+}


### PR DESCRIPTION
I put in backward compat handling, or deprecation warning, for all v2 changes except for one:

- If a middleware adds more resources, it must pass in the parent resource in options for .add().

I've updated our middleware to follow this rule, but if there are other ones floating around out there they will need to do this for child resources as well. Otherwise, they will get an error.

Also closes: #3116