### PR TITLE
Use `*._texture.*` instead of`*.texture.*`

### DIFF
--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -606,7 +606,7 @@ export default class Text extends Sprite
     {
         this.updateText(true);
 
-        return Math.abs(this.scale.x) * this.texture.orig.width;
+        return Math.abs(this.scale.x) * this._texture.orig.width;
     }
 
     /**
@@ -620,7 +620,7 @@ export default class Text extends Sprite
 
         const s = sign(this.scale.x) || 1;
 
-        this.scale.x = s * value / this.texture.orig.width;
+        this.scale.x = s * value / this._texture.orig.width;
         this._width = value;
     }
 
@@ -648,7 +648,7 @@ export default class Text extends Sprite
 
         const s = sign(this.scale.y) || 1;
 
-        this.scale.y = s * value / this.texture.orig.height;
+        this.scale.y = s * value / this._texture.orig.height;
         this._height = value;
     }
 


### PR DESCRIPTION
It could offer a bit little performance gains.

and in current version  https://github.com/pixijs/pixi.js/blob/master/src/core/text/Text.js#L637  , there is already used `_texture` .
So I think this patch is OK.