### PR TITLE
Fix a bug about compute Text canvas size.

### DIFF
--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -159,7 +159,7 @@ export default class Text extends Sprite
 
         width += style.padding * 2;
 
-        this.canvas.width = Math.ceil((width + this.context.lineWidth) * this.resolution);
+        this.canvas.width = Math.ceil((width + style.strokeThickness) * this.resolution);
 
         // calculate text height
         const lineHeight = this.style.lineHeight || fontProperties.fontSize + style.strokeThickness;

--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -157,7 +157,7 @@ export default class Text extends Sprite
             width += style.dropShadowDistance;
         }
 
-        this.canvas.width = Math.ceil((width + (style.padding * 2) * this.resolution);
+        this.canvas.width = Math.ceil((width + (style.padding * 2)) * this.resolution);
 
         // calculate text height
         const lineHeight = style.lineHeight || fontProperties.fontSize + style.strokeThickness;

--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -157,12 +157,10 @@ export default class Text extends Sprite
             width += style.dropShadowDistance;
         }
 
-        width += style.padding * 2;
-
-        this.canvas.width = Math.ceil(width * this.resolution);
+        this.canvas.width = Math.ceil((width + (style.padding * 2) * this.resolution);
 
         // calculate text height
-        const lineHeight = this.style.lineHeight || fontProperties.fontSize + style.strokeThickness;
+        const lineHeight = style.lineHeight || fontProperties.fontSize + style.strokeThickness;
 
         let height = Math.max(lineHeight, fontProperties.fontSize + style.strokeThickness)
             + ((lines.length - 1) * lineHeight);
@@ -172,7 +170,7 @@ export default class Text extends Sprite
             height += style.dropShadowDistance;
         }
 
-        this.canvas.height = Math.ceil((height + (this._style.padding * 2)) * this.resolution);
+        this.canvas.height = Math.ceil((height + (style.padding * 2)) * this.resolution);
 
         this.context.scale(this.resolution, this.resolution);
 

--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -402,8 +402,9 @@ export default class Text extends Sprite
         // Greedy wrapping algorithm that will wrap words as the line grows longer
         // than its horizontal bounds.
         let result = '';
+        const style = this._style;
         const lines = text.split('\n');
-        const wordWrapWidth = this._style.wordWrapWidth;
+        const wordWrapWidth = style.wordWrapWidth;
 
         for (let i = 0; i < lines.length; i++)
         {
@@ -414,7 +415,7 @@ export default class Text extends Sprite
             {
                 const wordWidth = this.context.measureText(words[j]).width;
 
-                if (this._style.breakWords && wordWidth > wordWrapWidth)
+                if (style.breakWords && wordWidth > wordWrapWidth)
                 {
                     // Word should be split in the middle
                     const characters = words[j].split('');

--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -159,7 +159,7 @@ export default class Text extends Sprite
 
         width += style.padding * 2;
 
-        this.canvas.width = Math.ceil((width + style.strokeThickness) * this.resolution);
+        this.canvas.width = Math.ceil(width * this.resolution);
 
         // calculate text height
         const lineHeight = this.style.lineHeight || fontProperties.fontSize + style.strokeThickness;


### PR DESCRIPTION
There are 2 bugs :
* should NOT use `this.context.lineWidth`  before `this.context.lineWidth = style.strokeThickness`.
* The default value of `style.strokeThickness` is `0` , but  `this.context.lineWidth` couldn't be 0 ( in HTML5 , context.lineWidth = 0 will be ignore). So we should NOT use `this.context.lineWidth` for computing size.

-------
Update commit https://github.com/pixijs/pixi.js/pull/3519/commits/81322e377e22d5978fe73e3f589e5b1cce139faf : 

In fact , we shouldn't ` + style.strokeThickness` again . because the `width` has added `style.strokeThickness`.
https://github.com/pixijs/pixi.js/blob/dev/src/core/text/Text.js#L153-L162
```js
// ****** has add style.strokeThickness to width 
        let width = maxLineWidth + style.strokeThickness;

        if (style.dropShadow)
        {
            width += style.dropShadowDistance;
        }

        width += style.padding * 2;

// ******* should NOT add  this.context.lineWidth or  style.strokeThickness again
        this.canvas.width = Math.ceil((width + this.context.lineWidth) * this.resolution);
```
 
------
Update  commit  https://github.com/pixijs/pixi.js/pull/3519/commits/3cb01312ce7bfa265f2c6f9bfa2fc7d088c45e4d  & https://github.com/pixijs/pixi.js/pull/3519/commits/ae71419675c8ebe0da56bdb54b85371036515213

We don't need `width` any more after compute canvas.width , so 
```js
width += style.padding * 2;
```
is needless.

We could use it like `height` at  https://github.com/pixijs/pixi.js/blob/dev/src/core/text/Text.js#L175
```js
// this._style could change to style
        this.canvas.height = Math.ceil((height + (this._style.padding * 2)) * this.resolution);
```


This PR include  https://github.com/pixijs/pixi.js/pull/3518 . So I closed #3518 .

.