### PR TITLE
Improved documentation of the destroy method

### DIFF
--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -523,6 +523,10 @@ export default class Container extends DisplayObject
      *  have been set to that value
      * @param {boolean} [options.children=false] - if set to true, all the children will have their destroy
      *  method called as well. 'options' will be passed on to those calls.
+     * @param {boolean} [options.texture=false] - Should it destroy the current texture of the sprite as well -
+     *  Only used for child Sprites if options.children is set to true
+     * @param {boolean} [options.baseTexture=false] - Should it destroy the base texture of the sprite as well -
+     *  Only used for child Sprites if options.children is set to true
      */
     destroy(options)
     {

--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -523,10 +523,10 @@ export default class Container extends DisplayObject
      *  have been set to that value
      * @param {boolean} [options.children=false] - if set to true, all the children will have their destroy
      *  method called as well. 'options' will be passed on to those calls.
-     * @param {boolean} [options.texture=false] - Should it destroy the current texture of the sprite as well -
-     *  Only used for child Sprites if options.children is set to true
-     * @param {boolean} [options.baseTexture=false] - Should it destroy the base texture of the sprite as well -
-     *  Only used for child Sprites if options.children is set to true
+     * @param {boolean} [options.texture=false] - Only used for child Sprites if options.children is set to true
+     *  Should it destroy the texture of the child sprite
+     * @param {boolean} [options.baseTexture=false] - Only used for child Sprites if options.children is set to true
+     *  Should it destroy the base texture of the child sprite
      */
     destroy(options)
     {

--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -1121,10 +1121,10 @@ export default class Graphics extends Container
      *  options have been set to that value
      * @param {boolean} [options.children=false] - if set to true, all the children will have
      *  their destroy method called as well. 'options' will be passed on to those calls.
-     * @param {boolean} [options.texture=false] - Should it destroy the current texture of the sprite as well -
-     *  Only used for child Sprites if options.children is set to true
-     * @param {boolean} [options.baseTexture=false] - Should it destroy the base texture of the sprite as well -
-     *  Only used for child Sprites if options.children is set to true
+     * @param {boolean} [options.texture=false] - Only used for child Sprites if options.children is set to true
+     *  Should it destroy the texture of the child sprite
+     * @param {boolean} [options.baseTexture=false] - Only used for child Sprites if options.children is set to true
+     *  Should it destroy the base texture of the child sprite
      */
     destroy(options)
     {

--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -1121,6 +1121,10 @@ export default class Graphics extends Container
      *  options have been set to that value
      * @param {boolean} [options.children=false] - if set to true, all the children will have
      *  their destroy method called as well. 'options' will be passed on to those calls.
+     * @param {boolean} [options.texture=false] - Should it destroy the current texture of the sprite as well -
+     *  Only used for child Sprites if options.children is set to true
+     * @param {boolean} [options.baseTexture=false] - Should it destroy the base texture of the sprite as well -
+     *  Only used for child Sprites if options.children is set to true
      */
     destroy(options)
     {

--- a/src/particles/ParticleContainer.js
+++ b/src/particles/ParticleContainer.js
@@ -328,10 +328,10 @@ export default class ParticleContainer extends core.Container
      *  have been set to that value
      * @param {boolean} [options.children=false] - if set to true, all the children will have their
      *  destroy method called as well. 'options' will be passed on to those calls.
-     * @param {boolean} [options.texture=false] - Should it destroy the current texture of the sprite as well -
-     *  Only used for child Sprites if options.children is set to true
-     * @param {boolean} [options.baseTexture=false] - Should it destroy the base texture of the sprite as well -
-     *  Only used for child Sprites if options.children is set to true
+     * @param {boolean} [options.texture=false] - Only used for child Sprites if options.children is set to true
+     *  Should it destroy the texture of the child sprite
+     * @param {boolean} [options.baseTexture=false] - Only used for child Sprites if options.children is set to true
+     *  Should it destroy the base texture of the child sprite
      */
     destroy(options)
     {

--- a/src/particles/ParticleContainer.js
+++ b/src/particles/ParticleContainer.js
@@ -328,6 +328,10 @@ export default class ParticleContainer extends core.Container
      *  have been set to that value
      * @param {boolean} [options.children=false] - if set to true, all the children will have their
      *  destroy method called as well. 'options' will be passed on to those calls.
+     * @param {boolean} [options.texture=false] - Should it destroy the current texture of the sprite as well -
+     *  Only used for child Sprites if options.children is set to true
+     * @param {boolean} [options.baseTexture=false] - Should it destroy the base texture of the sprite as well -
+     *  Only used for child Sprites if options.children is set to true
      */
     destroy(options)
     {


### PR DESCRIPTION
Documents the .texture and .baseTexture parameters for the destroy method settings object. They may not be used for the class itself, but could get propagated down to children.
Fixes https://github.com/pixijs/pixi.js/issues/3407