### PR TITLE
Fixes CanvasRenderer getting stuck at the last renderTexture resolution

### DIFF
--- a/src/core/renderers/canvas/CanvasRenderer.js
+++ b/src/core/renderers/canvas/CanvasRenderer.js
@@ -121,6 +121,8 @@ export default class CanvasRenderer extends SystemRenderer
 
         this.emit('prerender');
 
+        const rootResolution = this.resolution;
+
         if (renderTexture)
         {
             renderTexture = renderTexture.baseTexture || renderTexture;
@@ -206,6 +208,8 @@ export default class CanvasRenderer extends SystemRenderer
         this.context = context;
         displayObject.renderCanvas(this);
         this.context = tempContext;
+
+        this.resolution = rootResolution;
 
         this.emit('postrender');
     }


### PR DESCRIPTION
Fixes https://github.com/pixijs/pixi.js/issues/3135 and https://github.com/pixijs/pixi.js/issues/3359
Still allows requirement for dynamic changing of resolution which introduced this bug in the first place: https://github.com/pixijs/pixi.js/pull/2870