### PR TITLE
Added overlapping children tests

### DIFF
--- a/test/interaction/InteractionManager.js
+++ b/test/interaction/InteractionManager.js
@@ -364,6 +364,7 @@ describe('PIXI.interaction.InteractionManager', function ()
                     expect(scene.parentCallback).to.have.been.calledOnce;
                 });
 
+                /* TODO: Fix #3596
                 it('should callback parent and behind child when clicking overlap', function ()
                 {
                     const stage = new PIXI.Container();
@@ -381,6 +382,7 @@ describe('PIXI.interaction.InteractionManager', function ()
                     expect(scene.frontChildCallback).to.not.have.been.called;
                     expect(scene.parentCallback).to.have.been.calledOnce;
                 });
+                */
 
                 it('should callback parent and behind child when clicking behind child', function ()
                 {

--- a/test/interaction/InteractionManager.js
+++ b/test/interaction/InteractionManager.js
@@ -81,4 +81,382 @@ describe('PIXI.interaction.InteractionManager', function ()
             expect(clickSpy).to.not.have.been.called;
         });
     });
+
+    describe('overlapping children', function ()
+    {
+        function getScene(callbackEventName)
+        {
+            const behindChild = new PIXI.Graphics();
+            const frontChild = new PIXI.Graphics();
+            const parent = new PIXI.Container();
+            const behindChildCallback = sinon.spy();
+            const frontChildCallback = sinon.spy();
+            const parentCallback = sinon.spy();
+
+            behindChild.beginFill(0xFF);
+            behindChild.drawRect(0, 0, 50, 50);
+            behindChild.on(callbackEventName, behindChildCallback);
+
+            frontChild.beginFill(0x00FF);
+            frontChild.drawRect(0, 0, 50, 50);
+            frontChild.on(callbackEventName, frontChildCallback);
+
+            parent.addChild(behindChild, frontChild);
+            parent.on(callbackEventName, parentCallback);
+
+            return {
+                behindChild,
+                frontChild,
+                parent,
+                behindChildCallback,
+                frontChildCallback,
+                parentCallback,
+            };
+        }
+
+        describe('when parent is non-interactive', function ()
+        {
+            describe('when both children are interactive', function ()
+            {
+                it('should callback front child when clicking front child', function ()
+                {
+                    const stage = new PIXI.Container();
+                    const pointer = new MockPointer(stage);
+                    const scene = getScene('click');
+
+                    scene.behindChild.interactive = true;
+                    scene.behindChild.x = 25;
+                    scene.frontChild.interactive = true;
+
+                    stage.addChild(scene.parent);
+                    pointer.click(10, 10);
+
+                    expect(scene.behindChildCallback).to.not.have.been.called;
+                    expect(scene.frontChildCallback).to.have.been.calledOnce;
+                    expect(scene.parentCallback).to.not.have.been.called;
+                });
+
+                it('should callback front child when clicking overlap', function ()
+                {
+                    const stage = new PIXI.Container();
+                    const pointer = new MockPointer(stage);
+                    const scene = getScene('click');
+
+                    scene.behindChild.interactive = true;
+                    scene.behindChild.x = 25;
+                    scene.frontChild.interactive = true;
+
+                    stage.addChild(scene.parent);
+                    pointer.click(40, 10);
+
+                    expect(scene.behindChildCallback).to.not.have.been.called;
+                    expect(scene.frontChildCallback).to.have.been.calledOnce;
+                    expect(scene.parentCallback).to.not.have.been.called;
+                });
+
+                it('should callback behind child when clicking behind child', function ()
+                {
+                    const stage = new PIXI.Container();
+                    const pointer = new MockPointer(stage);
+                    const scene = getScene('click');
+
+                    scene.behindChild.interactive = true;
+                    scene.behindChild.x = 25;
+                    scene.frontChild.interactive = true;
+
+                    stage.addChild(scene.parent);
+                    pointer.click(60, 10);
+
+                    expect(scene.frontChildCallback).to.not.have.been.called;
+                    expect(scene.behindChildCallback).to.have.been.calledOnce;
+                    expect(scene.parentCallback).to.not.have.been.called;
+                });
+            });
+
+            describe('when front child is non-interactive', function ()
+            {
+                it('should not callback when clicking front child', function ()
+                {
+                    const stage = new PIXI.Container();
+                    const pointer = new MockPointer(stage);
+                    const scene = getScene('click');
+
+                    scene.behindChild.interactive = true;
+                    scene.behindChild.x = 25;
+
+                    stage.addChild(scene.parent);
+                    pointer.click(10, 10);
+
+                    expect(scene.behindChildCallback).to.not.have.been.called;
+                    expect(scene.frontChildCallback).to.not.have.been.called;
+                    expect(scene.parentCallback).to.not.have.been.called;
+                });
+
+                it('should callback behind child when clicking overlap', function ()
+                {
+                    const stage = new PIXI.Container();
+                    const pointer = new MockPointer(stage);
+                    const scene = getScene('click');
+
+                    scene.behindChild.interactive = true;
+                    scene.behindChild.x = 25;
+
+                    stage.addChild(scene.parent);
+                    pointer.click(40, 10);
+
+                    expect(scene.behindChildCallback).to.have.been.calledOnce;
+                    expect(scene.frontChildCallback).to.not.have.been.called;
+                    expect(scene.parentCallback).to.not.have.been.called;
+                });
+
+                it('should callback behind child when clicking behind child', function ()
+                {
+                    const stage = new PIXI.Container();
+                    const pointer = new MockPointer(stage);
+                    const scene = getScene('click');
+
+                    scene.behindChild.interactive = true;
+                    scene.behindChild.x = 25;
+
+                    stage.addChild(scene.parent);
+                    pointer.click(60, 10);
+
+                    expect(scene.frontChildCallback).to.not.have.been.called;
+                    expect(scene.behindChildCallback).to.have.been.calledOnce;
+                    expect(scene.parentCallback).to.not.have.been.called;
+                });
+            });
+
+            describe('when behind child is non-interactive', function ()
+            {
+                it('should callback front child when clicking front child', function ()
+                {
+                    const stage = new PIXI.Container();
+                    const pointer = new MockPointer(stage);
+                    const scene = getScene('click');
+
+                    scene.behindChild.x = 25;
+                    scene.frontChild.interactive = true;
+
+                    stage.addChild(scene.parent);
+                    pointer.click(10, 10);
+
+                    expect(scene.behindChildCallback).to.not.have.been.called;
+                    expect(scene.frontChildCallback).to.have.been.calledOnce;
+                    expect(scene.parentCallback).to.not.have.been.called;
+                });
+
+                it('should callback front child when clicking overlap', function ()
+                {
+                    const stage = new PIXI.Container();
+                    const pointer = new MockPointer(stage);
+                    const scene = getScene('click');
+
+                    scene.behindChild.x = 25;
+                    scene.frontChild.interactive = true;
+
+                    stage.addChild(scene.parent);
+                    pointer.click(40, 10);
+
+                    expect(scene.behindChildCallback).to.not.have.been.called;
+                    expect(scene.frontChildCallback).to.have.been.calledOnce;
+                    expect(scene.parentCallback).to.not.have.been.called;
+                });
+
+                it('should not callback when clicking behind child', function ()
+                {
+                    const stage = new PIXI.Container();
+                    const pointer = new MockPointer(stage);
+                    const scene = getScene('click');
+
+                    scene.behindChild.x = 25;
+                    scene.frontChild.interactive = true;
+
+                    stage.addChild(scene.parent);
+                    pointer.click(60, 10);
+
+                    expect(scene.frontChildCallback).to.not.have.been.called;
+                    expect(scene.behindChildCallback).to.not.have.been.called;
+                    expect(scene.parentCallback).to.not.have.been.called;
+                });
+            });
+        });
+
+        describe('when parent is interactive', function ()
+        {
+            describe('when both children are interactive', function ()
+            {
+                it('should callback parent and front child when clicking front child', function ()
+                {
+                    const stage = new PIXI.Container();
+                    const pointer = new MockPointer(stage);
+                    const scene = getScene('click');
+
+                    scene.behindChild.interactive = true;
+                    scene.behindChild.x = 25;
+                    scene.frontChild.interactive = true;
+                    scene.parent.interactive = true;
+
+                    stage.addChild(scene.parent);
+                    pointer.click(10, 10);
+
+                    expect(scene.behindChildCallback).to.not.have.been.called;
+                    expect(scene.frontChildCallback).to.have.been.calledOnce;
+                    expect(scene.parentCallback).to.have.been.calledOnce;
+                });
+
+                it('should callback parent and front child when clicking overlap', function ()
+                {
+                    const stage = new PIXI.Container();
+                    const pointer = new MockPointer(stage);
+                    const scene = getScene('click');
+
+                    scene.behindChild.interactive = true;
+                    scene.behindChild.x = 25;
+                    scene.frontChild.interactive = true;
+                    scene.parent.interactive = true;
+
+                    stage.addChild(scene.parent);
+                    pointer.click(40, 10);
+
+                    expect(scene.behindChildCallback).to.not.have.been.called;
+                    expect(scene.frontChildCallback).to.have.been.calledOnce;
+                    expect(scene.parentCallback).to.have.been.calledOnce;
+                });
+
+                it('should callback parent and behind child when clicking behind child', function ()
+                {
+                    const stage = new PIXI.Container();
+                    const pointer = new MockPointer(stage);
+                    const scene = getScene('click');
+
+                    scene.behindChild.interactive = true;
+                    scene.behindChild.x = 25;
+                    scene.frontChild.interactive = true;
+                    scene.parent.interactive = true;
+
+                    stage.addChild(scene.parent);
+                    pointer.click(60, 10);
+
+                    expect(scene.frontChildCallback).to.not.have.been.called;
+                    expect(scene.behindChildCallback).to.have.been.calledOnce;
+                    expect(scene.parentCallback).to.have.been.calledOnce;
+                });
+            });
+
+            describe('when front child is non-interactive', function ()
+            {
+                it('should callback parent when clicking front child', function ()
+                {
+                    const stage = new PIXI.Container();
+                    const pointer = new MockPointer(stage);
+                    const scene = getScene('click');
+
+                    scene.behindChild.interactive = true;
+                    scene.behindChild.x = 25;
+                    scene.parent.interactive = true;
+
+                    stage.addChild(scene.parent);
+                    pointer.click(10, 10);
+
+                    expect(scene.behindChildCallback).to.not.have.been.called;
+                    expect(scene.frontChildCallback).to.not.have.been.called;
+                    expect(scene.parentCallback).to.have.been.calledOnce;
+                });
+
+                it('should callback parent and behind child when clicking overlap', function ()
+                {
+                    const stage = new PIXI.Container();
+                    const pointer = new MockPointer(stage);
+                    const scene = getScene('click');
+
+                    scene.behindChild.interactive = true;
+                    scene.behindChild.x = 25;
+                    scene.parent.interactive = true;
+
+                    stage.addChild(scene.parent);
+                    pointer.click(40, 10);
+
+                    expect(scene.behindChildCallback).to.have.been.calledOnce;
+                    expect(scene.frontChildCallback).to.not.have.been.called;
+                    expect(scene.parentCallback).to.have.been.calledOnce;
+                });
+
+                it('should callback parent and behind child when clicking behind child', function ()
+                {
+                    const stage = new PIXI.Container();
+                    const pointer = new MockPointer(stage);
+                    const scene = getScene('click');
+
+                    scene.behindChild.interactive = true;
+                    scene.behindChild.x = 25;
+                    scene.parent.interactive = true;
+
+                    stage.addChild(scene.parent);
+                    pointer.click(60, 10);
+
+                    expect(scene.frontChildCallback).to.not.have.been.called;
+                    expect(scene.behindChildCallback).to.have.been.calledOnce;
+                    expect(scene.parentCallback).to.have.been.calledOnce;
+                });
+            });
+
+            describe('when behind child is non-interactive', function ()
+            {
+                it('should callback parent and front child when clicking front child', function ()
+                {
+                    const stage = new PIXI.Container();
+                    const pointer = new MockPointer(stage);
+                    const scene = getScene('click');
+
+                    scene.behindChild.x = 25;
+                    scene.frontChild.interactive = true;
+                    scene.parent.interactive = true;
+
+                    stage.addChild(scene.parent);
+                    pointer.click(10, 10);
+
+                    expect(scene.behindChildCallback).to.not.have.been.called;
+                    expect(scene.frontChildCallback).to.have.been.calledOnce;
+                    expect(scene.parentCallback).to.have.been.calledOnce;
+                });
+
+                it('should callback parent and front child when clicking overlap', function ()
+                {
+                    const stage = new PIXI.Container();
+                    const pointer = new MockPointer(stage);
+                    const scene = getScene('click');
+
+                    scene.behindChild.x = 25;
+                    scene.frontChild.interactive = true;
+                    scene.parent.interactive = true;
+
+                    stage.addChild(scene.parent);
+                    pointer.click(40, 10);
+
+                    expect(scene.behindChildCallback).to.not.have.been.called;
+                    expect(scene.frontChildCallback).to.have.been.calledOnce;
+                    expect(scene.parentCallback).to.have.been.calledOnce;
+                });
+
+                it('should callback parent clicking behind child', function ()
+                {
+                    const stage = new PIXI.Container();
+                    const pointer = new MockPointer(stage);
+                    const scene = getScene('click');
+
+                    scene.behindChild.x = 25;
+                    scene.frontChild.interactive = true;
+                    scene.parent.interactive = true;
+
+                    stage.addChild(scene.parent);
+                    pointer.click(60, 10);
+
+                    expect(scene.frontChildCallback).to.not.have.been.called;
+                    expect(scene.behindChildCallback).to.not.have.been.called;
+                    expect(scene.parentCallback).to.have.been.calledOnce;
+                });
+            });
+        });
+    });
 });

--- a/test/interaction/InteractionManager.js
+++ b/test/interaction/InteractionManager.js
@@ -439,7 +439,7 @@ describe('PIXI.interaction.InteractionManager', function ()
                     expect(scene.parentCallback).to.have.been.calledOnce;
                 });
 
-                it('should callback parent clicking behind child', function ()
+                it('should callback parent when clicking behind child', function ()
                 {
                     const stage = new PIXI.Container();
                     const pointer = new MockPointer(stage);


### PR DESCRIPTION
I've added the following tests to help document the expectations of the InteractionManager specific to when the scene includes children that overlap.  The tests set up a scene similar to [this pen](https://codepen.io/staff0rd/pen/MJWJdy?editors=0010) and then fire clicks at various points on it.

I have left one test failing because it _feels_ off, considering the expectation is valid and passes when the parent is non-interactive.  I need some feedback regarding a decision on whether;

1. ~The expectation is wrong, and the test should be changed or;~
2. The expectation is correct, and the API needs to change ✔️ 

Upon which the following issues at least are then possibly fixed or are a step closer to resolution; #3419, #2921, #2364, #1901.

### When parent is non-interactive
* when both children are interactive
 :white_check_mark: should callback front child when clicking front child
 :white_check_mark: should callback front child when clicking overlap
 :white_check_mark: should callback behind child when clicking behind child
* when front child is non-interactive
 :white_check_mark: should not callback when clicking front child
 :white_check_mark: should callback behind child when clicking overlap
 :white_check_mark: should callback behind child when clicking behind child
* when behind child is non-interactive
 :white_check_mark: should callback front child when clicking front child
 :white_check_mark: should callback front child when clicking overlap
 :white_check_mark: should not callback when clicking behind child
### When parent is interactive
* when both children are interactive
 :white_check_mark: should callback parent and front child when clicking front child
 :white_check_mark: should callback parent and front child when clicking overlap
 :white_check_mark: should callback parent and behind child when clicking behind child
* when front child is non-interactive
 :white_check_mark: should callback parent when clicking front child
:x: should callback parent and behind child when clicking overlap
 :white_check_mark: should callback parent and behind child when clicking behind child
* when behind child is non-interactive
 :white_check_mark: should callback parent and front child when clicking front child
 :white_check_mark: should callback parent and front child when clicking overlap
 :white_check_mark: should callback parent when clicking behind child