### PR TITLE
Adds hack for doc members fix

### DIFF
--- a/scripts/jsdoc-fix.js
+++ b/scripts/jsdoc-fix.js
@@ -7,6 +7,14 @@
 const rgxGross = /(\/\*{2}[\W\w]+?\*\/)\s*export\s+default\s+class\s+([^\s]*)/g;
 const grossReplace = 'export default $2;\n\n$1\nclass $2';
 
+// JSDoc has issues with expressing member properties within a class
+// this is another terrible hack to address this issue.
+// See: https://github.com/jsdoc3/jsdoc/issues/1301
+
+const rgxMember = /(\@member \{[^\}]+\})(\n[^\/]+\/[\b\s]+)(this\.([^\s]+))/g;
+const rgxClassName = /export (default )?class (.+?)\s/;
+const rgxNamespace = /\@memberof ([\.a-zA-Z0-9]+)\s/;
+
 exports.handlers = {
     /**
      * Called before parsing a file, giving us a change to replace the source.
@@ -17,6 +25,17 @@ exports.handlers = {
      */
     beforeParse(e)
     {
+        const namespace = e.source.match(rgxNamespace);
+        const className = e.source.match(rgxClassName);
+
+        // Fix members not showing up attached to class
+        if (namespace && className)
+        {
+            // console.log(`${namespace[1]}.${className[2]}`);
+            // Replaces "@member {Type}"" with "@member {Type} PIXI.ClassName#prop"
+            e.source = e.source.replace(rgxMember, `$1 ${namespace[1]}.${className[2]}#$4$2$3`);
+        }
+
         e.source = e.source.replace(rgxGross, grossReplace);
     },
 };


### PR DESCRIPTION
### Fixed

* Provides a workaround for JSDoc issue https://github.com/jsdoc3/jsdoc/issues/1301 causing member properties to be omitted.

**Preview:**
http://pixijs.download/fix-docs/docs/index.html

**Example:**
* [DisplayObject w/o hack](http://pixijs.download/dev/docs/PIXI.DisplayObject.html)
* [DisplayObject w/ hack](http://pixijs.download/fix-docs/docs/PIXI.DisplayObject.html)
