### PR TITLE
Ensure that polyfills are import first

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-// import polyfills
-import './polyfill';
+// import polyfills. Done as an export to make sure polyfills are imported first
+export * from './polyfill';
 
 // export core
 export * from './deprecation';


### PR DESCRIPTION
Fixes https://github.com/pixijs/pixi.js/issues/3291

Exporting the polyfills is a way of making sure they are also imported straight away.