### PR TITLE
Improved documentation

### DIFF
--- a/src/accessibility/AccessibilityManager.js
+++ b/src/accessibility/AccessibilityManager.js
@@ -28,6 +28,8 @@ const DIV_HOOK_ZINDEX = 2;
  * Much like interaction any DisplayObject can be made accessible. This manager will map the
  * events as if the mouse was being used, minimizing the efferot required to implement.
  *
+ * An instance of this class is automatically created by default, and can be found at renderer.plugins.accessibility
+ *
  * @class
  * @memberof PIXI
  */

--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -549,19 +549,13 @@ export default class Container extends DisplayObject
      * The width of the Container, setting this will actually modify the scale to achieve the value set
      *
      * @member {number}
-     * @memberof PIXI.Container#
      */
     get width()
     {
         return this.scale.x * this.getLocalBounds().width;
     }
 
-    /**
-     * Sets the width of the container by modifying the scale.
-     *
-     * @param {number} value - The value to set to.
-     */
-    set width(value)
+    set width(value) // eslint-disable-line require-jsdoc
     {
         const width = this.getLocalBounds().width;
 
@@ -581,19 +575,13 @@ export default class Container extends DisplayObject
      * The height of the Container, setting this will actually modify the scale to achieve the value set
      *
      * @member {number}
-     * @memberof PIXI.Container#
      */
     get height()
     {
         return this.scale.y * this.getLocalBounds().height;
     }
 
-    /**
-     * Sets the height of the container by modifying the scale.
-     *
-     * @param {number} value - The value to set to.
-     */
-    set height(value)
+    set height(value) // eslint-disable-line require-jsdoc
     {
         const height = this.getLocalBounds().height;
 

--- a/src/core/display/DisplayObject.js
+++ b/src/core/display/DisplayObject.js
@@ -410,19 +410,13 @@ export default class DisplayObject extends EventEmitter
      * An alias to position.x
      *
      * @member {number}
-     * @memberof PIXI.DisplayObject#
      */
     get x()
     {
         return this.position.x;
     }
 
-    /**
-     * Sets the X position of the object.
-     *
-     * @param {number} value - The value to set to.
-     */
-    set x(value)
+    set x(value) // eslint-disable-line require-jsdoc
     {
         this.transform.position.x = value;
     }
@@ -432,19 +426,13 @@ export default class DisplayObject extends EventEmitter
      * An alias to position.y
      *
      * @member {number}
-     * @memberof PIXI.DisplayObject#
      */
     get y()
     {
         return this.position.y;
     }
 
-    /**
-     * Sets the Y position of the object.
-     *
-     * @param {number} value - The value to set to.
-     */
-    set y(value)
+    set y(value) // eslint-disable-line require-jsdoc
     {
         this.transform.position.y = value;
     }
@@ -453,7 +441,6 @@ export default class DisplayObject extends EventEmitter
      * Current transform of the object based on world (parent) factors
      *
      * @member {PIXI.Matrix}
-     * @memberof PIXI.DisplayObject#
      * @readonly
      */
     get worldTransform()
@@ -465,7 +452,6 @@ export default class DisplayObject extends EventEmitter
      * Current transform of the object based on local factors: position, scale, other stuff
      *
      * @member {PIXI.Matrix}
-     * @memberof PIXI.DisplayObject#
      * @readonly
      */
     get localTransform()
@@ -478,19 +464,13 @@ export default class DisplayObject extends EventEmitter
      * Assignment by value since pixi-v4.
      *
      * @member {PIXI.Point|PIXI.ObservablePoint}
-     * @memberof PIXI.DisplayObject#
      */
     get position()
     {
         return this.transform.position;
     }
 
-    /**
-     * Copies the point to the position of the object.
-     *
-     * @param {PIXI.Point} value - The value to set to.
-     */
-    set position(value)
+    set position(value) // eslint-disable-line require-jsdoc
     {
         this.transform.position.copy(value);
     }
@@ -500,19 +480,13 @@ export default class DisplayObject extends EventEmitter
      * Assignment by value since pixi-v4.
      *
      * @member {PIXI.Point|PIXI.ObservablePoint}
-     * @memberof PIXI.DisplayObject#
      */
     get scale()
     {
         return this.transform.scale;
     }
 
-    /**
-     * Copies the point to the scale of the object.
-     *
-     * @param {PIXI.Point} value - The value to set to.
-     */
-    set scale(value)
+    set scale(value) // eslint-disable-line require-jsdoc
     {
         this.transform.scale.copy(value);
     }
@@ -522,19 +496,13 @@ export default class DisplayObject extends EventEmitter
      * Assignment by value since pixi-v4.
      *
      * @member {PIXI.Point|PIXI.ObservablePoint}
-     * @memberof PIXI.DisplayObject#
      */
     get pivot()
     {
         return this.transform.pivot;
     }
 
-    /**
-     * Copies the point to the pivot of the object.
-     *
-     * @param {PIXI.Point} value - The value to set to.
-     */
-    set pivot(value)
+    set pivot(value) // eslint-disable-line require-jsdoc
     {
         this.transform.pivot.copy(value);
     }
@@ -544,19 +512,13 @@ export default class DisplayObject extends EventEmitter
      * Assignment by value since pixi-v4.
      *
      * @member {PIXI.ObservablePoint}
-     * @memberof PIXI.DisplayObject#
      */
     get skew()
     {
         return this.transform.skew;
     }
 
-    /**
-     * Copies the point to the skew of the object.
-     *
-     * @param {PIXI.Point} value - The value to set to.
-     */
-    set skew(value)
+    set skew(value) // eslint-disable-line require-jsdoc
     {
         this.transform.skew.copy(value);
     }
@@ -565,19 +527,13 @@ export default class DisplayObject extends EventEmitter
      * The rotation of the object in radians.
      *
      * @member {number}
-     * @memberof PIXI.DisplayObject#
      */
     get rotation()
     {
         return this.transform.rotation;
     }
 
-    /**
-     * Sets the rotation of the object.
-     *
-     * @param {number} value - The value to set to.
-     */
-    set rotation(value)
+    set rotation(value) // eslint-disable-line require-jsdoc
     {
         this.transform.rotation = value;
     }
@@ -586,7 +542,6 @@ export default class DisplayObject extends EventEmitter
      * Indicates if the object is globally visible.
      *
      * @member {boolean}
-     * @memberof PIXI.DisplayObject#
      * @readonly
      */
     get worldVisible()
@@ -615,19 +570,13 @@ export default class DisplayObject extends EventEmitter
      * @todo For the moment, PIXI.CanvasRenderer doesn't support PIXI.Sprite as mask.
      *
      * @member {PIXI.Graphics|PIXI.Sprite}
-     * @memberof PIXI.DisplayObject#
      */
     get mask()
     {
         return this._mask;
     }
 
-    /**
-     * Sets the mask.
-     *
-     * @param {PIXI.Graphics|PIXI.Sprite} value - The value to set to.
-     */
-    set mask(value)
+    set mask(value) // eslint-disable-line require-jsdoc
     {
         if (this._mask)
         {
@@ -648,19 +597,13 @@ export default class DisplayObject extends EventEmitter
      * To remove filters simply set this property to 'null'
      *
      * @member {PIXI.Filter[]}
-     * @memberof PIXI.DisplayObject#
      */
     get filters()
     {
         return this._filters && this._filters.slice();
     }
 
-    /**
-     * Shallow copies the array to the filters of the object.
-     *
-     * @param {PIXI.Filter[]} value - The filters to set.
-     */
-    set filters(value)
+    set filters(value) // eslint-disable-line require-jsdoc
     {
         this._filters = value && value.slice();
     }

--- a/src/core/display/Transform.js
+++ b/src/core/display/Transform.js
@@ -134,19 +134,13 @@ export default class Transform extends TransformBase
      * The rotation of the object in radians.
      *
      * @member {number}
-     * @memberof PIXI.Transform#
      */
     get rotation()
     {
         return this._rotation;
     }
 
-    /**
-     * Set the rotation of the transform.
-     *
-     * @param {number} value - The value to set to.
-     */
-    set rotation(value)
+    set rotation(value) // eslint-disable-line require-jsdoc
     {
         this._rotation = value;
         this.updateSkew();

--- a/src/core/display/TransformStatic.js
+++ b/src/core/display/TransformStatic.js
@@ -165,19 +165,13 @@ export default class TransformStatic extends TransformBase
      * The rotation of the object in radians.
      *
      * @member {number}
-     * @memberof PIXI.TransformStatic#
      */
     get rotation()
     {
         return this._rotation;
     }
 
-    /**
-     * Sets the rotation of the transform.
-     *
-     * @param {number} value - The value to set to.
-     */
-    set rotation(value)
+    set rotation(value) // eslint-disable-line require-jsdoc
     {
         this._rotation = value;
         this.updateSkew();

--- a/src/core/math/ObservablePoint.js
+++ b/src/core/math/ObservablePoint.js
@@ -62,19 +62,13 @@ export default class ObservablePoint
      * The position of the displayObject on the x axis relative to the local coordinates of the parent.
      *
      * @member {number}
-     * @memberof PIXI.ObservablePoint#
      */
     get x()
     {
         return this._x;
     }
 
-    /**
-     * Sets the X component.
-     *
-     * @param {number} value - The value to set to.
-     */
-    set x(value)
+    set x(value) // eslint-disable-line require-jsdoc
     {
         if (this._x !== value)
         {
@@ -87,19 +81,13 @@ export default class ObservablePoint
      * The position of the displayObject on the x axis relative to the local coordinates of the parent.
      *
      * @member {number}
-     * @memberof PIXI.ObservablePoint#
      */
     get y()
     {
         return this._y;
     }
 
-    /**
-     * Sets the Y component.
-     *
-     * @param {number} value - The value to set to.
-     */
-    set y(value)
+    set y(value) // eslint-disable-line require-jsdoc
     {
         if (this._y !== value)
         {

--- a/src/core/math/shapes/Rectangle.js
+++ b/src/core/math/shapes/Rectangle.js
@@ -56,7 +56,6 @@ export default class Rectangle
      * returns the left edge of the rectangle
      *
      * @member {number}
-     * @memberof PIXI.Rectangle#
      */
     get left()
     {
@@ -67,7 +66,6 @@ export default class Rectangle
      * returns the right edge of the rectangle
      *
      * @member {number}
-     * @memberof PIXI.Rectangle
      */
     get right()
     {
@@ -78,7 +76,6 @@ export default class Rectangle
      * returns the top edge of the rectangle
      *
      * @member {number}
-     * @memberof PIXI.Rectangle
      */
     get top()
     {
@@ -89,7 +86,6 @@ export default class Rectangle
      * returns the bottom edge of the rectangle
      *
      * @member {number}
-     * @memberof PIXI.Rectangle
      */
     get bottom()
     {

--- a/src/core/renderers/SystemRenderer.js
+++ b/src/core/renderers/SystemRenderer.js
@@ -280,19 +280,13 @@ export default class SystemRenderer extends EventEmitter
      * The background color to fill if not transparent
      *
      * @member {number}
-     * @memberof PIXI.SystemRenderer#
      */
     get backgroundColor()
     {
         return this._backgroundColor;
     }
 
-    /**
-     * Sets the background color.
-     *
-     * @param {number} value - The value to set to.
-     */
-    set backgroundColor(value)
+    set backgroundColor(value) // eslint-disable-line require-jsdoc
     {
         this._backgroundColor = value;
         this._backgroundColorString = hex2string(value);

--- a/src/core/renderers/canvas/utils/CanvasRenderTarget.js
+++ b/src/core/renderers/canvas/utils/CanvasRenderTarget.js
@@ -72,19 +72,13 @@ export default class CanvasRenderTarget
      * The width of the canvas buffer in pixels.
      *
      * @member {number}
-     * @memberof PIXI.CanvasRenderTarget#
      */
     get width()
     {
         return this.canvas.width;
     }
 
-    /**
-     * Sets the width.
-     *
-     * @param {number} val - The value to set.
-     */
-    set width(val)
+    set width(val) // eslint-disable-line require-jsdoc
     {
         this.canvas.width = val;
     }
@@ -93,19 +87,13 @@ export default class CanvasRenderTarget
      * The height of the canvas buffer in pixels.
      *
      * @member {number}
-     * @memberof PIXI.CanvasRenderTarget#
      */
     get height()
     {
         return this.canvas.height;
     }
 
-    /**
-     * Sets the height.
-     *
-     * @param {number} val - The value to set.
-     */
-    set height(val)
+    set height(val) // eslint-disable-line require-jsdoc
     {
         this.canvas.height = val;
     }

--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -475,19 +475,13 @@ export default class Sprite extends Container
      * The width of the sprite, setting this will actually modify the scale to achieve the value set
      *
      * @member {number}
-     * @memberof PIXI.Sprite#
      */
     get width()
     {
         return Math.abs(this.scale.x) * this._texture.orig.width;
     }
 
-    /**
-     * Sets the width of the sprite by modifying the scale.
-     *
-     * @param {number} value - The value to set to.
-     */
-    set width(value)
+    set width(value) // eslint-disable-line require-jsdoc
     {
         const s = sign(this.scale.x) || 1;
 
@@ -499,19 +493,13 @@ export default class Sprite extends Container
      * The height of the sprite, setting this will actually modify the scale to achieve the value set
      *
      * @member {number}
-     * @memberof PIXI.Sprite#
      */
     get height()
     {
         return Math.abs(this.scale.y) * this._texture.orig.height;
     }
 
-    /**
-     * Sets the height of the sprite by modifying the scale.
-     *
-     * @param {number} value - The value to set to.
-     */
-    set height(value)
+    set height(value) // eslint-disable-line require-jsdoc
     {
         const s = sign(this.scale.y) || 1;
 
@@ -526,19 +514,13 @@ export default class Sprite extends Container
      * Setting the anchor to 1,1 would mean the texture's origin point will be the bottom right corner
      *
      * @member {PIXI.ObservablePoint}
-     * @memberof PIXI.Sprite#
      */
     get anchor()
     {
         return this._anchor;
     }
 
-    /**
-     * Copies the anchor to the sprite.
-     *
-     * @param {number} value - The value to set to.
-     */
-    set anchor(value)
+    set anchor(value) // eslint-disable-line require-jsdoc
     {
         this._anchor.copy(value);
     }
@@ -548,7 +530,6 @@ export default class Sprite extends Container
      * 0xFFFFFF will remove any tint effect.
      *
      * @member {number}
-     * @memberof PIXI.Sprite#
      * @default 0xFFFFFF
      */
     get tint()
@@ -556,12 +537,7 @@ export default class Sprite extends Container
         return this._tint;
     }
 
-    /**
-     * Sets the tint of the sprite.
-     *
-     * @param {number} value - The value to set to.
-     */
-    set tint(value)
+    set tint(value) // eslint-disable-line require-jsdoc
     {
         this._tint = value;
         this._tintRGB = (value >> 16) + (value & 0xff00) + ((value & 0xff) << 16);
@@ -571,19 +547,13 @@ export default class Sprite extends Container
      * The texture that the sprite is using
      *
      * @member {PIXI.Texture}
-     * @memberof PIXI.Sprite#
      */
     get texture()
     {
         return this._texture;
     }
 
-    /**
-     * Sets the texture of the sprite.
-     *
-     * @param {PIXI.Texture} value - The value to set to.
-     */
-    set texture(value)
+    set texture(value) // eslint-disable-line require-jsdoc
     {
         if (this._texture === value)
         {

--- a/src/core/sprites/webgl/BatchBuffer.js
+++ b/src/core/sprites/webgl/BatchBuffer.js
@@ -1,5 +1,6 @@
 /**
  * @class
+ * @memberof PIXI
  */
 export default class Buffer
 {

--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -600,7 +600,6 @@ export default class Text extends Sprite
      * The width of the Text, setting this will actually modify the scale to achieve the value set
      *
      * @member {number}
-     * @memberof PIXI.Text#
      */
     get width()
     {
@@ -609,12 +608,7 @@ export default class Text extends Sprite
         return Math.abs(this.scale.x) * this._texture.orig.width;
     }
 
-    /**
-     * Sets the width of the text.
-     *
-     * @param {number} value - The value to set to.
-     */
-    set width(value)
+    set width(value) // eslint-disable-line require-jsdoc
     {
         this.updateText(true);
 
@@ -628,7 +622,6 @@ export default class Text extends Sprite
      * The height of the Text, setting this will actually modify the scale to achieve the value set
      *
      * @member {number}
-     * @memberof PIXI.Text#
      */
     get height()
     {
@@ -637,12 +630,7 @@ export default class Text extends Sprite
         return Math.abs(this.scale.y) * this._texture.orig.height;
     }
 
-    /**
-     * Sets the height of the text.
-     *
-     * @param {number} value - The value to set to.
-     */
-    set height(value)
+    set height(value) // eslint-disable-line require-jsdoc
     {
         this.updateText(true);
 
@@ -657,19 +645,13 @@ export default class Text extends Sprite
      * object and mark the text as dirty.
      *
      * @member {object|PIXI.TextStyle}
-     * @memberof PIXI.Text#
      */
     get style()
     {
         return this._style;
     }
 
-    /**
-     * Sets the style of the text.
-     *
-     * @param {object} style - The value to set to.
-     */
-    set style(style)
+    set style(style) // eslint-disable-line require-jsdoc
     {
         style = style || {};
 
@@ -690,19 +672,13 @@ export default class Text extends Sprite
      * Set the copy for the text object. To split a line you can use '\n'.
      *
      * @member {string}
-     * @memberof PIXI.Text#
      */
     get text()
     {
         return this._text;
     }
 
-    /**
-     * Sets the text.
-     *
-     * @param {string} text - The value to set to.
-     */
-    set text(text)
+    set text(text) // eslint-disable-line require-jsdoc
     {
         text = String(text || ' ');
 

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -445,19 +445,13 @@ export default class Texture extends EventEmitter
      * The frame specifies the region of the base texture that this texture uses.
      *
      * @member {PIXI.Rectangle}
-     * @memberof PIXI.Texture#
      */
     get frame()
     {
         return this._frame;
     }
 
-    /**
-     * Set the frame.
-     *
-     * @param {Rectangle} frame - The new frame to set.
-     */
-    set frame(frame)
+    set frame(frame) // eslint-disable-line require-jsdoc
     {
         this._frame = frame;
 
@@ -496,12 +490,7 @@ export default class Texture extends EventEmitter
         return this._rotate;
     }
 
-    /**
-     * Set the rotation
-     *
-     * @param {number} rotate - The new rotation to set.
-     */
-    set rotate(rotate)
+    set rotate(rotate) // eslint-disable-line require-jsdoc
     {
         this._rotate = rotate;
         if (this.valid)

--- a/src/core/textures/VideoBaseTexture.js
+++ b/src/core/textures/VideoBaseTexture.js
@@ -267,19 +267,13 @@ export default class VideoBaseTexture extends BaseTexture
      * Should the base texture automatically update itself, set to true by default
      *
      * @member {boolean}
-     * @memberof PIXI.VideoBaseTexture#
      */
     get autoUpdate()
     {
         return this._autoUpdate;
     }
 
-    /**
-     * Sets autoUpdate property.
-     *
-     * @param {number} value - enable auto update or not
-     */
-    set autoUpdate(value)
+    set autoUpdate(value) // eslint-disable-line require-jsdoc
     {
         if (value !== this._autoUpdate)
         {

--- a/src/core/ticker/Ticker.js
+++ b/src/core/ticker/Ticker.js
@@ -337,7 +337,7 @@ export default class Ticker
      * {@link PIXI.ticker.Ticker#speed}, which is specific
      * to scaling {@link PIXI.ticker.Ticker#deltaTime}.
      *
-     * @memberof PIXI.ticker.Ticker#
+     * @member {number}
      * @readonly
      */
     get FPS()
@@ -353,7 +353,7 @@ export default class Ticker
      * When setting this property it is clamped to a value between
      * `0` and `PIXI.settings.TARGET_FPMS * 1000`.
      *
-     * @memberof PIXI.ticker.Ticker#
+     * @member {number}
      * @default 10
      */
     get minFPS()
@@ -361,12 +361,7 @@ export default class Ticker
         return 1000 / this._maxElapsedMS;
     }
 
-    /**
-     * Sets the min fps.
-     *
-     * @param {number} fps - value to set.
-     */
-    set minFPS(fps)
+    set minFPS(fps) // eslint-disable-line require-jsdoc
     {
         // Clamp: 0 to TARGET_FPMS
         const minFPMS = Math.min(Math.max(0, fps) / 1000, settings.TARGET_FPMS);

--- a/src/extract/canvas/CanvasExtract.js
+++ b/src/extract/canvas/CanvasExtract.js
@@ -5,6 +5,8 @@ const TEMP_RECT = new core.Rectangle();
 /**
  * The extract manager provides functionality to export content from the renderers.
  *
+ * An instance of this class is automatically created by default, and can be found at renderer.plugins.extract
+ *
  * @class
  * @memberof PIXI
  */

--- a/src/extract/webgl/WebGLExtract.js
+++ b/src/extract/webgl/WebGLExtract.js
@@ -6,6 +6,8 @@ const BYTES_PER_PIXEL = 4;
 /**
  * The extract manager provides functionality to export content from the renderers.
  *
+ * An instance of this class is automatically created by default, and can be found at renderer.plugins.extract
+ *
  * @class
  * @memberof PIXI
  */

--- a/src/extras/AnimatedSprite.js
+++ b/src/extras/AnimatedSprite.js
@@ -68,16 +68,14 @@ export default class AnimatedSprite extends core.Sprite
         /**
          * Function to call when a AnimatedSprite finishes playing
          *
-         * @method
-         * @memberof PIXI.extras.AnimatedSprite#
+         * @member {Function}
          */
         this.onComplete = null;
 
         /**
          * Function to call when a AnimatedSprite changes which texture is being rendered
          *
-         * @method
-         * @memberof PIXI.extras.AnimatedSprite#
+         * @member {Function}
          */
         this.onFrameChange = null;
 
@@ -300,7 +298,6 @@ export default class AnimatedSprite extends core.Sprite
      *
      * @readonly
      * @member {number}
-     * @memberof PIXI.extras.AnimatedSprite#
      * @default 0
      */
     get totalFrames()
@@ -312,19 +309,13 @@ export default class AnimatedSprite extends core.Sprite
      * The array of textures used for this AnimatedSprite
      *
      * @member {PIXI.Texture[]}
-     * @memberof PIXI.extras.AnimatedSprite#
      */
     get textures()
     {
         return this._textures;
     }
 
-    /**
-     * Sets the textures.
-     *
-     * @param {PIXI.Texture[]} value - The texture to set.
-     */
-    set textures(value)
+    set textures(value) // eslint-disable-line require-jsdoc
     {
         if (value[0] instanceof core.Texture)
         {
@@ -348,7 +339,6 @@ export default class AnimatedSprite extends core.Sprite
     * The AnimatedSprites current frame index
     *
     * @member {number}
-    * @memberof PIXI.extras.AnimatedSprite#
     * @readonly
     */
     get currentFrame()

--- a/src/extras/BitmapText.js
+++ b/src/extras/BitmapText.js
@@ -318,19 +318,13 @@ export default class BitmapText extends core.Container
      * The tint of the BitmapText object
      *
      * @member {number}
-     * @memberof PIXI.extras.BitmapText#
      */
     get tint()
     {
         return this._font.tint;
     }
 
-    /**
-     * Sets the tint.
-     *
-     * @param {number} value - The value to set to.
-     */
-    set tint(value)
+    set tint(value) // eslint-disable-line require-jsdoc
     {
         this._font.tint = (typeof value === 'number' && value >= 0) ? value : 0xFFFFFF;
 
@@ -342,19 +336,13 @@ export default class BitmapText extends core.Container
      *
      * @member {string}
      * @default 'left'
-     * @memberof PIXI.extras.BitmapText#
      */
     get align()
     {
         return this._font.align;
     }
 
-    /**
-     * Sets the alignment
-     *
-     * @param {string} value - The value to set to.
-     */
-    set align(value)
+    set align(value) // eslint-disable-line require-jsdoc
     {
         this._font.align = value || 'left';
 
@@ -368,19 +356,13 @@ export default class BitmapText extends core.Container
      * Setting the anchor to 1,1 would mean the text's origin point will be the bottom right corner
      *
      * @member {PIXI.Point | number}
-     * @memberof PIXI.extras.BitmapText#
      */
     get anchor()
     {
         return this._anchor;
     }
 
-    /**
-     * Sets the anchor.
-     *
-     * @param {PIXI.Point|number} value - The value to set to.
-     */
-    set anchor(value)
+    set anchor(value) // eslint-disable-line require-jsdoc
     {
         if (typeof value === 'number')
         {
@@ -396,19 +378,13 @@ export default class BitmapText extends core.Container
      * The font descriptor of the BitmapText object
      *
      * @member {string|object}
-     * @memberof PIXI.extras.BitmapText#
      */
     get font()
     {
         return this._font;
     }
 
-    /**
-     * Sets the font.
-     *
-     * @param {string|object} value - The value to set to.
-     */
-    set font(value)
+    set font(value) // eslint-disable-line require-jsdoc
     {
         if (!value)
         {
@@ -435,19 +411,13 @@ export default class BitmapText extends core.Container
      * The text of the BitmapText object
      *
      * @member {string}
-     * @memberof PIXI.extras.BitmapText#
      */
     get text()
     {
         return this._text;
     }
 
-    /**
-     * Sets the text.
-     *
-     * @param {string} value - The value to set to.
-     */
-    set text(value)
+    set text(value) // eslint-disable-line require-jsdoc
     {
         value = value.toString() || ' ';
         if (this._text === value)
@@ -463,7 +433,6 @@ export default class BitmapText extends core.Container
      * which is defined in the style object
      *
      * @member {number}
-     * @memberof PIXI.extras.BitmapText#
      * @readonly
      */
     get textWidth()
@@ -478,7 +447,6 @@ export default class BitmapText extends core.Container
      * which is defined in the style object
      *
      * @member {number}
-     * @memberof PIXI.extras.BitmapText#
      * @readonly
      */
     get textHeight()

--- a/src/extras/TextureTransform.js
+++ b/src/extras/TextureTransform.js
@@ -51,18 +51,13 @@ export default class TextureTransform {
     /**
      * texture property
      * @member {PIXI.Texture}
-     * @memberof PIXI.TextureTransform
      */
     get texture()
     {
         return this._texture;
     }
 
-    /**
-     * sets texture value
-     * @param {PIXI.Texture} value texture to be set
-     */
-    set texture(value)
+    set texture(value) // eslint-disable-line require-jsdoc
     {
         this._texture = value;
         this._lastTextureID = -1;

--- a/src/extras/TilingSprite.js
+++ b/src/extras/TilingSprite.js
@@ -85,19 +85,13 @@ export default class TilingSprite extends core.Sprite
      *
      * @default 0.5
      * @member {number}
-     * @memberof PIXI.TilingSprite
      */
     get clampMargin()
     {
         return this.uvTransform.clampMargin;
     }
 
-    /**
-     * setter for clampMargin
-     *
-     * @param {number} value assigned value
-     */
-    set clampMargin(value)
+    set clampMargin(value) // eslint-disable-line require-jsdoc
     {
         this.uvTransform.clampMargin = value;
         this.uvTransform.update(true);
@@ -107,19 +101,13 @@ export default class TilingSprite extends core.Sprite
      * The scaling of the image that is being tiled
      *
      * @member {PIXI.ObservablePoint}
-     * @memberof PIXI.DisplayObject#
      */
     get tileScale()
     {
         return this.tileTransform.scale;
     }
 
-    /**
-     * Copies the point to the scale of the tiled image.
-     *
-     * @param {PIXI.Point|PIXI.ObservablePoint} value - The value to set to.
-     */
-    set tileScale(value)
+    set tileScale(value) // eslint-disable-line require-jsdoc
     {
         this.tileTransform.scale.copy(value);
     }
@@ -128,19 +116,13 @@ export default class TilingSprite extends core.Sprite
      * The offset of the image that is being tiled
      *
      * @member {PIXI.ObservablePoint}
-     * @memberof PIXI.TilingSprite#
      */
     get tilePosition()
     {
         return this.tileTransform.position;
     }
 
-    /**
-     * Copies the point to the position of the tiled image.
-     *
-     * @param {PIXI.Point|PIXI.ObservablePoint} value - The value to set to.
-     */
-    set tilePosition(value)
+    set tilePosition(value) // eslint-disable-line require-jsdoc
     {
         this.tileTransform.position.copy(value);
     }
@@ -399,19 +381,13 @@ export default class TilingSprite extends core.Sprite
      * The width of the sprite, setting this will actually modify the scale to achieve the value set
      *
      * @member {number}
-     * @memberof PIXI.extras.TilingSprite#
      */
     get width()
     {
         return this._width;
     }
 
-    /**
-     * Sets the width.
-     *
-     * @param {number} value - The value to set to.
-     */
-    set width(value)
+    set width(value) // eslint-disable-line require-jsdoc
     {
         this._width = value;
     }
@@ -420,19 +396,13 @@ export default class TilingSprite extends core.Sprite
      * The height of the TilingSprite, setting this will actually modify the scale to achieve the value set
      *
      * @member {number}
-     * @memberof PIXI.extras.TilingSprite#
      */
     get height()
     {
         return this._height;
     }
 
-    /**
-     * Sets the width.
-     *
-     * @param {number} value - The value to set to.
-     */
-    set height(value)
+    set height(value) // eslint-disable-line require-jsdoc
     {
         this._height = value;
     }

--- a/src/extras/webgl/TilingSpriteRenderer.js
+++ b/src/extras/webgl/TilingSpriteRenderer.js
@@ -8,6 +8,10 @@ const tempArray = new Float32Array(4);
 
 /**
  * WebGL renderer plugin for tiling sprites
+ *
+ * @class
+ * @memberof PIXI
+ * @extends PIXI.ObjectRenderer
  */
 export default class TilingSpriteRenderer extends core.ObjectRenderer {
 

--- a/src/filters/blur/BlurFilter.js
+++ b/src/filters/blur/BlurFilter.js
@@ -53,7 +53,6 @@ export default class BlurFilter extends core.Filter
      * Sets the strength of both the blurX and blurY properties simultaneously
      *
      * @member {number}
-     * @memberOf PIXI.filters.BlurFilter#
      * @default 2
      */
     get blur()
@@ -61,12 +60,7 @@ export default class BlurFilter extends core.Filter
         return this.blurXFilter.blur;
     }
 
-    /**
-     * Sets the strength of the blur.
-     *
-     * @param {number} value - The value to set.
-     */
-    set blur(value)
+    set blur(value) // eslint-disable-line require-jsdoc
     {
         this.blurXFilter.blur = this.blurYFilter.blur = value;
         this.padding = Math.max(Math.abs(this.blurXFilter.strength), Math.abs(this.blurYFilter.strength)) * 2;
@@ -76,7 +70,6 @@ export default class BlurFilter extends core.Filter
      * Sets the number of passes for blur. More passes means higher quaility bluring.
      *
      * @member {number}
-     * @memberof PIXI.filters.BlurYFilter#
      * @default 1
      */
     get quality()
@@ -84,12 +77,7 @@ export default class BlurFilter extends core.Filter
         return this.blurXFilter.quality;
     }
 
-    /**
-     * Sets the quality of the blur.
-     *
-     * @param {number} value - The value to set.
-     */
-    set quality(value)
+    set quality(value) // eslint-disable-line require-jsdoc
     {
         this.blurXFilter.quality = this.blurYFilter.quality = value;
     }
@@ -98,7 +86,6 @@ export default class BlurFilter extends core.Filter
      * Sets the strength of the blurX property
      *
      * @member {number}
-     * @memberOf PIXI.filters.BlurFilter#
      * @default 2
      */
     get blurX()
@@ -106,12 +93,7 @@ export default class BlurFilter extends core.Filter
         return this.blurXFilter.blur;
     }
 
-    /**
-     * Sets the strength of the blurX.
-     *
-     * @param {number} value - The value to set.
-     */
-    set blurX(value)
+    set blurX(value) // eslint-disable-line require-jsdoc
     {
         this.blurXFilter.blur = value;
         this.padding = Math.max(Math.abs(this.blurXFilter.strength), Math.abs(this.blurYFilter.strength)) * 2;
@@ -121,7 +103,6 @@ export default class BlurFilter extends core.Filter
      * Sets the strength of the blurY property
      *
      * @member {number}
-     * @memberOf PIXI.filters.BlurFilter#
      * @default 2
      */
     get blurY()
@@ -129,12 +110,7 @@ export default class BlurFilter extends core.Filter
         return this.blurYFilter.blur;
     }
 
-    /**
-     * Sets the strength of the blurY.
-     *
-     * @param {number} value - The value to set.
-     */
-    set blurY(value)
+    set blurY(value) // eslint-disable-line require-jsdoc
     {
         this.blurYFilter.blur = value;
         this.padding = Math.max(Math.abs(this.blurXFilter.strength), Math.abs(this.blurYFilter.strength)) * 2;

--- a/src/filters/blur/BlurXFilter.js
+++ b/src/filters/blur/BlurXFilter.js
@@ -98,7 +98,6 @@ export default class BlurXFilter extends core.Filter
      * Sets the strength of both the blur.
      *
      * @member {number}
-     * @memberof PIXI.filters.BlurXFilter#
      * @default 16
      */
     get blur()
@@ -106,12 +105,7 @@ export default class BlurXFilter extends core.Filter
         return this.strength;
     }
 
-    /**
-     * Sets the strength of the blur.
-     *
-     * @param {number} value - The value to set.
-     */
-    set blur(value)
+    set blur(value) // eslint-disable-line require-jsdoc
     {
         this.padding = Math.abs(value) * 2;
         this.strength = value;
@@ -122,7 +116,6 @@ export default class BlurXFilter extends core.Filter
      * quaility bluring but the lower the performance.
      *
      * @member {number}
-     * @memberof PIXI.filters.BlurXFilter#
      * @default 4
      */
     get quality()
@@ -130,12 +123,7 @@ export default class BlurXFilter extends core.Filter
         return this._quality;
     }
 
-    /**
-     * Sets the quality of the blur.
-     *
-     * @param {number} value - The value to set.
-     */
-    set quality(value)
+    set quality(value) // eslint-disable-line require-jsdoc
     {
         this._quality = value;
         this.passes = value;

--- a/src/filters/blur/BlurYFilter.js
+++ b/src/filters/blur/BlurYFilter.js
@@ -97,7 +97,6 @@ export default class BlurYFilter extends core.Filter
      * Sets the strength of both the blur.
      *
      * @member {number}
-     * @memberof PIXI.filters.BlurYFilter#
      * @default 2
      */
     get blur()
@@ -105,12 +104,7 @@ export default class BlurYFilter extends core.Filter
         return this.strength;
     }
 
-    /**
-     * Sets the strength of the blur.
-     *
-     * @param {number} value - The value to set.
-     */
-    set blur(value)
+    set blur(value) // eslint-disable-line require-jsdoc
     {
         this.padding = Math.abs(value) * 2;
         this.strength = value;
@@ -121,7 +115,6 @@ export default class BlurYFilter extends core.Filter
      * quaility bluring but the lower the performance.
      *
      * @member {number}
-     * @memberof PIXI.filters.BlurXFilter#
      * @default 4
      */
     get quality()
@@ -129,12 +122,7 @@ export default class BlurYFilter extends core.Filter
         return this._quality;
     }
 
-    /**
-     * Sets the quality of the blur.
-     *
-     * @param {number} value - The value to set.
-     */
-    set quality(value)
+    set quality(value) // eslint-disable-line require-jsdoc
     {
         this._quality = value;
         this.passes = value;

--- a/src/filters/colormatrix/ColorMatrixFilter.js
+++ b/src/filters/colormatrix/ColorMatrixFilter.js
@@ -564,7 +564,6 @@ export default class ColorMatrixFilter extends core.Filter
      * The matrix of the color matrix filter
      *
      * @member {number[]}
-     * @memberof PIXI.filters.ColorMatrixFilter#
      * @default [1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0]
      */
     get matrix()
@@ -572,12 +571,7 @@ export default class ColorMatrixFilter extends core.Filter
         return this.uniforms.m;
     }
 
-    /**
-     * Sets the matrix directly.
-     *
-     * @param {number[]} value - the value to set to.
-     */
-    set matrix(value)
+    set matrix(value) // eslint-disable-line require-jsdoc
     {
         this.uniforms.m = value;
     }

--- a/src/filters/displacement/DisplacementFilter.js
+++ b/src/filters/displacement/DisplacementFilter.js
@@ -70,19 +70,13 @@ export default class DisplacementFilter extends core.Filter
      * The texture used for the displacement map. Must be power of 2 sized texture.
      *
      * @member {PIXI.Texture}
-     * @memberof PIXI.filters.DisplacementFilter#
      */
     get map()
     {
         return this.uniforms.mapSampler;
     }
 
-    /**
-     * Sets the texture to use for the displacement.
-     *
-     * @param {PIXI.Texture} value - The texture to set to.
-     */
-    set map(value)
+    set map(value) // eslint-disable-line require-jsdoc
     {
         this.uniforms.mapSampler = value;
     }

--- a/src/filters/noise/NoiseFilter.js
+++ b/src/filters/noise/NoiseFilter.js
@@ -35,7 +35,6 @@ export default class NoiseFilter extends core.Filter
      * The amount of noise to apply.
      *
      * @member {number}
-     * @memberof PIXI.filters.NoiseFilter#
      * @default 0.5
      */
     get noise()
@@ -43,12 +42,7 @@ export default class NoiseFilter extends core.Filter
         return this.uniforms.noise;
     }
 
-    /**
-     * Sets the amount of noise to apply.
-     *
-     * @param {number} value - The value to set to.
-     */
-    set noise(value)
+    set noise(value) // eslint-disable-line require-jsdoc
     {
         this.uniforms.noise = value;
     }

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -15,7 +15,8 @@ Object.assign(
  * The interaction manager deals with mouse and touch events. Any DisplayObject can be interactive
  * if its interactive parameter is set to true
  * This manager also supports multitouch.
- * By default, an instance of this class is automatically created, and can be found at renderer.plugins.interaction
+ *
+ * An instance of this class is automatically created by default, and can be found at renderer.plugins.interaction
  *
  * @class
  * @extends EventEmitter
@@ -113,8 +114,7 @@ export default class InteractionManager extends EventEmitter
          * It is currently set to false as this is how pixi used to work. This will be set to true in
          * future versions of pixi.
          *
-         * @member {boolean} moveWhenInside
-         * @memberof PIXI.interaction.InteractionManager#
+         * @member {boolean}
          * @default false
          */
         this.moveWhenInside = false;

--- a/src/mesh/Mesh.js
+++ b/src/mesh/Mesh.js
@@ -113,7 +113,6 @@ export default class Mesh extends core.Container
          * tint effect.
          *
          * @member {number}
-         * @memberof PIXI.mesh.Mesh#
          */
         this.tintRgb = new Float32Array([1, 1, 1]);
 
@@ -225,19 +224,13 @@ export default class Mesh extends core.Container
      * The texture that the mesh uses.
      *
      * @member {PIXI.Texture}
-     * @memberof PIXI.mesh.Mesh#
      */
     get texture()
     {
         return this._texture;
     }
 
-    /**
-     * Sets the texture the mesh uses.
-     *
-     * @param {Texture} value - The value to set.
-     */
-    set texture(value)
+    set texture(value) // eslint-disable-line require-jsdoc
     {
         if (this._texture === value)
         {
@@ -264,7 +257,6 @@ export default class Mesh extends core.Container
      * The tint applied to the mesh. This is a hex value. A value of 0xFFFFFF will remove any tint effect.
      *
      * @member {number}
-     * @memberof PIXI.mesh.Mesh#
      * @default 0xFFFFFF
      */
     get tint()
@@ -272,12 +264,7 @@ export default class Mesh extends core.Container
         return core.utils.rgb2hex(this.tintRgb);
     }
 
-    /**
-     * Sets the tint the mesh uses.
-     *
-     * @param {number} value - The value to set.
-     */
-    set tint(value)
+    set tint(value) // eslint-disable-line require-jsdoc
     {
         this.tintRgb = core.utils.hex2rgb(value, this.tintRgb);
     }

--- a/src/mesh/NineSlicePlane.js
+++ b/src/mesh/NineSlicePlane.js
@@ -84,6 +84,8 @@ export default class NineSlicePlane extends Plane
          * The width of the left column (a)
          *
          * @member {number}
+         * @memberof PIXI.NineSlicePlane#
+         * @override
          */
         this.leftWidth = typeof leftWidth !== 'undefined' ? leftWidth : DEFAULT_BORDER_SIZE;
 
@@ -91,6 +93,8 @@ export default class NineSlicePlane extends Plane
          * The width of the right column (b)
          *
          * @member {number}
+         * @memberof PIXI.NineSlicePlane#
+         * @override
          */
         this.rightWidth = typeof rightWidth !== 'undefined' ? rightWidth : DEFAULT_BORDER_SIZE;
 
@@ -98,6 +102,8 @@ export default class NineSlicePlane extends Plane
          * The height of the top row (c)
          *
          * @member {number}
+         * @memberof PIXI.NineSlicePlane#
+         * @override
          */
         this.topHeight = typeof topHeight !== 'undefined' ? topHeight : DEFAULT_BORDER_SIZE;
 
@@ -105,6 +111,8 @@ export default class NineSlicePlane extends Plane
          * The height of the bottom row (d)
          *
          * @member {number}
+         * @memberof PIXI.NineSlicePlane#
+         * @override
          */
         this.bottomHeight = typeof bottomHeight !== 'undefined' ? bottomHeight : DEFAULT_BORDER_SIZE;
     }
@@ -245,19 +253,13 @@ export default class NineSlicePlane extends Plane
      * The width of the NineSlicePlane, setting this will actually modify the vertices and UV's of this plane
      *
      * @member {number}
-     * @memberof PIXI.NineSlicePlane#
      */
     get width()
     {
         return this._width;
     }
 
-    /**
-     * Sets the width.
-     *
-     * @param {number} value - the value to set to.
-     */
-    set width(value)
+    set width(value) // eslint-disable-line require-jsdoc
     {
         this._width = value;
         this.updateVerticalVertices();
@@ -267,19 +269,13 @@ export default class NineSlicePlane extends Plane
      * The height of the NineSlicePlane, setting this will actually modify the vertices and UV's of this plane
      *
      * @member {number}
-     * @memberof PIXI.NineSlicePlane#
      */
     get height()
     {
         return this._height;
     }
 
-    /**
-     * Sets the height.
-     *
-     * @param {number} value - the value to set to.
-     */
-    set height(value)
+    set height(value) // eslint-disable-line require-jsdoc
     {
         this._height = value;
         this.updateHorizontalVertices();
@@ -295,12 +291,7 @@ export default class NineSlicePlane extends Plane
         return this._leftWidth;
     }
 
-    /**
-     * Sets the width of the left column.
-     *
-     * @param {number} value - the value to set to.
-     */
-    set leftWidth(value)
+    set leftWidth(value) // eslint-disable-line require-jsdoc
     {
         this._leftWidth = value;
 
@@ -323,12 +314,7 @@ export default class NineSlicePlane extends Plane
         return this._rightWidth;
     }
 
-    /**
-     * Sets the width of the right column.
-     *
-     * @param {number} value - the value to set to.
-     */
-    set rightWidth(value)
+    set rightWidth(value) // eslint-disable-line require-jsdoc
     {
         this._rightWidth = value;
 
@@ -351,12 +337,7 @@ export default class NineSlicePlane extends Plane
         return this._topHeight;
     }
 
-    /**
-     * Sets the height of the top row.
-     *
-     * @param {number} value - the value to set to.
-     */
-    set topHeight(value)
+    set topHeight(value) // eslint-disable-line require-jsdoc
     {
         this._topHeight = value;
 
@@ -379,12 +360,7 @@ export default class NineSlicePlane extends Plane
         return this._bottomHeight;
     }
 
-    /**
-     * Sets the height of the bottom row.
-     *
-     * @param {number} value - the value to set to.
-     */
-    set bottomHeight(value)
+    set bottomHeight(value) // eslint-disable-line require-jsdoc
     {
         this._bottomHeight = value;
 

--- a/src/mesh/webgl/MeshRenderer.js
+++ b/src/mesh/webgl/MeshRenderer.js
@@ -6,6 +6,10 @@ import { join } from 'path';
 
 /**
  * WebGL renderer plugin for tiling sprites
+ *
+ * @class
+ * @memberof PIXI
+ * @extends PIXI.ObjectRenderer
  */
 export default class MeshRenderer extends core.ObjectRenderer {
 

--- a/src/prepare/canvas/CanvasPrepare.js
+++ b/src/prepare/canvas/CanvasPrepare.js
@@ -9,6 +9,8 @@ const CANVAS_START_SIZE = 16;
  * textures to an offline canvas.
  * This draw call will force the texture to be moved onto the GPU.
  *
+ * An instance of this class is automatically created by default, and can be found at renderer.plugins.prepare
+ *
  * @class
  * @memberof PIXI
  */

--- a/src/prepare/webgl/WebGLPrepare.js
+++ b/src/prepare/webgl/WebGLPrepare.js
@@ -4,6 +4,8 @@ import BasePrepare from '../BasePrepare';
 /**
  * The prepare manager provides functionality to upload content to the GPU.
  *
+ * An instance of this class is automatically created by default, and can be found at renderer.plugins.prepare
+ *
  * @class
  * @memberof PIXI
  */


### PR DESCRIPTION
Class member documentation improved via removal of unnecessary @memberofs - more members now show up in the docs.
Class getter/setter documentation improved using technique above, and also by removing documentation for setters. Documentation was only showing the setter docs, whereas the getter is where the important information is. JSDoc maintainers themselves recommend just doccing the getter jsdoc3/jsdoc#973
Documented a few classes to let devs know that they are automatically created by PIXI and added to renderer.plugins, like interactionManager and prepare

## Preview

http://pixijs.download/improved-docs/docs/index.html