### PR TITLE
Remove `@private` of `updateTransform`.

### DIFF
--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -296,8 +296,6 @@ export default class Container extends DisplayObject
 
     /**
      * Updates the transform on all children of this container for rendering
-     *
-     * @private
      */
     updateTransform()
     {


### PR DESCRIPTION
In some complex/advanced  use case ， users would call `updateTransform` manually.

And , if  `renderWebGL` is public , `updateTransform` should be public too.