### PR TITLE
High density displays interaction had wrong point calculated.

### DIFF
--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -737,7 +737,7 @@ export default class InteractionManager extends EventEmitter
             rect = this.interactionDOMElement.getBoundingClientRect();
         }
 
-        const resolutionMultiplier = navigator.isCocoonJS ? this.resolution : (1.0 / this.resolution);
+        const resolutionMultiplier = navigator.isCocoonJS ? this.resolution : 1.0;
 
         point.x = ((x - rect.left) * (this.interactionDOMElement.width / rect.width)) * resolutionMultiplier;
         point.y = ((y - rect.top) * (this.interactionDOMElement.height / rect.height)) * resolutionMultiplier;


### PR DESCRIPTION
InteractionManager on higher resolution densities was thinking it pointed at 1/resolution point instead of target point.
After this change it will point properly.
Tested on:
Galaxy Tab S2
iPad Air 2
Chrome emulator
Samsung J7