### PR TITLE
Fix for resolution in high density devices.

### DIFF
--- a/src/core/renderers/SystemRenderer.js
+++ b/src/core/renderers/SystemRenderer.js
@@ -98,6 +98,7 @@ export default class SystemRenderer extends EventEmitter
          * @default 1
          */
         this.resolution = options.resolution || settings.RESOLUTION;
+        this.desiredResolution = this.resolution;
 
         /**
          * Whether the render view is transparent
@@ -199,16 +200,16 @@ export default class SystemRenderer extends EventEmitter
      */
     resize(width, height)
     {
-        this.width = width * this.resolution;
-        this.height = height * this.resolution;
+        this.width = width * this.desiredResolution;
+        this.height = height * this.desiredResolution;
 
         this.view.width = this.width;
         this.view.height = this.height;
 
         if (this.autoResize)
         {
-            this.view.style.width = `${this.width / this.resolution}px`;
-            this.view.style.height = `${this.height / this.resolution}px`;
+            this.view.style.width = `${this.width / this.desiredResolution}px`;
+            this.view.style.height = `${this.height / this.desiredResolution}px`;
         }
     }
 


### PR DESCRIPTION
Resolution here changes when te canvasrenderer is used to render to texture and it's reset to 1.
This prevents the overwrite of desired resolution variable and uses it properly during device orientation change.

Previously after resize resolution would snap back to 1 (and stuff would be upscaled)