### PR TITLE
expose mini-signals

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "earcut": "^2.0.7",
     "eventemitter3": "^2.0.0",
     "ismobilejs": "^0.4.0",
+    "mini-signals": "^1.1.1",
     "object-assign": "^4.0.1",
     "pixi-gl-core": "^1.0.3",
     "resource-loader": "^2.0.3"

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -1,6 +1,7 @@
 import { DATA_URI, URL_FILE_EXTENSION, SVG_SIZE, VERSION } from '../const';
 import settings from '../settings';
 import EventEmitter from 'eventemitter3';
+import Signal from 'mini-signals';
 import pluginTarget from './pluginTarget';
 import * as isMobile from 'ismobilejs';
 
@@ -27,6 +28,14 @@ export {
      * @type {EventEmitter}
      */
     EventEmitter,
+    /**
+     * @see {@link https://github.com/Hypercubed/mini-signals}
+     *
+     * @memberof PIXI.utils
+     * @class Signal
+     * @type {Signal}
+     */
+    Signal,
     /**
      * @memberof PIXI.utils
      * @function pluginTarget


### PR DESCRIPTION
it must be done if we are going to remove ee3 later
at this point, that will help with typescript definitions