### PR TITLE
Namespace Doc Updates

### DIFF
--- a/src/accessibility/AccessibilityManager.js
+++ b/src/accessibility/AccessibilityManager.js
@@ -31,7 +31,7 @@ const DIV_HOOK_ZINDEX = 2;
  * An instance of this class is automatically created by default, and can be found at renderer.plugins.accessibility
  *
  * @class
- * @memberof PIXI
+ * @memberof PIXI.accessibility
  */
 export default class AccessibilityManager
 {

--- a/src/accessibility/accessibleTarget.js
+++ b/src/accessibility/accessibleTarget.js
@@ -2,9 +2,8 @@
  * Default property values of accessible objects
  * used by {@link PIXI.accessibility.AccessibilityManager}.
  *
- * @mixin
- * @name accessibleTarget
- * @memberof PIXI
+ * @function accessibleTarget
+ * @memberof PIXI.accessibility
  * @example
  *      function MyObject() {}
  *

--- a/src/accessibility/index.js
+++ b/src/accessibility/index.js
@@ -1,5 +1,5 @@
 /**
- * @namespace PIXI.AccessibilityManager
+ * @namespace PIXI.accessibility
  */
 export { default as accessibleTarget } from './accessibleTarget';
 export { default as AccessibilityManager } from './AccessibilityManager';

--- a/src/core/math/GroupD8.js
+++ b/src/core/math/GroupD8.js
@@ -71,8 +71,8 @@ init();
  * This is the small part of gameofbombs.com portal system. It works.
  *
  * @author Ivan @ivanpopelyshev
- *
- * @namespace PIXI.GroupD8
+ * @class 
+ * @memberof PIXI
  */
 const GroupD8 = {
     E: 0,
@@ -104,7 +104,7 @@ const GroupD8 = {
     /**
      * Adds 180 degrees to rotation. Commutative operation.
      *
-     * @method
+     * @method PIXI.GroupD8.rotate180
      * @param {number} rotation - The number to rotate.
      * @returns {number} rotated number
      */
@@ -112,13 +112,15 @@ const GroupD8 = {
 
     /**
      * I dont know why sometimes width and heights needs to be swapped. We'll fix it later.
-     *
+     * 
+     * @method PIXI.GroupD8.isSwapWidthHeight
      * @param {number} rotation - The number to check.
      * @returns {boolean} Whether or not the width/height should be swapped.
      */
     isSwapWidthHeight: (rotation) => (rotation & 3) === 2,
 
     /**
+     * @method PIXI.GroupD8.byDirection
      * @param {number} dx - TODO
      * @param {number} dy - TODO
      *
@@ -164,6 +166,7 @@ const GroupD8 = {
     /**
      * Helps sprite to compensate texture packer rotation.
      *
+     * @method PIXI.GroupD8.matrixAppendRotationInv
      * @param {PIXI.Matrix} matrix - sprite world matrix
      * @param {number} rotation - The rotation factor to use.
      * @param {number} tx - sprite anchoring

--- a/src/core/math/GroupD8.js
+++ b/src/core/math/GroupD8.js
@@ -71,7 +71,7 @@ init();
  * This is the small part of gameofbombs.com portal system. It works.
  *
  * @author Ivan @ivanpopelyshev
- * @class 
+ * @class
  * @memberof PIXI
  */
 const GroupD8 = {
@@ -112,7 +112,7 @@ const GroupD8 = {
 
     /**
      * I dont know why sometimes width and heights needs to be swapped. We'll fix it later.
-     * 
+     *
      * @memberof PIXI.GroupD8
      * @param {number} rotation - The number to check.
      * @returns {boolean} Whether or not the width/height should be swapped.

--- a/src/core/math/GroupD8.js
+++ b/src/core/math/GroupD8.js
@@ -104,7 +104,7 @@ const GroupD8 = {
     /**
      * Adds 180 degrees to rotation. Commutative operation.
      *
-     * @method PIXI.GroupD8.rotate180
+     * @memberof PIXI.GroupD8
      * @param {number} rotation - The number to rotate.
      * @returns {number} rotated number
      */
@@ -113,14 +113,14 @@ const GroupD8 = {
     /**
      * I dont know why sometimes width and heights needs to be swapped. We'll fix it later.
      * 
-     * @method PIXI.GroupD8.isSwapWidthHeight
+     * @memberof PIXI.GroupD8
      * @param {number} rotation - The number to check.
      * @returns {boolean} Whether or not the width/height should be swapped.
      */
     isSwapWidthHeight: (rotation) => (rotation & 3) === 2,
 
     /**
-     * @method PIXI.GroupD8.byDirection
+     * @memberof PIXI.GroupD8
      * @param {number} dx - TODO
      * @param {number} dy - TODO
      *
@@ -166,7 +166,7 @@ const GroupD8 = {
     /**
      * Helps sprite to compensate texture packer rotation.
      *
-     * @method PIXI.GroupD8.matrixAppendRotationInv
+     * @memberof PIXI.GroupD8
      * @param {PIXI.Matrix} matrix - sprite world matrix
      * @param {number} rotation - The rotation factor to use.
      * @param {number} tx - sprite anchoring

--- a/src/core/sprites/canvas/CanvasTinter.js
+++ b/src/core/sprites/canvas/CanvasTinter.js
@@ -4,7 +4,8 @@ import canUseNewCanvasBlendModes from '../../renderers/canvas/utils/canUseNewCan
 /**
  * Utility methods for Sprite/Texture tinting.
  *
- * @namespace PIXI.CanvasTinter
+ * @class
+ * @memberof PIXI
  */
 const CanvasTinter = {
     /**


### PR DESCRIPTION
### Fixed

* Updates accessibility namespace, which was missing.
* CanvasTinter and GroupD8 should be doc’d as classes with static methods, not namespaces.

#### Examples

Preview: http://pixijs.download/docs/docs/index.html

PIXI: [new](http://pixijs.download/docs/docs/PIXI.html) [old](http://pixijs.download/release/docs/PIXI.html)
PIXI.accessibility: [new](http://pixijs.download/docs/docs/PIXI.accessibility.html)
GroupD8: [new](http://pixijs.download/docs/docs/PIXI.GroupD8.html) [old](http://pixijs.download/release/docs/PIXI.GroupD8.html)
CanvasTinter: [new](http://pixijs.download/docs/docs/PIXI.CanvasTinter.html) [old](http://pixijs.download/release/docs/PIXI.CanvasTinter.html)