### PR TITLE
Fixes path for renderers client

### DIFF
--- a/scripts/renders/client.js
+++ b/scripts/renders/client.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('../../bin/pixi');
+require('../../dist/pixi');
 PIXI.utils.skipHello();
 
 const fs = require('fs');


### PR DESCRIPTION
### Fixed

* Changes the path for Pixi when running `npm run renders`, causing the Electron app to fail.