### PR TITLE
Added Graphics.containsPoint with no fill expectation

### DIFF
--- a/test/core/Graphics.js
+++ b/test/core/Graphics.js
@@ -127,6 +127,16 @@ describe('PIXI.Graphics', function ()
 
             expect(graphics.containsPoint(point)).to.be.false;
         });
+
+        it('should return false when no fill', function ()
+        {
+            const point = new PIXI.Point(1, 1);
+            const graphics = new PIXI.Graphics();
+
+            graphics.drawRect(0, 0, 10, 10);
+
+            expect(graphics.containsPoint(point)).to.be.false;
+        });
     });
 
     describe('arc', function ()


### PR DESCRIPTION
Seems [this is the case](https://github.com/pixijs/pixi.js/blob/e1b98404a982467811ee655de8372bd5d1d77177/src/core/graphics/Graphics.js#L863-L866), so I've added the expectation to tests.