### PR TITLE
User can decide whether  auto-set the projection

### DIFF
--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -440,9 +440,10 @@ export default class WebGLRenderer extends SystemRenderer
      * Changes the current shader to the one given in parameter
      *
      * @param {PIXI.Shader} shader - the new shader
+     * @param {boolean} [autoProject=true] - Whether automatically set the projection matrix
      * @return {PIXI.WebGLRenderer} Returns itself.
      */
-    bindShader(shader)
+    bindShader(shader, autoProject)
     {
         // TODO cache
         if (this._activeShader !== shader)
@@ -450,8 +451,11 @@ export default class WebGLRenderer extends SystemRenderer
             this._activeShader = shader;
             shader.bind();
 
-            // automatically set the projection matrix
-            shader.uniforms.projectionMatrix = this._activeRenderTarget.projectionMatrix.toArray(true);
+            if (autoProject !== false)
+            {
+                // automatically set the projection matrix
+                shader.uniforms.projectionMatrix = this._activeRenderTarget.projectionMatrix.toArray(true);
+            }
         }
 
         return this;

--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -451,6 +451,9 @@ export default class WebGLRenderer extends SystemRenderer
             this._activeShader = shader;
             shader.bind();
 
+            // `autoProject` normally would be a default parameter set to true
+            // but because of how Babel transpiles default parameters
+            // it hinders the performance of this method.
             if (autoProject !== false)
             {
                 // automatically set the projection matrix


### PR DESCRIPTION
`bindShader` always  set the projection matrix  automatically . in most cases ,  that's OK.

But When I create some new renderers of PIXI ,  sometimes it would make some problems.
e.g. When : 
* shader no projectionMatrix
* shader need use a custom projectionMatrix (not  _activeRenderTarget's)
* shader use a cached array (don't want to call `toArray` every time)

So I add a new argument to `bindShader` , and the default value is true, so  it would NOT break any current code of PIXI

.