### PR TITLE
Fix resolution setting of PIXI.Filter, and another two wrong codes on resolution importing

### DIFF
--- a/src/core/renderers/canvas/utils/CanvasRenderTarget.js
+++ b/src/core/renderers/canvas/utils/CanvasRenderTarget.js
@@ -1,5 +1,4 @@
 import settings from '../../../settings';
-const { RESOLUTION } = settings;
 
 /**
  * Creates a Canvas element of the given size.
@@ -30,7 +29,7 @@ export default class CanvasRenderTarget
          */
         this.context = this.canvas.getContext('2d');
 
-        this.resolution = resolution || RESOLUTION;
+        this.resolution = resolution || settings.RESOLUTION;
 
         this.resize(width, height);
     }

--- a/src/core/renderers/webgl/filters/Filter.js
+++ b/src/core/renderers/webgl/filters/Filter.js
@@ -1,6 +1,7 @@
 import extractUniformsFromSrc from './extractUniformsFromSrc';
 import { uid } from '../../../utils';
 import { BLEND_MODES } from '../../../const';
+import settings from '../../../settings';
 
 const SOURCE_KEY_MAP = {};
 
@@ -80,7 +81,7 @@ class Filter
          *
          * @member {number}
          */
-        this.resolution = 1;
+        this.resolution = settings.RESOLUTION;
 
         /**
          * If enabled is true the filter is applied, if false it will not.

--- a/src/core/textures/BaseRenderTexture.js
+++ b/src/core/textures/BaseRenderTexture.js
@@ -1,7 +1,7 @@
 import BaseTexture from './BaseTexture';
 import settings from '../settings';
 
-const { RESOLUTION, SCALE_MODE } = settings;
+const { SCALE_MODE } = settings;
 
 /**
  * A BaseRenderTexture is a special texture that allows any Pixi display object to be rendered to it.
@@ -55,7 +55,7 @@ export default class BaseRenderTexture extends BaseTexture
     {
         super(null, scaleMode);
 
-        this.resolution = resolution || RESOLUTION;
+        this.resolution = resolution || settings.RESOLUTION;
 
         this.width = width;
         this.height = height;

--- a/src/filters/blur/BlurFilter.js
+++ b/src/filters/blur/BlurFilter.js
@@ -24,10 +24,9 @@ export default class BlurFilter extends core.Filter
 
         this.blurXFilter = new BlurXFilter(strength, quality, resolution, kernelSize);
         this.blurYFilter = new BlurYFilter(strength, quality, resolution, kernelSize);
-        this.resolution = 1;
 
         this.padding = 0;
-        this.resolution = resolution || 1;
+        this.resolution = resolution || core.settings.RESOLUTION;
         this.quality = quality || 4;
         this.blur = strength || 8;
     }

--- a/src/filters/blur/BlurXFilter.js
+++ b/src/filters/blur/BlurXFilter.js
@@ -31,7 +31,7 @@ export default class BlurXFilter extends core.Filter
             fragSrc
         );
 
-        this.resolution = resolution || 1;
+        this.resolution = resolution || core.settings.RESOLUTION;
 
         this._quality = 0;
 

--- a/src/filters/blur/BlurYFilter.js
+++ b/src/filters/blur/BlurYFilter.js
@@ -31,7 +31,7 @@ export default class BlurYFilter extends core.Filter
             fragSrc
         );
 
-        this.resolution = resolution || 1;
+        this.resolution = resolution || core.settings.RESOLUTION;
 
         this._quality = 0;
 


### PR DESCRIPTION
Set `this.resolution` to `settings.RESOLUTION` instead of `1`, otherwise texture will be blurred in retina screens (where `settings.RESOLUTION` may be setting to `2` or above).