### PR TITLE
CanvasTinter canvas size rounds up

### DIFF
--- a/src/core/sprites/canvas/CanvasTinter.js
+++ b/src/core/sprites/canvas/CanvasTinter.js
@@ -75,8 +75,8 @@ const CanvasTinter = {
         crop.width *= resolution;
         crop.height *= resolution;
 
-        canvas.width = crop.width;
-        canvas.height = crop.height;
+        canvas.width = Math.ceil(crop.width);
+        canvas.height = Math.ceil(crop.height);
 
         context.fillStyle = `#${(`00000${(color | 0).toString(16)}`).substr(-6)}`;
 
@@ -130,8 +130,8 @@ const CanvasTinter = {
         crop.width *= resolution;
         crop.height *= resolution;
 
-        canvas.width = crop.width;
-        canvas.height = crop.height;
+        canvas.width = Math.ceil(crop.width);
+        canvas.height = Math.ceil(crop.height);
 
         context.globalCompositeOperation = 'copy';
         context.fillStyle = `#${(`00000${(color | 0).toString(16)}`).substr(-6)}`;
@@ -172,8 +172,8 @@ const CanvasTinter = {
         crop.width *= resolution;
         crop.height *= resolution;
 
-        canvas.width = crop.width;
-        canvas.height = crop.height;
+        canvas.width = Math.ceil(crop.width);
+        canvas.height = Math.ceil(crop.height);
 
         context.globalCompositeOperation = 'copy';
         context.drawImage(


### PR DESCRIPTION
In my project I use resolution as an easy way to use smaller assets on mobile devices. This means that occasionally the `crop.width` or `crop.height` is a decimal. When you set a canvas to a decimal number it seems to always round down (at least it does for me). This sometimes results in the tinted image being very slightly cut off.

Rounding the canvas size up has fixed this issue for me.