### PR TITLE
Stops shadow blur appearing on the text as well as shadow

### DIFF
--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -189,10 +189,11 @@ export default class Text extends Sprite
 
         if (style.dropShadow)
         {
+            this.context.shadowBlur = style.dropShadowBlur;
+
             if (style.dropShadowBlur > 0)
             {
                 this.context.shadowColor = style.dropShadowColor;
-                this.context.shadowBlur = style.dropShadowBlur;
             }
             else
             {
@@ -239,6 +240,9 @@ export default class Text extends Sprite
 
         // set canvas text styles
         this.context.fillStyle = this._generateFillStyle(style, lines);
+
+        // remove blur if set for the drop shadow
+        this.context.shadowBlur = 0;
 
         // draw lines line by line
         for (let i = 0; i < lines.length; i++)


### PR DESCRIPTION
Does this by resetting this.context.shadowBlur both if it not required whilst drawing the shadow, and also after drawing the shadow
Fixes: https://github.com/pixijs/pixi.js/issues/3621