### PR TITLE
Fix #3609 , about `filterClamp` & `filterArea` 

### DIFF
--- a/src/core/renderers/webgl/managers/FilterManager.js
+++ b/src/core/renderers/webgl/managers/FilterManager.js
@@ -289,7 +289,7 @@ export default class FilterManager extends WebGLManager
         let textureCount = 1;
         let currentState;
 
-        if (shader.uniforms.data.filterArea)
+        if (uniforms.filterArea)
         {
             currentState = this.filterData.stack[this.filterData.index];
 
@@ -305,7 +305,7 @@ export default class FilterManager extends WebGLManager
 
         // use this to clamp displaced texture coords so they belong to filterArea
         // see displacementFilter fragment shader for an example
-        if (shader.uniforms.data.filterClamp)
+        if (uniforms.filterClamp)
         {
             currentState = this.filterData.stack[this.filterData.index];
 

--- a/src/core/renderers/webgl/managers/FilterManager.js
+++ b/src/core/renderers/webgl/managers/FilterManager.js
@@ -292,7 +292,8 @@ export default class FilterManager extends WebGLManager
         if (shader.uniforms.data.filterArea)
         {
             currentState = this.filterData.stack[this.filterData.index];
-            const filterArea = shader.uniforms.filterArea;
+
+            const filterArea = uniforms.filterArea;
 
             filterArea[0] = currentState.renderTarget.size.width;
             filterArea[1] = currentState.renderTarget.size.height;
@@ -308,7 +309,7 @@ export default class FilterManager extends WebGLManager
         {
             currentState = this.filterData.stack[this.filterData.index];
 
-            const filterClamp = shader.uniforms.filterClamp;
+            const filterClamp = uniforms.filterClamp;
 
             filterClamp[0] = 0;
             filterClamp[1] = 0;

--- a/src/filters/displacement/DisplacementFilter.js
+++ b/src/filters/displacement/DisplacementFilter.js
@@ -36,7 +36,7 @@ export default class DisplacementFilter extends core.Filter
         this.maskMatrix = maskMatrix;
 
         this.uniforms.mapSampler = sprite.texture;
-        this.uniforms.filterMatrix = maskMatrix.toArray(true);
+        this.uniforms.filterMatrix = maskMatrix;
         this.uniforms.scale = { x: 1, y: 1 };
 
         if (scale === null || scale === undefined)


### PR DESCRIPTION
There is a issue : If the filter used `filterClamp` or `filterArea` ,  the canvas will flash when the filter be added.
(see #3609 )

This PR fix this issue.