### PR TITLE
Allow non-interactive children to NOT trigger interactive parents

### DIFF
--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -877,6 +877,10 @@ export default class InteractionManager extends EventEmitter
 
                 func(displayObject, hit);
             }
+            else if (displayObject.parent && !displayObject.parent.nonInteractiveChildrenTriggerInteractiveParent)
+            {
+                hit = false;
+            }
         }
 
         return hit;

--- a/src/interaction/interactiveTarget.js
+++ b/src/interaction/interactiveTarget.js
@@ -30,6 +30,14 @@ export default {
     interactiveChildren: true,
 
     /**
+     * Whether hits on non-interactive children should cause events to be raised
+     * against their interactive parent
+     *
+     * @inner {boolean}
+     */
+    nonInteractiveChildrenTriggerInteractiveParent: true,
+
+    /**
      * Interaction shape. Children will be hit first, then this shape will be checked.
      * Setting this will cause this shape to be checked in hit tests rather than the displayObject's bounds.
      *

--- a/test/interaction/InteractionManager.js
+++ b/test/interaction/InteractionManager.js
@@ -373,6 +373,7 @@ describe('PIXI.interaction.InteractionManager', function ()
                     scene.behindChild.interactive = true;
                     scene.behindChild.x = 25;
                     scene.parent.interactive = true;
+                    scene.parent.nonInteractiveChildrenTriggerInteractiveParent = false;
 
                     stage.addChild(scene.parent);
                     pointer.click(40, 10);

--- a/test/interaction/InteractionManager.js
+++ b/test/interaction/InteractionManager.js
@@ -364,7 +364,6 @@ describe('PIXI.interaction.InteractionManager', function ()
                     expect(scene.parentCallback).to.have.been.calledOnce;
                 });
 
-                /* TODO: Fix #3596
                 it('should callback parent and behind child when clicking overlap', function ()
                 {
                     const stage = new PIXI.Container();
@@ -382,7 +381,6 @@ describe('PIXI.interaction.InteractionManager', function ()
                     expect(scene.frontChildCallback).to.not.have.been.called;
                     expect(scene.parentCallback).to.have.been.calledOnce;
                 });
-                */
 
                 it('should callback parent and behind child when clicking behind child', function ()
                 {


### PR DESCRIPTION
Resolves #3596 and the broken test in #3535

Adds the somewhat verbose, but hopefully descriptive property to `interactiveTarget`;

~~~javascript
/**
 * Whether hits on non-interactive children should cause events to be raised
 * against their interactive parent
 *
 * @inner {boolean}
 */
nonInteractiveChildrenTriggerInteractiveParent: true,
~~~

