### PR TITLE
Additional convenience getters for Application

### DIFF
--- a/src/core/Application.js
+++ b/src/core/Application.js
@@ -95,6 +95,26 @@ export default class Application
     }
 
     /**
+     * Convenience for the renderer's width.
+     * @member {Number}
+     * @readonly
+     */
+    get width()
+    {
+        return this.renderer.width;
+    }
+
+    /**
+     * Convenience for the renderer's height.
+     * @member {Number}
+     * @readonly
+     */
+    get height()
+    {
+        return this.renderer.height;
+    }
+
+    /**
      * Destroy and don't use after this.
      * @param {Boolean} [removeView=false] Automatically remove canvas from DOM.
      */


### PR DESCRIPTION
Adds `width` and `height` convenience getters to the Application class. There are lots of references in the examples to `renderer.width` and `renderer.height`, this would help to simplify even more.