### PR TITLE
Add an easy way to clear RenderTexture

### DIFF
--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -376,6 +376,23 @@ export default class WebGLRenderer extends SystemRenderer
     }
 
     /**
+     * Erases the render texture and fills the drawing area with a colour
+     *
+     * @param {PIXI.RenderTexture} renderTexture - The render texture to clear
+     * @param {number} [clearColor] - The colour
+     */
+    clearRenderTexture(renderTexture, clearColor)
+    {
+        const baseTexture = renderTexture.baseTexture;
+        const renderTarget = baseTexture._glRenderTargets[this.CONTEXT_UID];
+
+        if (renderTarget)
+        {
+            renderTarget.clear(clearColor);
+        }
+    }
+
+    /**
      * Binds a render texture for rendering
      *
      * @param {PIXI.RenderTexture} renderTexture - The render texture to render

--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -380,6 +380,7 @@ export default class WebGLRenderer extends SystemRenderer
      *
      * @param {PIXI.RenderTexture} renderTexture - The render texture to clear
      * @param {number} [clearColor] - The colour
+     * @return {PIXI.WebGLRenderer} Returns itself.
      */
     clearRenderTexture(renderTexture, clearColor)
     {
@@ -390,6 +391,8 @@ export default class WebGLRenderer extends SystemRenderer
         {
             renderTarget.clear(clearColor);
         }
+
+        return this;
     }
 
     /**


### PR DESCRIPTION
In current PIXI, clear a RenderTexture is complex : 
```
renderer.bindRenderTexture(myRenderTexture);
renderer.clear();
// restore the previous renderTexture
renderer.bindRenderTexture();
```
And bind renderTexture is a high-cost operation . We shouldn't call it for cleaning render texture.

So I  add this method.

relatived : https://github.com/pixijs/pixi.js/issues/3595