### PR TITLE
fix unexpected 0 text behaviour

### DIFF
--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -744,7 +744,7 @@ export default class Text extends Sprite
 
     set text(text) // eslint-disable-line require-jsdoc
     {
-        text = String(text || ' ');
+        text = String(text === '' || text === null || text === undefined ? ' ' : text);
 
         if (this._text === text)
         {

--- a/test/core/Text.js
+++ b/test/core/Text.js
@@ -112,4 +112,42 @@ describe('PIXI.Text', function ()
             expect(text.width).to.equal(300);
         });
     });
+
+    describe('text', function ()
+    {
+        it('should convert numbers into strings', function ()
+        {
+            const text = new PIXI.Text(2);
+
+            expect(text.text).to.equal('2');
+        });
+
+        it('should not change 0 to \'\'', function ()
+        {
+            const text = new PIXI.Text(0);
+
+            expect(text.text).to.equal('0');
+        });
+
+        it('should prevent setting null', function ()
+        {
+            const text = new PIXI.Text(null);
+
+            expect(text.text).to.equal(' ');
+        });
+
+        it('should prevent setting undefined', function ()
+        {
+            const text = new PIXI.Text();
+
+            expect(text.text).to.equal(' ');
+        });
+
+        it('should prevent setting \'\'', function ()
+        {
+            const text = new PIXI.Text('');
+
+            expect(text.text).to.equal(' ');
+        });
+    });
 });


### PR DESCRIPTION
We got a weird glitch upgrading from pixi 3 to 4, setting the text in a PIXI.Text to 0 results in the label actually saying ' '. This seems like unexpected behaviour considering all the other numbers work :)