### PR TITLE
initial commit for ultimate renderer dimensions solution

### DIFF
--- a/src/core/Application.js
+++ b/src/core/Application.js
@@ -95,6 +95,16 @@ export default class Application
     }
 
     /**
+     * Reference to the renderer's screen rectangle. Its safe to use as filterArea or hitArea for whole screen
+     * @member {PIXI.Rectangle}
+     * @readonly
+     */
+    get screen()
+    {
+        return this.renderer.screen;
+    }
+
+    /**
      * Destroy and don't use after this.
      * @param {Boolean} [removeView=false] Automatically remove canvas from DOM.
      */

--- a/src/core/renderers/SystemRenderer.js
+++ b/src/core/renderers/SystemRenderer.js
@@ -1,5 +1,5 @@
 import { sayHello, hex2string, hex2rgb } from '../utils';
-import { Matrix } from '../math';
+import { Matrix, Rectangle } from '../math';
 import { RENDERER_TYPE } from '../const';
 import settings from '../settings';
 import Container from '../display/Container';
@@ -21,8 +21,8 @@ export default class SystemRenderer extends EventEmitter
 {
     /**
      * @param {string} system - The name of the system this renderer is for.
-     * @param {number} [width=800] - the width of the canvas view
-     * @param {number} [height=600] - the height of the canvas view
+     * @param {number} [screenWidth=800] - the width of the screen
+     * @param {number} [screenHeight=600] - the height of the screen
      * @param {object} [options] - The optional renderer parameters
      * @param {HTMLCanvasElement} [options.view] - the canvas to use as a view, optional
      * @param {boolean} [options.transparent=false] - If the render view is transparent, default false
@@ -37,7 +37,7 @@ export default class SystemRenderer extends EventEmitter
      * @param {boolean} [options.roundPixels=false] - If true Pixi will Math.floor() x/y values when rendering,
      *  stopping pixel interpolation.
      */
-    constructor(system, width, height, options)
+    constructor(system, screenWidth, screenHeight, options)
     {
         super();
 
@@ -69,20 +69,13 @@ export default class SystemRenderer extends EventEmitter
         this.type = RENDERER_TYPE.UNKNOWN;
 
         /**
-         * The width of the canvas view
+         * Measurements of the screen. (0, 0, screenWidth, screenHeight)
          *
-         * @member {number}
-         * @default 800
-         */
-        this.width = width || 800;
-
-        /**
-         * The height of the canvas view
+         * Its safe to use as filterArea or hitArea for whole stage
          *
-         * @member {number}
-         * @default 600
+         * @member {PIXI.Rectangle}
          */
-        this.height = height || 600;
+        this.screen = new Rectangle(0, 0, screenWidth || 800, screenHeight || 600);
 
         /**
          * The canvas element that everything is drawn to
@@ -107,7 +100,7 @@ export default class SystemRenderer extends EventEmitter
         this.transparent = options.transparent;
 
         /**
-         * Whether the render view should be resized automatically
+         * Whether css dimensions of canvas view should be resized to screen dimensions automatically
          *
          * @member {boolean}
          */
@@ -192,23 +185,48 @@ export default class SystemRenderer extends EventEmitter
     }
 
     /**
-     * Resizes the canvas view to the specified width and height
+     * Same as view.width, actual number of pixels in the canvas by horizontal
      *
-     * @param {number} width - the new width of the canvas view
-     * @param {number} height - the new height of the canvas view
+     * @member {number}
+     * @readonly
+     * @default 800
      */
-    resize(width, height)
+    get width()
     {
-        this.width = width * this.resolution;
-        this.height = height * this.resolution;
+        return this.view.width;
+    }
 
-        this.view.width = this.width;
-        this.view.height = this.height;
+    /**
+     * Same as view.height, actual number of pixels in the canvas by vertical
+     *
+     * @member {number}
+     * @readonly
+     * @default 600
+     */
+    get height()
+    {
+        return this.view.height;
+    }
+
+    /**
+     * Resizes the screen and canvas to the specified width and height
+     * Canvas dimensions are multiplied by resolution
+     *
+     * @param {number} screenWidth - the new width of the screen
+     * @param {number} screenHeight - the new height of the screen
+     */
+    resize(screenWidth, screenHeight)
+    {
+        this.screen.width = screenWidth;
+        this.screen.height = screenHeight;
+
+        this.view.width = screenWidth * this.resolution;
+        this.view.height = screenHeight * this.resolution;
 
         if (this.autoResize)
         {
-            this.view.style.width = `${this.width / this.resolution}px`;
-            this.view.style.height = `${this.height / this.resolution}px`;
+            this.view.style.width = `${screenWidth}px`;
+            this.view.style.height = `${screenHeight}px`;
         }
     }
 
@@ -249,10 +267,9 @@ export default class SystemRenderer extends EventEmitter
 
         this.type = RENDERER_TYPE.UNKNOWN;
 
-        this.width = 0;
-        this.height = 0;
-
         this.view = null;
+
+        this.screen = null;
 
         this.resolution = 0;
 

--- a/src/core/renderers/canvas/CanvasRenderer.js
+++ b/src/core/renderers/canvas/CanvasRenderer.js
@@ -18,8 +18,8 @@ import settings from '../../settings';
 export default class CanvasRenderer extends SystemRenderer
 {
     /**
-     * @param {number} [width=800] - the width of the canvas view
-     * @param {number} [height=600] - the height of the canvas view
+     * @param {number} [screenWidth=800] - the width of the screen
+     * @param {number} [screenHeight=600] - the height of the screen
      * @param {object} [options] - The optional renderer parameters
      * @param {HTMLCanvasElement} [options.view] - the canvas to use as a view, optional
      * @param {boolean} [options.transparent=false] - If the render view is transparent, default false
@@ -34,9 +34,9 @@ export default class CanvasRenderer extends SystemRenderer
      * @param {boolean} [options.roundPixels=false] - If true Pixi will Math.floor() x/y values when rendering,
      *  stopping pixel interpolation.
      */
-    constructor(width, height, options = {})
+    constructor(screenWidth, screenHeight, options = {})
     {
-        super('Canvas', width, height, options);
+        super('Canvas', screenWidth, screenHeight, options);
 
         this.type = RENDERER_TYPE.CANVAS;
 
@@ -96,7 +96,7 @@ export default class CanvasRenderer extends SystemRenderer
         this.context = null;
         this.renderingToScreen = false;
 
-        this.resize(width, height);
+        this.resize(screenWidth, screenHeight);
     }
 
     /**
@@ -283,12 +283,12 @@ export default class CanvasRenderer extends SystemRenderer
      *
      * @extends PIXI.SystemRenderer#resize
      *
-     * @param {number} width - The new width of the canvas view
-     * @param {number} height - The new height of the canvas view
+     * @param {number} screenWidth - the new width of the screen
+     * @param {number} screenHeight - the new height of the screen
      */
-    resize(width, height)
+    resize(screenWidth, screenHeight)
     {
-        super.resize(width, height);
+        super.resize(screenWidth, screenHeight);
 
         // reset the scale mode.. oddly this seems to be reset when the canvas is resized.
         // surely a browser bug?? Let pixi fix that for you..

--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -30,8 +30,8 @@ export default class WebGLRenderer extends SystemRenderer
 {
     /**
      *
-     * @param {number} [width=0] - the width of the canvas view
-     * @param {number} [height=0] - the height of the canvas view
+     * @param {number} [screenWidth=800] - the width of the screen
+     * @param {number} [screenHeight=600] - the height of the screen
      * @param {object} [options] - The optional renderer parameters
      * @param {HTMLCanvasElement} [options.view] - the canvas to use as a view, optional
      * @param {boolean} [options.transparent=false] - If the render view is transparent, default false
@@ -50,9 +50,9 @@ export default class WebGLRenderer extends SystemRenderer
      * @param {boolean} [options.roundPixels=false] - If true Pixi will Math.floor() x/y values when
      *  rendering, stopping pixel interpolation.
      */
-    constructor(width, height, options = {})
+    constructor(screenWidth, screenHeight, options = {})
     {
-        super('WebGL', width, height, options);
+        super('WebGL', screenWidth, screenHeight, options);
 
         /**
          * The type of this renderer as a standardised const
@@ -229,7 +229,7 @@ export default class WebGLRenderer extends SystemRenderer
         this.emit('context', gl);
 
         // setup the width/height properties and gl viewport
-        this.resize(this.width, this.height);
+        this.resize(this.screen.width, this.screen.height);
     }
 
     /**
@@ -323,16 +323,16 @@ export default class WebGLRenderer extends SystemRenderer
     /**
      * Resizes the webGL view to the specified width and height.
      *
-     * @param {number} width - the new width of the webGL view
-     * @param {number} height - the new height of the webGL view
+     * @param {number} screenWidth - the new width of the screen
+     * @param {number} screenHeight - the new height of the screen
      */
-    resize(width, height)
+    resize(screenWidth, screenHeight)
     {
       //  if(width * this.resolution === this.width && height * this.resolution === this.height)return;
 
-        SystemRenderer.prototype.resize.call(this, width, height);
+        SystemRenderer.prototype.resize.call(this, screenWidth, screenHeight);
 
-        this.rootRenderTarget.resize(width, height);
+        this.rootRenderTarget.resize(screenWidth, screenHeight);
 
         if (this._activeRenderTarget === this.rootRenderTarget)
         {


### PR DESCRIPTION
According to #3641, we really have a problem. Not even core developers know what does "width" or "height" mean.

Proposition:

1. screen.width and screen.height are used for the stage
2. view.width and view.height are size of canvas, thus they are measured in real pixels

If this one will be approved, I will move forward to

1. ultimate resize logic: resizeView, resizeScreen, resizeCss with autoUpdate tying them to each other. resizeBack for overriding by canvas&webgl. onResize event/signal/whatever
2. possible accessability fixes, I just saw a number of uses of "renderer.width" there which aren't that clear
3. jsdocs for all "width"s and "height"s, explaining which are actually screen coords and which are physical pixels. Most of them will be screen'ed, of course.
4. possible deprecation of "renderer.width", "renderer.height", just to be clear. I won't press for that, but may be team decides so
5. EXAMPLES FOR ALL THE POSSIBLE CASES of autoUpdate, setting width, height and resolution logic.