### PR TITLE
Improve error message for out-of-bounds Textures

### DIFF
--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -459,7 +459,9 @@ export default class Texture extends EventEmitter
 
         if (frame.x + frame.width > this.baseTexture.width || frame.y + frame.height > this.baseTexture.height)
         {
-            throw new Error(`Texture Error: frame does not fit inside the base Texture dimensions ${this}`);
+            throw new Error('Texture Error: frame does not fit inside the base Texture dimensions: '
+                + `X: ${frame.x} + ${frame.width} > ${this.baseTexture.width} `
+                + `Y: ${frame.y} + ${frame.height} > ${this.baseTexture.height}`);
         }
 
         // this.valid = frame && frame.width && frame.height && this.baseTexture.source && this.baseTexture.hasLoaded;


### PR DESCRIPTION
Every now and then we stumble across this error in our logs:
```Texture Error: frame does not fit inside the base Texture dimensions [object Object]```

It's most likely a problem with some of our sprite packing, but it's always a hard one to debug. It doesn't help that the ```[object Object]``` bit is very unhelpful ;)

I know this error is not very common, but if one does come across it it's going to be a massive help to have a bit more information that helps pinpoint the culprit.