### PR TITLE
FilterManager shaderCache reset as object

### DIFF
--- a/src/core/renderers/webgl/managers/FilterManager.js
+++ b/src/core/renderers/webgl/managers/FilterManager.js
@@ -484,7 +484,7 @@ export default class FilterManager extends WebGLManager
      */
     destroy()
     {
-        this.shaderCache = [];
+        this.shaderCache = {};
         this.emptyPool();
     }
 


### PR DESCRIPTION
The shaderCache is initially created as an object. When the Filter Manager gets destroyed, it should be reset to an empty object, not an array.