### PR TITLE
Better use of scale mode default

### DIFF
--- a/src/core/renderers/webgl/utils/RenderTarget.js
+++ b/src/core/renderers/webgl/utils/RenderTarget.js
@@ -124,7 +124,7 @@ export default class RenderTarget
          * @default PIXI.settings.SCALE_MODE
          * @see PIXI.SCALE_MODES
          */
-        this.scaleMode = scaleMode || settings.SCALE_MODE;
+        this.scaleMode = scaleMode !== undefined ? scaleMode : settings.SCALE_MODE;
 
         /**
          * Whether this object is the root element or not

--- a/src/core/textures/BaseRenderTexture.js
+++ b/src/core/textures/BaseRenderTexture.js
@@ -1,8 +1,6 @@
 import BaseTexture from './BaseTexture';
 import settings from '../settings';
 
-const { SCALE_MODE } = settings;
-
 /**
  * A BaseRenderTexture is a special texture that allows any Pixi display object to be rendered to it.
  *
@@ -62,7 +60,7 @@ export default class BaseRenderTexture extends BaseTexture
         this.realWidth = this.width * this.resolution;
         this.realHeight = this.height * this.resolution;
 
-        this.scaleMode = scaleMode || SCALE_MODE;
+        this.scaleMode = scaleMode !== undefined ? scaleMode : settings.SCALE_MODE;
         this.hasLoaded = true;
 
         /**

--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -77,7 +77,7 @@ export default class BaseTexture extends EventEmitter
          * @default PIXI.settings.SCALE_MODE
          * @see PIXI.SCALE_MODES
          */
-        this.scaleMode = scaleMode || settings.SCALE_MODE;
+        this.scaleMode = scaleMode !== undefined ? scaleMode : settings.SCALE_MODE;
 
         /**
          * Set to true once the base texture has successfully loaded.

--- a/src/core/textures/RenderTexture.js
+++ b/src/core/textures/RenderTexture.js
@@ -54,8 +54,8 @@ export default class RenderTexture extends Texture
             /* eslint-disable prefer-rest-params, no-console */
             const width = arguments[1];
             const height = arguments[2];
-            const scaleMode = arguments[3] || 0;
-            const resolution = arguments[4] || 1;
+            const scaleMode = arguments[3];
+            const resolution = arguments[4];
 
             // we have an old render texture..
             console.warn(`Please use RenderTexture.create(${width}, ${height}) instead of the ctor directly.`);


### PR DESCRIPTION
Resolves #3660 

RenderTexture was not respecting the `PIXI.settings.SCALE_MODE` as the proper default.

Also, this fixes the logic in several class using the SCALE_MODE as the default. Because LINEAR is `0`, setting this manually would always default to the default.

* **Broken** [example](https://jsfiddle.net/k9ror7dL/1/) (latest release)
* **Fixed** [example](https://jsfiddle.net/8sz55dxt/3/)