### PR TITLE
Fixes tests check for isWebGL

### DIFF
--- a/test/core/WebGLRenderer.js
+++ b/test/core/WebGLRenderer.js
@@ -2,12 +2,12 @@
 
 function isWebGLSupported(fn)
 {
-    return PIXI.utils.isWebGLSupported() ? fn : function () {}; // eslint-disable-line no-empty-function
+    return PIXI.utils.isWebGLSupported() ? fn : undefined;
 }
 
-describe('PIXI.WebGLRenderer', isWebGLSupported(function ()
+describe('PIXI.WebGLRenderer', function ()
 {
-    it('setting option legacy should disable VAOs and set minimum SPRITE_MAX_TEXTURES to 1', function ()
+    it('setting option legacy should disable VAOs and SPRITE_MAX_TEXTURES', isWebGLSupported(function ()
     {
         const renderer = new PIXI.WebGLRenderer(1, 1, { legacy: true });
 
@@ -15,5 +15,5 @@ describe('PIXI.WebGLRenderer', isWebGLSupported(function ()
         expect(renderer.plugins.sprite.MAX_TEXTURES).to.equal(1);
 
         renderer.destroy();
-    });
-}));
+    }));
+});


### PR DESCRIPTION
Small tweak follow-up to #3630

This way WebGL-only tests show-up as skipped in the Mocha output.