### PR TITLE
Fixed #3698 (Matrix constructor now takes parameters)

### DIFF
--- a/src/core/math/Matrix.js
+++ b/src/core/math/Matrix.js
@@ -15,43 +15,43 @@ export default class Matrix
     /**
      *
      */
-    constructor()
+    constructor(a = 1, b = 0, c = 0, d = 1, tx = 0, ty = 0)
     {
         /**
          * @member {number}
          * @default 1
          */
-        this.a = 1;
+        this.a = a;
 
         /**
          * @member {number}
          * @default 0
          */
-        this.b = 0;
+        this.b = b;
 
         /**
          * @member {number}
          * @default 0
          */
-        this.c = 0;
+        this.c = c;
 
         /**
          * @member {number}
          * @default 1
          */
-        this.d = 1;
+        this.d = d;
 
         /**
          * @member {number}
          * @default 0
          */
-        this.tx = 0;
+        this.tx = tx;
 
         /**
          * @member {number}
          * @default 0
          */
-        this.ty = 0;
+        this.ty = ty;
 
         this.array = null;
     }

--- a/src/core/math/Matrix.js
+++ b/src/core/math/Matrix.js
@@ -13,7 +13,12 @@ import Point from './Point';
 export default class Matrix
 {
     /**
-     *
+     * @param {number} [a=1] - x scale
+     * @param {number} [b=0] - y skew
+     * @param {number} [c=0] - x skew
+     * @param {number} [d=1] - y scale
+     * @param {number} [tx=0] - x translation
+     * @param {number} [ty=0] - y translation
      */
     constructor(a = 1, b = 0, c = 0, d = 1, tx = 0, ty = 0)
     {


### PR DESCRIPTION
Fixes #3698 

Matrix can now be constructed with optional parameters for its a, b, c, d, tx and ty properties. If no parameters are given, a matrix with the default values is created. 