### PR TITLE
Fix cursors not working as expected in nested interactive objects

### DIFF
--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -507,6 +507,9 @@ export default class InteractionManager extends EventEmitter
         {
             window.document.addEventListener('pointermove', this.onPointerMove, true);
             this.interactionDOMElement.addEventListener('pointerdown', this.onPointerDown, true);
+            // pointerout is fired in addition to pointerup (for touch events) and pointercancel
+            // we already handle those, so for the purposes of what we do in onPointerOut, we only
+            // care about the pointerleave event
             this.interactionDOMElement.addEventListener('pointerleave', this.onPointerOut, true);
             this.interactionDOMElement.addEventListener('pointerover', this.onPointerOver, true);
             window.addEventListener('pointercancel', this.onPointerCancel, true);

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -651,10 +651,7 @@ export default class InteractionManager extends EventEmitter
             }
         }
 
-        if (this.currentCursorMode !== this.cursor)
-        {
-            this.setCursorMode(this.cursor);
-        }
+        this.setCursorMode(this.cursor);
 
         // TODO
     }
@@ -667,6 +664,11 @@ export default class InteractionManager extends EventEmitter
     setCursorMode(mode)
     {
         mode = mode || 'default';
+        // if the mode didn't actually change, bail early
+        if (this.currentCursorMode === mode)
+        {
+            return;
+        }
         this.currentCursorMode = mode;
         const style = this.cursorStyles[mode];
 
@@ -1192,10 +1194,7 @@ export default class InteractionManager extends EventEmitter
 
         if (events[0].pointerType === 'mouse')
         {
-            if (this.currentCursorMode !== this.cursor)
-            {
-                this.setCursorMode(this.cursor);
-            }
+            this.setCursorMode(this.cursor);
 
             // TODO BUG for parents interactive object (border order issue)
         }

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -1416,7 +1416,7 @@ export default class InteractionManager extends EventEmitter
         // This is the way InteractionManager processed touch events before the refactoring, so I've kept
         // it here. But it doesn't make that much sense to me, since mapPositionToPoint already factors
         // in this.resolution, so this just divides by this.resolution twice for touch events...
-        if (navigator.isCocoonJS && event.pointerType === 'touch')
+        if (navigator.isCocoonJS && pointerEvent.pointerType === 'touch')
         {
             interactionData.global.x = interactionData.global.x / this.resolution;
             interactionData.global.y = interactionData.global.y / this.resolution;

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -507,7 +507,7 @@ export default class InteractionManager extends EventEmitter
         {
             window.document.addEventListener('pointermove', this.onPointerMove, true);
             this.interactionDOMElement.addEventListener('pointerdown', this.onPointerDown, true);
-            this.interactionDOMElement.addEventListener('pointerout', this.onPointerOut, true);
+            this.interactionDOMElement.addEventListener('pointerleave', this.onPointerOut, true);
             this.interactionDOMElement.addEventListener('pointerover', this.onPointerOver, true);
             window.addEventListener('pointercancel', this.onPointerCancel, true);
             window.addEventListener('pointerup', this.onPointerUp, true);
@@ -561,7 +561,7 @@ export default class InteractionManager extends EventEmitter
         {
             window.document.removeEventListener('pointermove', this.onPointerMove, true);
             this.interactionDOMElement.removeEventListener('pointerdown', this.onPointerDown, true);
-            this.interactionDOMElement.removeEventListener('pointerout', this.onPointerOut, true);
+            this.interactionDOMElement.removeEventListener('pointerleave', this.onPointerOut, true);
             this.interactionDOMElement.removeEventListener('pointerover', this.onPointerOver, true);
             window.removeEventListener('pointercancel', this.onPointerCancel, true);
             window.removeEventListener('pointerup', this.onPointerUp, true);

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -1301,7 +1301,9 @@ export default class InteractionManager extends EventEmitter
                 }
             }
 
-            if (isMouse)
+            // only change the cursor if it has not already been changed (by something deeper in the
+            // display tree)
+            if (isMouse && this.cursor === null)
             {
                 this.cursor = displayObject.cursor;
             }

--- a/test/interaction/InteractionManager.js
+++ b/test/interaction/InteractionManager.js
@@ -837,6 +837,26 @@ describe('PIXI.interaction.InteractionManager', function ()
             expect(defaultSpy).to.have.been.called;
         });
 
+        it('cursor callback should only be called if the cursor actually changed', function ()
+        {
+            const stage = new PIXI.Container();
+            const graphics = new PIXI.Graphics();
+            const defaultSpy = sinon.spy();
+            const pointer = new MockPointer(stage);
+
+            stage.addChild(graphics);
+            graphics.beginFill(0xFFFFFF);
+            graphics.drawRect(0, 0, 50, 50);
+            graphics.interactive = true;
+            graphics.cursor = null;
+            pointer.interaction.cursorStyles.default = defaultSpy;
+
+            pointer.mousemove(10, 10);
+            pointer.mousemove(20, 20);
+
+            expect(defaultSpy).to.have.been.calledOnce;
+        });
+
         it('cursor style object should be fully applied', function ()
         {
             const stage = new PIXI.Container();

--- a/test/interaction/InteractionManager.js
+++ b/test/interaction/InteractionManager.js
@@ -899,6 +899,59 @@ describe('PIXI.interaction.InteractionManager', function ()
             pointer.mousemove(60, 60);
             expect(pointer.renderer.view.style.cursor).to.equal('');
         });
+
+        it('cursor should be the cursor of deepest item hit', function ()
+        {
+            const stage = new PIXI.Container();
+            const graphics = new PIXI.Graphics();
+            const pointer = new MockPointer(stage);
+            const container = new PIXI.Container();
+
+            stage.addChild(container);
+            container.interactive = true;
+            container.hitArea = new PIXI.Rectangle(0, 0, 300, 300);
+            container.cursor = 'pointer';
+
+            container.addChild(graphics);
+            graphics.beginFill(0xFFFFFF);
+            graphics.drawRect(0, 0, 50, 50);
+            graphics.interactive = true;
+            graphics.cursor = 'help';
+            pointer.interaction.cursorStyles.help = 'help';
+
+            pointer.mousemove(10, 10);
+
+            expect(pointer.renderer.view.style.cursor).to.equal('help');
+        });
+
+        it('cursor should be middle item if deepest did not specify cursor', function ()
+        {
+            const stage = new PIXI.Container();
+            const inner = new PIXI.Graphics();
+            const pointer = new MockPointer(stage);
+            const outer = new PIXI.Container();
+            const middle = new PIXI.Container();
+
+            stage.addChild(outer);
+            outer.interactive = true;
+            outer.hitArea = new PIXI.Rectangle(0, 0, 300, 300);
+            outer.cursor = 'pointer';
+
+            outer.addChild(middle);
+            middle.interactive = true;
+            middle.hitArea = new PIXI.Rectangle(0, 0, 300, 300);
+            middle.cursor = 'help';
+
+            middle.addChild(inner);
+            inner.beginFill(0xFFFFFF);
+            inner.drawRect(0, 0, 50, 50);
+            inner.interactive = true;
+            pointer.interaction.cursorStyles.help = 'help';
+
+            pointer.mousemove(10, 10);
+
+            expect(pointer.renderer.view.style.cursor).to.equal('help');
+        });
     });
 
     describe('recursive hitTesting', function ()

--- a/test/interaction/InteractionManager.js
+++ b/test/interaction/InteractionManager.js
@@ -173,14 +173,14 @@ describe('PIXI.interaction.InteractionManager', function ()
 
             expect(element.addEventListener).to.have.been.calledThrice;
             expect(element.addEventListener).to.have.been.calledWith('pointerdown');
-            expect(element.addEventListener).to.have.been.calledWith('pointerout');
+            expect(element.addEventListener).to.have.been.calledWith('pointerleave');
             expect(element.addEventListener).to.have.been.calledWith('pointerover');
 
             manager.removeEvents();
 
             expect(element.removeEventListener).to.have.been.calledThrice;
             expect(element.removeEventListener).to.have.been.calledWith('pointerdown');
-            expect(element.removeEventListener).to.have.been.calledWith('pointerout');
+            expect(element.removeEventListener).to.have.been.calledWith('pointerleave');
             expect(element.removeEventListener).to.have.been.calledWith('pointerover');
         });
 
@@ -898,59 +898,6 @@ describe('PIXI.interaction.InteractionManager', function ()
 
             pointer.mousemove(60, 60);
             expect(pointer.renderer.view.style.cursor).to.equal('');
-        });
-
-        it('cursor should be the cursor of deepest item hit', function ()
-        {
-            const stage = new PIXI.Container();
-            const graphics = new PIXI.Graphics();
-            const pointer = new MockPointer(stage);
-            const container = new PIXI.Container();
-
-            stage.addChild(container);
-            container.interactive = true;
-            container.hitArea = new PIXI.Rectangle(0, 0, 300, 300);
-            container.cursor = 'pointer';
-
-            container.addChild(graphics);
-            graphics.beginFill(0xFFFFFF);
-            graphics.drawRect(0, 0, 50, 50);
-            graphics.interactive = true;
-            graphics.cursor = 'help';
-            pointer.interaction.cursorStyles.help = 'help';
-
-            pointer.mousemove(10, 10);
-
-            expect(pointer.renderer.view.style.cursor).to.equal('help');
-        });
-
-        it('cursor should be middle item if deepest did not specify cursor', function ()
-        {
-            const stage = new PIXI.Container();
-            const inner = new PIXI.Graphics();
-            const pointer = new MockPointer(stage);
-            const outer = new PIXI.Container();
-            const middle = new PIXI.Container();
-
-            stage.addChild(outer);
-            outer.interactive = true;
-            outer.hitArea = new PIXI.Rectangle(0, 0, 300, 300);
-            outer.cursor = 'pointer';
-
-            outer.addChild(middle);
-            middle.interactive = true;
-            middle.hitArea = new PIXI.Rectangle(0, 0, 300, 300);
-            middle.cursor = 'help';
-
-            middle.addChild(inner);
-            inner.beginFill(0xFFFFFF);
-            inner.drawRect(0, 0, 50, 50);
-            inner.interactive = true;
-            pointer.interaction.cursorStyles.help = 'help';
-
-            pointer.mousemove(10, 10);
-
-            expect(pointer.renderer.view.style.cursor).to.equal('help');
         });
     });
 


### PR DESCRIPTION
* Fixes #3689  - cursors not respecting the most specific thing that was moused over.
* Also fixes cursor changes being handled multiple times when mousing over any display object with a `cursor` property of `null` (the default).
* Changes the `pointerout` event that we were listening to to `pointerleave`, which should not give us any extra events that we don't need.
* Fixes #3668 