### PR TITLE
Fast rect blendMode problem

### DIFF
--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -804,6 +804,7 @@ export default class Graphics extends Container
         }
         this._spriteRect.alpha = this.graphicsData[0].fillAlpha;
         this._spriteRect.worldAlpha = this.worldAlpha * this._spriteRect.alpha;
+        this._spriteRect.blendMode = this.blendMode;
 
         Graphics._SPRITE_TEXTURE._frame.width = rect.width;
         Graphics._SPRITE_TEXTURE._frame.height = rect.height;

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -95,7 +95,7 @@ export function hex2string(hex)
  */
 export function rgb2hex(rgb)
 {
-    return (((rgb[0] * 255) << 16) + ((rgb[1] * 255) << 8) + (rgb[2] * 255));
+    return (((rgb[0] * 255) << 16) + ((rgb[1] * 255) << 8) + (rgb[2] * 255 | 0));
 }
 
 /**

--- a/test/core/Graphics.js
+++ b/test/core/Graphics.js
@@ -2,6 +2,11 @@
 
 const MockPointer = require('../interaction/MockPointer');
 
+function isWebGLSupported(fn)
+{
+    return PIXI.utils.isWebGLSupported() ? fn : undefined;
+}
+
 describe('PIXI.Graphics', function ()
 {
     describe('constructor', function ()
@@ -329,5 +334,36 @@ describe('PIXI.Graphics', function ()
 
             expect(spy).to.have.been.calledOnce;
         });
+
+        it('should calculate tint, alpha and blendMode of fastRect correctly', isWebGLSupported(function ()
+        {
+            const renderer = new PIXI.WebGLRenderer(200, 200, {});
+            const graphics = new PIXI.Graphics();
+
+            graphics.beginFill(0x102030, 0.6);
+            graphics.drawRect(2, 3, 100, 100);
+            graphics.endFill();
+            graphics.tint = 0x101010;
+            graphics.blendMode = 2;
+            graphics.alpha = 0.3;
+
+            renderer.render(graphics);
+
+            expect(graphics.isFastRect()).to.be.true;
+
+            const sprite = graphics._spriteRect;
+
+            expect(sprite).to.not.be.equals(null);
+            expect(sprite.worldAlpha).to.equals(0.18);
+            expect(sprite.blendMode).to.equals(2);
+            expect(sprite.tint).to.equals(0x010203);
+
+            const bounds = sprite.getBounds();
+
+            expect(bounds.x).to.equals(2);
+            expect(bounds.y).to.equals(3);
+            expect(bounds.width).to.equals(100);
+            expect(bounds.height).to.equals(100);
+        }));
     });
 });

--- a/test/core/util.js
+++ b/test/core/util.js
@@ -47,6 +47,11 @@ describe('PIXI.utils', function ()
                 .to.be.a('function');
         });
 
+        it('should calculate correctly', function ()
+        {
+            expect(PIXI.utils.rgb2hex([0.3, 0.2, 0.1])).to.equals(0x4c3319);
+        });
+
         // it('should properly convert rgb array to hex color string');
     });
 


### PR DESCRIPTION
It seems that fastrected graphics doesn't have blendMode. Tested it on pixi-examples, there is a problem.