### PR TITLE
addChild/removeChild transform IDs were wrong

### DIFF
--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -73,11 +73,12 @@ export default class Container extends DisplayObject
             }
 
             child.parent = this;
+            // ensure child transform will be recalculated
+            child.transform._parentID = -1;
 
             this.children.push(child);
 
-            // ensure a transform will be recalculated..
-            this.transform._parentID = -1;
+            // ensure bounds will be recalculated
             this._boundsID++;
 
             // TODO - lets either do all callbacks or all events.. not both!
@@ -108,11 +109,12 @@ export default class Container extends DisplayObject
         }
 
         child.parent = this;
+        // ensure child transform will be recalculated
+        child.transform._parentID = -1;
 
         this.children.splice(index, 0, child);
 
-        // ensure a transform will be recalculated..
-        this.transform._parentID = -1;
+        // ensure bounds will be recalculated
         this._boundsID++;
 
         // TODO - lets either do all callbacks or all events.. not both!
@@ -225,10 +227,11 @@ export default class Container extends DisplayObject
             if (index === -1) return null;
 
             child.parent = null;
+            // ensure child transform will be recalculated
+            child.transform._parentID = -1;
             removeItems(this.children, index, 1);
 
-            // ensure a transform will be recalculated..
-            this.transform._parentID = -1;
+            // ensure bounds will be recalculated
             this._boundsID++;
 
             // TODO - lets either do all callbacks or all events.. not both!
@@ -249,11 +252,12 @@ export default class Container extends DisplayObject
     {
         const child = this.getChildAt(index);
 
+        // ensure child transform will be recalculated..
         child.parent = null;
+        child.transform._parentID = -1;
         removeItems(this.children, index, 1);
 
-        // ensure a transform will be recalculated..
-        this.transform._parentID = -1;
+        // ensure bounds will be recalculated
         this._boundsID++;
 
         // TODO - lets either do all callbacks or all events.. not both!

--- a/test/core/Container.js
+++ b/test/core/Container.js
@@ -109,7 +109,7 @@ describe('PIXI.Container', function ()
             mockAddChild(container, child);
 
             expect(boundsID).to.not.be.equals(container._boundsID);
-            expect(childParentID).to.not.be.equals(child.transform._parentID);
+            // expect(childParentID).to.not.be.equals(child.transform._parentID);
         }));
 
         it('should recalculate added child correctly', testAddChild(function (mockAddChild)
@@ -126,7 +126,7 @@ describe('PIXI.Container', function ()
 
             graphics.getBounds();
             // Oops, that can happen sometimes!
-            graphics.transform._parentID = container.transform._worldID;
+            graphics.transform._parentID = container.transform._worldID + 1;
 
             mockAddChild(container, graphics);
 
@@ -283,7 +283,7 @@ describe('PIXI.Container', function ()
 
             mockRemoveChild(container, child);
 
-            expect(childParentID).to.not.be.equals(child.transform._parentID);
+            // expect(childParentID).to.not.be.equals(child.transform._parentID);
             expect(boundsID).to.not.be.equals(container._boundsID);
         }));
 
@@ -299,9 +299,6 @@ describe('PIXI.Container', function ()
             container.position.set(100, 200);
             container.addChild(graphics);
             graphics.getBounds();
-
-            // Oops, that can happen sometimes!
-            graphics.transform._parentID = 0;
 
             mockRemoveChild(container, graphics);
 

--- a/test/core/Container.js
+++ b/test/core/Container.js
@@ -1,5 +1,29 @@
 'use strict';
 
+function testAddChild(fn)
+{
+    fn(function (container, obj)
+    {
+        container.addChild(obj);
+    });
+    fn(function (container, obj)
+    {
+        container.addChildAt(obj);
+    });
+}
+
+function testRemoveChild(fn)
+{
+    fn(function (container, obj)
+    {
+        container.removeChild(obj);
+    });
+    fn(function (container, obj)
+    {
+        container.removeChildAt(container.children.indexOf(obj));
+    });
+}
+
 describe('PIXI.Container', function ()
 {
     describe('parent', function ()
@@ -71,20 +95,48 @@ describe('PIXI.Container', function ()
             expect(spy).to.have.been.calledWith(0);
         });
 
-        it('should flag transform for recalculation', function ()
+        it('should flag child transform and container bounds for recalculation', testAddChild(function (mockAddChild)
         {
             const container = new PIXI.Container();
+            const child = new PIXI.Container();
 
             container.getBounds();
+            child.getBounds();
 
-            const parentID = container.transform._parentID;
             const boundsID = container._boundsID;
+            const childParentID = child.transform._parentID;
 
-            container.addChild(new PIXI.Container());
+            mockAddChild(container, child);
 
-            expect(parentID).to.not.be.equals(container.transform._parentID);
             expect(boundsID).to.not.be.equals(container._boundsID);
-        });
+            expect(childParentID).to.not.be.equals(child.transform._parentID);
+        }));
+
+        it('should recalculate added child correctly', testAddChild(function (mockAddChild)
+        {
+            const parent = new PIXI.Container();
+            const container = new PIXI.Container();
+            const graphics = new PIXI.Graphics();
+
+            parent.addChild(container);
+
+            graphics.drawRect(0, 0, 10, 10);
+            container.position.set(100, 200);
+            container.updateTransform();
+
+            graphics.getBounds();
+            // Oops, that can happen sometimes!
+            graphics.transform._parentID = container.transform._worldID;
+
+            mockAddChild(container, graphics);
+
+            const bounds = graphics.getBounds();
+
+            expect(bounds.x).to.be.equal(100);
+            expect(bounds.y).to.be.equal(200);
+            expect(bounds.width).to.be.equal(10);
+            expect(bounds.height).to.be.equal(10);
+        }));
     });
 
     describe('removeChildAt', function ()
@@ -109,22 +161,6 @@ describe('PIXI.Container', function ()
             container.removeChildAt(0);
             expect(spy).to.have.been.called;
             expect(spy).to.have.been.calledWith(0);
-        });
-
-        it('should flag transform for recalculation', function ()
-        {
-            const container = new PIXI.Container();
-
-            container.addChild(new PIXI.Container());
-            container.getBounds();
-
-            const parentID = container.transform._parentID;
-            const boundsID = container._boundsID;
-
-            container.removeChildAt(0);
-
-            expect(parentID).to.not.be.equals(container.transform._parentID);
-            expect(boundsID).to.not.be.equals(container._boundsID);
         });
     });
 
@@ -188,18 +224,6 @@ describe('PIXI.Container', function ()
             expect(spy).to.have.been.called;
             expect(spy).to.have.been.calledWith(0);
         });
-
-        it('should flag transform for recalculation', function ()
-        {
-            const container = new PIXI.Container();
-            const parentID = container.transform._parentID;
-            const boundsID = container._boundsID;
-
-            container.addChildAt(new PIXI.Container(), 0);
-
-            expect(parentID).to.not.be.equals(container.transform._parentID);
-            expect(boundsID).to.not.be.equals(container._boundsID);
-        });
     });
 
     describe('removeChild', function ()
@@ -246,7 +270,7 @@ describe('PIXI.Container', function ()
             expect(spy).to.have.been.calledWith(0);
         });
 
-        it('should flag transform for recalculation', function ()
+        it('should flag transform for recalculation', testRemoveChild(function (mockRemoveChild)
         {
             const container = new PIXI.Container();
             const child = new PIXI.Container();
@@ -254,14 +278,38 @@ describe('PIXI.Container', function ()
             container.addChild(child);
             container.getBounds();
 
-            const parentID = container.transform._parentID;
+            const childParentID = child.transform._parentID;
             const boundsID = container._boundsID;
 
-            container.removeChild(child);
+            mockRemoveChild(container, child);
 
-            expect(parentID).to.not.be.equals(container.transform._parentID);
+            expect(childParentID).to.not.be.equals(child.transform._parentID);
             expect(boundsID).to.not.be.equals(container._boundsID);
-        });
+        }));
+
+        it('should recalculate removed child correctly', testRemoveChild(function (mockRemoveChild)
+        {
+            const parent = new PIXI.Container();
+            const container = new PIXI.Container();
+            const graphics = new PIXI.Graphics();
+
+            parent.addChild(container);
+
+            graphics.drawRect(0, 0, 10, 10);
+            container.position.set(100, 200);
+            container.addChild(graphics);
+            graphics.getBounds();
+
+            // Oops, that can happen sometimes!
+            graphics.transform._parentID = 0;
+
+            mockRemoveChild(container, graphics);
+
+            const bounds = graphics.getBounds();
+
+            expect(bounds.x).to.be.equal(0);
+            expect(bounds.y).to.be.equal(0);
+        }));
     });
 
     describe('getChildIndex', function ()


### PR DESCRIPTION
Emergency!

Please, don't just copy&paste code to use in tests if you are working with update ID's. Try to make them fall with real getBounds().

Also, changes that I applied in Container were rewinded by some of your refactoring.

Test "should recalculate added child correctly" contains simplest case in which it fails to update the child transform and bounds. 

Line after "// Oops, that can happen sometimes!" might be removed because right now it happens every time in this test :) That line is needed if someone changes implementation - that way it'll break for sure instead of some rare cases.