### PR TITLE
same texture can be used in some sprite and a mask/filter

### DIFF
--- a/src/core/renderers/webgl/managers/FilterManager.js
+++ b/src/core/renderers/webgl/managers/FilterManager.js
@@ -260,7 +260,9 @@ export default class FilterManager extends WebGLManager
         // free unit 0 for us, doesn't matter what was there
         // don't try to restore it, because syncUniforms can upload it to another slot
         // and it'll be a problem
-        this.renderer.boundTextures[0] = this.renderer.emptyTextures[0];
+        const tex = this.renderer.emptyTextures[0];
+
+        this.renderer.boundTextures[0] = tex;
         // this syncs the pixi filters  uniforms with glsl uniforms
         this.syncUniforms(shader, filter);
 
@@ -271,7 +273,7 @@ export default class FilterManager extends WebGLManager
 
         this.quad.vao.draw(this.renderer.gl.TRIANGLES, 6, 0);
 
-        gl.bindTexture(gl.TEXTURE_2D, this.renderer.emptyTextures[0]._glTextures[this.CONTEXT_UID]);
+        gl.bindTexture(gl.TEXTURE_2D, tex._glTextures[this.renderer.CONTEXT_UID].texture);
     }
 
     /**

--- a/src/core/renderers/webgl/managers/FilterManager.js
+++ b/src/core/renderers/webgl/managers/FilterManager.js
@@ -257,25 +257,27 @@ export default class FilterManager extends WebGLManager
 
         renderer.bindShader(shader);
 
+        // free unit 0 for us, doesn't matter what was there
+        // don't try to restore it, because syncUniforms can upload it to another slot
+        // and it'll be a problem
+        this.renderer.boundTextures[0] = this.renderer.emptyTextures[0];
         // this syncs the pixi filters  uniforms with glsl uniforms
         this.syncUniforms(shader, filter);
 
         renderer.state.setBlendMode(filter.blendMode);
-
-        // temporary bypass cache..
-        const tex = this.renderer.boundTextures[0];
 
         gl.activeTexture(gl.TEXTURE0);
         gl.bindTexture(gl.TEXTURE_2D, input.texture.texture);
 
         this.quad.vao.draw(this.renderer.gl.TRIANGLES, 6, 0);
 
-        // restore cache.
-        gl.bindTexture(gl.TEXTURE_2D, tex._glTextures[this.renderer.CONTEXT_UID].texture);
+        gl.bindTexture(gl.TEXTURE_2D, this.renderer.emptyTextures[0]._glTextures[this.CONTEXT_UID]);
     }
 
     /**
      * Uploads the uniforms of the filter.
+     *
+     * Texture unit 0 cant be used here!
      *
      * @param {GLShader} shader - The underlying gl shader.
      * @param {PIXI.Filter} filter - The filter we are synchronizing.


### PR DESCRIPTION
That's a big problem. Some texture can reside in unit #0, syncUniforms doesn't upload it, and then we use  unit#0 for something. 

iPad and legacy-mode devices use only #0 and that bug appears there often.

Example: 

```
var tex1 = Texture.fromImage("texture1.png");
var tex2 = Texture.fromImage("texture2.png");
var container = new PIXI.Container();
container.addChild(new PIXI.Sprite(tex1));
container.addChild(new PIXI.Sprite(tex2));
container.addChild(new PIXI.Sprite(tex1));
container.children[1].mask = container.children[2];
```

There's one more critical issue, I'll address it in next PR.