### PR TITLE
fix slot #0 texture

### DIFF
--- a/src/core/renderers/webgl/managers/FilterManager.js
+++ b/src/core/renderers/webgl/managers/FilterManager.js
@@ -257,20 +257,22 @@ export default class FilterManager extends WebGLManager
 
         renderer.bindShader(shader);
 
+        // free unit 0 for us, doesn't matter what was there
+        // don't try to restore it, because syncUniforms can upload it to another slot
+        // and it'll be a problem
+        const tex = this.renderer.emptyTextures[0];
+
+        this.renderer.boundTextures[0] = tex;
         // this syncs the pixi filters  uniforms with glsl uniforms
         this.syncUniforms(shader, filter);
 
         renderer.state.setBlendMode(filter.blendMode);
-
-        // temporary bypass cache..
-        const tex = this.renderer.boundTextures[0];
 
         gl.activeTexture(gl.TEXTURE0);
         gl.bindTexture(gl.TEXTURE_2D, input.texture.texture);
 
         this.quad.vao.draw(this.renderer.gl.TRIANGLES, 6, 0);
 
-        // restore cache.
         gl.bindTexture(gl.TEXTURE_2D, tex._glTextures[this.renderer.CONTEXT_UID].texture);
     }
 


### PR DESCRIPTION
If some texture already exists in slot #0, and syncUniforms is trying to use it - mask wont be rendered at all.

Fiddle: https://jsfiddle.net/jdngw3xy/