### PR TITLE
fixed lint warnings

### DIFF
--- a/src/core/graphics/webgl/utils/buildRoundedRectangle.js
+++ b/src/core/graphics/webgl/utils/buildRoundedRectangle.js
@@ -76,13 +76,18 @@ export default function buildRoundedRectangle(graphicsData, webGLData)
     }
 }
 
-/** 
+/**
  * Calculate a single point for a quadratic bezier curve.
  * Utility function used by quadraticBezierCurve.
  * Ignored from docs since it is not directly exposed.
  *
  * @ignore
  * @private
+ * @param {number} n1 - first number
+ * @param {number} n2 - second number
+ * @param {number} perc - percentage
+ * @return {number} the result
+ *
  */
 function getPt(n1, n2, perc)
 {

--- a/src/core/renderers/webgl/TextureManager.js
+++ b/src/core/renderers/webgl/TextureManager.js
@@ -61,7 +61,7 @@ export default class TextureManager
      * Updates and/or Creates a WebGL texture for the renderer's context.
      *
      * @param {PIXI.BaseTexture|PIXI.Texture} texture - the texture to update
-     * @param {Number} location - the location the texture will be bound to.
+     * @param {number} location - the location the texture will be bound to.
      * @return {GLTexture} The gl texture.
      */
     updateTexture(texture, location)


### PR DESCRIPTION
Eslint was complaining about missing doc comments / parameter types in buildRoundedRectangle.js.

Also changed doc type {Number} -> {number} in TextureManager for consistency.

