### PR TITLE
More thorough Texture/BaseTexture cleanup

### DIFF
--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -597,6 +597,7 @@ export default class BaseTexture extends EventEmitter
             }
         }
         // An svg source has both `imageUrl` and `__pixiId`, so no `else if` here
+        // this does cleanup for SVG and canvas
         if (this.source && this.source._pixiId)
         {
             delete BaseTextureCache[this.source._pixiId];
@@ -605,6 +606,9 @@ export default class BaseTexture extends EventEmitter
         this.source = null;
 
         this.dispose();
+
+        // tell any Textures that reference this that it is time to go
+        this.emit('destroy', this);
     }
 
     /**

--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -217,6 +217,14 @@ export default class BaseTexture extends EventEmitter
          * @event error
          * @memberof PIXI.BaseTexture#
          */
+
+        /**
+         * Fired when destroy() is called.
+         *
+         * @protected
+         * @event destroy
+         * @memberof PIXI.BaseTexture#
+         */
     }
 
     /**

--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -579,8 +579,15 @@ export default class BaseTexture extends EventEmitter
     {
         if (this.imageUrl)
         {
-            delete BaseTextureCache[this.imageUrl];
-            delete TextureCache[this.imageUrl];
+            // remove this texture from the global texture cache
+            if (BaseTextureCache[this.imageUrl] === this)
+            {
+                delete BaseTextureCache[this.imageUrl];
+            }
+            if (TextureCache[this.imageUrl] && TextureCache[this.imageUrl].baseTexture === this)
+            {
+                delete TextureCache[this.imageUrl];
+            }
 
             this.imageUrl = null;
 

--- a/src/core/textures/Spritesheet.js
+++ b/src/core/textures/Spritesheet.js
@@ -207,6 +207,7 @@ export default class Spritesheet
                 );
 
                 // lets also add the frame to pixi's global cache for fromFrame and fromImage functions
+                this.textures[i].name = i;
                 TextureCache[i] = this.textures[i];
             }
 

--- a/src/core/textures/Spritesheet.js
+++ b/src/core/textures/Spritesheet.js
@@ -209,6 +209,8 @@ export default class Spritesheet
                 // lets also add the frame to pixi's global cache for fromFrame and fromImage functions
                 this.textures[i].name = i;
                 TextureCache[i] = this.textures[i];
+                // add listener to clean the cache when the base texture is destroyed
+                this.textures[i].listenForDestroy();
             }
 
             frameIndex++;

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -140,7 +140,6 @@ export default class Texture extends EventEmitter
         {
             baseTexture.once('loaded', this.onBaseTextureLoaded, this);
         }
-        baseTexture.on('destroy', this.destroy, this);
 
         /**
          * Fired when the texture is updated. This happens if the frame or the baseTexture is updated.
@@ -164,6 +163,18 @@ export default class Texture extends EventEmitter
          * @type {string}
          */
         this.name = null;
+    }
+
+    /**
+     * Attaches a "destroy" listener to the base texture, so that it is destroyed and removed from
+     * global texture caches when the base texture is destroyed.
+     */
+    listenForDestroy()
+    {
+        if (this.baseTexture)
+        {
+            this.baseTexture.once('destroy', this.destroy, this);
+        }
     }
 
     /**
@@ -468,6 +479,9 @@ export default class Texture extends EventEmitter
             TextureCache[imageUrl] = texture;
         }
 
+        // set up listener to clean the cache when the base texture is destroyed
+        texture.listenForDestroy();
+
         return texture;
     }
 
@@ -487,6 +501,8 @@ export default class Texture extends EventEmitter
             texture.name = id;
         }
         TextureCache[id] = texture;
+        // set up listener to clean the cache when the base texture is destroyed
+        texture.listenForDestroy();
     }
 
     /**

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -319,6 +319,8 @@ export default class Texture extends EventEmitter
         {
             texture = new Texture(BaseTexture.fromImage(imageUrl, crossorigin, scaleMode, sourceScale));
             TextureCache[imageUrl] = texture;
+            // set up listener to clean the cache when the base texture is destroyed
+            texture.listenForDestroy();
         }
 
         return texture;

--- a/test/core/Spritesheet.js
+++ b/test/core/Spritesheet.js
@@ -18,9 +18,11 @@ describe('PIXI.Spritesheet', function ()
                 expect(textures[id]).to.be.an.instanceof(PIXI.Texture);
                 expect(textures[id].width).to.equal(spritesheet.data.frames[id].frame.w / spritesheet.resolution);
                 expect(textures[id].height).to.equal(spritesheet.data.frames[id].frame.h / spritesheet.resolution);
+                expect(PIXI.utils.TextureCache[id]).to.be.an.instanceof(PIXI.Texture);
                 spritesheet.destroy(true);
                 expect(spritesheet.textures).to.be.null;
                 expect(spritesheet.baseTexture).to.be.null;
+                expect(PIXI.utils.TextureCache[id]).to.not.exist;
                 done();
             });
         };

--- a/test/core/Texture.js
+++ b/test/core/Texture.js
@@ -16,4 +16,127 @@ describe('PIXI.Texture', function ()
         expect(PIXI.utils.TextureCache[URL]).to.equal(texture);
         expect(PIXI.utils.BaseTextureCache[URL]).to.equal(texture.baseTexture);
     });
+
+    it('should remove Texture and BaseTexture from caches in destroy(true)', function ()
+    {
+        const URL = 'foo.png';
+        const NAME = 'bar';
+        const image = new Image();
+
+        const texture = PIXI.Texture.fromLoader(image, URL, NAME);
+
+        expect(PIXI.utils.TextureCache[NAME],
+            'TextureCache[name] is the texture').to.equal(texture);
+        expect(PIXI.utils.BaseTextureCache[NAME],
+            'BaseTextureCache[name] is the base texture').to.equal(texture.baseTexture);
+        expect(PIXI.utils.TextureCache[URL],
+            'TextureCache[imageUrl] is the texture').to.equal(texture);
+        expect(PIXI.utils.BaseTextureCache[URL],
+            'BaseTextureCache[imageUrl] is the base texture').to.equal(texture.baseTexture);
+
+        texture.destroy(true);
+
+        expect(PIXI.utils.TextureCache[NAME],
+            'TextureCache[name] is cleared').to.be.undefined;
+        expect(PIXI.utils.BaseTextureCache[NAME],
+            'BaseTextureCache[name] is cleared').to.be.undefined;
+        expect(PIXI.utils.TextureCache[URL],
+            'TextureCache[imageUrl] is cleared').to.be.undefined;
+        expect(PIXI.utils.BaseTextureCache[URL],
+            'BaseTextureCache[imageUrl] is cleared').to.be.undefined;
+    });
+
+    it('should not remove Texture and BaseTexture from caches in destroy(true) if overwritten first', function ()
+    {
+        const URL = 'foo.png';
+        const NAME = 'bar';
+        const image = new Image();
+
+        const texture = PIXI.Texture.fromLoader(image, URL, NAME);
+
+        PIXI.utils.TextureCache[NAME] = 'I\'m a little teapot';
+        PIXI.utils.BaseTextureCache[NAME] = 'short and stout';
+        PIXI.utils.TextureCache[URL] = 'Here is my handle';
+        PIXI.utils.BaseTextureCache[URL] = 'here is my spout';
+
+        texture.destroy(true);
+
+        expect(PIXI.utils.TextureCache[NAME],
+            'TextureCache[name] is not cleared').to.be.equal('I\'m a little teapot');
+        expect(PIXI.utils.BaseTextureCache[NAME],
+            'BaseTextureCache[name] is not cleared').to.be.equal('short and stout');
+        expect(PIXI.utils.TextureCache[URL],
+            'TextureCache[imageUrl] is not cleared').to.be.equal('Here is my handle');
+        expect(PIXI.utils.BaseTextureCache[URL],
+            'BaseTextureCache[imageUrl] is not cleared').to.be.equal('here is my spout');
+    });
+
+    it('should not remove BaseTexture from caches in destroy()', function ()
+    {
+        const URL = 'foo.png';
+        const NAME = 'bar';
+        const image = new Image();
+
+        const texture = PIXI.Texture.fromLoader(image, URL, NAME);
+        const baseTexture = texture.baseTexture;
+
+        texture.destroy();
+
+        expect(PIXI.utils.BaseTextureCache[NAME],
+            'BaseTextureCache[name] is not cleared').to.equal(baseTexture);
+        expect(PIXI.utils.BaseTextureCache[URL],
+            'BaseTextureCache[imageUrl] is not cleared').to.equal(baseTexture);
+        expect(baseTexture.source,
+            'base texture has not been destroyed').to.exist;
+    });
+
+    it('should remove Texture and BaseTexture from caches when base texture is destroyed', function ()
+    {
+        const URL = 'foo.png';
+        const NAME = 'bar';
+        const image = new Image();
+
+        const texture = PIXI.Texture.fromLoader(image, URL, NAME);
+
+        expect(PIXI.utils.TextureCache[NAME],
+            'TextureCache[name] is the texture').to.equal(texture);
+        expect(PIXI.utils.BaseTextureCache[NAME],
+            'BaseTextureCache[name] is the base texture').to.equal(texture.baseTexture);
+        expect(PIXI.utils.TextureCache[URL],
+            'TextureCache[imageUrl] is the texture').to.equal(texture);
+        expect(PIXI.utils.BaseTextureCache[URL],
+            'BaseTextureCache[imageUrl] is the base texture').to.equal(texture.baseTexture);
+
+        texture.baseTexture.destroy();
+
+        expect(PIXI.utils.TextureCache[NAME],
+            'TextureCache[name] is cleared').to.be.undefined;
+        expect(PIXI.utils.BaseTextureCache[NAME],
+            'BaseTextureCache[name] is cleared').to.be.undefined;
+        expect(PIXI.utils.TextureCache[URL],
+            'TextureCache[imageUrl] is cleared').to.be.undefined;
+        expect(PIXI.utils.BaseTextureCache[URL],
+            'BaseTextureCache[imageUrl] is cleared').to.be.undefined;
+    });
+
+    it('should remove additional Textures from cache when base texture is destroyed', function ()
+    {
+        const URL = 'foo.png';
+        const NAME = 'bar';
+        const image = new Image();
+        const NAME2 = 'teapot';
+
+        const texture = PIXI.Texture.fromLoader(image, URL, NAME);
+        const texture2 = new PIXI.Texture(texture.baseTexture);
+
+        PIXI.Texture.addTextureToCache(texture2, NAME2);
+
+        expect(PIXI.utils.TextureCache[NAME2],
+            'TextureCache[NAME2] is texture2').to.equal(texture2);
+
+        texture.baseTexture.destroy();
+
+        expect(PIXI.utils.TextureCache[NAME2],
+            'TextureCache[NAME2] is cleared').to.be.undefined;
+    });
 });


### PR DESCRIPTION
* Added `name` property to Texture for tracking what name the Texture was added to the TextureCache under.
* Added a `destroy` event to BaseTexture for taking Textures based off that BaseTexture with it when destroyed.
* Made Texture and BaseTexture work together to try to make sure that everything is cleaned out of the texture cache when they are destroyed.