### PR TITLE
Fix doc: add missing type of parameter

### DIFF
--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -365,7 +365,8 @@ export default class Texture extends EventEmitter
      * The source can be - frame id, image url, video url, canvas element, video element, base texture
      *
      * @static
-     * @param {number|string|PIXI.BaseTexture|HTMLCanvasElement|HTMLVideoElement} source - Source to create texture from
+     * @param {number|string|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement|PIXI.BaseTexture}
+                source - Source to create texture from
      * @return {PIXI.Texture} The newly created texture
      */
     static from(source)

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -366,7 +366,7 @@ export default class Texture extends EventEmitter
      *
      * @static
      * @param {number|string|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement|PIXI.BaseTexture}
-     *          source - Source to create texture from
+     *        source - Source to create texture from
      * @return {PIXI.Texture} The newly created texture
      */
     static from(source)

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -366,7 +366,7 @@ export default class Texture extends EventEmitter
      *
      * @static
      * @param {number|string|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement|PIXI.BaseTexture}
-                source - Source to create texture from
+     *          source - Source to create texture from
      * @return {PIXI.Texture} The newly created texture
      */
     static from(source)


### PR DESCRIPTION
Add `HTMLImageElement`.
Breaking line because the line is too long (eslint reports error)