### PR TITLE
Fix precision setting change not being picked up

### DIFF
--- a/src/core/Shader.js
+++ b/src/core/Shader.js
@@ -1,8 +1,6 @@
 import { GLShader } from 'pixi-gl-core';
 import settings from './settings';
 
-const { PRECISION } = settings;
-
 function checkPrecision(src)
 {
     if (src instanceof Array)
@@ -11,14 +9,14 @@ function checkPrecision(src)
         {
             const copy = src.slice(0);
 
-            copy.unshift(`precision ${PRECISION} float;`);
+            copy.unshift(`precision ${settings.PRECISION} float;`);
 
             return copy;
         }
     }
     else if (src.substring(0, 9) !== 'precision')
     {
-        return `precision ${PRECISION} float;\n${src}`;
+        return `precision ${settings.PRECISION} float;\n${src}`;
     }
 
     return src;


### PR DESCRIPTION
PIXI.settings.PRECISION = 'highp';
Wasn't getting picked up in my game.

It turns out, the style of using the PRECISION setting meant it was a static value. This has been changed so that it's looking to the reference of the settings object to pick up the live changed value