### PR TITLE
[v4.4] different settings for vertex and fragment shader

### DIFF
--- a/src/core/Shader.js
+++ b/src/core/Shader.js
@@ -1,7 +1,7 @@
 import { GLShader } from 'pixi-gl-core';
 import settings from './settings';
 
-function checkPrecision(src)
+function checkPrecision(src, def)
 {
     if (src instanceof Array)
     {
@@ -9,14 +9,14 @@ function checkPrecision(src)
         {
             const copy = src.slice(0);
 
-            copy.unshift(`precision ${settings.PRECISION} float;`);
+            copy.unshift(`precision ${def} float;`);
 
             return copy;
         }
     }
     else if (src.substring(0, 9) !== 'precision')
     {
-        return `precision ${settings.PRECISION} float;\n${src}`;
+        return `precision ${def} float;\n${src}`;
     }
 
     return src;
@@ -40,6 +40,7 @@ export default class Shader extends GLShader
      */
     constructor(gl, vertexSrc, fragmentSrc)
     {
-        super(gl, checkPrecision(vertexSrc), checkPrecision(fragmentSrc));
+        super(gl, checkPrecision(vertexSrc, settings.PRECISION_VERTEX),
+            checkPrecision(fragmentSrc, settings.PRECISION_FRAGMENT));
     }
 }

--- a/src/core/settings.js
+++ b/src/core/settings.js
@@ -175,14 +175,24 @@ export default {
     SCALE_MODE: 0,
 
     /**
-     * Default specify float precision in shaders.
+     * Default specify float precision in vertex shader.
+     *
+     * @static
+     * @memberof PIXI.settings
+     * @type {PIXI.PRECISION}
+     * @default PIXI.PRECISION.HIGH
+     */
+    PRECISION_VERTEX: 'highp',
+
+    /**
+     * Default specify float precision in fragment shader.
      *
      * @static
      * @memberof PIXI.settings
      * @type {PIXI.PRECISION}
      * @default PIXI.PRECISION.MEDIUM
      */
-    PRECISION: 'mediump',
+    PRECISION_FRAGMENT: 'mediump',
 
     /**
      * Can we upload the same buffer in a single frame?

--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -535,7 +535,7 @@ const defaults = [
     { parent: 'GC_MODES', target: 'GC_MODE' },
     { parent: 'WRAP_MODES', target: 'WRAP_MODE' },
     { parent: 'SCALE_MODES', target: 'SCALE_MODE' },
-    { parent: 'PRECISION', target: 'PRECISION' },
+    { parent: 'PRECISION', target: 'PRECISION_FRAGMENT' },
 ];
 
 for (let i = 0; i < defaults.length; i++)
@@ -558,6 +558,32 @@ for (let i = 0; i < defaults.length; i++)
         },
     });
 }
+
+Object.defineProperties(core.settings, {
+
+    /**
+     * @static
+     * @name PRECISION
+     * @memberof PIXI.settings
+     * @see PIXI.PRECISION
+     * @deprecated since version 4.4.0
+     */
+    PRECISION: {
+        enumerable: true,
+        get()
+        {
+            warn('PIXI.settings.PRECISION has been deprecated, please use PIXI.settings.PRECISION_FRAGMENT');
+
+            return core.settings.PRECISION_FRAGMENT;
+        },
+        set(value)
+        {
+            warn('PIXI.settings.PRECISION has been deprecated, please use PIXI.settings.PRECISION_FRAGMENT');
+
+            core.settings.PRECISION_FRAGMENT = value;
+        },
+    },
+});
 
 Object.defineProperties(extras, {
 


### PR DESCRIPTION
Follow #3742 #3749

Best practice: use highp on vertex shaders, mediump on fragment. 

Use https://dl.dropboxusercontent.com/u/46636530/pixijs/wobble/pixi.js if you want to test it with bunnymark. Sorry, I prefer not to create branches that I forget to delete later ;)