### PR TITLE
Fix #3755

### DIFF
--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -114,13 +114,14 @@ export function getResolutionOfUrl(url, defaultValue)
     {
         const lastIndex = url.lastIndexOf('@');
 
-        url = lastIndex === -1 ? url : url.substring(lastIndex);
-
-        const resolution = settings.RETINA_PREFIX.exec(url);
-
-        if (resolution)
+        if (lastIndex !== -1)
         {
-            return parseFloat(resolution[1]);
+            const resolution = settings.RETINA_PREFIX.exec(url.substring(lastIndex));
+
+            if (resolution)
+            {
+                return parseFloat(resolution[1]);
+            }
         }
     }
 

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -110,11 +110,18 @@ export function rgb2hex(rgb)
  */
 export function getResolutionOfUrl(url, defaultValue)
 {
-    const resolution = settings.RETINA_PREFIX.exec(url);
-
-    if (resolution)
+    if (url)
     {
-        return parseFloat(resolution[1]);
+        const lastIndex = url.lastIndexOf('@');
+
+        url = lastIndex === -1 ? url : url.substring(lastIndex);
+
+        const resolution = settings.RETINA_PREFIX.exec(url);
+
+        if (resolution)
+        {
+            return parseFloat(resolution[1]);
+        }
     }
 
     return defaultValue !== undefined ? defaultValue : 1;


### PR DESCRIPTION
If there are multi '@' in url ,  only reserve the last one,  then exec RETINA_PREFIX.