### PR TITLE
[v4.4] fix SpriteRenderer for multiple webgl renderers, fix tests, add "withGL"

### DIFF
--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -765,28 +765,14 @@ export default class Graphics extends Container
 
         if (!this._spriteRect)
         {
-            if (!Graphics._SPRITE_TEXTURE)
-            {
-                Graphics._SPRITE_TEXTURE = RenderTexture.create(10, 10);
-
-                const canvas = document.createElement('canvas');
-
-                canvas.width = 10;
-                canvas.height = 10;
-
-                const context = canvas.getContext('2d');
-
-                context.fillStyle = 'white';
-                context.fillRect(0, 0, 10, 10);
-
-                Graphics._SPRITE_TEXTURE = Texture.fromCanvas(canvas);
-            }
-
-            this._spriteRect = new Sprite(Graphics._SPRITE_TEXTURE);
+            this._spriteRect = new Sprite(new Texture(Texture.WHITE));
         }
+
+        const sprite = this._spriteRect;
+
         if (this.tint === 0xffffff)
         {
-            this._spriteRect.tint = this.graphicsData[0].fillColor;
+            sprite.tint = this.graphicsData[0].fillColor;
         }
         else
         {
@@ -800,21 +786,21 @@ export default class Graphics extends Container
             t1[1] *= t2[1];
             t1[2] *= t2[2];
 
-            this._spriteRect.tint = rgb2hex(t1);
+            sprite.tint = rgb2hex(t1);
         }
-        this._spriteRect.alpha = this.graphicsData[0].fillAlpha;
-        this._spriteRect.worldAlpha = this.worldAlpha * this._spriteRect.alpha;
-        this._spriteRect.blendMode = this.blendMode;
+        sprite.alpha = this.graphicsData[0].fillAlpha;
+        sprite.worldAlpha = this.worldAlpha * sprite.alpha;
+        sprite.blendMode = this.blendMode;
 
-        Graphics._SPRITE_TEXTURE._frame.width = rect.width;
-        Graphics._SPRITE_TEXTURE._frame.height = rect.height;
+        sprite.texture._frame.width = rect.width;
+        sprite.texture._frame.height = rect.height;
 
-        this._spriteRect.transform.worldTransform = this.transform.worldTransform;
+        sprite.transform.worldTransform = this.transform.worldTransform;
 
-        this._spriteRect.anchor.set(-rect.x / rect.width, -rect.y / rect.height);
-        this._spriteRect._onAnchorUpdate();
+        sprite.anchor.set(-rect.x / rect.width, -rect.y / rect.height);
+        sprite._onAnchorUpdate();
 
-        this._spriteRect._renderWebGL(renderer);
+        sprite._renderWebGL(renderer);
     }
 
     /**

--- a/src/core/sprites/webgl/SpriteRenderer.js
+++ b/src/core/sprites/webgl/SpriteRenderer.js
@@ -75,7 +75,6 @@ export default class SpriteRenderer extends ObjectRenderer
         this.shader = null;
 
         this.currentIndex = 0;
-        TICK = 0;
         this.groups = [];
 
         for (let k = 0; k < this.size; k++)

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -560,6 +560,29 @@ export default class Texture extends EventEmitter
     }
 }
 
+function createWhiteTexture()
+{
+    const canvas = document.createElement('canvas');
+
+    canvas.width = 10;
+    canvas.height = 10;
+
+    const context = canvas.getContext('2d');
+
+    context.fillStyle = 'white';
+    context.fillRect(0, 0, 10, 10);
+
+    return new Texture(new BaseTexture(canvas));
+}
+
+function removeAllHandlers(tex)
+{
+    tex.destroy = function _emptyDestroy() { /* empty */ };
+    tex.on = function _emptyOn() { /* empty */ };
+    tex.once = function _emptyOnce() { /* empty */ };
+    tex.emit = function _emptyEmit() { /* empty */ };
+}
+
 /**
  * An empty texture, used often to not have to create multiple empty textures.
  * Can not be destroyed.
@@ -568,7 +591,14 @@ export default class Texture extends EventEmitter
  * @constant
  */
 Texture.EMPTY = new Texture(new BaseTexture());
-Texture.EMPTY.destroy = function _emptyDestroy() { /* empty */ };
-Texture.EMPTY.on = function _emptyOn() { /* empty */ };
-Texture.EMPTY.once = function _emptyOnce() { /* empty */ };
-Texture.EMPTY.emit = function _emptyEmit() { /* empty */ };
+removeAllHandlers(Texture.EMPTY);
+
+/**
+ * A white texture of 10x10 size, used for graphics and other things
+ * Can not be destroyed.
+ *
+ * @static
+ * @constant
+ */
+Texture.WHITE = createWhiteTexture();
+removeAllHandlers(Texture.WHITE);

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -362,3 +362,43 @@ export const TextureCache = {};
  * @private
  */
 export const BaseTextureCache = {};
+
+/**
+ * Destroys all texture in the cache
+ *
+ * @memberof PIXI.utils
+ * @function destroyTextureCache
+ */
+export function destroyTextureCache()
+{
+    let key;
+
+    for (key in TextureCache)
+    {
+        TextureCache[key].destroy();
+    }
+    for (key in BaseTextureCache)
+    {
+        BaseTextureCache[key].destroy();
+    }
+}
+
+/**
+ * Removes all textures from cache, but does not destroy them
+ *
+ * @memberof PIXI.utils
+ * @function clearTextureCache
+ */
+export function clearTextureCache()
+{
+    let key;
+
+    for (key in TextureCache)
+    {
+        delete TextureCache[key];
+    }
+    for (key in BaseTextureCache)
+    {
+        delete BaseTextureCache[key];
+    }
+}

--- a/test/core/Graphics.js
+++ b/test/core/Graphics.js
@@ -331,12 +331,11 @@ describe('PIXI.Graphics', function ()
             expect(spy).to.have.been.calledOnce;
         });
 
-        it('should calculate tint, alpha and blendMode of fastRect correctly', withGL(
-            function ()
-            {
-                return new PIXI.WebGLRenderer(200, 200, {});
-            },
-            function (renderer)
+        it('should calculate tint, alpha and blendMode of fastRect correctly', withGL(function ()
+        {
+            const renderer = new PIXI.WebGLRenderer(200, 200, {});
+
+            try
             {
                 const graphics = new PIXI.Graphics();
 
@@ -364,6 +363,11 @@ describe('PIXI.Graphics', function ()
                 expect(bounds.y).to.equals(3);
                 expect(bounds.width).to.equals(100);
                 expect(bounds.height).to.equals(100);
-            }));
+            }
+            finally
+            {
+                renderer.destroy();
+            }
+        }));
     });
 });

--- a/test/core/Graphics.js
+++ b/test/core/Graphics.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const MockPointer = require('../interaction/MockPointer');
-const isWebGLSupported = require('../isWebGLSupported');
+const withGL = require('../withGL');
 
 describe('PIXI.Graphics', function ()
 {
@@ -331,35 +331,39 @@ describe('PIXI.Graphics', function ()
             expect(spy).to.have.been.calledOnce;
         });
 
-        it('should calculate tint, alpha and blendMode of fastRect correctly', isWebGLSupported(function ()
-        {
-            const renderer = new PIXI.WebGLRenderer(200, 200, {});
-            const graphics = new PIXI.Graphics();
+        it('should calculate tint, alpha and blendMode of fastRect correctly', withGL(
+            function ()
+            {
+                return new PIXI.WebGLRenderer(200, 200, {});
+            },
+            function (renderer)
+            {
+                const graphics = new PIXI.Graphics();
 
-            graphics.beginFill(0x102030, 0.6);
-            graphics.drawRect(2, 3, 100, 100);
-            graphics.endFill();
-            graphics.tint = 0x101010;
-            graphics.blendMode = 2;
-            graphics.alpha = 0.3;
+                graphics.beginFill(0x102030, 0.6);
+                graphics.drawRect(2, 3, 100, 100);
+                graphics.endFill();
+                graphics.tint = 0x101010;
+                graphics.blendMode = 2;
+                graphics.alpha = 0.3;
 
-            renderer.render(graphics);
+                renderer.render(graphics);
 
-            expect(graphics.isFastRect()).to.be.true;
+                expect(graphics.isFastRect()).to.be.true;
 
-            const sprite = graphics._spriteRect;
+                const sprite = graphics._spriteRect;
 
-            expect(sprite).to.not.be.equals(null);
-            expect(sprite.worldAlpha).to.equals(0.18);
-            expect(sprite.blendMode).to.equals(2);
-            expect(sprite.tint).to.equals(0x010203);
+                expect(sprite).to.not.be.equals(null);
+                expect(sprite.worldAlpha).to.equals(0.18);
+                expect(sprite.blendMode).to.equals(2);
+                expect(sprite.tint).to.equals(0x010203);
 
-            const bounds = sprite.getBounds();
+                const bounds = sprite.getBounds();
 
-            expect(bounds.x).to.equals(2);
-            expect(bounds.y).to.equals(3);
-            expect(bounds.width).to.equals(100);
-            expect(bounds.height).to.equals(100);
-        }));
+                expect(bounds.x).to.equals(2);
+                expect(bounds.y).to.equals(3);
+                expect(bounds.width).to.equals(100);
+                expect(bounds.height).to.equals(100);
+            }));
     });
 });

--- a/test/core/WebGLRenderer.js
+++ b/test/core/WebGLRenderer.js
@@ -1,16 +1,17 @@
 'use strict';
 
-const isWebGLSupported = require('../isWebGLSupported');
+const withGL = require('../withGL');
 
 describe('PIXI.WebGLRenderer', function ()
 {
-    it('setting option legacy should disable VAOs and SPRITE_MAX_TEXTURES', isWebGLSupported(function ()
-    {
-        const renderer = new PIXI.WebGLRenderer(1, 1, { legacy: true });
-
-        expect(PIXI.glCore.VertexArrayObject.FORCE_NATIVE).to.equal(true);
-        expect(renderer.plugins.sprite.MAX_TEXTURES).to.equal(1);
-
-        renderer.destroy();
-    }));
+    it('setting option legacy should disable VAOs and SPRITE_MAX_TEXTURES', withGL(
+        function ()
+        {
+            return new PIXI.WebGLRenderer(1, 1, { legacy: true });
+        },
+        function (renderer)
+        {
+            expect(PIXI.glCore.VertexArrayObject.FORCE_NATIVE).to.equal(true);
+            expect(renderer.plugins.sprite.MAX_TEXTURES).to.equal(1);
+        }));
 });

--- a/test/core/WebGLRenderer.js
+++ b/test/core/WebGLRenderer.js
@@ -4,14 +4,18 @@ const withGL = require('../withGL');
 
 describe('PIXI.WebGLRenderer', function ()
 {
-    it('setting option legacy should disable VAOs and SPRITE_MAX_TEXTURES', withGL(
-        function ()
-        {
-            return new PIXI.WebGLRenderer(1, 1, { legacy: true });
-        },
-        function (renderer)
+    it('setting option legacy should disable VAOs and SPRITE_MAX_TEXTURES', withGL(function ()
+    {
+        const renderer = new PIXI.WebGLRenderer(1, 1, { legacy: true });
+
+        try
         {
             expect(PIXI.glCore.VertexArrayObject.FORCE_NATIVE).to.equal(true);
             expect(renderer.plugins.sprite.MAX_TEXTURES).to.equal(1);
-        }));
+        }
+        finally
+        {
+            renderer.destroy();
+        }
+    }));
 });

--- a/test/isWebGLSupported.js
+++ b/test/isWebGLSupported.js
@@ -1,8 +1,0 @@
-'use strict';
-
-function isWebGLSupported(fn)
-{
-    return PIXI.utils.isWebGLSupported() ? fn : undefined;
-}
-
-module.exports = isWebGLSupported;

--- a/test/withGL.js
+++ b/test/withGL.js
@@ -1,23 +1,8 @@
 'use strict';
 
-function withGL(init, fn)
+function withGL(fn)
 {
-    if (!PIXI.utils.isWebGLSupported())
-    {
-        return undefined;
-    }
-
-    const renderer = init();
-
-    try
-    {
-        return fn(renderer);
-    }
-    finally
-    {
-        PIXI.utils.destroyTextureCache();
-        renderer.destroy();
-    }
+    return PIXI.utils.isWebGLSupported() ? fn : undefined;
 }
 
 module.exports = withGL;

--- a/test/withGL.js
+++ b/test/withGL.js
@@ -1,0 +1,23 @@
+'use strict';
+
+function withGL(init, fn)
+{
+    if (!PIXI.utils.isWebGLSupported())
+    {
+        return undefined;
+    }
+
+    const renderer = init();
+
+    try
+    {
+        return fn(renderer);
+    }
+    finally
+    {
+        PIXI.utils.destroyTextureCache();
+        renderer.destroy();
+    }
+}
+
+module.exports = withGL;


### PR DESCRIPTION
Fixes problem in SpriteRenderer, TICK was set to 0 every time webglrenderer was created. That was a cause that our tests were failing.

Yes, I know that TICK++ will overflow bunnymark after few years of work, I can add "if tick>2^52, tick=0" there. Same with our transforms, so lets not address that issue there ;)

This is cumulative patch, it also adds some APIs that can be used in tests and in runtime:

- added Texture.WHITE, 10x10 texture is used by Graphics for spriteRect
- cleaned spriteRect code
- added clearTextureCache() and destroyTextureCache()
- added withGL transformer to simplify webgl tests
