### PR TITLE
[v4.4] Revert "Fix #3609 , about `filterClamp` & `filterArea`  (#3626)"

### DIFF
--- a/src/core/renderers/webgl/filters/extractUniformsFromSrc.js
+++ b/src/core/renderers/webgl/filters/extractUniformsFromSrc.js
@@ -12,7 +12,7 @@ export default function extractUniformsFromSrc(vertexSrc, fragmentSrc, mask)
 
 function extractUniformsFromString(string)
 {
-    const maskRegex = new RegExp('^(projectionMatrix|uSampler|filterArea)$');
+    const maskRegex = new RegExp('^(projectionMatrix|uSampler|filterArea|filterClamp)$');
 
     const uniforms = {};
     let nameSplit;

--- a/src/core/renderers/webgl/managers/FilterManager.js
+++ b/src/core/renderers/webgl/managers/FilterManager.js
@@ -291,6 +291,9 @@ export default class FilterManager extends WebGLManager
         let textureCount = 1;
         let currentState;
 
+        // filterArea and filterClamp that are handled by FilterManager directly
+        // they must not appear in uniformData
+
         if (shader.uniforms.filterArea)
         {
             currentState = this.filterData.stack[this.filterData.index];

--- a/src/core/renderers/webgl/managers/FilterManager.js
+++ b/src/core/renderers/webgl/managers/FilterManager.js
@@ -291,11 +291,11 @@ export default class FilterManager extends WebGLManager
         let textureCount = 1;
         let currentState;
 
-        if (uniforms.filterArea)
+        if (shader.uniforms.filterArea)
         {
             currentState = this.filterData.stack[this.filterData.index];
 
-            const filterArea = uniforms.filterArea;
+            const filterArea = shader.uniforms.filterArea;
 
             filterArea[0] = currentState.renderTarget.size.width;
             filterArea[1] = currentState.renderTarget.size.height;
@@ -307,11 +307,11 @@ export default class FilterManager extends WebGLManager
 
         // use this to clamp displaced texture coords so they belong to filterArea
         // see displacementFilter fragment shader for an example
-        if (uniforms.filterClamp)
+        if (shader.uniforms.filterClamp)
         {
             currentState = this.filterData.stack[this.filterData.index];
 
-            const filterClamp = uniforms.filterClamp;
+            const filterClamp = shader.uniforms.filterClamp;
 
             filterClamp[0] = 0;
             filterClamp[1] = 0;

--- a/test/core/filters.js
+++ b/test/core/filters.js
@@ -1,0 +1,21 @@
+'use strict';
+
+describe('PIXI.filters', function ()
+{
+    it('should correctly form uniformData', function ()
+    {
+        const sprite = new PIXI.Sprite(PIXI.Texture.EMPTY);
+        const displ = new PIXI.filters.DisplacementFilter(sprite);
+
+        expect(!!displ.uniformData.scale).to.be.true;
+        expect(!!displ.uniformData.filterMatrix).to.be.true;
+        expect(!!displ.uniformData.mapSampler).to.be.true;
+        // it does have filterClamp, but it is handled by FilterManager
+        expect(!!displ.uniformData.filterClamp).to.be.false;
+
+        const fxaa = new PIXI.filters.FXAAFilter();
+
+        // it does have filterArea, but it is handled by FilterManager
+        expect(!!fxaa.uniformData.filterArea).to.be.false;
+    });
+});

--- a/test/core/index.js
+++ b/test/core/index.js
@@ -27,3 +27,4 @@ require('./SpriteRenderer');
 require('./WebGLRenderer');
 require('./Ellipse');
 require('./Texture');
+require('./filters');


### PR DESCRIPTION
I found the real reason behind that bug. 

"filterClamp" and "filterArea" are special cases, they can't appear in extractUniformsFromSrc

That fixes outlineFilter and glowFilter.