### PR TITLE
Application & Renderer Constructor Options Improvements

### DIFF
--- a/src/core/Application.js
+++ b/src/core/Application.js
@@ -1,6 +1,7 @@
 import { autoDetectRenderer } from './autoDetectRenderer';
 import Container from './display/Container';
 import { shared, Ticker } from './ticker';
+import settings from './settings';
 
 /**
  * Convenience class to create a new PIXI application.
@@ -22,28 +23,46 @@ import { shared, Ticker } from './ticker';
  */
 export default class Application
 {
+    // eslint-disable-next-line valid-jsdoc
     /**
-     * @param {number} [width=800] - the width of the renderers view
-     * @param {number} [height=600] - the height of the renderers view
      * @param {object} [options] - The optional renderer parameters
+     * @param {number} [options.width=800] - the width of the renderers view
+     * @param {number} [options.height=600] - the height of the renderers view
      * @param {HTMLCanvasElement} [options.view] - the canvas to use as a view, optional
      * @param {boolean} [options.transparent=false] - If the render view is transparent, default false
      * @param {boolean} [options.antialias=false] - sets antialias (only applicable in chrome at the moment)
      * @param {boolean} [options.preserveDrawingBuffer=false] - enables drawing buffer preservation, enable this if you
      *      need to call toDataUrl on the webgl context
      * @param {number} [options.resolution=1] - The resolution / device pixel ratio of the renderer, retina would be 2
-     * @param {boolean} [noWebGL=false] - prevents selection of WebGL renderer, even if such is present
+     * @param {boolean} [options.forceCanvas=false] - prevents selection of WebGL renderer, even if such is present
      * @param {boolean} [options.legacy=false] - If true Pixi will aim to ensure compatibility
      * with older / less advanced devices. If you experience unexplained flickering try setting this to true.
-     * @param {boolean} [useSharedTicker=false] - `true` to use PIXI.ticker.shared, `false` to create new ticker.
+     * @param {boolean} [options.sharedTicker=false] - `true` to use PIXI.ticker.shared, `false` to create new ticker.
      */
-    constructor(width, height, options, noWebGL, useSharedTicker = false)
+    constructor(options, arg2, arg3, arg4, arg5)
     {
+        // Support for constructor(width, height, options, noWebGL, useSharedTicker)
+        if (typeof options === 'number')
+        {
+            options = Object.assign({
+                width: options,
+                height: arg2 || settings.RENDER_OPTIONS.height,
+                forceCanvas: !!arg4,
+                sharedTicker: !!arg5,
+            }, arg3);
+        }
+
+        // Set the default options
+        options = Object.assign({
+            sharedTicker: false,
+            forceCanvas: false,
+        }, options);
+
         /**
          * WebGL renderer if available, otherwise CanvasRenderer
          * @member {PIXI.WebGLRenderer|PIXI.CanvasRenderer}
          */
-        this.renderer = autoDetectRenderer(width, height, options, noWebGL);
+        this.renderer = autoDetectRenderer(options);
 
         /**
          * The root display container that's rendered.
@@ -63,7 +82,7 @@ export default class Application
          * @member {PIXI.ticker.Ticker}
          * @default PIXI.ticker.shared
          */
-        this.ticker = useSharedTicker ? shared : new Ticker();
+        this.ticker = options.sharedTicker ? shared : new Ticker();
 
         // Start the rendering
         this.start();

--- a/src/core/autoDetectRenderer.js
+++ b/src/core/autoDetectRenderer.js
@@ -2,6 +2,7 @@ import * as utils from './utils';
 import CanvasRenderer from './renderers/canvas/CanvasRenderer';
 import WebGLRenderer from './renderers/webgl/WebGLRenderer';
 
+// eslint-disable-next-line valid-jsdoc
 /**
  * This helper function will automatically detect which renderer you should be using.
  * WebGL is the preferred renderer as it is a lot faster. If webGL is not supported by
@@ -9,24 +10,32 @@ import WebGLRenderer from './renderers/webgl/WebGLRenderer';
  *
  * @memberof PIXI
  * @function autoDetectRenderer
- * @param {number} [width=800] - the width of the renderers view
- * @param {number} [height=600] - the height of the renderers view
  * @param {object} [options] - The optional renderer parameters
+ * @param {number} [options.width=800] - the width of the renderers view
+ * @param {number} [options.height=600] - the height of the renderers view
  * @param {HTMLCanvasElement} [options.view] - the canvas to use as a view, optional
  * @param {boolean} [options.transparent=false] - If the render view is transparent, default false
  * @param {boolean} [options.antialias=false] - sets antialias (only applicable in chrome at the moment)
  * @param {boolean} [options.preserveDrawingBuffer=false] - enables drawing buffer preservation, enable this if you
  *      need to call toDataUrl on the webgl context
  * @param {number} [options.resolution=1] - The resolution / device pixel ratio of the renderer, retina would be 2
- * @param {boolean} [noWebGL=false] - prevents selection of WebGL renderer, even if such is present
+ * @param {boolean} [options.forceCanvas=false] - prevents selection of WebGL renderer, even if such is present
  * @return {PIXI.WebGLRenderer|PIXI.CanvasRenderer} Returns WebGL renderer if available, otherwise CanvasRenderer
  */
-export function autoDetectRenderer(width = 800, height = 600, options, noWebGL)
+export function autoDetectRenderer(options, arg1, arg2, arg3)
 {
-    if (!noWebGL && utils.isWebGLSupported())
+    // Backward-compatible support for noWebGL option
+    let forceCanvas = options && options.forceCanvas;
+
+    if (arg3 !== undefined)
     {
-        return new WebGLRenderer(width, height, options);
+        forceCanvas = arg3;
     }
 
-    return new CanvasRenderer(width, height, options);
+    if (!forceCanvas && utils.isWebGLSupported())
+    {
+        return new WebGLRenderer(options, arg1, arg2);
+    }
+
+    return new CanvasRenderer(options, arg1, arg2);
 }

--- a/src/core/renderers/SystemRenderer.js
+++ b/src/core/renderers/SystemRenderer.js
@@ -19,11 +19,12 @@ const tempMatrix = new Matrix();
  */
 export default class SystemRenderer extends EventEmitter
 {
+    // eslint-disable-next-line valid-jsdoc
     /**
      * @param {string} system - The name of the system this renderer is for.
-     * @param {number} [screenWidth=800] - the width of the screen
-     * @param {number} [screenHeight=600] - the height of the screen
      * @param {object} [options] - The optional renderer parameters
+     * @param {number} [options.width=800] - the width of the screen
+     * @param {number} [options.height=600] - the height of the screen
      * @param {HTMLCanvasElement} [options.view] - the canvas to use as a view, optional
      * @param {boolean} [options.transparent=false] - If the render view is transparent, default false
      * @param {boolean} [options.autoResize=false] - If the render view is automatically resized, default false
@@ -37,27 +38,31 @@ export default class SystemRenderer extends EventEmitter
      * @param {boolean} [options.roundPixels=false] - If true Pixi will Math.floor() x/y values when rendering,
      *  stopping pixel interpolation.
      */
-    constructor(system, screenWidth, screenHeight, options)
+    constructor(system, options, arg2, arg3)
     {
         super();
 
         sayHello(system);
 
-        // prepare options
-        if (options)
+        // Support for constructor(system, screenWidth, screenHeight, options)
+        if (typeof options === 'number')
         {
-            for (const i in settings.RENDER_OPTIONS)
-            {
-                if (typeof options[i] === 'undefined')
-                {
-                    options[i] = settings.RENDER_OPTIONS[i];
-                }
-            }
+            options = Object.assign({
+                width: options,
+                height: arg2 || settings.RENDER_OPTIONS.height,
+            }, arg3);
         }
-        else
-        {
-            options = settings.RENDER_OPTIONS;
-        }
+
+        // Add the default render options
+        options = Object.assign({}, settings.RENDER_OPTIONS, options);
+
+        /**
+         * The supplied constructor options.
+         *
+         * @member {Object}
+         * @readOnly
+         */
+        this.options = options;
 
         /**
          * The type of the renderer.
@@ -75,7 +80,7 @@ export default class SystemRenderer extends EventEmitter
          *
          * @member {PIXI.Rectangle}
          */
-        this.screen = new Rectangle(0, 0, screenWidth || 800, screenHeight || 600);
+        this.screen = new Rectangle(0, 0, options.width, options.height);
 
         /**
          * The canvas element that everything is drawn to
@@ -278,6 +283,8 @@ export default class SystemRenderer extends EventEmitter
         this.autoResize = false;
 
         this.blendModes = null;
+
+        this.options = null;
 
         this.preserveDrawingBuffer = false;
         this.clearBeforeRender = false;

--- a/src/core/renderers/canvas/CanvasRenderer.js
+++ b/src/core/renderers/canvas/CanvasRenderer.js
@@ -17,10 +17,11 @@ import settings from '../../settings';
  */
 export default class CanvasRenderer extends SystemRenderer
 {
+    // eslint-disable-next-line valid-jsdoc
     /**
-     * @param {number} [screenWidth=800] - the width of the screen
-     * @param {number} [screenHeight=600] - the height of the screen
      * @param {object} [options] - The optional renderer parameters
+     * @param {number} [options.width=800] - the width of the screen
+     * @param {number} [options.height=600] - the height of the screen
      * @param {HTMLCanvasElement} [options.view] - the canvas to use as a view, optional
      * @param {boolean} [options.transparent=false] - If the render view is transparent, default false
      * @param {boolean} [options.autoResize=false] - If the render view is automatically resized, default false
@@ -34,9 +35,9 @@ export default class CanvasRenderer extends SystemRenderer
      * @param {boolean} [options.roundPixels=false] - If true Pixi will Math.floor() x/y values when rendering,
      *  stopping pixel interpolation.
      */
-    constructor(screenWidth, screenHeight, options = {})
+    constructor(options, arg2, arg3)
     {
-        super('Canvas', screenWidth, screenHeight, options);
+        super('Canvas', options, arg2, arg3);
 
         this.type = RENDERER_TYPE.CANVAS;
 
@@ -96,7 +97,7 @@ export default class CanvasRenderer extends SystemRenderer
         this.context = null;
         this.renderingToScreen = false;
 
-        this.resize(screenWidth, screenHeight);
+        this.resize(this.options.width, this.options.height);
     }
 
     /**

--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -28,11 +28,12 @@ let CONTEXT_UID = 0;
  */
 export default class WebGLRenderer extends SystemRenderer
 {
+    // eslint-disable-next-line valid-jsdoc
     /**
      *
-     * @param {number} [screenWidth=800] - the width of the screen
-     * @param {number} [screenHeight=600] - the height of the screen
      * @param {object} [options] - The optional renderer parameters
+     * @param {number} [options.width=800] - the width of the screen
+     * @param {number} [options.height=600] - the height of the screen
      * @param {HTMLCanvasElement} [options.view] - the canvas to use as a view, optional
      * @param {boolean} [options.transparent=false] - If the render view is transparent, default false
      * @param {boolean} [options.autoResize=false] - If the render view is automatically resized, default false
@@ -52,11 +53,11 @@ export default class WebGLRenderer extends SystemRenderer
      * @param {boolean} [options.legacy=false] - If true Pixi will aim to ensure compatibility
      * with older / less advanced devices. If you experiance unexplained flickering try setting this to true.
      */
-    constructor(screenWidth, screenHeight, options = {})
+    constructor(options, arg2, arg3)
     {
-        super('WebGL', screenWidth, screenHeight, options);
+        super('WebGL', options, arg2, arg3);
 
-        this.legacy = !!options.legacy;
+        this.legacy = this.options.legacy;
 
         if (this.legacy)
         {
@@ -85,10 +86,10 @@ export default class WebGLRenderer extends SystemRenderer
          */
         this._contextOptions = {
             alpha: this.transparent,
-            antialias: options.antialias,
+            antialias: this.options.antialias,
             premultipliedAlpha: this.transparent && this.transparent !== 'notMultiplied',
             stencil: true,
-            preserveDrawingBuffer: options.preserveDrawingBuffer,
+            preserveDrawingBuffer: this.options.preserveDrawingBuffer,
         };
 
         this._backgroundColorRgba[3] = this.transparent ? 0 : 1;
@@ -129,13 +130,13 @@ export default class WebGLRenderer extends SystemRenderer
          * @member {WebGLRenderingContext}
          */
         // initialize the context so it is ready for the managers.
-        if (options.context)
+        if (this.options.context)
         {
             // checks to see if a context is valid..
-            validateContext(options.context);
+            validateContext(this.options.context);
         }
 
-        this.gl = options.context || glCore.createContext(this.view, this._contextOptions);
+        this.gl = this.options.context || glCore.createContext(this.view, this._contextOptions);
 
         this.CONTEXT_UID = CONTEXT_UID++;
 

--- a/src/core/settings.js
+++ b/src/core/settings.js
@@ -101,6 +101,9 @@ export default {
      * @property {boolean} clearBeforeRender=true
      * @property {boolean} preserveDrawingBuffer=false
      * @property {boolean} roundPixels=false
+     * @property {number} width=800
+     * @property {number} height=600
+     * @property {boolean} legacy=false
      */
     RENDER_OPTIONS: {
         view: null,
@@ -112,6 +115,9 @@ export default {
         clearBeforeRender: true,
         preserveDrawingBuffer: false,
         roundPixels: false,
+        width: 800,
+        height: 600,
+        legacy: false,
     },
 
     /**


### PR DESCRIPTION
## Overview

This provides an alternative, standardized argument style for `PIXI.autoDetectRenderer` and constructors for `PIXI.Application`, `PIXI.CanvasRenderer`, and `PIXI.WebGLRenderer` to support a single options object instead of optional width/height _and then_ optional options. It maintains backward-compatible support and is therefore **a non-breaking change**. 

### Legacy Style (Current)

To set some renderer options, but you _need_ to provide a width and height:
```js
// Application construction
const app = new PIXI.Application(800, 600, {
    view: document.getElementById('pixi'),
    backgroundColor: 0xffffff
});

// Renderer construction
const renderer = PIXI.autoDetectRenderer(800, 600, {
    view: document.getElementById('pixi'),
    backgroundColor: 0xffffff
});
```

### New Style

Since `width` and `height` are now part of the options object, you do not need to set the defaults when providing the options. For instance:

```js
// Application construction
const app = new PIXI.Application({
    view: document.getElementById('pixi'),
    backgroundColor: 0xffffff
});

// Renderer construction
const renderer = PIXI.autoDetectRenderer({
    view: document.getElementById('pixi'),
    backgroundColor: 0xffffff
});
```

If you want to provide screen width and height, you can pass these in as options:

```js
const app = new PIXI.Application({
    width: 200
    height: 100
});
const renderer = PIXI.autoDetectRenderer({
    width: 200
    height: 100
});
```

### Notes

* The 4th argument of `autoDetectRenderer` and `PIXI.Application`'s constructor was `noWebGL=false`; can now use `options.forceCanvas=false`.
* The 5th argument of `PIXI.Application`'s constructor was `useSharedTicker`; can now use `options.sharedTicker=false`.


### Docs

* [WebGLRenderer](http://pixijs.download/dev-renderer-options/docs/PIXI.WebGLRenderer.html)
* [CanvasRenderer](http://pixijs.download/dev-renderer-options/docs/PIXI.CanvasRenderer.html)
* [Application](http://pixijs.download/dev-renderer-options/docs/PIXI.Application.html)