### PR TITLE
Use `*._texture.*` directly in Sprite.js

### DIFF
--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -147,12 +147,12 @@ export default class Sprite extends Container
         // so if _width is 0 then width was not set..
         if (this._width)
         {
-            this.scale.x = sign(this.scale.x) * this._width / this.texture.orig.width;
+            this.scale.x = sign(this.scale.x) * this._width / this._texture.orig.width;
         }
 
         if (this._height)
         {
-            this.scale.y = sign(this.scale.y) * this._height / this.texture.orig.height;
+            this.scale.y = sign(this.scale.y) * this._height / this._texture.orig.height;
         }
     }
 


### PR DESCRIPTION
It could offer a bit little performance gains.
And  read texture via `_texture` is a common way/style in  PIXI.js