### PR TITLE
default value for settings.SCALE_MODE was not respected in loader

### DIFF
--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -424,8 +424,8 @@ export default class Texture extends EventEmitter
      * @return {PIXI.Texture} Output texture
      */
     static fromLoader(source, imageUrl, name)
-    {
-        const baseTexture = new BaseTexture(source, null, getResolutionOfUrl(imageUrl));
+        {
+        const baseTexture = new BaseTexture(source, undefined, getResolutionOfUrl(imageUrl));
         const texture = new Texture(baseTexture);
 
         baseTexture.imageUrl = imageUrl;


### PR DESCRIPTION
default value for settings.SCALE_MODE was not respected in loader because "undefined !== null"