### PR TITLE
Small Texture Cache enhancements

### DIFF
--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -579,7 +579,6 @@ export default class BaseTexture extends EventEmitter
     {
         if (this.imageUrl)
         {
-            delete BaseTextureCache[this.imageUrl];
             delete TextureCache[this.imageUrl];
 
             this.imageUrl = null;
@@ -589,15 +588,18 @@ export default class BaseTexture extends EventEmitter
                 this.source.src = '';
             }
         }
-        // An svg source has both `imageUrl` and `__pixiId`, so no `else if` here
-        if (this.source && this.source._pixiId)
-        {
-            delete BaseTextureCache[this.source._pixiId];
-        }
 
         this.source = null;
 
         this.dispose();
+
+        for (const prop in BaseTextureCache)
+        {
+            if (BaseTextureCache[prop] === this)
+            {
+                delete BaseTextureCache[prop];
+            }
+        }
     }
 
     /**

--- a/src/core/textures/Spritesheet.js
+++ b/src/core/textures/Spritesheet.js
@@ -208,6 +208,7 @@ export default class Spritesheet
 
                 // lets also add the frame to pixi's global cache for fromFrame and fromImage functions
                 TextureCache[i] = this.textures[i];
+                this.textures[i].textureCacheId = i;
             }
 
             frameIndex++;

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -156,6 +156,15 @@ export default class Texture extends EventEmitter
          * @type {Object}
          */
         this.transform = null;
+
+        /**
+         * The id under which this Texture has been added to the texture cache. This is
+         * automatically set in certain cases, but may not always be accurate, particularly if
+         * the texture is in the cache under multiple ids.
+         *
+         * @member {string}
+         */
+        this.textureCacheId = null;
     }
 
     /**
@@ -238,11 +247,17 @@ export default class Texture extends EventEmitter
         this._uvs = null;
         this.trim = null;
         this.orig = null;
+        this.textureCacheId = null;
 
         this.valid = false;
 
-        this.off('dispose', this.dispose, this);
-        this.off('update', this.update, this);
+        for (const prop in TextureCache)
+        {
+            if (TextureCache[prop] === this)
+            {
+                delete TextureCache[prop];
+            }
+        }
     }
 
     /**
@@ -439,6 +454,7 @@ export default class Texture extends EventEmitter
         // lets also add the frame to pixi's global cache for fromFrame and fromImage fucntions
         BaseTextureCache[name] = baseTexture;
         TextureCache[name] = texture;
+        texture.textureCacheId = name;
 
         // also add references by url if they are different.
         if (name !== imageUrl)
@@ -459,6 +475,10 @@ export default class Texture extends EventEmitter
      */
     static addTextureToCache(texture, id)
     {
+        if (!texture.textureCacheId)
+        {
+            texture.textureCacheId = id;
+        }
         TextureCache[id] = texture;
     }
 

--- a/test/core/BaseTexture.js
+++ b/test/core/BaseTexture.js
@@ -14,4 +14,28 @@ describe('BaseTexture', function ()
             expect(baseTexture.imageType).to.be.equals('png');
         });
     });
+
+    it('should remove Canvas BaseTexture from cache on destroy', function ()
+    {
+        const canvas = document.createElement('canvas');
+        const texture = PIXI.BaseTexture.fromCanvas(canvas);
+        const _pixiId = canvas._pixiId;
+
+        expect(PIXI.utils.BaseTextureCache[_pixiId]).to.equal(texture);
+        texture.destroy();
+        expect(PIXI.utils.BaseTextureCache[_pixiId]).to.equal(undefined);
+    });
+
+    it('should remove Image BaseTexture from cache on destroy', function ()
+    {
+        const URL = 'foo.png';
+        const NAME = 'bar';
+        const image = new Image();
+
+        const texture = PIXI.Texture.fromLoader(image, URL, NAME);
+
+        expect(PIXI.utils.BaseTextureCache[NAME]).to.equal(texture.baseTexture);
+        texture.destroy(true);
+        expect(PIXI.utils.BaseTextureCache[NAME]).to.equal(undefined);
+    });
 });

--- a/test/core/Spritesheet.js
+++ b/test/core/Spritesheet.js
@@ -18,6 +18,7 @@ describe('PIXI.Spritesheet', function ()
                 expect(textures[id]).to.be.an.instanceof(PIXI.Texture);
                 expect(textures[id].width).to.equal(spritesheet.data.frames[id].frame.w / spritesheet.resolution);
                 expect(textures[id].height).to.equal(spritesheet.data.frames[id].frame.h / spritesheet.resolution);
+                expect(textures[id].textureCacheId).to.equal(id);
                 spritesheet.destroy(true);
                 expect(spritesheet.textures).to.be.null;
                 expect(spritesheet.baseTexture).to.be.null;

--- a/test/core/Texture.js
+++ b/test/core/Texture.js
@@ -16,4 +16,20 @@ describe('PIXI.Texture', function ()
         expect(PIXI.utils.TextureCache[URL]).to.equal(texture);
         expect(PIXI.utils.BaseTextureCache[URL]).to.equal(texture.baseTexture);
     });
+
+    it('should remove Texture from cache on destroy', function ()
+    {
+        const NAME = 'foo';
+        const NAME2 = 'bar';
+        const texture = new PIXI.Texture(new PIXI.BaseTexture());
+
+        PIXI.Texture.addTextureToCache(texture, NAME);
+        PIXI.Texture.addTextureToCache(texture, NAME2);
+        expect(texture.textureCacheId).to.equal(NAME);
+        expect(PIXI.utils.TextureCache[NAME]).to.equal(texture);
+        expect(PIXI.utils.TextureCache[NAME2]).to.equal(texture);
+        texture.destroy();
+        expect(PIXI.utils.TextureCache[NAME]).to.equal(undefined);
+        expect(PIXI.utils.TextureCache[NAME2]).to.equal(undefined);
+    });
 });


### PR DESCRIPTION
From the dicussion of #3730:

* added `textureCacheId` to Texture, for giving a useful name to Texture objects that hopefully matches what they are in the TextureCache as.
* Textures and BaseTextures do a thorough search of their respective caches in `destroy()` to remove themselves, so that subsequent Texture.fromX calls don't attempt to reuse a destroyed object.
* Removed some event listener cleanup in Texture.destroy() that wasn't actually cleaning up anything that ever got added.