### PR TITLE
cacheAsBitmap is leaking objects

### DIFF
--- a/src/extras/cacheAsBitmap.js
+++ b/src/extras/cacheAsBitmap.js
@@ -357,6 +357,7 @@ DisplayObject.prototype._destroyCachedDisplayObject = function _destroyCachedDis
 /**
  * Destroys the cached object.
  *
+ * @private
  * @param {object|boolean} [options] - Options parameter. A boolean will act as if all options
  *  have been set to that value. 
  *  Used when destroying containers, see the Container.destroy method.

--- a/src/extras/cacheAsBitmap.js
+++ b/src/extras/cacheAsBitmap.js
@@ -359,8 +359,8 @@ DisplayObject.prototype._destroyCachedDisplayObject = function _destroyCachedDis
  *
  * @private
  */
-DisplayObject.prototype._cacheAsBitmapDestroy = function _cacheAsBitmapDestroy()
+DisplayObject.prototype._cacheAsBitmapDestroy = function _cacheAsBitmapDestroy(options)
 {
     this.cacheAsBitmap = false;
-    this.destroy();
+    this.destroy(options);
 };

--- a/src/extras/cacheAsBitmap.js
+++ b/src/extras/cacheAsBitmap.js
@@ -357,7 +357,9 @@ DisplayObject.prototype._destroyCachedDisplayObject = function _destroyCachedDis
 /**
  * Destroys the cached object.
  *
- * @private
+ * @param {object|boolean} [options] - Options parameter. A boolean will act as if all options
+ *  have been set to that value. 
+ *  Used when destroying containers, see the Container.destroy method.
  */
 DisplayObject.prototype._cacheAsBitmapDestroy = function _cacheAsBitmapDestroy(options)
 {


### PR DESCRIPTION
When destroying objects that had cacheAsBitmap, the internal objects were being retained - options parameter decides whether the children should be destroyed.
If you pass true to a containers destroy that's being cached as bitmap, the containers contents would not be destroyed, unless we pass the parameter to the original destroy method here.

To observe:
1. Create an object containing other objects inside.
2. Cache it to bitmap
3. Destroy the object
4. Goto 1

It will leak the containers sub objects and in the end crash the browser(observable on mobile mostly where memory is much more limited)