### PR TITLE
Fix preparation of destroyed items

### DIFF
--- a/src/core/display/DisplayObject.js
+++ b/src/core/display/DisplayObject.js
@@ -113,6 +113,14 @@ export default class DisplayObject extends EventEmitter
          * @private
          */
         this._mask = null;
+
+        /**
+         * If the object has been destroyed via destroy(). If true, it should not be used.
+         *
+         * @member {boolean}
+         * @readonly
+         */
+        this.isDestroyed = false;
     }
 
     /**
@@ -403,6 +411,8 @@ export default class DisplayObject extends EventEmitter
 
         this.interactive = false;
         this.interactiveChildren = false;
+
+        this.isDestroyed = true;
     }
 
     /**

--- a/src/core/display/DisplayObject.js
+++ b/src/core/display/DisplayObject.js
@@ -118,9 +118,10 @@ export default class DisplayObject extends EventEmitter
          * If the object has been destroyed via destroy(). If true, it should not be used.
          *
          * @member {boolean}
+         * @private
          * @readonly
          */
-        this.isDestroyed = false;
+        this._destroyed = false;
     }
 
     /**
@@ -412,7 +413,7 @@ export default class DisplayObject extends EventEmitter
         this.interactive = false;
         this.interactiveChildren = false;
 
-        this.isDestroyed = true;
+        this._destroyed = true;
     }
 
     /**

--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -203,6 +203,14 @@ export default class BaseTexture extends EventEmitter
         }
 
         /**
+         * If the object has been destroyed via destroy(). If true, it should not be used.
+         *
+         * @member {boolean}
+         * @readonly
+         */
+        this.isDestroyed = false;
+
+        /**
          * Fired when a not-immediately-available source finishes loading.
          *
          * @protected
@@ -598,6 +606,8 @@ export default class BaseTexture extends EventEmitter
         this.source = null;
 
         this.dispose();
+
+        this.isDestroyed = true;
     }
 
     /**

--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -206,9 +206,10 @@ export default class BaseTexture extends EventEmitter
          * If the object has been destroyed via destroy(). If true, it should not be used.
          *
          * @member {boolean}
+         * @private
          * @readonly
          */
-        this.isDestroyed = false;
+        this._destroyed = false;
 
         /**
          * Fired when a not-immediately-available source finishes loading.
@@ -607,7 +608,7 @@ export default class BaseTexture extends EventEmitter
 
         this.dispose();
 
-        this.isDestroyed = true;
+        this._destroyed = true;
     }
 
     /**

--- a/src/prepare/BasePrepare.js
+++ b/src/prepare/BasePrepare.js
@@ -172,13 +172,16 @@ export default class BasePrepare
             const item = this.queue[0];
             let uploaded = false;
 
-            for (let i = 0, len = this.uploadHooks.length; i < len; i++)
+            if (item && !item.isDestroyed)
             {
-                if (this.uploadHooks[i](this.uploadHookHelper, item))
+                for (let i = 0, len = this.uploadHooks.length; i < len; i++)
                 {
-                    this.queue.shift();
-                    uploaded = true;
-                    break;
+                    if (this.uploadHooks[i](this.uploadHookHelper, item))
+                    {
+                        this.queue.shift();
+                        uploaded = true;
+                        break;
+                    }
                 }
             }
 

--- a/src/prepare/BasePrepare.js
+++ b/src/prepare/BasePrepare.js
@@ -172,7 +172,7 @@ export default class BasePrepare
             const item = this.queue[0];
             let uploaded = false;
 
-            if (item && !item.isDestroyed)
+            if (item && !item._destroyed)
             {
                 for (let i = 0, len = this.uploadHooks.length; i < len; i++)
                 {

--- a/test/prepare/BasePrepare.js
+++ b/test/prepare/BasePrepare.js
@@ -144,7 +144,7 @@ describe('PIXI.prepare.BasePrepare', function ()
 
         expect(prep.queue).to.have.lengthOf(1);
 
-        item.isDestroyed = true;
+        item._destroyed = true;
         prep.prepareItems();
 
         expect(prep.queue).to.be.empty;

--- a/test/prepare/BasePrepare.js
+++ b/test/prepare/BasePrepare.js
@@ -121,6 +121,40 @@ describe('PIXI.prepare.BasePrepare', function ()
         prep.destroy();
     });
 
+    it('should remove destroyed items from queue', function ()
+    {
+        const prep = new PIXI.prepare.BasePrepare();
+
+        const addHook = sinon.spy(function (item, queue)
+        {
+            queue.push(item);
+
+            return true;
+        });
+        const uploadHook = sinon.spy(function ()
+        {
+            return false;
+        });
+        const complete = sinon.spy(function () { /* empty */ });
+
+        prep.register(addHook, uploadHook);
+        const item = {};
+
+        prep.upload(item, complete);
+
+        expect(prep.queue).to.have.lengthOf(1);
+
+        item.isDestroyed = true;
+        prep.prepareItems();
+
+        expect(prep.queue).to.be.empty;
+        expect(addHook.calledOnce).to.be.true;
+        expect(uploadHook.called).to.be.false;
+        expect(complete.calledOnce).to.be.true;
+
+        prep.destroy();
+    });
+
     it('should attach to SharedTicker', function (done)
     {
         const prep = new PIXI.prepare.BasePrepare();


### PR DESCRIPTION
* Added `isDestroyed` to DisplayObject, BaseTexture, which is automatically set in `destroy()`.
* The prepare plugins will automatically skip destroyed items, by checking the `isDestroyed` property.