### PR TITLE
Prepare plugin support for objects with multiple BaseTextures

### DIFF
--- a/src/prepare/BasePrepare.js
+++ b/src/prepare/BasePrepare.js
@@ -225,7 +225,7 @@ export default class BasePrepare
      * Adds hooks for finding items.
      *
      * @param {Function} [addHook] - Function call that takes two parameters: `item:*, queue:Array`
-              function must return `true` if it was able to add item to the queue.
+     *          function must return `true` if it was able to add item to the queue.
      * @return {PIXI.CanvasPrepare} Instance of plugin for chaining.
      */
     registerFindHook(addHook)
@@ -242,7 +242,7 @@ export default class BasePrepare
      * Adds hooks for uploading items.
      *
      * @param {Function} [uploadHook] - Function call that takes two parameters: `prepare:CanvasPrepare, item:*` and
-     *        function must return `true` if it was able to handle upload of item.
+     *          function must return `true` if it was able to handle upload of item.
      * @return {PIXI.CanvasPrepare} Instance of plugin for chaining.
      */
     registerUploadHook(uploadHook)

--- a/src/prepare/BasePrepare.js
+++ b/src/prepare/BasePrepare.js
@@ -385,6 +385,51 @@ function findTexture(item, queue)
 
     return false;
 }
+/**
+ * Built-in hook to draw PIXI.Text to its texture.
+ *
+ * @private
+ * @param {PIXI.WebGLRenderer|PIXI.CanvasPrepare} helper - Not used by this upload handler
+ * @param {PIXI.DisplayObject} item - Item to check
+ * @return {boolean} If item was uploaded.
+ */
+function drawText(helper, item)
+{
+    if (item instanceof core.Text)
+    {
+        // updating text will return early if it is not dirty
+        item.updateText(true);
+
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * Built-in hook to calculate a text style for a PIXI.Text object.
+ *
+ * @private
+ * @param {PIXI.WebGLRenderer|PIXI.CanvasPrepare} helper - Not used by this upload handler
+ * @param {PIXI.DisplayObject} item - Item to check
+ * @return {boolean} If item was uploaded.
+ */
+function calculateTextStyle(helper, item)
+{
+    if (item instanceof core.TextStyle)
+    {
+        const font = core.Text.getFontStyle(item);
+
+        if (!core.Text.fontPropertiesCache[font])
+        {
+            core.Text.calculateFontProperties(font);
+        }
+
+        return true;
+    }
+
+    return false;
+}
 
 /**
  * Built-in hook to find Text objects.
@@ -437,52 +482,6 @@ function findTextStyle(item, queue)
         if (queue.indexOf(item) === -1)
         {
             queue.push(item);
-        }
-
-        return true;
-    }
-
-    return false;
-}
-
-/**
- * Built-in hook to draw PIXI.Text to its texture.
- *
- * @private
- * @param {PIXI.WebGLRenderer|PIXI.CanvasPrepare} helper - Not used by this upload handler
- * @param {PIXI.DisplayObject} item - Item to check
- * @return {boolean} If item was uploaded.
- */
-function drawText(helper, item)
-{
-    if (item instanceof core.Text)
-    {
-        // updating text will return early if it is not dirty
-        item.updateText(true);
-
-        return true;
-    }
-
-    return false;
-}
-
-/**
- * Built-in hook to calculate a text style for a PIXI.Text object.
- *
- * @private
- * @param {PIXI.WebGLRenderer|PIXI.CanvasPrepare} helper - Not used by this upload handler
- * @param {PIXI.DisplayObject} item - Item to check
- * @return {boolean} If item was uploaded.
- */
-function calculateTextStyle(helper, item)
-{
-    if (item instanceof core.TextStyle)
-    {
-        const font = core.Text.getFontStyle(item);
-
-        if (!core.Text.fontPropertiesCache[font])
-        {
-            core.Text.calculateFontProperties(font);
         }
 
         return true;

--- a/src/prepare/BasePrepare.js
+++ b/src/prepare/BasePrepare.js
@@ -1,5 +1,4 @@
 import * as core from '../core';
-import * as extras from '../extras';
 import CountLimiter from './limiters/CountLimiter';
 const SharedTicker = core.ticker.shared;
 
@@ -104,7 +103,7 @@ export default class BasePrepare
         // hooks to find the correct texture
         this.registerFindHook(findText);
         this.registerFindHook(findTextStyle);
-        this.registerFindHook(findBaseTexturesFromAnimatedSprites);
+        this.registerFindHook(findMultipleBaseTextures);
         this.registerFindHook(findBaseTexture);
         this.registerFindHook(findTexture);
 
@@ -309,21 +308,21 @@ export default class BasePrepare
 }
 
 /**
- * Built-in hook to find textures from Sprites.
+ * Built-in hook to find multiple textures from objects like AnimatedSprites.
  *
  * @private
  * @param {PIXI.DisplayObject} item - Display object to check
  * @param {Array<*>} queue - Collection of items to upload
  * @return {boolean} if a PIXI.Texture object was found.
  */
-function findBaseTexturesFromAnimatedSprites(item, queue)
+function findMultipleBaseTextures(item, queue)
 {
     // Objects with mutliple textures
-    if (item instanceof extras.AnimatedSprite)
+    if (item && item._textures && item._textures.length)
     {
-        for (let i = 0; i < item.textures.length; i++)
+        for (let i = 0; i < item._textures.length; i++)
         {
-            const baseTexture = item.textures[i].baseTexture;
+            const baseTexture = item._textures[i].baseTexture;
 
             if (queue.indexOf(baseTexture) === -1)
             {

--- a/src/prepare/BasePrepare.js
+++ b/src/prepare/BasePrepare.js
@@ -291,7 +291,7 @@ export default class BasePrepare
     /**
      * Built-in hook to find textures from Sprites.
      *
-     * @private
+     * @static
      * @param {PIXI.DisplayObject} item - Display object to check
      * @param {Array<*>} queue - Collection of items to upload
      * @return {boolean} if a PIXI.Texture object was found.
@@ -326,7 +326,7 @@ export default class BasePrepare
     /**
      * Built-in hook to find mutliple BaseTextures in AnimatedSprite objects.
      *
-     * @private
+     * @static
      * @param {PIXI.DisplayObject} item - Display object to check
      * @param {Array<*>} queue - Collection of items to upload
      * @return {boolean} if a PIXI.AnimatedSprite object was found.
@@ -354,7 +354,7 @@ export default class BasePrepare
     /**
      * Built-in hook to find Text objects.
      *
-     * @private
+     * @static
      * @param {PIXI.DisplayObject} item - Display object to check
      * @param {Array<*>} queue - Collection of items to upload
      * @return {boolean} if a PIXI.Text object was found.
@@ -390,7 +390,7 @@ export default class BasePrepare
     /**
      * Built-in hook to find TextStyle objects.
      *
-     * @private
+     * @static
      * @param {PIXI.TextStyle} item - Display object to check
      * @param {Array<*>} queue - Collection of items to upload
      * @return {boolean} if a PIXI.TextStyle object was found.

--- a/src/prepare/BasePrepare.js
+++ b/src/prepare/BasePrepare.js
@@ -298,8 +298,23 @@ export default class BasePrepare
      */
     static findBaseTextures(item, queue)
     {
+        // Objects with mutliple textures
+        if (item instanceof extras.AnimatedSprite)
+        {
+            for (let i = 0; i < item.textures.length; i++)
+            {
+                const baseTexture = item.textures[i].baseTexture;
+
+                if (queue.indexOf(baseTexture) === -1)
+                {
+                    queue.push(baseTexture);
+                }
+            }
+
+            return true;
+        }
         // Objects with textures, like Sprites/Text
-        if (item instanceof core.BaseTexture)
+        else if (item instanceof core.BaseTexture)
         {
             if (queue.indexOf(item) === -1)
             {
@@ -315,34 +330,6 @@ export default class BasePrepare
             if (queue.indexOf(texture) === -1)
             {
                 queue.push(texture);
-            }
-
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * Built-in hook to find mutliple BaseTextures in AnimatedSprite objects.
-     *
-     * @static
-     * @param {PIXI.DisplayObject} item - Display object to check
-     * @param {Array<*>} queue - Collection of items to upload
-     * @return {boolean} if a PIXI.AnimatedSprite object was found.
-     */
-    static findAnimatedSpriteBaseTextures(item, queue)
-    {
-        if (item instanceof extras.AnimatedSprite)
-        {
-            for (let i = 0; i < item.textures.length; i++)
-            {
-                const baseTexture = item.textures[i].baseTexture;
-
-                if (queue.indexOf(baseTexture) === -1)
-                {
-                    queue.push(baseTexture);
-                }
             }
 
             return true;

--- a/src/prepare/canvas/CanvasPrepare.js
+++ b/src/prepare/canvas/CanvasPrepare.js
@@ -43,7 +43,7 @@ export default class CanvasPrepare extends BasePrepare
         this.ctx = this.canvas.getContext('2d');
 
         // Add textures to upload
-        this.register(BasePrepare.findBaseTextures, uploadBaseTextures);
+        this.registerUploadHook(uploadBaseTextures);
     }
 
     /**

--- a/src/prepare/canvas/CanvasPrepare.js
+++ b/src/prepare/canvas/CanvasPrepare.js
@@ -43,7 +43,8 @@ export default class CanvasPrepare extends BasePrepare
         this.ctx = this.canvas.getContext('2d');
 
         // Add textures to upload
-        this.register(findBaseTextures, uploadBaseTextures);
+        this.register(BasePrepare.findAnimatedSpriteBaseTextures, uploadBaseTextures)
+            .register(BasePrepare.findBaseTextures, uploadBaseTextures);
     }
 
     /**
@@ -82,41 +83,6 @@ function uploadBaseTextures(prepare, item)
         // Only a small subsections is required to be drawn to have the whole texture uploaded to the GPU
         // A smaller draw can be faster.
         prepare.ctx.drawImage(image, 0, 0, imageWidth, imageHeight, 0, 0, prepare.canvas.width, prepare.canvas.height);
-
-        return true;
-    }
-
-    return false;
-}
-
-/**
- * Built-in hook to find textures from Sprites.
- *
- * @private
- * @param {PIXI.DisplayObject} item  -Display object to check
- * @param {Array<*>} queue - Collection of items to upload
- * @return {boolean} if a PIXI.Texture object was found.
- */
-function findBaseTextures(item, queue)
-{
-    // Objects with textures, like Sprites/Text
-    if (item instanceof core.BaseTexture)
-    {
-        if (queue.indexOf(item) === -1)
-        {
-            queue.push(item);
-        }
-
-        return true;
-    }
-    else if (item._texture && item._texture instanceof core.Texture)
-    {
-        const texture = item._texture.baseTexture;
-
-        if (queue.indexOf(texture) === -1)
-        {
-            queue.push(texture);
-        }
 
         return true;
     }

--- a/src/prepare/canvas/CanvasPrepare.js
+++ b/src/prepare/canvas/CanvasPrepare.js
@@ -43,8 +43,7 @@ export default class CanvasPrepare extends BasePrepare
         this.ctx = this.canvas.getContext('2d');
 
         // Add textures to upload
-        this.register(BasePrepare.findAnimatedSpriteBaseTextures, uploadBaseTextures)
-            .register(BasePrepare.findBaseTextures, uploadBaseTextures);
+        this.register(BasePrepare.findBaseTextures, uploadBaseTextures);
     }
 
     /**

--- a/src/prepare/webgl/WebGLPrepare.js
+++ b/src/prepare/webgl/WebGLPrepare.js
@@ -22,8 +22,29 @@ export default class WebGLPrepare extends BasePrepare
         this.uploadHookHelper = this.renderer;
 
         // Add textures and graphics to upload
-        this.register(findBaseTextures, uploadBaseTextures)
-            .register(findGraphics, uploadGraphics);
+        this.register(BasePrepare.findAnimatedSpriteBaseTextures, uploadBaseTextures)
+            .register(BasePrepare.findBaseTextures, uploadBaseTextures)
+            .register(WebGLPrepare.findGraphics, uploadGraphics);
+    }
+
+    /**
+     * Built-in hook to find graphics.
+     *
+     * @private
+     * @param {PIXI.DisplayObject} item - Display object to check
+     * @param {Array<*>} queue - Collection of items to upload
+     * @return {boolean} if a PIXI.Graphics object was found.
+     */
+    static findGraphics(item, queue)
+    {
+        if (item instanceof core.Graphics)
+        {
+            queue.push(item);
+
+            return true;
+        }
+
+        return false;
     }
 
 }
@@ -72,61 +93,6 @@ function uploadGraphics(renderer, item)
         {
             renderer.plugins.graphics.updateGraphics(item);
         }
-
-        return true;
-    }
-
-    return false;
-}
-
-/**
- * Built-in hook to find textures from Sprites.
- *
- * @private
- * @param {PIXI.DisplayObject} item - Display object to check
- * @param {Array<*>} queue - Collection of items to upload
- * @return {boolean} if a PIXI.Texture object was found.
- */
-function findBaseTextures(item, queue)
-{
-    // Objects with textures, like Sprites/Text
-    if (item instanceof core.BaseTexture)
-    {
-        if (queue.indexOf(item) === -1)
-        {
-            queue.push(item);
-        }
-
-        return true;
-    }
-    else if (item._texture && item._texture instanceof core.Texture)
-    {
-        const texture = item._texture.baseTexture;
-
-        if (queue.indexOf(texture) === -1)
-        {
-            queue.push(texture);
-        }
-
-        return true;
-    }
-
-    return false;
-}
-
-/**
- * Built-in hook to find graphics.
- *
- * @private
- * @param {PIXI.DisplayObject} item - Display object to check
- * @param {Array<*>} queue - Collection of items to upload
- * @return {boolean} if a PIXI.Graphics object was found.
- */
-function findGraphics(item, queue)
-{
-    if (item instanceof core.Graphics)
-    {
-        queue.push(item);
 
         return true;
     }

--- a/src/prepare/webgl/WebGLPrepare.js
+++ b/src/prepare/webgl/WebGLPrepare.js
@@ -30,7 +30,7 @@ export default class WebGLPrepare extends BasePrepare
     /**
      * Built-in hook to find graphics.
      *
-     * @private
+     * @static
      * @param {PIXI.DisplayObject} item - Display object to check
      * @param {Array<*>} queue - Collection of items to upload
      * @return {boolean} if a PIXI.Graphics object was found.

--- a/src/prepare/webgl/WebGLPrepare.js
+++ b/src/prepare/webgl/WebGLPrepare.js
@@ -27,27 +27,6 @@ export default class WebGLPrepare extends BasePrepare
         this.registerUploadHook(uploadGraphics);
     }
 }
-
-/**
- * Built-in hook to find graphics.
- *
- * @private
- * @param {PIXI.DisplayObject} item - Display object to check
- * @param {Array<*>} queue - Collection of items to upload
- * @return {boolean} if a PIXI.Graphics object was found.
- */
-function findGraphics(item, queue)
-{
-    if (item instanceof core.Graphics)
-    {
-        queue.push(item);
-
-        return true;
-    }
-
-    return false;
-}
-
 /**
  * Built-in hook to upload PIXI.Texture objects to the GPU.
  *
@@ -92,6 +71,26 @@ function uploadGraphics(renderer, item)
         {
             renderer.plugins.graphics.updateGraphics(item);
         }
+
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * Built-in hook to find graphics.
+ *
+ * @private
+ * @param {PIXI.DisplayObject} item - Display object to check
+ * @param {Array<*>} queue - Collection of items to upload
+ * @return {boolean} if a PIXI.Graphics object was found.
+ */
+function findGraphics(item, queue)
+{
+    if (item instanceof core.Graphics)
+    {
+        queue.push(item);
 
         return true;
     }

--- a/src/prepare/webgl/WebGLPrepare.js
+++ b/src/prepare/webgl/WebGLPrepare.js
@@ -22,30 +22,30 @@ export default class WebGLPrepare extends BasePrepare
         this.uploadHookHelper = this.renderer;
 
         // Add textures and graphics to upload
-        this.register(BasePrepare.findBaseTextures, uploadBaseTextures)
-            .register(WebGLPrepare.findGraphics, uploadGraphics);
+        this.registerFindHook(findGraphics);
+        this.registerUploadHook(uploadBaseTextures);
+        this.registerUploadHook(uploadGraphics);
     }
+}
 
-    /**
-     * Built-in hook to find graphics.
-     *
-     * @static
-     * @param {PIXI.DisplayObject} item - Display object to check
-     * @param {Array<*>} queue - Collection of items to upload
-     * @return {boolean} if a PIXI.Graphics object was found.
-     */
-    static findGraphics(item, queue)
+/**
+ * Built-in hook to find graphics.
+ *
+ * @private
+ * @param {PIXI.DisplayObject} item - Display object to check
+ * @param {Array<*>} queue - Collection of items to upload
+ * @return {boolean} if a PIXI.Graphics object was found.
+ */
+function findGraphics(item, queue)
+{
+    if (item instanceof core.Graphics)
     {
-        if (item instanceof core.Graphics)
-        {
-            queue.push(item);
+        queue.push(item);
 
-            return true;
-        }
-
-        return false;
+        return true;
     }
 
+    return false;
 }
 
 /**

--- a/src/prepare/webgl/WebGLPrepare.js
+++ b/src/prepare/webgl/WebGLPrepare.js
@@ -22,8 +22,7 @@ export default class WebGLPrepare extends BasePrepare
         this.uploadHookHelper = this.renderer;
 
         // Add textures and graphics to upload
-        this.register(BasePrepare.findAnimatedSpriteBaseTextures, uploadBaseTextures)
-            .register(BasePrepare.findBaseTextures, uploadBaseTextures)
+        this.register(BasePrepare.findBaseTextures, uploadBaseTextures)
             .register(WebGLPrepare.findGraphics, uploadGraphics);
     }
 

--- a/test/prepare/BasePrepare.js
+++ b/test/prepare/BasePrepare.js
@@ -10,7 +10,7 @@ describe('PIXI.prepare.BasePrepare', function ()
         expect(prep.renderer).to.equal(renderer);
         expect(prep.uploadHookHelper).to.be.null;
         expect(prep.queue).to.be.empty;
-        expect(prep.addHooks).to.have.lengthOf(2);
+        expect(prep.addHooks).to.have.lengthOf(5);
         expect(prep.uploadHooks).to.have.lengthOf(2);
         expect(prep.completes).to.be.empty;
 
@@ -23,10 +23,11 @@ describe('PIXI.prepare.BasePrepare', function ()
         function uploadHook() { /* empty */ }
         const prep = new PIXI.prepare.BasePrepare();
 
-        prep.register(addHook, uploadHook);
+        prep.registerFindHook(addHook);
+        prep.registerUploadHook(uploadHook);
 
         expect(prep.addHooks).to.contain(addHook);
-        expect(prep.addHooks).to.have.lengthOf(3);
+        expect(prep.addHooks).to.have.lengthOf(6);
         expect(prep.uploadHooks).to.contain(uploadHook);
         expect(prep.uploadHooks).to.have.lengthOf(3);
 
@@ -58,7 +59,8 @@ describe('PIXI.prepare.BasePrepare', function ()
         });
         const complete = sinon.spy(function () { /* empty */ });
 
-        prep.register(addHook, uploadHook);
+        prep.registerFindHook(addHook);
+        prep.registerUploadHook(uploadHook);
         prep.upload(uploadItem, complete);
 
         expect(prep.queue).to.contain(uploadItem);
@@ -82,7 +84,7 @@ describe('PIXI.prepare.BasePrepare', function ()
         }
         const complete = sinon.spy(function () { /* empty */ });
 
-        prep.register(addHook);
+        prep.registerFindHook(addHook);
         prep.upload({}, complete);
 
         expect(complete.calledOnce).to.be.true;
@@ -106,7 +108,8 @@ describe('PIXI.prepare.BasePrepare', function ()
         });
         const complete = sinon.spy(function () { /* empty */ });
 
-        prep.register(addHook, uploadHook);
+        prep.registerFindHook(addHook);
+        prep.registerUploadHook(uploadHook);
         prep.upload({}, complete);
 
         expect(prep.queue).to.have.lengthOf(1);
@@ -137,7 +140,8 @@ describe('PIXI.prepare.BasePrepare', function ()
         });
         const complete = sinon.spy(function () { /* empty */ });
 
-        prep.register(addHook, uploadHook);
+        prep.registerFindHook(addHook);
+        prep.registerUploadHook(uploadHook);
         const item = {};
 
         prep.upload(item, complete);
@@ -181,7 +185,8 @@ describe('PIXI.prepare.BasePrepare', function ()
             done();
         }
 
-        prep.register(addHook, uploadHook);
+        prep.registerFindHook(addHook);
+        prep.registerUploadHook(uploadHook);
         prep.upload({}, complete);
 
         expect(prep.queue).to.have.lengthOf(1);


### PR DESCRIPTION
The entire discussion for this task and its development is found at #3829 

Changes:

- Adds support for AnimatedSprites with more than 1 source texture to the Prepare plugins
- Removes the duplicate `function findBaseTextures()` found in both WebGL & CanvasPrepare
- Moves `function findBaseTextures()` to BasePrepare.js
- Splits the `BasePrepare.register(addHook,uploadHook) into 2 separate methods
- Updates unit tests

I am not thoroughly please with the naming of the `findBaseTexure` and `findTexture` methods, hopefully there are some better suggestions