### PR TITLE
TilingSprite matrix calculation fix

### DIFF
--- a/src/extras/webgl/TilingSpriteRenderer.js
+++ b/src/extras/webgl/TilingSpriteRenderer.js
@@ -131,7 +131,7 @@ export default class TilingSpriteRenderer extends core.ObjectRenderer
         tempMat.invert();
         if (isSimple)
         {
-            tempMat.append(uv.mapCoord);
+            tempMat.prepend(uv.mapCoord);
         }
         else
         {


### PR DESCRIPTION
Take that demo: http://pixijs.github.io/examples/#/basics/tiling-sprite.js

Now add this into app.ticker:

```js
    if (texture.valid && texture.rotate == 0) {
      texture.rotate = 8;
    }
```

OK, texture is rotated by 180 degrees, but sprite moving in wrong direction! But what if its not calculated in renderer, but in shader itself? Lets cut the texture, calculation moves to shader:

```js
    if (texture.valid && texture.rotate == 0) {
      var w = texture.frame.width, h = texture.frame.height;
      texture.frame = new PIXI.Rectangle(1, 1, w-2, h-2);
      texture.orig = new PIXI.Rectangle(1, 1, w-2, h-2);
      texture.rotate = 8;
    }
```

It works!

So, whats the fix? Just swap texture translate and texture transform order. That way is consistent with shader and behaviour that user expects.