### PR TITLE
Improvements to how and what is stored in the texture caches.

### DIFF
--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -1071,7 +1071,7 @@ export default class Graphics extends Container
 
         canvasRenderer.render(this, canvasBuffer, true, tempMatrix);
 
-        const texture = Texture.fromCanvas(canvasBuffer.baseTexture._canvasRenderTarget.canvas, scaleMode);
+        const texture = Texture.fromCanvas(canvasBuffer.baseTexture._canvasRenderTarget.canvas, scaleMode, 'graphics');
 
         texture.baseTexture.resolution = resolution;
         texture.baseTexture.update();

--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -50,7 +50,7 @@ export default class Text extends Sprite
         super(texture);
 
         // base texture is already automatically added to the cache, now adding the actual texture
-        Texture.addToCache(this._texture, this._texture.baseTexture.textureCacheId);
+        Texture.addToCache(this._texture, this._texture.baseTexture.textureCacheId[0]);
 
         /**
          * The canvas element that everything is drawn to

--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -50,7 +50,7 @@ export default class Text extends Sprite
         super(texture);
 
         // base texture is already automatically added to the cache, now adding the actual texture
-        Texture.addToCache(this._texture, this._texture.baseTexture.textureCacheId[0]);
+        Texture.addToCache(this._texture, this._texture.baseTexture.textureCacheIds[0]);
 
         /**
          * The canvas element that everything is drawn to

--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -42,12 +42,15 @@ export default class Text extends Sprite
         canvas.width = 3;
         canvas.height = 3;
 
-        const texture = Texture.fromCanvas(canvas);
+        const texture = Texture.fromCanvas(canvas, settings.SCALE_MODE, 'text');
 
         texture.orig = new Rectangle();
         texture.trim = new Rectangle();
 
         super(texture);
+
+        // base texture is already automatically added to the cache, now adding the actual texture
+        Texture.addTextureToCache(this._texture, this._texture.baseTexture.baseTextureCacheId);
 
         /**
          * The canvas element that everything is drawn to

--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -50,7 +50,7 @@ export default class Text extends Sprite
         super(texture);
 
         // base texture is already automatically added to the cache, now adding the actual texture
-        Texture.addTextureToCache(this._texture, this._texture.baseTexture.baseTextureCacheId);
+        Texture.addToCache(this._texture, this._texture.baseTexture.textureCacheId);
 
         /**
          * The canvas element that everything is drawn to

--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -798,7 +798,7 @@ export default class BaseTexture extends EventEmitter
      */
     static removeFromCache(id)
     {
-        const baseTexture = TextureCache[id];
+        const baseTexture = BaseTextureCache[id];
 
         if (baseTexture)
         {

--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -698,12 +698,12 @@ export default class BaseTexture extends EventEmitter
      * @static
      * @param {HTMLCanvasElement} canvas - The canvas element source of the texture
      * @param {number} scaleMode - See {@link PIXI.SCALE_MODES} for possible values
-     * @param {string} [origin] - A string origin of who created the base texture
+     * @param {string} [origin='canvas'] - A string origin of who created the base texture
      * @return {PIXI.BaseTexture} The new base texture.
      */
-    static fromCanvas(canvas, scaleMode, origin)
+    static fromCanvas(canvas, scaleMode, origin = 'canvas')
     {
-        const name = origin ? `${origin}_` : 'canvas_';
+        const name = `${origin}_`;
 
         if (!canvas._pixiId)
         {

--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -697,11 +697,9 @@ export default class BaseTexture extends EventEmitter
      */
     static fromCanvas(canvas, scaleMode, origin = 'canvas')
     {
-        const name = `${origin}_`;
-
         if (!canvas._pixiId)
         {
-            canvas._pixiId = `${name}${uid()}`;
+            canvas._pixiId = `${origin}_${uid()}`;
         }
 
         let baseTexture = BaseTextureCache[canvas._pixiId];

--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -212,7 +212,7 @@ export default class BaseTexture extends EventEmitter
          *
          * @member {string[]}
          */
-        this.textureCacheId = [];
+        this.textureCacheIds = [];
 
         // if no source passed don't try to load
         if (source)
@@ -612,7 +612,7 @@ export default class BaseTexture extends EventEmitter
         this.dispose();
 
         BaseTexture.removeFromCache(this);
-        this.textureCacheId = null;
+        this.textureCacheIds = null;
 
         this._destroyed = true;
     }
@@ -774,9 +774,9 @@ export default class BaseTexture extends EventEmitter
     {
         if (id)
         {
-            if (baseTexture.textureCacheId.indexOf(id) === -1)
+            if (baseTexture.textureCacheIds.indexOf(id) === -1)
             {
-                baseTexture.textureCacheId.push(id);
+                baseTexture.textureCacheIds.push(id);
             }
 
             // @if DEBUG
@@ -807,11 +807,11 @@ export default class BaseTexture extends EventEmitter
 
             if (baseTextureFromCache)
             {
-                const index = baseTextureFromCache.textureCacheId.indexOf(baseTexture);
+                const index = baseTextureFromCache.textureCacheIds.indexOf(baseTexture);
 
                 if (index > -1)
                 {
-                    baseTextureFromCache.textureCacheId.splice(index, 1);
+                    baseTextureFromCache.textureCacheIds.splice(index, 1);
                 }
 
                 delete BaseTextureCache[baseTexture];
@@ -821,12 +821,12 @@ export default class BaseTexture extends EventEmitter
         }
         else
         {
-            for (let i = 0; i < baseTexture.textureCacheId.length; ++i)
+            for (let i = 0; i < baseTexture.textureCacheIds.length; ++i)
             {
-                delete BaseTextureCache[baseTexture.textureCacheId[i]];
+                delete BaseTextureCache[baseTexture.textureCacheIds[i]];
             }
 
-            baseTexture.textureCacheId.length = 0;
+            baseTexture.textureCacheIds.length = 0;
 
             return baseTexture;
         }

--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -770,11 +770,11 @@ export default class BaseTexture extends EventEmitter
     }
 
     /**
-     * Adds a texture to the global BaseTextureCache. This cache is shared across the whole PIXI object.
+     * Adds a BaseTexture to the global BaseTextureCache. This cache is shared across the whole PIXI object.
      *
      * @static
      * @param {PIXI.BaseTexture} baseTexture - The BaseTexture to add to the cache.
-     * @param {string} id - The id that the base texture will be stored against.
+     * @param {string} id - The id that the BaseTexture will be stored against.
      */
     static addToCache(baseTexture, id)
     {
@@ -785,25 +785,51 @@ export default class BaseTexture extends EventEmitter
                 baseTexture.textureCacheId = id;
             }
 
+            // @if DEBUG
+            /* eslint-disable no-console */
+            if (BaseTextureCache[id])
+            {
+                console.warn(`BaseTexture added to the cache with an id [${id}] that already had an entry`);
+            }
+            /* eslint-enable no-console */
+            // @endif
+
             BaseTextureCache[id] = baseTexture;
         }
     }
 
     /**
-     * Remove a texture from the global BaseTextureCache.
+     * Remove a BaseTexture from the global BaseTextureCache.
      *
      * @static
-     * @param {string} id - The id of the base texture to be removed
-     * @return {PIXI.BaseTexture|null} The BaseTexture that was removed
+     * @param {string|PIXI.BaseTexture} baseTexture - id of a BaseTexture to be removed, or a BaseTexture instance itself.
+     * @return {PIXI.BaseTexture|null} The BaseTexture that was removed.
      */
-    static removeFromCache(id)
+    static removeFromCache(baseTexture)
     {
-        const baseTexture = BaseTextureCache[id];
-
-        if (baseTexture)
+        if (typeof baseTexture === 'string')
         {
+            const baseTextureFromCache = BaseTextureCache[baseTexture];
+
+            if (baseTextureFromCache)
+            {
+                baseTextureFromCache.textureCacheId = null;
+                delete BaseTextureCache[baseTexture];
+
+                return baseTextureFromCache;
+            }
+        }
+        else
+        {
+            for (const prop in BaseTextureCache)
+            {
+                if (BaseTextureCache[prop] === baseTexture)
+                {
+                    delete BaseTextureCache[prop];
+                }
+            }
+
             baseTexture.textureCacheId = null;
-            delete BaseTextureCache[id];
 
             return baseTexture;
         }

--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -803,7 +803,6 @@ export default class BaseTexture extends EventEmitter
         if (baseTexture)
         {
             baseTexture.textureCacheId = null;
-
             delete BaseTextureCache[id];
 
             return baseTexture;

--- a/src/core/textures/Spritesheet.js
+++ b/src/core/textures/Spritesheet.js
@@ -207,7 +207,7 @@ export default class Spritesheet
                 );
 
                 // lets also add the frame to pixi's global cache for fromFrame and fromImage functions
-                Texture.addTextureToCache(this.textures[i], i);
+                Texture.addToCache(this.textures[i], i);
             }
 
             frameIndex++;

--- a/src/core/textures/Spritesheet.js
+++ b/src/core/textures/Spritesheet.js
@@ -1,5 +1,5 @@
 import { Rectangle, Texture } from '../';
-import { getResolutionOfUrl, TextureCache } from '../utils';
+import { getResolutionOfUrl } from '../utils';
 
 /**
  * Utility class for maintaining reference to a collection
@@ -207,8 +207,7 @@ export default class Spritesheet
                 );
 
                 // lets also add the frame to pixi's global cache for fromFrame and fromImage functions
-                TextureCache[i] = this.textures[i];
-                this.textures[i].textureCacheId = i;
+                Texture.addTextureToCache(this.textures[i], i);
             }
 
             frameIndex++;

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -468,11 +468,11 @@ export default class Texture extends EventEmitter
     }
 
     /**
-     * Adds a texture to the global TextureCache. This cache is shared across the whole PIXI object.
+     * Adds a Texture to the global TextureCache. This cache is shared across the whole PIXI object.
      *
      * @static
      * @param {PIXI.Texture} texture - The Texture to add to the cache.
-     * @param {string} id - The id that the texture will be stored against.
+     * @param {string} id - The id that the Texture will be stored against.
      */
     static addToCache(texture, id)
     {
@@ -483,25 +483,51 @@ export default class Texture extends EventEmitter
                 texture.textureCacheId = id;
             }
 
+            // @if DEBUG
+            /* eslint-disable no-console */
+            if (TextureCache[id])
+            {
+                console.warn(`Texture added to the cache with an id [${id}] that already had an entry`);
+            }
+            /* eslint-enable no-console */
+            // @endif
+
             TextureCache[id] = texture;
         }
     }
 
     /**
-     * Remove a texture from the global TextureCache.
+     * Remove a Texture from the global TextureCache.
      *
      * @static
-     * @param {string} id - The id of the texture to be removed
-     * @return {PIXI.Texture|null} The texture that was removed
+     * @param {string|PIXI.Texture} texture - id of a Texture to be removed, or a Texture instance itself
+     * @return {PIXI.Texture|null} The Texture that was removed
      */
-    static removeFromCache(id)
+    static removeFromCache(texture)
     {
-        const texture = TextureCache[id];
-
-        if (texture)
+        if (typeof texture === 'string')
         {
+            const textureFromCache = TextureCache[texture];
+
+            if (textureFromCache)
+            {
+                textureFromCache.textureCacheId = null;
+                delete TextureCache[texture];
+
+                return textureFromCache;
+            }
+        }
+        else
+        {
+            for (const prop in TextureCache)
+            {
+                if (TextureCache[prop] === texture)
+                {
+                    delete TextureCache[prop];
+                }
+            }
+
             texture.textureCacheId = null;
-            delete TextureCache[id];
 
             return texture;
         }

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -232,7 +232,7 @@ export default class Texture extends EventEmitter
                 // this only needs to be removed if the base texture is actually destroyed too..
                 if (TextureCache[this.baseTexture.imageUrl])
                 {
-                    this.removeTextureFromCache(this.baseTexture.imageUrl);
+                    this.removeFromCache(this.baseTexture.imageUrl);
                 }
 
                 this.baseTexture.destroy();
@@ -248,10 +248,10 @@ export default class Texture extends EventEmitter
         this._uvs = null;
         this.trim = null;
         this.orig = null;
-        this.textureCacheId = null;
 
         this.valid = false;
 
+        this.textureCacheId = null;
         for (const prop in TextureCache)
         {
             if (TextureCache[prop] === this)
@@ -306,7 +306,7 @@ export default class Texture extends EventEmitter
         if (!texture)
         {
             texture = new Texture(BaseTexture.fromImage(imageUrl, crossorigin, scaleMode, sourceScale));
-            Texture.addTextureToCache(texture, imageUrl);
+            Texture.addToCache(texture, imageUrl);
         }
 
         return texture;
@@ -454,14 +454,14 @@ export default class Texture extends EventEmitter
         }
 
         // lets also add the frame to pixi's global cache for fromFrame and fromImage fucntions
-        BaseTexture.addBaseTextureToCache(texture, name);
-        Texture.addTextureToCache(texture, name);
+        BaseTexture.addToCache(texture, name);
+        Texture.addToCache(texture, name);
 
         // also add references by url if they are different.
         if (name !== imageUrl)
         {
-            BaseTexture.addBaseTextureToCache(texture, imageUrl);
-            Texture.addTextureToCache(texture, imageUrl);
+            BaseTexture.addToCache(texture, imageUrl);
+            Texture.addToCache(texture, imageUrl);
         }
 
         return texture;
@@ -474,7 +474,7 @@ export default class Texture extends EventEmitter
      * @param {PIXI.Texture} texture - The Texture to add to the cache.
      * @param {string} id - The id that the texture will be stored against.
      */
-    static addTextureToCache(texture, id)
+    static addToCache(texture, id)
     {
         if (id)
         {
@@ -494,7 +494,7 @@ export default class Texture extends EventEmitter
      * @param {string} id - The id of the texture to be removed
      * @return {PIXI.Texture|null} The texture that was removed
      */
-    static removeTextureFromCache(id)
+    static removeFromCache(id)
     {
         const texture = TextureCache[id];
 

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -159,13 +159,13 @@ export default class Texture extends EventEmitter
         this.transform = null;
 
         /**
-         * The id under which this Texture has been added to the texture cache. This is
-         * automatically set in certain cases, but may not always be accurate, particularly if
-         * the texture is in the cache under multiple ids.
+         * The ids under which this Texture has been added to the texture cache. This is
+         * automatically set as long as Texture.addToCache is used, but may not be set if a
+         * Texture is added directly to the TextureCache array.
          *
-         * @member {string}
+         * @member {string[]}
          */
-        this.textureCacheId = null;
+        this.textureCacheId = [];
     }
 
     /**
@@ -251,14 +251,8 @@ export default class Texture extends EventEmitter
 
         this.valid = false;
 
+        Texture.removeFromCache(this);
         this.textureCacheId = null;
-        for (const prop in TextureCache)
-        {
-            if (TextureCache[prop] === this)
-            {
-                delete TextureCache[prop];
-            }
-        }
     }
 
     /**
@@ -478,9 +472,9 @@ export default class Texture extends EventEmitter
     {
         if (id)
         {
-            if (!texture.textureCacheId)
+            if (texture.textureCacheId.indexOf(id) === -1)
             {
-                texture.textureCacheId = id;
+                texture.textureCacheId.push(id);
             }
 
             // @if DEBUG
@@ -511,7 +505,13 @@ export default class Texture extends EventEmitter
 
             if (textureFromCache)
             {
-                textureFromCache.textureCacheId = null;
+                const index = textureFromCache.textureCacheId.indexOf(texture);
+
+                if (index > -1)
+                {
+                    textureFromCache.textureCacheId.splice(index, 1);
+                }
+
                 delete TextureCache[texture];
 
                 return textureFromCache;
@@ -519,15 +519,12 @@ export default class Texture extends EventEmitter
         }
         else
         {
-            for (const prop in TextureCache)
+            for (let i = 0; i < texture.textureCacheId.length; ++i)
             {
-                if (TextureCache[prop] === texture)
-                {
-                    delete TextureCache[prop];
-                }
+                delete TextureCache[texture.textureCacheId[i]];
             }
 
-            texture.textureCacheId = null;
+            texture.textureCacheId.length = 0;
 
             return texture;
         }

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -165,7 +165,7 @@ export default class Texture extends EventEmitter
          *
          * @member {string[]}
          */
-        this.textureCacheId = [];
+        this.textureCacheIds = [];
     }
 
     /**
@@ -252,7 +252,7 @@ export default class Texture extends EventEmitter
         this.valid = false;
 
         Texture.removeFromCache(this);
-        this.textureCacheId = null;
+        this.textureCacheIds = null;
     }
 
     /**
@@ -472,9 +472,9 @@ export default class Texture extends EventEmitter
     {
         if (id)
         {
-            if (texture.textureCacheId.indexOf(id) === -1)
+            if (texture.textureCacheIds.indexOf(id) === -1)
             {
-                texture.textureCacheId.push(id);
+                texture.textureCacheIds.push(id);
             }
 
             // @if DEBUG
@@ -505,11 +505,11 @@ export default class Texture extends EventEmitter
 
             if (textureFromCache)
             {
-                const index = textureFromCache.textureCacheId.indexOf(texture);
+                const index = textureFromCache.textureCacheIds.indexOf(texture);
 
                 if (index > -1)
                 {
-                    textureFromCache.textureCacheId.splice(index, 1);
+                    textureFromCache.textureCacheIds.splice(index, 1);
                 }
 
                 delete TextureCache[texture];
@@ -519,12 +519,12 @@ export default class Texture extends EventEmitter
         }
         else
         {
-            for (let i = 0; i < texture.textureCacheId.length; ++i)
+            for (let i = 0; i < texture.textureCacheIds.length; ++i)
             {
-                delete TextureCache[texture.textureCacheId[i]];
+                delete TextureCache[texture.textureCacheIds[i]];
             }
 
-            texture.textureCacheId.length = 0;
+            texture.textureCacheIds.length = 0;
 
             return texture;
         }

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -338,10 +338,10 @@ export default class Texture extends EventEmitter
      * @static
      * @param {HTMLCanvasElement} canvas - The canvas element source of the texture
      * @param {number} [scaleMode=PIXI.settings.SCALE_MODE] - See {@link PIXI.SCALE_MODES} for possible values
-     * @param {string} [origin] - A string origin of who created the base texture
+     * @param {string} [origin='canvas'] - A string origin of who created the base texture
      * @return {PIXI.Texture} The newly created texture
      */
-    static fromCanvas(canvas, scaleMode, origin)
+    static fromCanvas(canvas, scaleMode, origin = 'canvas')
     {
         return new Texture(BaseTexture.fromCanvas(canvas, scaleMode, origin));
     }

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -501,7 +501,6 @@ export default class Texture extends EventEmitter
         if (texture)
         {
             texture.textureCacheId = null;
-
             delete TextureCache[id];
 
             return texture;

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -232,7 +232,7 @@ export default class Texture extends EventEmitter
                 // this only needs to be removed if the base texture is actually destroyed too..
                 if (TextureCache[this.baseTexture.imageUrl])
                 {
-                    this.removeFromCache(this.baseTexture.imageUrl);
+                    Texture.removeFromCache(this.baseTexture.imageUrl);
                 }
 
                 this.baseTexture.destroy();
@@ -454,13 +454,13 @@ export default class Texture extends EventEmitter
         }
 
         // lets also add the frame to pixi's global cache for fromFrame and fromImage fucntions
-        BaseTexture.addToCache(texture, name);
+        BaseTexture.addToCache(texture.baseTexture, name);
         Texture.addToCache(texture, name);
 
         // also add references by url if they are different.
         if (name !== imageUrl)
         {
-            BaseTexture.addToCache(texture, imageUrl);
+            BaseTexture.addToCache(texture.baseTexture, imageUrl);
             Texture.addToCache(texture, imageUrl);
         }
 

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -3,7 +3,8 @@ import VideoBaseTexture from './VideoBaseTexture';
 import TextureUvs from './TextureUvs';
 import EventEmitter from 'eventemitter3';
 import { Rectangle } from '../math';
-import { TextureCache, BaseTextureCache, getResolutionOfUrl } from '../utils';
+import { TextureCache, getResolutionOfUrl } from '../utils';
+import settings from '../settings';
 
 /**
  * A texture stores the information that represents an image or part of an image. It cannot be added
@@ -231,7 +232,7 @@ export default class Texture extends EventEmitter
                 // this only needs to be removed if the base texture is actually destroyed too..
                 if (TextureCache[this.baseTexture.imageUrl])
                 {
-                    delete TextureCache[this.baseTexture.imageUrl];
+                    this.removeTextureFromCache(this.baseTexture.imageUrl);
                 }
 
                 this.baseTexture.destroy();
@@ -305,7 +306,7 @@ export default class Texture extends EventEmitter
         if (!texture)
         {
             texture = new Texture(BaseTexture.fromImage(imageUrl, crossorigin, scaleMode, sourceScale));
-            TextureCache[imageUrl] = texture;
+            Texture.addTextureToCache(texture, imageUrl);
         }
 
         return texture;
@@ -337,11 +338,12 @@ export default class Texture extends EventEmitter
      * @static
      * @param {HTMLCanvasElement} canvas - The canvas element source of the texture
      * @param {number} [scaleMode=PIXI.settings.SCALE_MODE] - See {@link PIXI.SCALE_MODES} for possible values
+     * @param {string} [origin] - A string origin of who created the base texture
      * @return {PIXI.Texture} The newly created texture
      */
-    static fromCanvas(canvas, scaleMode)
+    static fromCanvas(canvas, scaleMode, origin)
     {
-        return new Texture(BaseTexture.fromCanvas(canvas, scaleMode));
+        return new Texture(BaseTexture.fromCanvas(canvas, scaleMode, origin));
     }
 
     /**
@@ -413,7 +415,7 @@ export default class Texture extends EventEmitter
         }
         else if (source instanceof HTMLCanvasElement)
         {
-            return Texture.fromCanvas(source);
+            return Texture.fromCanvas(source, settings.SCALE_MODE, 'HTMLCanvasElement');
         }
         else if (source instanceof HTMLVideoElement)
         {
@@ -452,15 +454,14 @@ export default class Texture extends EventEmitter
         }
 
         // lets also add the frame to pixi's global cache for fromFrame and fromImage fucntions
-        BaseTextureCache[name] = baseTexture;
-        TextureCache[name] = texture;
-        texture.textureCacheId = name;
+        BaseTexture.addBaseTextureToCache(texture, name);
+        Texture.addTextureToCache(texture, name);
 
         // also add references by url if they are different.
         if (name !== imageUrl)
         {
-            BaseTextureCache[imageUrl] = baseTexture;
-            TextureCache[imageUrl] = texture;
+            BaseTexture.addBaseTextureToCache(texture, imageUrl);
+            Texture.addTextureToCache(texture, imageUrl);
         }
 
         return texture;
@@ -475,11 +476,15 @@ export default class Texture extends EventEmitter
      */
     static addTextureToCache(texture, id)
     {
-        if (!texture.textureCacheId)
+        if (id)
         {
-            texture.textureCacheId = id;
+            if (!texture.textureCacheId)
+            {
+                texture.textureCacheId = id;
+            }
+
+            TextureCache[id] = texture;
         }
-        TextureCache[id] = texture;
     }
 
     /**
@@ -487,16 +492,22 @@ export default class Texture extends EventEmitter
      *
      * @static
      * @param {string} id - The id of the texture to be removed
-     * @return {PIXI.Texture} The texture that was removed
+     * @return {PIXI.Texture|null} The texture that was removed
      */
     static removeTextureFromCache(id)
     {
         const texture = TextureCache[id];
 
-        delete TextureCache[id];
-        delete BaseTextureCache[id];
+        if (texture)
+        {
+            texture.textureCacheId = null;
 
-        return texture;
+            delete TextureCache[id];
+
+            return texture;
+        }
+
+        return null;
     }
 
     /**

--- a/src/core/textures/VideoBaseTexture.js
+++ b/src/core/textures/VideoBaseTexture.js
@@ -193,7 +193,7 @@ export default class VideoBaseTexture extends BaseTexture
 
         if (this.source && this.source._pixiId)
         {
-            BaseTexture.removeBaseTextureFromCache(this.source._pixiId);
+            BaseTexture.removeFromCache(this.source._pixiId);
             delete this.source._pixiId;
         }
 
@@ -220,7 +220,7 @@ export default class VideoBaseTexture extends BaseTexture
         if (!baseTexture)
         {
             baseTexture = new VideoBaseTexture(video, scaleMode);
-            BaseTexture.addBaseTextureToCache(baseTexture, video._pixiId);
+            BaseTexture.addToCache(baseTexture, video._pixiId);
         }
 
         return baseTexture;

--- a/src/core/textures/VideoBaseTexture.js
+++ b/src/core/textures/VideoBaseTexture.js
@@ -192,7 +192,7 @@ export default class VideoBaseTexture extends BaseTexture
 
         if (this.source && this.source._pixiId)
         {
-            delete BaseTextureCache[this.source._pixiId];
+            BaseTexture.removeBaseTextureFromCache(this.source._pixiId);
             delete this.source._pixiId;
         }
 
@@ -219,7 +219,7 @@ export default class VideoBaseTexture extends BaseTexture
         if (!baseTexture)
         {
             baseTexture = new VideoBaseTexture(video, scaleMode);
-            BaseTextureCache[video._pixiId] = baseTexture;
+            BaseTexture.addBaseTextureToCache(baseTexture, video._pixiId);
         }
 
         return baseTexture;

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -353,7 +353,7 @@ export function removeItems(arr, startIdx, removeCount)
  * @memberof PIXI.utils
  * @private
  */
-export const TextureCache = {};
+export const TextureCache = Object.create(null);
 
 /**
  * @todo Describe property usage
@@ -361,7 +361,7 @@ export const TextureCache = {};
  * @memberof PIXI.utils
  * @private
  */
-export const BaseTextureCache = {};
+export const BaseTextureCache = Object.create(null);
 
 /**
  * Destroys all texture in the cache

--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -848,15 +848,15 @@ core.Texture.addTextureToCache = function addTextureToCache(texture, id)
 /**
  * @static
  * @function
- * @name PIXI.Texture.removeFromTextureCache
+ * @name PIXI.Texture.removeTextureFromCache
  * @see PIXI.Texture.removeFromCache
  * @deprecated since 4.5.0
  * @param {string} id - The id of the texture to be removed
  * @return {PIXI.Texture|null} The texture that was removed
  */
-core.Texture.removeFromTextureCache = function removeFromTextureCache(id)
+core.Texture.removeTextureFromCache = function removeTextureFromCache(id)
 {
-    warn('Texture.removeFromTextureCache is deprecated, please use Texture.removeFromCache from now on. '
+    warn('Texture.removeTextureFromCache is deprecated, please use Texture.removeFromCache from now on. '
      + 'Be aware that Texture.removeFromCache does not automatically its BaseTexture from the BaseTextureCache. '
      + 'For that, use BaseTexture.removeFromCache');
 

--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -830,6 +830,49 @@ core.Texture.prototype.setFrame = function setFrame(frame)
     warn('setFrame is now deprecated, please use the frame property, e.g: myTexture.frame = frame;');
 };
 
+/**
+ * @static
+ * @function
+ * @name PIXI.Texture.addTextureToCache
+ * @see PIXI.Texture.addToCache
+ * @deprecated since 4.5.0
+ * @param {PIXI.Texture} texture - The Texture to add to the cache.
+ * @param {string} id - The id that the texture will be stored against.
+ */
+core.Texture.addTextureToCache = function addTextureToCache(texture, id)
+{
+    core.Texture.addToCache(texture, id);
+    warn('Texture.addTextureToCache is deprecated, please use Texture.addToCache from now on.');
+};
+
+/**
+ * @static
+ * @function
+ * @name PIXI.Texture.removeFromTextureCache
+ * @see PIXI.Texture.removeFromCache
+ * @deprecated since 4.5.0
+ * @param {string} id - The id of the texture to be removed
+ * @return {PIXI.Texture|null} The texture that was removed
+ */
+core.Texture.removeFromTextureCache = function removeFromTextureCache(id)
+{
+    warn('Texture.removeFromTextureCache is deprecated, please use Texture.removeFromCache from now on. '
+     + 'Be aware that Texture.removeFromCache does not automatically its BaseTexture from the BaseTextureCache. '
+     + 'For that, use BaseTexture.removeFromCache');
+
+    const texture = core.Texture.removeFromCache(id);
+
+    if (texture)
+    {
+        texture.baseTexture.texureCacheId = null;
+        delete core.utils.BaseTextureCache[id];
+
+        return texture;
+    }
+
+    return null;
+};
+
 Object.defineProperties(filters, {
 
     /**

--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -860,17 +860,9 @@ core.Texture.removeTextureFromCache = function removeTextureFromCache(id)
      + 'Be aware that Texture.removeFromCache does not automatically its BaseTexture from the BaseTextureCache. '
      + 'For that, use BaseTexture.removeFromCache');
 
-    const texture = core.Texture.removeFromCache(id);
+    core.BaseTexture.removeFromCache(id);
 
-    if (texture)
-    {
-        texture.baseTexture.texureCacheId = null;
-        delete core.utils.BaseTextureCache[id];
-
-        return texture;
-    }
-
-    return null;
+    return core.Texture.removeFromCache(id);
 };
 
 Object.defineProperties(filters, {

--- a/src/extras/cacheAsBitmap.js
+++ b/src/extras/cacheAsBitmap.js
@@ -1,4 +1,7 @@
 import * as core from '../core';
+import Texture from '../core/textures/Texture';
+import BaseTexture from '../core/textures/BaseTexture';
+import { uid } from '../core/utils';
 
 const DisplayObject = core.DisplayObject;
 const _tempMatrix = new core.Matrix();
@@ -20,6 +23,8 @@ class CacheData
      */
     constructor()
     {
+        this.textureCacheId = null;
+
         this.originalRenderWebGL = null;
         this.originalRenderCanvas = null;
         this.originalCalculateBounds = null;
@@ -185,6 +190,13 @@ DisplayObject.prototype._initCachedDisplayObject = function _initCachedDisplayOb
 
     const renderTexture = core.RenderTexture.create(bounds.width | 0, bounds.height | 0);
 
+    const textureCacheId = `cacheAsBitmap_${uid()}`;
+
+    this._cacheData.textureCacheId = textureCacheId;
+
+    BaseTexture.addBaseTextureToCache(renderTexture.baseTexture, textureCacheId);
+    Texture.addTextureToCache(renderTexture, textureCacheId);
+
     // need to set //
     const m = _tempMatrix;
 
@@ -280,6 +292,13 @@ DisplayObject.prototype._initCachedDisplayObjectCanvas = function _initCachedDis
 
     const renderTexture = core.RenderTexture.create(bounds.width | 0, bounds.height | 0);
 
+    const textureCacheId = `cacheAsBitmap_${uid()}`;
+
+    this._cacheData.textureCacheId = textureCacheId;
+
+    BaseTexture.addBaseTextureToCache(renderTexture.baseTexture, textureCacheId);
+    Texture.addTextureToCache(renderTexture, textureCacheId);
+
     // need to set //
     const m = _tempMatrix;
 
@@ -352,6 +371,11 @@ DisplayObject.prototype._destroyCachedDisplayObject = function _destroyCachedDis
 {
     this._cacheData.sprite._texture.destroy(true);
     this._cacheData.sprite = null;
+
+    BaseTexture.removeBaseTextureFromCache(this._cacheData.textureCacheId);
+    Texture.removeTextureFromCache(this._cacheData.textureCacheId);
+
+    this._cacheData.textureCacheId = null;
 };
 
 /**

--- a/src/extras/cacheAsBitmap.js
+++ b/src/extras/cacheAsBitmap.js
@@ -194,8 +194,8 @@ DisplayObject.prototype._initCachedDisplayObject = function _initCachedDisplayOb
 
     this._cacheData.textureCacheId = textureCacheId;
 
-    BaseTexture.addBaseTextureToCache(renderTexture.baseTexture, textureCacheId);
-    Texture.addTextureToCache(renderTexture, textureCacheId);
+    BaseTexture.addToCache(renderTexture.baseTexture, textureCacheId);
+    Texture.addToCache(renderTexture, textureCacheId);
 
     // need to set //
     const m = _tempMatrix;
@@ -305,8 +305,8 @@ DisplayObject.prototype._initCachedDisplayObjectCanvas = function _initCachedDis
 
     this._cacheData.textureCacheId = textureCacheId;
 
-    BaseTexture.addBaseTextureToCache(renderTexture.baseTexture, textureCacheId);
-    Texture.addTextureToCache(renderTexture, textureCacheId);
+    BaseTexture.addToCache(renderTexture.baseTexture, textureCacheId);
+    Texture.addToCache(renderTexture, textureCacheId);
 
     // need to set //
     const m = _tempMatrix;
@@ -391,8 +391,8 @@ DisplayObject.prototype._destroyCachedDisplayObject = function _destroyCachedDis
     this._cacheData.sprite._texture.destroy(true);
     this._cacheData.sprite = null;
 
-    BaseTexture.removeBaseTextureFromCache(this._cacheData.textureCacheId);
-    Texture.removeTextureFromCache(this._cacheData.textureCacheId);
+    BaseTexture.removeFromCache(this._cacheData.textureCacheId);
+    Texture.removeFromCache(this._cacheData.textureCacheId);
 
     this._cacheData.textureCacheId = null;
 };

--- a/test/core/BaseTexture.js
+++ b/test/core/BaseTexture.js
@@ -37,11 +37,13 @@ describe('BaseTexture', function ()
         cleanCache();
 
         const canvas = document.createElement('canvas');
-        const texture = PIXI.BaseTexture.fromCanvas(canvas);
+        const baseTexture = PIXI.BaseTexture.fromCanvas(canvas);
         const _pixiId = canvas._pixiId;
 
-        expect(PIXI.utils.BaseTextureCache[_pixiId]).to.equal(texture);
-        texture.destroy();
+        expect(baseTexture.textureCacheIds.indexOf(_pixiId)).to.equal(0);
+        expect(PIXI.utils.BaseTextureCache[_pixiId]).to.equal(baseTexture);
+        baseTexture.destroy();
+        expect(baseTexture.textureCacheIds).to.equal(null);
         expect(PIXI.utils.BaseTextureCache[_pixiId]).to.equal(undefined);
     });
 
@@ -53,9 +55,13 @@ describe('BaseTexture', function ()
 
         const texture = PIXI.Texture.fromLoader(image, URL, NAME);
 
+        expect(texture.baseTexture.textureCacheIds.indexOf(NAME)).to.equal(0);
+        expect(texture.baseTexture.textureCacheIds.indexOf(URL)).to.equal(1);
         expect(PIXI.utils.BaseTextureCache[NAME]).to.equal(texture.baseTexture);
         texture.destroy(true);
+        expect(texture.baseTexture).to.equal(null);
         expect(PIXI.utils.BaseTextureCache[NAME]).to.equal(undefined);
+        expect(PIXI.utils.BaseTextureCache[URL]).to.equal(undefined);
     });
 
     it('should remove BaseTexture from entire cache using removeFromCache (by BaseTexture instance)', function ()
@@ -66,10 +72,13 @@ describe('BaseTexture', function ()
 
         PIXI.BaseTexture.addToCache(baseTexture, NAME);
         PIXI.BaseTexture.addToCache(baseTexture, NAME2);
-        expect(baseTexture.textureCacheId).to.equal(NAME);
+        expect(baseTexture.textureCacheIds.indexOf(NAME)).to.equal(0);
+        expect(baseTexture.textureCacheIds.indexOf(NAME2)).to.equal(1);
         expect(PIXI.utils.BaseTextureCache[NAME]).to.equal(baseTexture);
         expect(PIXI.utils.BaseTextureCache[NAME2]).to.equal(baseTexture);
         PIXI.BaseTexture.removeFromCache(baseTexture);
+        expect(baseTexture.textureCacheIds.indexOf(NAME)).to.equal(-1);
+        expect(baseTexture.textureCacheIds.indexOf(NAME2)).to.equal(-1);
         expect(PIXI.utils.BaseTextureCache[NAME]).to.equal(undefined);
         expect(PIXI.utils.BaseTextureCache[NAME2]).to.equal(undefined);
     });
@@ -82,10 +91,13 @@ describe('BaseTexture', function ()
 
         PIXI.BaseTexture.addToCache(baseTexture, NAME);
         PIXI.BaseTexture.addToCache(baseTexture, NAME2);
-        expect(baseTexture.textureCacheId).to.equal(NAME);
+        expect(baseTexture.textureCacheIds.indexOf(NAME)).to.equal(0);
+        expect(baseTexture.textureCacheIds.indexOf(NAME2)).to.equal(1);
         expect(PIXI.utils.BaseTextureCache[NAME]).to.equal(baseTexture);
         expect(PIXI.utils.BaseTextureCache[NAME2]).to.equal(baseTexture);
         PIXI.BaseTexture.removeFromCache(NAME);
+        expect(baseTexture.textureCacheIds.indexOf(NAME)).to.equal(-1);
+        expect(baseTexture.textureCacheIds.indexOf(NAME2)).to.equal(0);
         expect(PIXI.utils.BaseTextureCache[NAME]).to.equal(undefined);
         expect(PIXI.utils.BaseTextureCache[NAME2]).to.equal(baseTexture);
     });

--- a/test/core/BaseTexture.js
+++ b/test/core/BaseTexture.js
@@ -1,11 +1,28 @@
 'use strict';
 
+const URL = 'foo.png';
+const NAME = 'foo';
+const NAME2 = 'bar';
+
+function cleanCache()
+{
+    delete PIXI.utils.BaseTextureCache[URL];
+    delete PIXI.utils.BaseTextureCache[NAME];
+    delete PIXI.utils.BaseTextureCache[NAME2];
+
+    delete PIXI.utils.TextureCache[URL];
+    delete PIXI.utils.TextureCache[NAME];
+    delete PIXI.utils.TextureCache[NAME2];
+}
+
 describe('BaseTexture', function ()
 {
     describe('updateImageType', function ()
     {
         it('should allow no extension', function ()
         {
+            cleanCache();
+
             const baseTexture = new PIXI.BaseTexture();
 
             baseTexture.imageUrl = 'http://some.domain.org/100/100';
@@ -17,6 +34,8 @@ describe('BaseTexture', function ()
 
     it('should remove Canvas BaseTexture from cache on destroy', function ()
     {
+        cleanCache();
+
         const canvas = document.createElement('canvas');
         const texture = PIXI.BaseTexture.fromCanvas(canvas);
         const _pixiId = canvas._pixiId;
@@ -28,8 +47,8 @@ describe('BaseTexture', function ()
 
     it('should remove Image BaseTexture from cache on destroy', function ()
     {
-        const URL = 'foo.png';
-        const NAME = 'bar';
+        cleanCache();
+
         const image = new Image();
 
         const texture = PIXI.Texture.fromLoader(image, URL, NAME);
@@ -37,5 +56,37 @@ describe('BaseTexture', function ()
         expect(PIXI.utils.BaseTextureCache[NAME]).to.equal(texture.baseTexture);
         texture.destroy(true);
         expect(PIXI.utils.BaseTextureCache[NAME]).to.equal(undefined);
+    });
+
+    it('should remove BaseTexture from entire cache using removeFromCache (by BaseTexture instance)', function ()
+    {
+        cleanCache();
+
+        const baseTexture = new PIXI.BaseTexture();
+
+        PIXI.BaseTexture.addToCache(baseTexture, NAME);
+        PIXI.BaseTexture.addToCache(baseTexture, NAME2);
+        expect(baseTexture.textureCacheId).to.equal(NAME);
+        expect(PIXI.utils.BaseTextureCache[NAME]).to.equal(baseTexture);
+        expect(PIXI.utils.BaseTextureCache[NAME2]).to.equal(baseTexture);
+        PIXI.BaseTexture.removeFromCache(baseTexture);
+        expect(PIXI.utils.BaseTextureCache[NAME]).to.equal(undefined);
+        expect(PIXI.utils.BaseTextureCache[NAME2]).to.equal(undefined);
+    });
+
+    it('should remove BaseTexture from single cache entry using removeFromCache (by id)', function ()
+    {
+        cleanCache();
+
+        const baseTexture = new PIXI.BaseTexture();
+
+        PIXI.BaseTexture.addToCache(baseTexture, NAME);
+        PIXI.BaseTexture.addToCache(baseTexture, NAME2);
+        expect(baseTexture.textureCacheId).to.equal(NAME);
+        expect(PIXI.utils.BaseTextureCache[NAME]).to.equal(baseTexture);
+        expect(PIXI.utils.BaseTextureCache[NAME2]).to.equal(baseTexture);
+        PIXI.BaseTexture.removeFromCache(NAME);
+        expect(PIXI.utils.BaseTextureCache[NAME]).to.equal(undefined);
+        expect(PIXI.utils.BaseTextureCache[NAME2]).to.equal(baseTexture);
     });
 });

--- a/test/core/Bounds.js
+++ b/test/core/Bounds.js
@@ -350,7 +350,7 @@ describe('getBounds', function ()
         expect(bounds.height).to.equal(20);
     });
 
-    it('should register correct width/height with an a Text Object', function ()
+    it('should register correct width/height with a Text Object', function ()
     {
         const parent = new PIXI.Container();
 

--- a/test/core/Spritesheet.js
+++ b/test/core/Spritesheet.js
@@ -18,7 +18,7 @@ describe('PIXI.Spritesheet', function ()
                 expect(textures[id]).to.be.an.instanceof(PIXI.Texture);
                 expect(textures[id].width).to.equal(spritesheet.data.frames[id].frame.w / spritesheet.resolution);
                 expect(textures[id].height).to.equal(spritesheet.data.frames[id].frame.h / spritesheet.resolution);
-                expect(textures[id].textureCacheId).to.equal(id);
+                expect(textures[id].textureCacheIds.indexOf(id)).to.equal(0);
                 spritesheet.destroy(true);
                 expect(spritesheet.textures).to.be.null;
                 expect(spritesheet.baseTexture).to.be.null;

--- a/test/core/Texture.js
+++ b/test/core/Texture.js
@@ -1,11 +1,26 @@
 'use strict';
 
+const URL = 'foo.png';
+const NAME = 'foo';
+const NAME2 = 'bar';
+
+function cleanCache()
+{
+    delete PIXI.utils.BaseTextureCache[URL];
+    delete PIXI.utils.BaseTextureCache[NAME];
+    delete PIXI.utils.BaseTextureCache[NAME2];
+
+    delete PIXI.utils.TextureCache[URL];
+    delete PIXI.utils.TextureCache[NAME];
+    delete PIXI.utils.TextureCache[NAME2];
+}
+
 describe('PIXI.Texture', function ()
 {
     it('should register Texture from Loader', function ()
     {
-        const URL = 'foo.png';
-        const NAME = 'bar';
+        cleanCache();
+
         const image = new Image();
 
         const texture = PIXI.Texture.fromLoader(image, URL, NAME);
@@ -19,17 +34,83 @@ describe('PIXI.Texture', function ()
 
     it('should remove Texture from cache on destroy', function ()
     {
-        const NAME = 'foo';
-        const NAME2 = 'bar';
+        cleanCache();
+
         const texture = new PIXI.Texture(new PIXI.BaseTexture());
 
-        PIXI.Texture.addTextureToCache(texture, NAME);
-        PIXI.Texture.addTextureToCache(texture, NAME2);
+        PIXI.Texture.addToCache(texture, NAME);
+        PIXI.Texture.addToCache(texture, NAME2);
         expect(texture.textureCacheId).to.equal(NAME);
         expect(PIXI.utils.TextureCache[NAME]).to.equal(texture);
         expect(PIXI.utils.TextureCache[NAME2]).to.equal(texture);
         texture.destroy();
         expect(PIXI.utils.TextureCache[NAME]).to.equal(undefined);
+        expect(PIXI.utils.TextureCache[NAME]).to.equal(undefined);
         expect(PIXI.utils.TextureCache[NAME2]).to.equal(undefined);
+    });
+
+    it('adding and removing Textures', function ()
+    {
+        cleanCache();
+
+        const texture = new PIXI.Texture(new PIXI.BaseTexture());
+
+        PIXI.BaseTexture.addToCache(texture.baseTexture, NAME);
+        PIXI.Texture.addToCache(texture, NAME);
+        expect(texture.baseTexture.textureCacheId).to.equal(NAME);
+        expect(texture.textureCacheId).to.equal(NAME);
+        expect(PIXI.utils.BaseTextureCache[NAME]).to.equal(texture.baseTexture);
+        expect(PIXI.utils.TextureCache[NAME]).to.equal(texture);
+        PIXI.Texture.removeFromCache(NAME);
+        expect(PIXI.utils.BaseTextureCache[NAME]).to.equal(texture.baseTexture);
+        expect(PIXI.utils.TextureCache[NAME]).to.equal(undefined);
+    });
+
+    it('adding and removing Textures - Legacy', function ()
+    {
+        cleanCache();
+
+        const texture = new PIXI.Texture(new PIXI.BaseTexture());
+
+        PIXI.utils.BaseTextureCache[NAME] = texture.baseTexture;
+        PIXI.Texture.addTextureToCache(texture, NAME);
+        expect(texture.textureCacheId).to.equal(NAME);
+        expect(PIXI.utils.BaseTextureCache[NAME]).to.equal(texture.baseTexture);
+        expect(PIXI.utils.TextureCache[NAME]).to.equal(texture);
+        PIXI.Texture.removeTextureFromCache(NAME);
+        expect(PIXI.utils.BaseTextureCache[NAME]).to.equal(undefined);
+        expect(PIXI.utils.TextureCache[NAME]).to.equal(undefined);
+    });
+
+    it('should remove Texture from entire cache using removeFromCache (by Texture instance)', function ()
+    {
+        cleanCache();
+
+        const texture = new PIXI.Texture(new PIXI.BaseTexture());
+
+        PIXI.Texture.addToCache(texture, NAME);
+        PIXI.Texture.addToCache(texture, NAME2);
+        expect(texture.textureCacheId).to.equal(NAME);
+        expect(PIXI.utils.TextureCache[NAME]).to.equal(texture);
+        expect(PIXI.utils.TextureCache[NAME2]).to.equal(texture);
+        PIXI.Texture.removeFromCache(texture);
+        expect(PIXI.utils.TextureCache[NAME]).to.equal(undefined);
+        expect(PIXI.utils.TextureCache[NAME2]).to.equal(undefined);
+    });
+
+    it('should remove Texture from single cache entry using removeFromCache (by id)', function ()
+    {
+        cleanCache();
+
+        const texture = new PIXI.Texture(new PIXI.BaseTexture());
+
+        PIXI.Texture.addToCache(texture, NAME);
+        PIXI.Texture.addToCache(texture, NAME2);
+        expect(texture.textureCacheId).to.equal(NAME);
+        expect(PIXI.utils.TextureCache[NAME]).to.equal(texture);
+        expect(PIXI.utils.TextureCache[NAME2]).to.equal(texture);
+        PIXI.Texture.removeFromCache(NAME);
+        expect(PIXI.utils.TextureCache[NAME]).to.equal(undefined);
+        expect(PIXI.utils.TextureCache[NAME2]).to.equal(texture);
     });
 });

--- a/test/core/Texture.js
+++ b/test/core/Texture.js
@@ -40,16 +40,18 @@ describe('PIXI.Texture', function ()
 
         PIXI.Texture.addToCache(texture, NAME);
         PIXI.Texture.addToCache(texture, NAME2);
-        expect(texture.textureCacheId).to.equal(NAME);
+        expect(texture.textureCacheIds.indexOf(NAME)).to.equal(0);
+        expect(texture.textureCacheIds.indexOf(NAME2)).to.equal(1);
         expect(PIXI.utils.TextureCache[NAME]).to.equal(texture);
         expect(PIXI.utils.TextureCache[NAME2]).to.equal(texture);
         texture.destroy();
-        expect(PIXI.utils.TextureCache[NAME]).to.equal(undefined);
+        expect(texture.textureCacheIds).to.equal(null);
         expect(PIXI.utils.TextureCache[NAME]).to.equal(undefined);
         expect(PIXI.utils.TextureCache[NAME2]).to.equal(undefined);
     });
 
-    it('adding and removing Textures', function ()
+    it('should be added to the texture cache correctly, '
+     + 'and should remove only itself, not effecting the base texture and its cache', function ()
     {
         cleanCache();
 
@@ -57,27 +59,33 @@ describe('PIXI.Texture', function ()
 
         PIXI.BaseTexture.addToCache(texture.baseTexture, NAME);
         PIXI.Texture.addToCache(texture, NAME);
-        expect(texture.baseTexture.textureCacheId).to.equal(NAME);
-        expect(texture.textureCacheId).to.equal(NAME);
+        expect(texture.baseTexture.textureCacheIds.indexOf(NAME)).to.equal(0);
+        expect(texture.textureCacheIds.indexOf(NAME)).to.equal(0);
         expect(PIXI.utils.BaseTextureCache[NAME]).to.equal(texture.baseTexture);
         expect(PIXI.utils.TextureCache[NAME]).to.equal(texture);
         PIXI.Texture.removeFromCache(NAME);
+        expect(texture.baseTexture.textureCacheIds.indexOf(NAME)).to.equal(0);
+        expect(texture.textureCacheIds.indexOf(NAME)).to.equal(-1);
         expect(PIXI.utils.BaseTextureCache[NAME]).to.equal(texture.baseTexture);
         expect(PIXI.utils.TextureCache[NAME]).to.equal(undefined);
     });
 
-    it('adding and removing Textures - Legacy', function ()
+    it('should be added to the texture cache correctly using legacy addTextureToCache, '
+     + 'and should remove also remove the base texture from its cache with removeTextureFromCache', function ()
     {
         cleanCache();
 
         const texture = new PIXI.Texture(new PIXI.BaseTexture());
 
-        PIXI.utils.BaseTextureCache[NAME] = texture.baseTexture;
+        PIXI.BaseTexture.addToCache(texture.baseTexture, NAME);
         PIXI.Texture.addTextureToCache(texture, NAME);
-        expect(texture.textureCacheId).to.equal(NAME);
+        expect(texture.baseTexture.textureCacheIds.indexOf(NAME)).to.equal(0);
+        expect(texture.textureCacheIds.indexOf(NAME)).to.equal(0);
         expect(PIXI.utils.BaseTextureCache[NAME]).to.equal(texture.baseTexture);
         expect(PIXI.utils.TextureCache[NAME]).to.equal(texture);
         PIXI.Texture.removeTextureFromCache(NAME);
+        expect(texture.baseTexture.textureCacheIds.indexOf(NAME)).to.equal(-1);
+        expect(texture.textureCacheIds.indexOf(NAME)).to.equal(-1);
         expect(PIXI.utils.BaseTextureCache[NAME]).to.equal(undefined);
         expect(PIXI.utils.TextureCache[NAME]).to.equal(undefined);
     });
@@ -90,10 +98,13 @@ describe('PIXI.Texture', function ()
 
         PIXI.Texture.addToCache(texture, NAME);
         PIXI.Texture.addToCache(texture, NAME2);
-        expect(texture.textureCacheId).to.equal(NAME);
+        expect(texture.textureCacheIds.indexOf(NAME)).to.equal(0);
+        expect(texture.textureCacheIds.indexOf(NAME2)).to.equal(1);
         expect(PIXI.utils.TextureCache[NAME]).to.equal(texture);
         expect(PIXI.utils.TextureCache[NAME2]).to.equal(texture);
         PIXI.Texture.removeFromCache(texture);
+        expect(texture.textureCacheIds.indexOf(NAME)).to.equal(-1);
+        expect(texture.textureCacheIds.indexOf(NAME2)).to.equal(-1);
         expect(PIXI.utils.TextureCache[NAME]).to.equal(undefined);
         expect(PIXI.utils.TextureCache[NAME2]).to.equal(undefined);
     });
@@ -106,10 +117,13 @@ describe('PIXI.Texture', function ()
 
         PIXI.Texture.addToCache(texture, NAME);
         PIXI.Texture.addToCache(texture, NAME2);
-        expect(texture.textureCacheId).to.equal(NAME);
+        expect(texture.textureCacheIds.indexOf(NAME)).to.equal(0);
+        expect(texture.textureCacheIds.indexOf(NAME2)).to.equal(1);
         expect(PIXI.utils.TextureCache[NAME]).to.equal(texture);
         expect(PIXI.utils.TextureCache[NAME2]).to.equal(texture);
         PIXI.Texture.removeFromCache(NAME);
+        expect(texture.textureCacheIds.indexOf(NAME)).to.equal(-1);
+        expect(texture.textureCacheIds.indexOf(NAME2)).to.equal(0);
         expect(PIXI.utils.TextureCache[NAME]).to.equal(undefined);
         expect(PIXI.utils.TextureCache[NAME2]).to.equal(texture);
     });

--- a/test/core/index.js
+++ b/test/core/index.js
@@ -27,6 +27,7 @@ require('./Graphics');
 require('./SpriteRenderer');
 require('./WebGLRenderer');
 require('./Ellipse');
+require('./BaseTexture');
 require('./Texture');
 require('./Ticker');
 require('./filters');


### PR DESCRIPTION
Built upon the good work from https://github.com/pixijs/pixi.js/pull/3789
+ For Text, the base textures were in the BaseTextureCache, but textures weren't in the TextureCache. This has been fixed
+ Now able to tell the BaseTexture the origin of where the canvas being passed through has come from. ie. was it from the text class? was it from the graphic class? was it from caching as a bitmap? More information now to track where these canvases (canvii??) have been generated from
+ BaseTexture has addBaseTextureToCache and removeBaseTextureFromCache functions, to match regular Texture. Any adding or removing to the BaseTextureCache is now through these functions
+ Protection around adding and remove items to the caches using the functions

! Breaking change. When you call Texture.fromTextureFromCache - it no longer automatically removes it's base texture from the base texture cache. Not sure how people feel about this

? I don't like lines 233 to 236 in Texture.js, and line 591 in BaseTexture.js - I don't see why they are there or why they are needed, but I chickened out on removing them!