### PR TITLE
Mesh update of average size, perfect for v4.5

### DIFF
--- a/src/core/math/GroupD8.js
+++ b/src/core/math/GroupD8.js
@@ -111,13 +111,14 @@ const GroupD8 = {
     rotate180: (rotation) => rotation ^ 4,
 
     /**
-     * I dont know why sometimes width and heights needs to be swapped. We'll fix it later.
+     * Direction of main vector can be horizontal, vertical or diagonal.
+     * Some objects work with vertical directions different.
      *
      * @memberof PIXI.GroupD8
      * @param {number} rotation - The number to check.
-     * @returns {boolean} Whether or not the width/height should be swapped.
+     * @returns {boolean} Whether or not the direction is vertical
      */
-    isSwapWidthHeight: (rotation) => (rotation & 3) === 2,
+    isVertical: (rotation) => (rotation & 3) === 2,
 
     /**
      * @memberof PIXI.GroupD8

--- a/src/mesh/Mesh.js
+++ b/src/mesh/Mesh.js
@@ -31,6 +31,11 @@ export default class Mesh extends core.Container
          */
         this._texture = texture;
 
+        if (!texture.baseTexture.hasLoaded)
+        {
+            texture.once('update', this._onTextureUpdate, this);
+        }
+
         /**
          * The Uvs of the Mesh
          *
@@ -74,7 +79,7 @@ export default class Mesh extends core.Container
         this.indexDirty = 0;
 
         /**
-         * The blend mode to be applied to the sprite. Set to `PIXI.BLEND_MODES.NORMAL` to remove
+         * The blend mode to be applied to the mesh. Set to `PIXI.BLEND_MODES.NORMAL` to remove
          * any blend mode.
          *
          * @member {number}
@@ -130,7 +135,7 @@ export default class Mesh extends core.Container
          * @member {PIXI.extras.TextureTransform}
          * @private
          */
-        this._uvTransform = new TextureTransform(texture);
+        this._uvTransform = new TextureTransform(texture, 0);
 
         /**
          * whether or not upload uvTransform to shader
@@ -151,6 +156,17 @@ export default class Mesh extends core.Container
     }
 
     /**
+     * Updates the object transform for rendering
+     *
+     * @private
+     */
+    updateTransform()
+    {
+        this.refresh();
+        this.containerUpdateTransform();
+    }
+
+    /**
      * Renders the object using the WebGL renderer
      *
      * @private
@@ -158,7 +174,6 @@ export default class Mesh extends core.Container
      */
     _renderWebGL(renderer)
     {
-        this.refresh();
         renderer.setObjectRenderer(renderer.plugins[this.pluginName]);
         renderer.plugins[this.pluginName].render(this);
     }
@@ -171,7 +186,6 @@ export default class Mesh extends core.Container
      */
     _renderCanvas(renderer)
     {
-        this.refresh();
         renderer.plugins[this.pluginName].render(this);
     }
 
@@ -209,7 +223,7 @@ export default class Mesh extends core.Container
     {
         if (this._uvTransform.update(forceUpdate))
         {
-            this._refresh();
+            this._refreshUvs();
         }
     }
 
@@ -217,7 +231,7 @@ export default class Mesh extends core.Container
      * re-calculates mesh coords
      * @protected
      */
-    _refresh()
+    _refreshUvs()
     {
         /* empty */
     }

--- a/src/mesh/NineSlicePlane.js
+++ b/src/mesh/NineSlicePlane.js
@@ -46,40 +46,6 @@ export default class NineSlicePlane extends Plane
     {
         super(texture, 4, 4);
 
-        const uvs = this.uvs;
-
-        // right and bottom uv's are always 1
-        uvs[6] = uvs[14] = uvs[22] = uvs[30] = 1;
-        uvs[25] = uvs[27] = uvs[29] = uvs[31] = 1;
-
-        this._origWidth = texture.orig.width;
-        this._origHeight = texture.orig.height;
-        this._uvw = 1 / this._origWidth;
-        this._uvh = 1 / this._origHeight;
-
-        /**
-         * The width of the NineSlicePlane, setting this will actually modify the vertices and UV's of this plane
-         *
-         * @member {number}
-         * @memberof PIXI.NineSlicePlane#
-         * @override
-         */
-        this.width = this._origWidth;
-
-        /**
-         * The height of the NineSlicePlane, setting this will actually modify the vertices and UV's of this plane
-         *
-         * @member {number}
-         * @memberof PIXI.NineSlicePlane#
-         * @override
-         */
-        this.height = this._origHeight;
-
-        uvs[2] = uvs[10] = uvs[18] = uvs[26] = this._uvw * leftWidth;
-        uvs[4] = uvs[12] = uvs[20] = uvs[28] = 1 - (this._uvw * rightWidth);
-        uvs[9] = uvs[11] = uvs[13] = uvs[15] = this._uvh * topHeight;
-        uvs[17] = uvs[19] = uvs[21] = uvs[23] = 1 - (this._uvh * bottomHeight);
-
         /**
          * The width of the left column (a)
          *
@@ -87,7 +53,7 @@ export default class NineSlicePlane extends Plane
          * @memberof PIXI.NineSlicePlane#
          * @override
          */
-        this.leftWidth = typeof leftWidth !== 'undefined' ? leftWidth : DEFAULT_BORDER_SIZE;
+        this._leftWidth = typeof leftWidth !== 'undefined' ? leftWidth : DEFAULT_BORDER_SIZE;
 
         /**
          * The width of the right column (b)
@@ -96,7 +62,7 @@ export default class NineSlicePlane extends Plane
          * @memberof PIXI.NineSlicePlane#
          * @override
          */
-        this.rightWidth = typeof rightWidth !== 'undefined' ? rightWidth : DEFAULT_BORDER_SIZE;
+        this._rightWidth = typeof rightWidth !== 'undefined' ? rightWidth : DEFAULT_BORDER_SIZE;
 
         /**
          * The height of the top row (c)
@@ -105,7 +71,7 @@ export default class NineSlicePlane extends Plane
          * @memberof PIXI.NineSlicePlane#
          * @override
          */
-        this.topHeight = typeof topHeight !== 'undefined' ? topHeight : DEFAULT_BORDER_SIZE;
+        this._topHeight = typeof topHeight !== 'undefined' ? topHeight : DEFAULT_BORDER_SIZE;
 
         /**
          * The height of the bottom row (d)
@@ -114,19 +80,150 @@ export default class NineSlicePlane extends Plane
          * @memberof PIXI.NineSlicePlane#
          * @override
          */
-        this.bottomHeight = typeof bottomHeight !== 'undefined' ? bottomHeight : DEFAULT_BORDER_SIZE;
+        this._bottomHeight = typeof bottomHeight !== 'undefined' ? bottomHeight : DEFAULT_BORDER_SIZE;
 
         this.refresh(true);
     }
 
     /**
-     * Updates the horizontal vertices.
+     * The width of the left column
      *
+     * @member {number}
+     */
+    get leftWidth()
+    {
+        return this._leftWidth;
+    }
+
+    set leftWidth(value) // eslint-disable-line require-jsdoc
+    {
+        if (this._leftWidth === value)
+        {
+            return;
+        }
+        this._leftWidth = value;
+        this._verticesID++;
+    }
+
+    /**
+     * The width of the right column
+     *
+     * @member {number}
+     */
+    get rightWidth()
+    {
+        return this._rightWidth;
+    }
+
+    set rightWidth(value) // eslint-disable-line require-jsdoc
+    {
+        if (this._rightWidth === value)
+        {
+            return;
+        }
+        this._rightWidth = value;
+        this._verticesID++;
+    }
+
+    /**
+     * The height of the top row
+     *
+     * @member {number}
+     */
+    get topHeight()
+    {
+        return this._topHeight;
+    }
+
+    set topHeight(value) // eslint-disable-line require-jsdoc
+    {
+        if (this._topHeight === value)
+        {
+            return;
+        }
+        this._topHeight = value;
+        this._verticesID++;
+    }
+
+    /**
+     * The height of the bottom row
+     *
+     * @member {number}
+     */
+    get bottomHeight()
+    {
+        return this._bottomHeight;
+    }
+
+    set bottomHeight(value) // eslint-disable-line require-jsdoc
+    {
+        if (this._bottomHeight === value)
+        {
+            return;
+        }
+        this._bottomHeight = value;
+        this._verticesID++;
+    }
+
+    /**
+     * refreshes both vertices and uvs
+     *
+     * @private
+     */
+    _refreshVertices()
+    {
+        this.updateHorizontalVertices();
+        this.updateVerticalVertices();
+
+        const vertices = this.vertices;
+        const offsetX = this._anchor._x * this.width;
+        const offsetY = this._anchor._y * this.height;
+
+        for (let i = 0; i < 32; i += 2)
+        {
+            vertices[i] += offsetX;
+            vertices[i + 1] += offsetY;
+        }
+        this.dirty++;
+    }
+
+    /**
+     * does nothing
+     *
+     * @private
+     */
+    _refreshUvs()
+    {
+        this._uvsID = this._lastUvsID;
+
+        const uvs = this.uvs;
+        const texture = this._texture;
+        const width = texture.orig.width;
+        const height = texture.orig.height;
+
+        uvs[0] = uvs[8] = uvs[16] = uvs[24] = 0;
+        uvs[2] = uvs[10] = uvs[18] = uvs[26] = this._leftWidth / width;
+        uvs[4] = uvs[12] = uvs[20] = uvs[28] = 1 - (this._rightWidth / width);
+        uvs[6] = uvs[14] = uvs[22] = uvs[30] = 1;
+
+        uvs[1] = uvs[3] = uvs[5] = uvs[7] = 0;
+        uvs[9] = uvs[11] = uvs[13] = uvs[15] = this._topHeight / height;
+        uvs[17] = uvs[19] = uvs[21] = uvs[23] = 1 - (this._bottomHeight / height);
+        uvs[25] = uvs[27] = uvs[29] = uvs[31] = 1;
+
+        this.dirty++;
+
+        this.multiplyUvs();
+    }
+
+    /**
+     * Updates the horizontal vertices.
      */
     updateHorizontalVertices()
     {
         const vertices = this.vertices;
 
+        vertices[1] = vertices[3] = vertices[5] = vertices[7] = 0;
         vertices[9] = vertices[11] = vertices[13] = vertices[15] = this._topHeight;
         vertices[17] = vertices[19] = vertices[21] = vertices[23] = this._height - this._bottomHeight;
         vertices[25] = vertices[27] = vertices[29] = vertices[31] = this._height;
@@ -140,6 +237,7 @@ export default class NineSlicePlane extends Plane
     {
         const vertices = this.vertices;
 
+        vertices[0] = vertices[8] = vertices[16] = vertices[24] = 0;
         vertices[2] = vertices[10] = vertices[18] = vertices[26] = this._leftWidth;
         vertices[4] = vertices[12] = vertices[20] = vertices[28] = this._width - this._rightWidth;
         vertices[6] = vertices[14] = vertices[22] = vertices[30] = this._width;
@@ -153,6 +251,20 @@ export default class NineSlicePlane extends Plane
      */
     _renderCanvas(renderer)
     {
+        // no texture - no drawImage
+        if (!this._texture.valid)
+        {
+            return;
+        }
+
+        // advanced rendering - allow texture rotates
+        if (this._texture.rotate)
+        {
+            super._renderCanvas(renderer);
+
+            return;
+        }
+
         const context = renderer.context;
 
         context.globalAlpha = this.worldAlpha;
@@ -249,129 +361,5 @@ export default class NineSlicePlane extends Plane
         }
 
         context.drawImage(textureSource, uvs[x1] * w, uvs[y1] * h, sw, sh, vertices[x1], vertices[y1], dw, dh);
-    }
-
-    /**
-     * The width of the NineSlicePlane, setting this will actually modify the vertices and UV's of this plane
-     *
-     * @member {number}
-     */
-    get width()
-    {
-        return this._width;
-    }
-
-    set width(value) // eslint-disable-line require-jsdoc
-    {
-        this._width = value;
-        this.updateVerticalVertices();
-    }
-
-    /**
-     * The height of the NineSlicePlane, setting this will actually modify the vertices and UV's of this plane
-     *
-     * @member {number}
-     */
-    get height()
-    {
-        return this._height;
-    }
-
-    set height(value) // eslint-disable-line require-jsdoc
-    {
-        this._height = value;
-        this.updateHorizontalVertices();
-    }
-
-    /**
-     * The width of the left column
-     *
-     * @member {number}
-     */
-    get leftWidth()
-    {
-        return this._leftWidth;
-    }
-
-    set leftWidth(value) // eslint-disable-line require-jsdoc
-    {
-        this._leftWidth = value;
-
-        const uvs = this.uvs;
-        const vertices = this.vertices;
-
-        uvs[2] = uvs[10] = uvs[18] = uvs[26] = this._uvw * value;
-        vertices[2] = vertices[10] = vertices[18] = vertices[26] = value;
-
-        this.dirty = true;
-    }
-
-    /**
-     * The width of the right column
-     *
-     * @member {number}
-     */
-    get rightWidth()
-    {
-        return this._rightWidth;
-    }
-
-    set rightWidth(value) // eslint-disable-line require-jsdoc
-    {
-        this._rightWidth = value;
-
-        const uvs = this.uvs;
-        const vertices = this.vertices;
-
-        uvs[4] = uvs[12] = uvs[20] = uvs[28] = 1 - (this._uvw * value);
-        vertices[4] = vertices[12] = vertices[20] = vertices[28] = this._width - value;
-
-        this.dirty = true;
-    }
-
-    /**
-     * The height of the top row
-     *
-     * @member {number}
-     */
-    get topHeight()
-    {
-        return this._topHeight;
-    }
-
-    set topHeight(value) // eslint-disable-line require-jsdoc
-    {
-        this._topHeight = value;
-
-        const uvs = this.uvs;
-        const vertices = this.vertices;
-
-        uvs[9] = uvs[11] = uvs[13] = uvs[15] = this._uvh * value;
-        vertices[9] = vertices[11] = vertices[13] = vertices[15] = value;
-
-        this.dirty = true;
-    }
-
-    /**
-     * The height of the bottom row
-     *
-     * @member {number}
-     */
-    get bottomHeight()
-    {
-        return this._bottomHeight;
-    }
-
-    set bottomHeight(value) // eslint-disable-line require-jsdoc
-    {
-        this._bottomHeight = value;
-
-        const uvs = this.uvs;
-        const vertices = this.vertices;
-
-        uvs[17] = uvs[19] = uvs[21] = uvs[23] = 1 - (this._uvh * value);
-        vertices[17] = vertices[19] = vertices[21] = vertices[23] = this._height - value;
-
-        this.dirty = true;
     }
 }

--- a/src/mesh/Plane.js
+++ b/src/mesh/Plane.js
@@ -59,6 +59,11 @@ export default class Plane extends Mesh
 
         this._lastVerticesID = -1;
 
+        /*
+         * @member {Float32Array} Generated vertices positions, useful as starting position for vertices
+         */
+        this.calculatedVertices = null;
+
         /**
          *  Version counter for uvs updates
          *
@@ -254,12 +259,12 @@ export default class Plane extends Mesh
      */
     refresh(forceUpdate)
     {
+        this.refreshDimensions(forceUpdate);
+
         if (this._texture.noFrame)
         {
             return;
         }
-
-        this.refreshDimensions(forceUpdate);
 
         if (this._lastWidth !== this.width
             || this._lastHeight !== this.height)

--- a/src/mesh/Plane.js
+++ b/src/mesh/Plane.js
@@ -1,3 +1,4 @@
+import * as core from '../core';
 import Mesh from './Mesh';
 
 /**
@@ -19,60 +20,296 @@ export default class Plane extends Mesh
 {
     /**
      * @param {PIXI.Texture} texture - The texture to use on the Plane.
-     * @param {number} verticesX - The number of vertices in the x-axis
-     * @param {number} verticesY - The number of vertices in the y-axis
+     * @param {number} [verticesX=2] - The number of vertices in the x-axis
+     * @param {number} [verticesY=2] - The number of vertices in the y-axis
+     * @param {number} [direction=0] - Direction of the mesh. See {@link PIXI.GroupD8} for explanation
      */
-    constructor(texture, verticesX, verticesY)
+    constructor(texture, verticesX, verticesY, direction)
     {
         super(texture);
 
+        this._verticesX = verticesX || 2;
+        this._verticesY = verticesY || 2;
+
+        this._direction = (direction || 0) & (~1);
+
+        this._lastWidth = texture.orig.width;
+        this._lastHeight = texture.orig.height;
+
+        this._width = 0;
+        this._height = 0;
+
         /**
-         * Tracker for if the Plane is ready to be drawn. Needed because Mesh ctor can
-         * call _onTextureUpdated which could call refresh too early.
+         *  Version counter for verticesX/verticesY change
          *
-         * @member {boolean}
+         * @member {number}
          * @private
          */
-        this._ready = true;
+        this._dimensionsID = 0;
 
-        this.verticesX = verticesX || 10;
-        this.verticesY = verticesY || 10;
+        this._lastDimensionsID = -1;
+
+        /**
+         *  Version counter for vertices updates
+         *
+         * @member {number}
+         * @private
+         */
+        this._verticesID = 0;
+
+        this._lastVerticesID = -1;
+
+        /**
+         *  Version counter for uvs updates
+         *
+         * @member {number}
+         * @private
+         */
+        this._uvsID = 0;
+
+        this._lastUvsID = -1;
+
+        /**
+         * anchor for a plane
+         *
+         * @member {PIXI.ObservablePoint}
+         * @private
+         */
+        this._anchor = new core.ObservablePoint(this._onAnchorUpdate, this);
 
         this.drawMode = Mesh.DRAW_MODES.TRIANGLES;
+
+        /**
+         * reset the points on dimensions change
+         * @member {boolean}
+         * @default true
+         */
+        this.autoResetVertices = true;
+
         this.refresh();
     }
 
     /**
-     * Refreshes plane coordinates
+     * The width of the sprite, setting this will actually modify the scale to achieve the value set
      *
+     * @member {number}
      */
-    _refresh()
+    get verticesX()
     {
-        const texture = this._texture;
-        const total = this.verticesX * this.verticesY;
-        const verts = [];
-        const colors = [];
-        const uvs = [];
-        const indices = [];
+        return this._verticesX;
+    }
 
-        const segmentsX = this.verticesX - 1;
-        const segmentsY = this.verticesY - 1;
-
-        const sizeX = texture.width / segmentsX;
-        const sizeY = texture.height / segmentsY;
-
-        for (let i = 0; i < total; i++)
+    set verticesX(value) // eslint-disable-line require-jsdoc
+    {
+        if (this._verticesX === value)
         {
-            const x = (i % this.verticesX);
-            const y = ((i / this.verticesX) | 0);
+            return;
+        }
+        this._verticesX = value;
+        this._dimensionsID++;
+    }
 
-            verts.push(x * sizeX, y * sizeY);
+    /**
+     * The height of the TilingSprite, setting this will actually modify the scale to achieve the value set
+     *
+     * @member {number}
+     */
+    get verticesY()
+    {
+        return this._verticesY;
+    }
 
-            uvs.push(x / segmentsX, y / segmentsY);
+    set verticesY(value) // eslint-disable-line require-jsdoc
+    {
+        if (this._verticesY === value)
+        {
+            return;
+        }
+        this._verticesY = value;
+        this._dimensionsID++;
+    }
+
+    /**
+     * Direction of the mesh, see {@link PIXI.GroupD8} for explanation
+     *
+     * @param {number} [direction=0] - Direction of the mesh.
+     */
+    get direction()
+    {
+        return this._direction;
+    }
+
+    set direction(value) // eslint-disable-line require-jsdoc
+    {
+        if (value % 2 !== 0)
+        {
+            throw new Error('plane does not support diamond shape yet');
         }
 
-        //  cons
+        if (this._direction === value)
+        {
+            return;
+        }
+        this._direction = value;
+        this._verticesID++;
+    }
 
+    /**
+     * The width of the Plane, settings this wont modify the scale, but vertices will be cleared
+     *
+     * @member {number}
+     */
+    get width()
+    {
+        return this._width || this.texture.orig.width;
+    }
+
+    set width(value) // eslint-disable-line require-jsdoc
+    {
+        if (this._width === value)
+        {
+            return;
+        }
+        this._width = value;
+        this._verticesID++;
+    }
+
+    /**
+     * The height of the Plane, settings this wont modify the scale, but vertices will be cleared
+     *
+     * @member {number}
+     */
+    get height()
+    {
+        return this._height || this.texture.orig.height;
+    }
+
+    set height(value) // eslint-disable-line require-jsdoc
+    {
+        if (this._height === value)
+        {
+            return;
+        }
+        this._height = value;
+        this._verticesID++;
+    }
+
+    /**
+     * The anchor sets the origin point of the texture.
+     * The default is 0,0 this means the texture's origin is the top left
+     * Setting the anchor to 0.5,0.5 means the texture's origin is centered
+     * Setting the anchor to 1,1 would mean the texture's origin point will be the bottom right corner
+     *
+     * @member {PIXI.ObservablePoint}
+     */
+    get anchor()
+    {
+        return this._anchor;
+    }
+
+    set anchor(value) // eslint-disable-line require-jsdoc
+    {
+        this._anchor.copy(value);
+    }
+
+    /**
+     * updates vertices after anchor changes
+     *
+     * @private
+     */
+    _onAnchorUpdate()
+    {
+        this._verticesID++;
+    }
+
+    /**
+     * Call when you updated some parameters manually
+     */
+    invalidateVertices()
+    {
+        this._verticesID++;
+    }
+
+    /**
+     * Call when you updated some parameters manually
+     */
+    invalidateUvs()
+    {
+        this._uvsID++;
+    }
+
+    /**
+     * Call when you updated some parameters manually
+     */
+    invalidate()
+    {
+        this._verticesID++;
+        this._uvsID++;
+    }
+
+    /**
+     * Refreshes the plane mesh
+     *
+     * @param {boolean} [forceUpdate=false] if true, everything will be updated in any case
+     */
+    refresh(forceUpdate)
+    {
+        if (this._texture.noFrame)
+        {
+            return;
+        }
+
+        this.refreshDimensions(forceUpdate);
+
+        if (this._lastWidth !== this.width
+            || this._lastHeight !== this.height)
+        {
+            this._lastWidth = this.width;
+            this._lastHeight = this.height;
+            if (this.autoResetVertices)
+            {
+                this._verticesID++;
+            }
+        }
+
+        if (this._uvTransform.update(forceUpdate))
+        {
+            this._uvsID++;
+        }
+
+        if (this._uvsID !== this._lastUvsID)
+        {
+            this._refreshUvs();
+        }
+
+        this.refreshVertices();
+    }
+
+    /**
+     * Refreshes structure of the plane mesh
+     * when its done, refreshes vertices and uvs too
+     *
+     * @param {boolean} [forceUpdate=false] if true, dimensions will be updated any case
+     */
+    refreshDimensions(forceUpdate)
+    {
+        // won't be overwritten, that's why there's no private method
+
+        if (!forceUpdate && this._lastDimensionsID === this._dimensionsID)
+        {
+            return;
+        }
+
+        this._lastDimensionsID = this._dimensionsID;
+        this._verticesID++;
+        this._uvsID++;
+
+        const total = this._verticesX * this._verticesY;
+
+        const segmentsX = this._verticesX - 1;
+        const segmentsY = this._verticesY - 1;
+
+        const indices = [];
         const totalSub = segmentsX * segmentsY;
 
         for (let i = 0; i < totalSub; i++)
@@ -80,39 +317,148 @@ export default class Plane extends Mesh
             const xpos = i % segmentsX;
             const ypos = (i / segmentsX) | 0;
 
-            const value = (ypos * this.verticesX) + xpos;
-            const value2 = (ypos * this.verticesX) + xpos + 1;
-            const value3 = ((ypos + 1) * this.verticesX) + xpos;
-            const value4 = ((ypos + 1) * this.verticesX) + xpos + 1;
+            const value = (ypos * this._verticesX) + xpos;
+            const value2 = (ypos * this._verticesX) + xpos + 1;
+            const value3 = ((ypos + 1) * this._verticesX) + xpos;
+            const value4 = ((ypos + 1) * this._verticesX) + xpos + 1;
 
             indices.push(value, value2, value3);
             indices.push(value2, value4, value3);
         }
-
-        // console.log(indices)
-        this.vertices = new Float32Array(verts);
-        this.uvs = new Float32Array(uvs);
-        this.colors = new Float32Array(colors);
         this.indices = new Uint16Array(indices);
-        this.indexDirty = true;
+        this.uvs = new Float32Array(total * 2);
+        this.vertices = new Float32Array(total * 2);
+        this.calculatedVertices = new Float32Array(total * 2);
+
+        this.indexDirty++;
+    }
+
+    /**
+     * Refreshes plane vertices coords
+     * by default, makes them uniformly distributed
+     *
+     * @param {boolean} [forceUpdate=false] if true, vertices will be updated any case
+     */
+    refreshVertices(forceUpdate)
+    {
+        const texture = this._texture;
+
+        if (texture.noFrame)
+        {
+            return;
+        }
+
+        if (forceUpdate || this._lastVerticesID !== this._verticesID)
+        {
+            this._lastVerticesID = this._verticesID;
+            this._refreshVertices();
+        }
+    }
+
+    /**
+     * Refreshes plane UV coordinates
+     *
+     */
+    _refreshUvs()
+    {
+        this._uvsID = this._lastUvsID;
+
+        const total = this._verticesX * this._verticesY;
+        const uvs = this.uvs;
+
+        const direction = this._direction;
+
+        const ux = core.GroupD8.uX(direction);
+        const uy = core.GroupD8.uY(direction);
+        const vx = core.GroupD8.vX(direction);
+        const vy = core.GroupD8.vY(direction);
+
+        const factorU = 1.0 / (this._verticesX - 1);
+        const factorV = 1.0 / (this._verticesY - 1);
+
+        for (let i = 0; i < total; i++)
+        {
+            let x = (i % this._verticesX);
+            let y = ((i / this._verticesX) | 0);
+
+            x = (x * factorU) - 0.5;
+            y = (y * factorV) - 0.5;
+
+            uvs[i * 2] = (ux * x) + (vx * y) + 0.5;
+            uvs[(i * 2) + 1] = (uy * x) + (vy * y) + 0.5;
+        }
+
+        this.dirty++;
 
         this.multiplyUvs();
     }
 
     /**
-     * Clear texture UVs when new texture is set
-     *
-     * @private
+     * calculates supposed position of vertices
      */
-    _onTextureUpdate()
+    calcVertices()
     {
-        Mesh.prototype._onTextureUpdate.call(this);
+        const total = this._verticesX * this._verticesY;
+        const vertices = this.calculatedVertices;
 
-        // wait for the Plane ctor to finish before calling refresh
-        if (this._ready)
+        const width = this.width;
+        const height = this.height;
+        const direction = this._direction;
+
+        let ux = core.GroupD8.uX(direction);
+        let uy = core.GroupD8.uY(direction);
+        let vx = core.GroupD8.vX(direction);
+        let vy = core.GroupD8.vY(direction);
+
+        const offsetX = (0.5 * (1 - (ux + vx))) - this._anchor._x;
+        const offsetY = (0.5 * (1 - (uy + vy))) - this._anchor._y;
+        const factorU = 1.0 / (this._verticesX - 1);
+        const factorV = 1.0 / (this._verticesY - 1);
+
+        ux *= factorU;
+        uy *= factorU;
+        vx *= factorV;
+        vy *= factorV;
+
+        for (let i = 0; i < total; i++)
         {
-            this.refresh();
+            const x = (i % this._verticesX);
+            const y = ((i / this._verticesX) | 0);
+
+            vertices[i * 2] = ((ux * x) + (vx * y) + offsetX) * width;
+            vertices[(i * 2) + 1] = ((uy * x) + (vy * y) + offsetY) * height;
         }
     }
 
+    /**
+     * Refreshes vertices of Plane mesh
+     * by default, makes them uniformly distributed
+     *
+     * @private
+     */
+    _refreshVertices()
+    {
+        this.calcVertices();
+
+        const vertices = this.vertices;
+        const calculatedVertices = this.calculatedVertices;
+        const len = vertices.length;
+
+        for (let i = 0; i < len; i++)
+        {
+            vertices[i] = calculatedVertices[i];
+        }
+    }
+
+    /**
+     * resets everything to defaults
+     */
+    reset()
+    {
+        if (!this.texture.noFrame)
+        {
+            this._refreshUvs();
+            this.refreshVertices(true);
+        }
+    }
 }

--- a/src/mesh/Rope.js
+++ b/src/mesh/Rope.js
@@ -1,161 +1,265 @@
-import Mesh from './Mesh';
+import Plane from './Plane';
+import RopePoint from './RopePoint';
+import * as core from '../core';
 
 /**
- * The rope allows you to draw a texture across several points and them manipulate these points
+ * The rope sprite allows you to hack a rope that behaves like a sprite
  *
- *```js
- * for (let i = 0; i < 20; i++) {
- *     points.push(new PIXI.Point(i * 50, 0));
- * };
- * let rope = new PIXI.Rope(PIXI.Texture.fromImage("snake.png"), points);
- *  ```
+ * ```
+ * let rope = new PIXI.mesh.Rope(PIXI.Texture.fromImage("snake.png"), 5, 2, vertical ? 2 : 0);
+ * rope.anchor.set(0.5, 0.5);
+ * rope.clearPoints(); // set them according to anchor
+ * rope.points[1].y = 15; // middle Y goes down
+ * rope.points[2].offset = 15; // shift is better
+ * rope.points[3].scale = 1.2; // scale a bit
+ * ```
  *
  * @class
- * @extends PIXI.mesh.Mesh
+ * @extends PIXI.mesh.Rope
  * @memberof PIXI.mesh
  *
  */
-export default class Rope extends Mesh
+export default class Rope extends Plane
 {
     /**
      * @param {PIXI.Texture} texture - The texture to use on the rope.
-     * @param {PIXI.Point[]} points - An array of {@link PIXI.Point} objects to construct this rope.
+     * @param {number|PIXI.mesh.RopePoint[]} [verticesX=2] - How many vertices on diameter of the rope,
+     * you can also pass pre-created points here.
+     * @param {number} [verticesY=2] - How many vertices on meridian of the rope, make it 2 or 3
+     * @param {number} [direction=0] - Direction of the rope. See {@link PIXI.GroupD8} for explanation
      */
-    constructor(texture, points)
+    constructor(texture, verticesX, verticesY, direction)
     {
-        super(texture);
+        super(texture, verticesX.length || verticesX, verticesY, direction);
 
         /*
-         * @member {PIXI.Point[]} An array of points that determine the rope
+         * @member {PIXI.mesh.RopePoint[]} An array of points that determine the rope
          */
-        this.points = points;
-
+        this.points = [];
         /*
-         * @member {Float32Array} An array of vertices used to construct this rope.
+         * @member {PIXI.mesh.RopePoint[]} Generated points positions, useful as starting position for points
          */
-        this.vertices = new Float32Array(points.length * 4);
+        this.calculatedPoints = [];
 
-        /*
-         * @member {Float32Array} The WebGL Uvs of the rope.
-         */
-        this.uvs = new Float32Array(points.length * 4);
+        if (verticesX instanceof Array)
+        {
+            this.points = verticesX;
+            this.autoResetVertices = false;
+        }
 
-        /*
-         * @member {Float32Array} An array containing the color components
-         */
-        this.colors = new Float32Array(points.length * 2);
-
-        /*
-         * @member {Uint16Array} An array containing the indices of the vertices
-         */
-        this.indices = new Uint16Array(points.length * 2);
+        this._checkPointsLen();
 
         /**
-         * refreshes vertices on every updateTransform
+         * invalidates points on every updateTransform
          * @member {boolean}
          * @default true
          */
         this.autoUpdate = true;
 
+        if (core.GroupD8.isVertical(direction))
+        {
+            this._anchor._x = 0.5;
+        }
+        else
+        {
+            this._anchor._y = 0.5;
+        }
+
         this.refresh();
     }
 
     /**
-     * Refreshes
-     *
+     * Updates the object transform for rendering
      */
-    _refresh()
+    updateTransform()
     {
-        const points = this.points;
-
-        // if too little points, or texture hasn't got UVs set yet just move on.
-        if (points.length < 1 || !this._texture._uvs)
+        if (this.autoUpdate)
         {
-            return;
+            this._verticesID++;
         }
-
-        // if the number of points has changed we will need to recreate the arraybuffers
-        if (this.vertices.length / 4 !== points.length)
-        {
-            this.vertices = new Float32Array(points.length * 4);
-            this.uvs = new Float32Array(points.length * 4);
-            this.colors = new Float32Array(points.length * 2);
-            this.indices = new Uint16Array(points.length * 2);
-        }
-
-        const uvs = this.uvs;
-
-        const indices = this.indices;
-        const colors = this.colors;
-
-        uvs[0] = 0;
-        uvs[1] = 0;
-        uvs[2] = 0;
-        uvs[3] = 1;
-
-        colors[0] = 1;
-        colors[1] = 1;
-
-        indices[0] = 0;
-        indices[1] = 1;
-
-        const total = points.length;
-
-        for (let i = 1; i < total; i++)
-        {
-            // time to do some smart drawing!
-            let index = i * 4;
-            const amount = i / (total - 1);
-
-            uvs[index] = amount;
-            uvs[index + 1] = 0;
-
-            uvs[index + 2] = amount;
-            uvs[index + 3] = 1;
-
-            index = i * 2;
-            colors[index] = 1;
-            colors[index + 1] = 1;
-
-            index = i * 2;
-            indices[index] = index;
-            indices[index + 1] = index + 1;
-        }
-
-        // ensure that the changes are uploaded
-        this.dirty++;
-        this.indexDirty++;
-
-        this.multiplyUvs();
-        this.refreshVertices();
+        this.refresh();
+        this.containerUpdateTransform();
     }
 
     /**
-     * refreshes vertices of Rope mesh
+     * updates everything when anchor was changed
+     *
+     * @private
      */
-    refreshVertices()
+    _onAnchorUpdate()
     {
-        const points = this.points;
+        this.reset();
+    }
 
-        if (points.length < 1)
+    /**
+     * sets default points coordinates
+     *
+     */
+    _checkPointsLen()
+    {
+        const len = this._verticesX;
+        const points = this.points;
+        const calculatedPoints = this.calculatedPoints;
+
+        if (points.length > len)
+        {
+            points.length = len;
+        }
+
+        while (points.length < len)
+        {
+            points.push(new RopePoint(0, 0, 0, 1.0));
+        }
+
+        if (calculatedPoints.length > len)
+        {
+            calculatedPoints.length = len;
+        }
+
+        while (calculatedPoints.length < len)
+        {
+            calculatedPoints.push(new RopePoint(0, 0, 0, 1.0));
+        }
+    }
+
+    /**
+     * Refreshes the rope sprite mesh
+     *
+     * @param {boolean} [forceUpdate=false] if true, everything will be updated in any case
+     */
+    refresh(forceUpdate)
+    {
+        // using "this.points" instead of old "ready" hack
+
+        if (!this.points || this._texture.noFrame)
         {
             return;
         }
 
+        if (this._lastWidth !== this.width
+            || this._lastHeight !== this.height)
+        {
+            this._lastWidth = this.width;
+            this._lastHeight = this.height;
+            if (this.autoResetVertices)
+            {
+                this.resetPoints();
+            }
+        }
+
+        super.refresh(forceUpdate);
+    }
+
+    /**
+     * Calculate default position for points
+     */
+    calcPoints()
+    {
+        const len = this._verticesX;
+        const points = this.calculatedPoints;
+
+        const dir = this._direction;
+
+        const width = this.width;
+        const height = this.height;
+
+        const dx = core.GroupD8.uX(dir);
+        const dy = core.GroupD8.uY(dir);
+
+        const offsetX = dx !== 0 ? 0.5 - this._anchor._x : 0;
+        const offsetY = dy !== 0 ? 0.5 - this._anchor._y : 0;
+
+        for (let i = 0; i < len; i++)
+        {
+            const t = (i - ((len - 1) * 0.5)) / (len - 1);
+
+            points[i].x = ((t * dx) + offsetX) * width;
+            points[i].y = ((t * dy) + offsetY) * height;
+        }
+    }
+
+    /**
+     * sets default points coordinates
+     */
+    resetPoints()
+    {
+        this.calcPoints();
+
+        const len = this._verticesX;
+        const points = this.points;
+        const calculatedPoints = this.calculatedPoints;
+
+        for (let i = 0; i < len; i++)
+        {
+            points[i].x = calculatedPoints[i].x;
+            points[i].y = calculatedPoints[i].y;
+        }
+    }
+
+    /**
+     * sets default shift - zero
+     */
+    resetOffsets()
+    {
+        const points = this.points;
+        const len = points.length;
+
+        for (let i = 0; i < len; i++)
+        {
+            points.offset = 0.0;
+        }
+
+        for (let i = 0; i < len; i++)
+        {
+            points.scale = 1.0;
+        }
+    }
+
+    /**
+     * clears rope points
+     */
+    reset()
+    {
+        this._checkPointsLen();
+        this.resetPoints();
+        this.resetOffsets();
+
+        super.reset();
+    }
+
+    /**
+     * Refreshes vertices of Rope mesh
+     */
+    calcVertices()
+    {
+        const points = this.points;
+
         let lastPoint = points[0];
         let nextPoint;
-        let perpX = 0;
-        let perpY = 0;
+        let normalX = 0;
+        let normalY = 0;
 
-        // this.count -= 0.2;
+        const width = this.width;
+        const height = this.height;
+        const vertices = this.calculatedVertices;
+        const verticesX = this.verticesX;
+        const verticesY = this.verticesY;
+        const direction = this._direction;
 
-        const vertices = this.vertices;
-        const total = points.length;
+        const vx = core.GroupD8.vX(direction);
+        const vy = core.GroupD8.vY(direction);
 
-        for (let i = 0; i < total; i++)
+        const wide = (vx * width) + (vy * height);
+
+        const normalOffset = wide * ((this._anchor._x * vx) + (this._anchor._y * vy));
+        const normalFactor = -Math.abs(wide) / (verticesY - 1);
+
+        for (let i = 0; i < verticesX; i++)
         {
             const point = points[i];
-            const index = i * 4;
+            // in case someone used Point instead of RopePoint
+            const offset = points[i].offset || 0;
+            const scale = (points[i].scale !== undefined) ? points[i].scale : 1.0;
 
             if (i < points.length - 1)
             {
@@ -166,46 +270,23 @@ export default class Rope extends Mesh
                 nextPoint = point;
             }
 
-            perpY = -(nextPoint.x - lastPoint.x);
-            perpX = nextPoint.y - lastPoint.y;
+            normalY = -(nextPoint.x - lastPoint.x);
+            normalX = nextPoint.y - lastPoint.y;
 
-            let ratio = (1 - (i / (total - 1))) * 10;
+            const perpLength = Math.sqrt((normalX * normalX) + (normalY * normalY));
 
-            if (ratio > 1)
+            normalX /= perpLength;
+            normalY /= perpLength;
+
+            for (let j = 0; j < verticesY; j++)
             {
-                ratio = 1;
+                const ind = (i + (j * verticesX)) * 2;
+
+                vertices[ind] = point.x + (normalX * (offset + (scale * (normalOffset + (normalFactor * j)))));
+                vertices[ind + 1] = point.y + (normalY * (offset + (scale * (normalOffset + (normalFactor * j)))));
             }
-
-            const perpLength = Math.sqrt((perpX * perpX) + (perpY * perpY));
-            const num = this._texture.height / 2; // (20 + Math.abs(Math.sin((i + this.count) * 0.3) * 50) )* ratio;
-
-            perpX /= perpLength;
-            perpY /= perpLength;
-
-            perpX *= num;
-            perpY *= num;
-
-            vertices[index] = point.x + perpX;
-            vertices[index + 1] = point.y + perpY;
-            vertices[index + 2] = point.x - perpX;
-            vertices[index + 3] = point.y - perpY;
 
             lastPoint = point;
         }
     }
-
-    /**
-     * Updates the object transform for rendering
-     *
-     * @private
-     */
-    updateTransform()
-    {
-        if (this.autoUpdate)
-        {
-            this.refreshVertices();
-        }
-        this.containerUpdateTransform();
-    }
-
 }

--- a/src/mesh/RopePoint.js
+++ b/src/mesh/RopePoint.js
@@ -1,0 +1,68 @@
+import { default as Point } from '../core/math/Point';
+
+/**
+ * The Rope Point object is a point with some info about normals
+ *
+ * @class
+ * @memberof PIXI.mesh
+ */
+export default class RopePoint extends Point
+{
+    /**
+     * @param {number} [x=0] - position of the point on the x axis
+     * @param {number} [y=0] - position of the point on the y axis
+     * @param {number} [offset=0] - offsets the point by normal
+     * @param {number} [scale=1.0] - scales the point by normal
+     */
+    constructor(x = 0, y = 0, offset = 0, scale = 1.0)
+    {
+        super(x, y);
+        /**
+         * @member {number} position of the
+         * @default 0
+         */
+        this.offset = offset;
+        /**
+         * @member {number}
+         * @default 1.0
+         */
+        this.scale = scale;
+    }
+
+    /**
+     * Creates a clone of this point
+     *
+     * @return {PIXI.RopePoint} a copy of the point
+     */
+    clone()
+    {
+        return new Point(this.x, this.y, this.offset, this.scale);
+    }
+
+    /**
+     * Copies everything from the given point
+     *
+     * @param {PIXI.Point | PIXI.RopePoint} p - The point to copy.
+     */
+    copy(p)
+    {
+        this.set(p.x, p.y, p.offset, p.scale);
+    }
+
+    /**
+     * Sets the point to a new x and y position.
+     * If y is omitted, both x and y will be set to x.
+     *
+     * @param {number} [x=0] - position of the point on the x axis
+     * @param {number} [y=0] - position of the point on the y axis
+     * @param {number} [offset=0] - offsets the point by normal
+     * @param {number} [scale=1.0] - scales the point by normal
+     */
+    set(x, y, offset, scale)
+    {
+        this.x = x || 0;
+        this.y = y || ((y !== 0) ? this.x : 0);
+        this.offset = offset || 0;
+        this.scale = (scale !== undefined) ? scale : 1.0;
+    }
+}

--- a/src/mesh/index.js
+++ b/src/mesh/index.js
@@ -7,3 +7,4 @@ export { default as CanvasMeshRenderer } from './canvas/CanvasMeshRenderer';
 export { default as Plane } from './Plane';
 export { default as NineSlicePlane } from './NineSlicePlane';
 export { default as Rope } from './Rope';
+export { default as RopePoint } from './RopePoint';

--- a/src/mesh/webgl/MeshRenderer.js
+++ b/src/mesh/webgl/MeshRenderer.js
@@ -40,6 +40,9 @@ export default class MeshRenderer extends core.ObjectRenderer
         this.shader = new core.Shader(gl,
             readFileSync(join(__dirname, './mesh.vert'), 'utf8'),
             readFileSync(join(__dirname, './mesh.frag'), 'utf8'));
+        this.shaderTrim = new core.Shader(gl,
+            readFileSync(join(__dirname, './mesh.vert'), 'utf8'),
+            readFileSync(join(__dirname, './mesh_trim.frag'), 'utf8'));
     }
 
     /**
@@ -65,7 +68,6 @@ export default class MeshRenderer extends core.ObjectRenderer
             renderer.bindVao(null);
 
             glData = {
-                shader: this.shader,
                 vertexBuffer: glCore.GLBuffer.createVertexBuffer(gl, mesh.vertices, gl.STREAM_DRAW),
                 uvBuffer: glCore.GLBuffer.createVertexBuffer(gl, mesh.uvs, gl.STREAM_DRAW),
                 indexBuffer: glCore.GLBuffer.createIndexBuffer(gl, mesh.indices, gl.STATIC_DRAW),
@@ -78,8 +80,8 @@ export default class MeshRenderer extends core.ObjectRenderer
             // build the vao object that will render..
             glData.vao = new glCore.VertexArrayObject(gl)
                 .addIndex(glData.indexBuffer)
-                .addAttribute(glData.vertexBuffer, glData.shader.attributes.aVertexPosition, gl.FLOAT, false, 2 * 4, 0)
-                .addAttribute(glData.uvBuffer, glData.shader.attributes.aTextureCoord, gl.FLOAT, false, 2 * 4, 0);
+                .addAttribute(glData.vertexBuffer, this.shader.attributes.aVertexPosition, gl.FLOAT, false, 2 * 4, 0)
+                .addAttribute(glData.uvBuffer, this.shader.attributes.aTextureCoord, gl.FLOAT, false, 2 * 4, 0);
 
             mesh._glDatas[renderer.CONTEXT_UID] = glData;
         }
@@ -100,26 +102,34 @@ export default class MeshRenderer extends core.ObjectRenderer
 
         glData.vertexBuffer.upload(mesh.vertices);
 
-        renderer.bindShader(glData.shader);
+        const isTrimmed = texture.trim && (texture.trim.width < texture.orig.width
+            || texture.trim.height < texture.orig.height);
+        const shader = isTrimmed ? this.shaderTrim : this.shader;
 
-        glData.shader.uniforms.uSampler = renderer.bindTexture(texture);
+        renderer.bindShader(shader);
+
+        shader.uniforms.uSampler = renderer.bindTexture(texture);
 
         renderer.state.setBlendMode(mesh.blendMode);
 
-        if (glData.shader.uniforms.uTransform)
+        if (shader.uniforms.uTransform)
         {
             if (mesh.uploadUvTransform)
             {
-                glData.shader.uniforms.uTransform = mesh._uvTransform.mapCoord.toArray(true);
+                shader.uniforms.uTransform = mesh._uvTransform.mapCoord.toArray(true);
             }
             else
             {
-                glData.shader.uniforms.uTransform = matrixIdentity.toArray(true);
+                shader.uniforms.uTransform = matrixIdentity.toArray(true);
             }
         }
-        glData.shader.uniforms.translationMatrix = mesh.worldTransform.toArray(true);
-        glData.shader.uniforms.alpha = mesh.worldAlpha;
-        glData.shader.uniforms.tint = mesh.tintRgb;
+        if (isTrimmed)
+        {
+            shader.uniforms.uClampFrame = mesh._uvTransform.uClampFrame;
+        }
+        shader.uniforms.translationMatrix = mesh.worldTransform.toArray(true);
+        shader.uniforms.alpha = mesh.worldAlpha;
+        shader.uniforms.tint = mesh.tintRgb;
 
         const drawMode = mesh.drawMode === Mesh.DRAW_MODES.TRIANGLE_MESH ? gl.TRIANGLE_STRIP : gl.TRIANGLES;
 

--- a/src/mesh/webgl/mesh_trim.frag
+++ b/src/mesh/webgl/mesh_trim.frag
@@ -1,0 +1,15 @@
+varying vec2 vTextureCoord;
+uniform float alpha;
+uniform vec3 tint;
+uniform vec4 uClampFrame;
+
+uniform sampler2D uSampler;
+
+void main(void)
+{
+    vec2 coord = vTextureCoord;
+    if (coord.x < uClampFrame.x || coord.x > uClampFrame.z
+        || coord.y < uClampFrame.y || coord.y > uClampFrame.w)
+            discard;
+    gl_FragColor = texture2D(uSampler, coord) * vec4(tint * alpha, alpha);
+}


### PR DESCRIPTION
This WIP PR is dedicated to @finscn

This PR is also one step forward towards polygon packing.

Add those lines in the end of assetsLoaded of [Spritesheet example](http://pixijs.github.io/examples/?v=dev-mesh-update#/basics/spritesheet.js)

```js
    // here are the changes:
  
const mesh = new PIXI.mesh.Plane(anim.texture, 3, 3)
mesh.anchor.set(0.5);
mesh.position.set(anim.x - 200, anim.y);
app.stage.addChild(mesh);
app.ticker.add(function() {
    mesh.texture = anim.texture;
    mesh.vertices[9] = Math.cos(anim.rotation * 10)*30;
});
```

The case for mesh trim:
1. we have 1000 sprites
2. we want to apply filters on several of them , and we can spend performance on that. 
3. we also want to apply geometry effect - swap some sprites to meshes.
4. API of meshes is the same as sprite, same logic applies + some distortion on them.

In that case, developer doesn't have to repack stuff into separate atlas without trim just because he spontaneously wants to use some "effect".