### PR TITLE
ticker listeners with priority, uses mini-runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "jaguarjs-jsdoc": "^1.0.1",
     "js-md5": "^0.4.1",
     "jsdoc": "^3.4.2",
+    "mini-runner": "https://github.com/drkibitz/mini-runner/archive/dev/priorities.tar.gz",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "parallelshell": "^2.0.0",

--- a/src/core/Application.js
+++ b/src/core/Application.js
@@ -97,12 +97,23 @@ export default class Application
         this._ticker = ticker;
         if (ticker)
         {
-            ticker.add(this.render, this);
+            ticker.add(this, settings.UPDATE_PRIORITY.low);
         }
     }
     get ticker() // eslint-disable-line require-jsdoc
     {
         return this._ticker;
+    }
+
+    /**
+     * Handle tick update
+     *
+     * @private
+     * @param {number} deltaTime - Time since last tick.
+     */
+    onUpdate()
+    {
+        this.renderer.render(this.stage);
     }
 
     /**
@@ -156,6 +167,7 @@ export default class Application
     destroy(removeView)
     {
         this.stop();
+        this.ticker.remove(this);
         this.ticker = null;
 
         this.stage.destroy();

--- a/src/core/settings.js
+++ b/src/core/settings.js
@@ -17,6 +17,29 @@ export default {
     TARGET_FPMS: 0.06,
 
     /**
+     * Listener priorities that are both the actual priorities of
+     * internal listeners added to {@link PIXI.ticker.Ticker}
+     * as well as a guideline to priorities of new listeners.
+     *
+     * @static
+     * @constant
+     * @memberof PIXI.settings
+     * @type {object}
+     * @property {number} interaction=50
+     * @property {number} high=25
+     * @property {number} default=0
+     * @property {number} low=-25
+     * @property {number} utility=-50
+     */
+    UPDATE_PRIORITY: {
+        interactive: 50,
+        high: 25,
+        default: 0,
+        low: -25,
+        utility: -50,
+    },
+
+    /**
      * If set to true WebGL will attempt make textures mimpaped by default.
      * Mipmapping will only succeed if the base texture uploaded has power of two dimensions.
      *

--- a/src/core/textures/VideoBaseTexture.js
+++ b/src/core/textures/VideoBaseTexture.js
@@ -1,5 +1,6 @@
 import BaseTexture from './BaseTexture';
 import { uid, BaseTextureCache } from '../utils';
+import settings from '../settings';
 import * as ticker from '../ticker';
 
 /**
@@ -67,7 +68,6 @@ export default class VideoBaseTexture extends BaseTexture
          */
         this.autoPlay = true;
 
-        this.update = this.update.bind(this);
         this._onCanPlay = this._onCanPlay.bind(this);
 
         source.addEventListener('play', this._onPlayStart.bind(this));
@@ -84,6 +84,17 @@ export default class VideoBaseTexture extends BaseTexture
         {
             this._onCanPlay();
         }
+    }
+
+    /**
+     * Handle tick update
+     *
+     * @private
+     * @param {number} deltaTime - Time since last tick.
+     */
+    onUpdate()
+    {
+        this.update();
     }
 
     /**
@@ -125,7 +136,7 @@ export default class VideoBaseTexture extends BaseTexture
 
         if (!this._isAutoUpdating && this.autoUpdate)
         {
-            ticker.shared.add(this.update, this);
+            ticker.shared.add(this, settings.UPDATE_PRIORITY.high);
             this._isAutoUpdating = true;
         }
     }
@@ -139,7 +150,7 @@ export default class VideoBaseTexture extends BaseTexture
     {
         if (this._isAutoUpdating)
         {
-            ticker.shared.remove(this.update, this);
+            ticker.shared.remove(this);
             this._isAutoUpdating = false;
         }
     }
@@ -187,7 +198,7 @@ export default class VideoBaseTexture extends BaseTexture
     {
         if (this._isAutoUpdating)
         {
-            ticker.shared.remove(this.update, this);
+            ticker.shared.remove(this);
         }
 
         if (this.source && this.source._pixiId)
@@ -281,12 +292,12 @@ export default class VideoBaseTexture extends BaseTexture
 
             if (!this._autoUpdate && this._isAutoUpdating)
             {
-                ticker.shared.remove(this.update, this);
+                ticker.shared.remove(this);
                 this._isAutoUpdating = false;
             }
             else if (this._autoUpdate && !this._isAutoUpdating)
             {
-                ticker.shared.add(this.update, this);
+                ticker.shared.add(this, settings.UPDATE_PRIORITY.texture);
                 this._isAutoUpdating = true;
             }
         }

--- a/src/extras/AnimatedSprite.js
+++ b/src/extras/AnimatedSprite.js
@@ -137,7 +137,7 @@ export default class AnimatedSprite extends core.Sprite
         this.playing = true;
         if (this._autoUpdate)
         {
-            core.ticker.shared.add(this.update, this);
+            core.ticker.shared.add(this, core.settings.UPDATE_PRIORITY.high);
         }
     }
 
@@ -185,7 +185,7 @@ export default class AnimatedSprite extends core.Sprite
      * @private
      * @param {number} deltaTime - Time since last tick.
      */
-    update(deltaTime)
+    onUpdate(deltaTime)
     {
         const elapsed = this.animationSpeed * deltaTime;
         const previousFrame = this.currentFrame;

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -487,7 +487,7 @@ export default class InteractionManager extends EventEmitter
             return;
         }
 
-        core.ticker.shared.add(this.update, this);
+        core.ticker.shared.add(this, core.settings.UPDATE_PRIORITY.interactive);
 
         if (window.navigator.msPointerEnabled)
         {
@@ -548,7 +548,7 @@ export default class InteractionManager extends EventEmitter
             return;
         }
 
-        core.ticker.shared.remove(this.update, this);
+        core.ticker.shared.remove(this);
 
         if (window.navigator.msPointerEnabled)
         {
@@ -595,9 +595,10 @@ export default class InteractionManager extends EventEmitter
      * Updates the state of interactive objects.
      * Invoked by a throttled ticker update from {@link PIXI.ticker.shared}.
      *
+     * @private
      * @param {number} deltaTime - time delta since last tick
      */
-    update(deltaTime)
+    onUpdate(deltaTime)
     {
         this._deltaTime += deltaTime;
 

--- a/src/prepare/BasePrepare.js
+++ b/src/prepare/BasePrepare.js
@@ -158,7 +158,7 @@ export default class BasePrepare
             if (!this.ticking)
             {
                 this.ticking = true;
-                SharedTicker.addOnce(this.tick, this);
+                SharedTicker.add(this, core.settings.UPDATE_PRIORITY.utility);
             }
         }
         else if (done)
@@ -171,9 +171,11 @@ export default class BasePrepare
      * Handle tick update
      *
      * @private
+     * @param {number} deltaTime - Time since last tick.
      */
-    tick()
+    onUpdate()
     {
+        SharedTicker.remove(this);
         setTimeout(this.delayedTick, 0);
     }
 
@@ -228,7 +230,7 @@ export default class BasePrepare
         else
         {
             // if we are not finished, on the next rAF do this again
-            SharedTicker.addOnce(this.tick, this);
+            SharedTicker.add(this, core.settings.UPDATE_PRIORITY.utility);
         }
     }
 
@@ -305,7 +307,7 @@ export default class BasePrepare
     {
         if (this.ticking)
         {
-            SharedTicker.remove(this.tick, this);
+            SharedTicker.remove(this);
         }
         this.ticking = false;
         this.addHooks = null;

--- a/test/core/Application.js
+++ b/test/core/Application.js
@@ -11,10 +11,12 @@ describe('PIXI.Application', function ()
         expect(app.ticker).to.be.instanceof(PIXI.ticker.Ticker);
         expect(app.renderer).to.be.ok;
 
-        app.ticker.addOnce(() =>
-        {
-            app.destroy();
-            done();
+        app.ticker.add({
+            onUpdate: () =>
+            {
+                app.destroy();
+                done();
+            },
         });
     });
 });


### PR DESCRIPTION
- Removes internal emitter implementation and manages listeners using mini-runner

Addresses https://github.com/pixijs/pixi.js/issues/3835

---

Please note this is a WIP. It uses a fork or mini-runner with priority insertion, which is in PR here https://github.com/GoodBoyDigital/mini-runner/pull/6

I'm not set on the implementation, but just trying to contribute something. The name `onUpdate` has been fairly common in my past experience, so I just went with it. Could have also just went with `tick`, but since the name `update` means something different depending on which class you look at, I decided against it. Also `update` is a verb, and `onUpdate` is an event, where the first would most likely trigger the second. I also completely removed the `addOnce` from ticker, as the only thing using it was `BasePrepare` and a test. I have not added deprecations for any of this, but it should be possible to do for `addOnce`, but for `add`, which changes the method signature it will be more difficult, but should be doable.

As for the setting `UPDATE_PRIORITY`, that is definitely a first pass. I figured having specific priorities for everything used by PIXI would be helpful. Also not set on the names, or the members themselves. It made sense that `default` was somewhere in between `interactive` and `utility`. The others are just guesses. The goal there was just to make sure consumers of PIXI would get the default, and when using `PIXI.Application`, that their handlers would be called before rendering.

---

Hope people have a chance to take a look, and as always, I welcome feedback.

Thanks!