### PR TITLE
Support that cache Sprite as Bitmap directly.

### DIFF
--- a/src/extras/cacheAsBitmap.js
+++ b/src/extras/cacheAsBitmap.js
@@ -227,7 +227,17 @@ DisplayObject.prototype._initCachedDisplayObject = function _initCachedDisplayOb
 
     this.transform._parentID = -1;
     // restore the transform of the cached sprite to avoid the nasty flicker..
-    this.updateTransform();
+
+    if (!this.parent)
+    {
+        this.parent = renderer._tempDisplayObjectParent;
+        this.updateTransform();
+        this.parent = null;
+    }
+    else
+    {
+        this.updateTransform();
+    }
 
     // map the hit test..
     this.containsPoint = cachedSprite.containsPoint.bind(cachedSprite);
@@ -314,7 +324,17 @@ DisplayObject.prototype._initCachedDisplayObjectCanvas = function _initCachedDis
     cachedSprite._bounds = this._bounds;
     cachedSprite.alpha = cacheAlpha;
 
-    this.updateTransform();
+    if (!this.parent)
+    {
+        this.parent = renderer._tempDisplayObjectParent;
+        this.updateTransform();
+        this.parent = null;
+    }
+    else
+    {
+        this.updateTransform();
+    }
+
     this.updateTransform = this.displayObjectUpdateTransform;
 
     this._cacheData.sprite = cachedSprite;

--- a/src/extras/cacheAsBitmap.js
+++ b/src/extras/cacheAsBitmap.js
@@ -227,7 +227,6 @@ DisplayObject.prototype._initCachedDisplayObject = function _initCachedDisplayOb
 
     this.transform._parentID = -1;
     // restore the transform of the cached sprite to avoid the nasty flicker..
-
     if (!this.parent)
     {
         this.parent = renderer._tempDisplayObjectParent;


### PR DESCRIPTION
In the current pixi.js , when we want to cache a sprite as Bitmap, we have to put the sprite into a container , like this : 
```js
var texture = PIXI.Texture.from(img);
var sprite = new PIXI.Sprite(texture);
sprite.cacheAsBitmap = true;
var renderTexture = PIXI.RenderTexture.create(sprite.width, sprite.height);

var container = new PIXI.Container();
container.addChild(sprite);
renderer.render(container, renderTexture);
```

With this PR , user could cache the sprite directly : 
```js
var texture = PIXI.Texture.from(img);
var sprite = new PIXI.Sprite(texture);
sprite.cacheAsBitmap = true;
var renderTexture = PIXI.RenderTexture.create(sprite.width, sprite.height);

renderer.render(sprite, renderTexture);
```