### PR TITLE
fix  brace-style

### DIFF
--- a/src/mesh/RopePoint.js
+++ b/src/mesh/RopePoint.js
@@ -6,7 +6,8 @@ import { default as Point } from '../core/math/Point';
  * @class
  * @memberof PIXI.mesh
  */
-export default class RopePoint extends Point {
+export default class RopePoint extends Point
+{
     /**
      * @param {number} [x=0] - position of the point on the x axis
      * @param {number} [y=0] - position of the point on the y axis


### PR DESCRIPTION
avoid `warning  Opening curly brace appears on the same line as controlling statement  brace-style`