### PR TITLE
Expose normalized event properties.

### DIFF
--- a/src/interaction/InteractionData.js
+++ b/src/interaction/InteractionData.js
@@ -40,6 +40,93 @@ export default class InteractionData
          * @member {number}
          */
         this.identifier = null;
+
+        /**
+         * Indicates whether or not the pointer device that created the event is the primary pointer.
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/isPrimary
+         * @type {Boolean}
+         */
+        this.isPrimary = false;
+        /**
+         * Indicates which button was pressed on the mouse or pointer device to trigger the event.
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
+         * @type {number}
+         */
+        this.button = 0;
+        /**
+         * Indicates which buttons are pressed on the mouse or pointer device when the event is triggered.
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
+         * @type {number}
+         */
+        this.buttons = 0;
+        /**
+         * The width of the pointer's contact along the x-axis, measured in CSS pixels.
+         * radiusX of TouchEvents will be represented by this value.
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/width
+         * @type {number}
+         */
+        this.width = 0;
+        /**
+         * The height of the pointer's contact along the y-axis, measured in CSS pixels.
+         * radiusY of TouchEvents will be represented by this value.
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/height
+         * @type {number}
+         */
+        this.height = 0;
+        /**
+         * The angle, in degrees, between the pointer device and the screen.
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/tiltX
+         * @type {number}
+         */
+        this.tiltX = 0;
+        /**
+         * The angle, in degrees, between the pointer device and the screen.
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/tiltY
+         * @type {number}
+         */
+        this.tiltY = 0;
+        /**
+         * The type of pointer that triggered the event.
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/pointerType
+         * @type {string}
+         */
+        this.pointerType = null;
+        /**
+         * Pressure applied by the pointing device during the event. A Touch's force property
+         * will be represented by this value.
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/pressure
+         * @type {number}
+         */
+        this.pressure = 0;
+        /**
+         * From TouchEvents (not PointerEvents triggered by touches), the rotationAngle of the Touch.
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/Touch/rotationAngle
+         * @type {number}
+         */
+        this.rotationAngle = 0;
+        /**
+         * Twist of a stylus pointer.
+         * @see https://w3c.github.io/pointerevents/#pointerevent-interface
+         * @type {number}
+         */
+        this.twist = 0;
+        /**
+         * Barrel pressure on a stylus pointer.
+         * @see https://w3c.github.io/pointerevents/#pointerevent-interface
+         * @type {number}
+         */
+        this.tangentialPressure = 0;
+    }
+
+    /**
+     * The unique identifier of the pointer. It will be the same as `identifier`.
+     * @readonly
+     * @member {number}
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/pointerId
+     */
+    get pointerId()
+    {
+        return this.identifier;
     }
 
     /**
@@ -57,5 +144,45 @@ export default class InteractionData
     getLocalPosition(displayObject, point, globalPos)
     {
         return displayObject.worldTransform.applyInverse(globalPos || this.global, point);
+    }
+
+    /**
+     * Copies properties from normalized event data.
+     *
+     * @param {Touch|MouseEvent|PointerEvent} event The normalized event data
+     * @private
+     */
+    _copyEvent(event)
+    {
+        // isPrimary should only change on touchstart/pointerdown, so we don't want to overwrite
+        // it with "false" on later events when our shim for it on touch events might not be
+        // accurate
+        if (event.isPrimary)
+        {
+            this.isPrimary = true;
+        }
+        this.button = event.button;
+        this.buttons = event.buttons;
+        this.width = event.width;
+        this.height = event.height;
+        this.tiltX = event.tiltX;
+        this.tiltY = event.tiltY;
+        this.pointerType = event.pointerType;
+        this.pressure = event.pressure;
+        this.rotationAngle = event.rotationAngle;
+        this.twist = event.twist || 0;
+        this.tangentialPressure = event.tangentialPressure || 0;
+    }
+
+    /**
+     * Resets the data for pooling.
+     *
+     * @private
+     */
+    _reset()
+    {
+        // isPrimary is the only property that we really need to reset - everything else is
+        // guaranteed to be overwritten
+        this.isPrimary = false;
     }
 }

--- a/src/interaction/InteractionData.js
+++ b/src/interaction/InteractionData.js
@@ -47,18 +47,21 @@ export default class InteractionData
          * @type {Boolean}
          */
         this.isPrimary = false;
+
         /**
          * Indicates which button was pressed on the mouse or pointer device to trigger the event.
          * @see https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
          * @type {number}
          */
         this.button = 0;
+
         /**
          * Indicates which buttons are pressed on the mouse or pointer device when the event is triggered.
          * @see https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
          * @type {number}
          */
         this.buttons = 0;
+
         /**
          * The width of the pointer's contact along the x-axis, measured in CSS pixels.
          * radiusX of TouchEvents will be represented by this value.
@@ -66,6 +69,7 @@ export default class InteractionData
          * @type {number}
          */
         this.width = 0;
+
         /**
          * The height of the pointer's contact along the y-axis, measured in CSS pixels.
          * radiusY of TouchEvents will be represented by this value.
@@ -73,24 +77,28 @@ export default class InteractionData
          * @type {number}
          */
         this.height = 0;
+
         /**
          * The angle, in degrees, between the pointer device and the screen.
          * @see https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/tiltX
          * @type {number}
          */
         this.tiltX = 0;
+
         /**
          * The angle, in degrees, between the pointer device and the screen.
          * @see https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/tiltY
          * @type {number}
          */
         this.tiltY = 0;
+
         /**
          * The type of pointer that triggered the event.
          * @see https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/pointerType
          * @type {string}
          */
         this.pointerType = null;
+
         /**
          * Pressure applied by the pointing device during the event. A Touch's force property
          * will be represented by this value.
@@ -98,18 +106,21 @@ export default class InteractionData
          * @type {number}
          */
         this.pressure = 0;
+
         /**
          * From TouchEvents (not PointerEvents triggered by touches), the rotationAngle of the Touch.
          * @see https://developer.mozilla.org/en-US/docs/Web/API/Touch/rotationAngle
          * @type {number}
          */
         this.rotationAngle = 0;
+
         /**
          * Twist of a stylus pointer.
          * @see https://w3c.github.io/pointerevents/#pointerevent-interface
          * @type {number}
          */
         this.twist = 0;
+
         /**
          * Barrel pressure on a stylus pointer.
          * @see https://w3c.github.io/pointerevents/#pointerevent-interface

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -1382,19 +1382,25 @@ export default class InteractionManager extends EventEmitter
     {
         const pointerId = event.pointerId;
 
+        let interactionData;
+
         if (pointerId === MOUSE_POINTER_ID || event.pointerType === 'mouse')
         {
-            return this.mouse;
+            interactionData = this.mouse;
         }
         else if (this.activeInteractionData[pointerId])
         {
-            return this.activeInteractionData[pointerId];
+            interactionData = this.activeInteractionData[pointerId];
         }
-
-        const interactionData = this.interactionDataPool.pop() || new InteractionData();
-
-        interactionData.identifier = pointerId;
-        this.activeInteractionData[pointerId] = interactionData;
+        else
+        {
+            interactionData = this.interactionDataPool.pop() || new InteractionData();
+            interactionData.identifier = pointerId;
+            this.activeInteractionData[pointerId] = interactionData;
+        }
+        // copy properties from the event, so that we can make sure that touch/pointer specific
+        // data is available
+        interactionData._copyEvent(event);
 
         return interactionData;
     }
@@ -1412,6 +1418,7 @@ export default class InteractionManager extends EventEmitter
         if (interactionData)
         {
             delete this.activeInteractionData[pointerId];
+            interactionData._reset();
             this.interactionDataPool.push(interactionData);
         }
     }
@@ -1473,7 +1480,10 @@ export default class InteractionManager extends EventEmitter
 
                 if (typeof touch.button === 'undefined') touch.button = event.touches.length ? 1 : 0;
                 if (typeof touch.buttons === 'undefined') touch.buttons = event.touches.length ? 1 : 0;
-                if (typeof touch.isPrimary === 'undefined') touch.isPrimary = event.touches.length === 1;
+                if (typeof touch.isPrimary === 'undefined')
+                {
+                    touch.isPrimary = event.touches.length === 1 && event.type === 'touchstart';
+                }
                 if (typeof touch.width === 'undefined') touch.width = touch.radiusX || 1;
                 if (typeof touch.height === 'undefined') touch.height = touch.radiusY || 1;
                 if (typeof touch.tiltX === 'undefined') touch.tiltX = 0;
@@ -1481,8 +1491,10 @@ export default class InteractionManager extends EventEmitter
                 if (typeof touch.pointerType === 'undefined') touch.pointerType = 'touch';
                 if (typeof touch.pointerId === 'undefined') touch.pointerId = touch.identifier || 0;
                 if (typeof touch.pressure === 'undefined') touch.pressure = touch.force || 0.5;
-                if (typeof touch.rotation === 'undefined') touch.rotation = touch.rotationAngle || 0;
-
+                touch.twist = 0;
+                touch.tangentialPressure = 0;
+                // TODO: Remove these, as layerX/Y is not a standard, deprecated, with uneven
+                // support, and the fill ins are not quite the same
                 if (typeof touch.layerX === 'undefined') touch.layerX = touch.offsetX = touch.clientX;
                 if (typeof touch.layerY === 'undefined') touch.layerY = touch.offsetY = touch.clientY;
 
@@ -1503,7 +1515,8 @@ export default class InteractionManager extends EventEmitter
             if (typeof event.pointerType === 'undefined') event.pointerType = 'mouse';
             if (typeof event.pointerId === 'undefined') event.pointerId = MOUSE_POINTER_ID;
             if (typeof event.pressure === 'undefined') event.pressure = 0.5;
-            if (typeof event.rotation === 'undefined') event.rotation = 0;
+            event.twist = 0;
+            event.tangentialPressure = 0;
 
             // mark the mouse event as normalized, just so that we know we did it
             event.isNormalized = true;

--- a/test/interaction/InteractionManager.js
+++ b/test/interaction/InteractionManager.js
@@ -1198,4 +1198,34 @@ describe('PIXI.interaction.InteractionManager', function ()
             expect(pointer.interaction.activeInteractionData[42]).to.be.undefined;
         });
     });
+
+    describe('InteractionData properties', function ()
+    {
+        it('isPrimary should be set for first touch only', function ()
+        {
+            const stage = new PIXI.Container();
+            const graphics = new PIXI.Graphics();
+            const pointer = this.pointer = new MockPointer(stage);
+
+            stage.addChild(graphics);
+            graphics.beginFill(0xFFFFFF);
+            graphics.drawRect(0, 0, 50, 50);
+            graphics.interactive = true;
+
+            pointer.touchstart(10, 10, 1);
+            expect(pointer.interaction.activeInteractionData[1]).to.exist;
+            expect(pointer.interaction.activeInteractionData[1].isPrimary,
+                    'first touch should be primary on touch start').to.be.true;
+            pointer.touchstart(13, 9, 2);
+            expect(pointer.interaction.activeInteractionData[2].isPrimary,
+                    'second touch should not be primary').to.be.false;
+            pointer.touchmove(10, 20, 1);
+            expect(pointer.interaction.activeInteractionData[1].isPrimary,
+                    'first touch should still be primary after move').to.be.true;
+            pointer.touchend(10, 10, 1);
+            pointer.touchmove(13, 29, 2);
+            expect(pointer.interaction.activeInteractionData[2].isPrimary,
+                    'second touch should still not be primary after first is done').to.be.false;
+        });
+    });
 });


### PR DESCRIPTION
Fixes #3886 by exposing normalized pointer event data on InteractionData:
**Properties from PointerEvent:**
`isPrimary`, `button`, `buttons`, `width`, `height`, `tiltX`, `tiltY`, `pointerType`, `pressure`, `twist`, `tangentialPressure`.
**Properties from Touch:**
`rotationAngle`
**Properties from Touch normalized to PointerEvent standards:**
* `radiusX` -> `width`
* `radiusY` -> `height`
* `force` -> `pressure`