### PR TITLE
Hot-fix for Ticker's destroy

### DIFF
--- a/src/core/ticker/Ticker.js
+++ b/src/core/ticker/Ticker.js
@@ -389,15 +389,19 @@ export default class Ticker
 
             this.deltaTime = elapsedMS * settings.TARGET_FPMS * this.speed;
 
+            // Cache a local reference, in-case ticker is destroyed
+            // during the emit, we can still check for head.next
+            const head = this._head;
+
             // Invoke listeners added to internal emitter
-            let listener = this._head.next;
+            let listener = head.next;
 
             while (listener)
             {
                 listener = listener.emit(this.deltaTime);
             }
 
-            if (!this._head.next)
+            if (!head.next)
             {
                 this._cancelIfNeeded();
             }

--- a/test/core/Ticker.js
+++ b/test/core/Ticker.js
@@ -303,13 +303,20 @@ describe('PIXI.ticker.Ticker', function ()
     it('should destroy on listener', function (done)
     {
         const ticker = new Ticker();
+        const listener2 = sinon.spy();
         const listener = sinon.spy(() =>
         {
             ticker.destroy();
-            done();
+            setTimeout(() =>
+            {
+                expect(listener2.called).to.be.false;
+                expect(listener.calledOnce).to.be.true;
+                done();
+            }, 0);
         });
 
         ticker.add(listener);
+        ticker.add(listener2, null, PIXI.UPDATE_PRIORITY.LOW);
         ticker.start();
     });
 });

--- a/test/core/Ticker.js
+++ b/test/core/Ticker.js
@@ -299,4 +299,17 @@ describe('PIXI.ticker.Ticker', function ()
 
         expect(this.length()).to.equal(length);
     });
+
+    it('should destroy on listener', function (done)
+    {
+        const ticker = new Ticker();
+        const listener = sinon.spy(() =>
+        {
+            ticker.destroy();
+            done();
+        });
+
+        ticker.add(listener);
+        ticker.start();
+    });
 });


### PR DESCRIPTION
### Fixed

* Resolves issue when destroying Ticker on listener callback which generates this error:
![screen shot 2017-04-03 at 10 09 47 am](https://cloud.githubusercontent.com/assets/864393/24613493/7b08eb5c-1856-11e7-92d9-20d1c330b45f.png)
* Adds an additional unit-test to handle this case. 