### PR TITLE
Documentation Updates: namespaces & plugins

### DIFF
--- a/scripts/jsdoc.conf.json
+++ b/scripts/jsdoc.conf.json
@@ -43,7 +43,7 @@
     },
     "markdown"  : {
         "parser"        : "gfm",
-        "hardwrap"      : true
+        "hardwrap"      : false
     },
     "opts": {
         "encoding"      : "utf8",

--- a/src/accessibility/AccessibilityManager.js
+++ b/src/accessibility/AccessibilityManager.js
@@ -21,7 +21,7 @@ const DIV_HOOK_POS_Y = -1000;
 const DIV_HOOK_ZINDEX = 2;
 
 /**
- * The Accessibility manager reacreates the ability to tab and and have content read by screen
+ * The Accessibility manager recreates the ability to tab and and have content read by screen
  * readers. This is very important as it can possibly help people with disabilities access pixi
  * content.
  *

--- a/src/accessibility/index.js
+++ b/src/accessibility/index.js
@@ -1,4 +1,8 @@
 /**
+ * This namespace contains a renderer plugin for interaction accessibility for end-users
+ * with physical impairments which require screen-renders, keyboard navigation, etc.
+ *
+ * Do not instanciate this plugin directly. It is available from the `plugins` renderer property.
  * @namespace PIXI.accessibility
  */
 export { default as accessibleTarget } from './accessibleTarget';

--- a/src/accessibility/index.js
+++ b/src/accessibility/index.js
@@ -2,7 +2,8 @@
  * This namespace contains a renderer plugin for interaction accessibility for end-users
  * with physical impairments which require screen-renders, keyboard navigation, etc.
  *
- * Do not instanciate this plugin directly. It is available from the `plugins` renderer property.
+ * Do not instanciate this plugin directly. It is available from the `renderer.plugins` property.
+ * See {@link PIXI.CanvasRenderer#plugins} or {@link PIXI.WebGLRenderer#plugins}.
  * @namespace PIXI.accessibility
  */
 export { default as accessibleTarget } from './accessibleTarget';

--- a/src/accessibility/index.js
+++ b/src/accessibility/index.js
@@ -2,7 +2,7 @@
  * This namespace contains a renderer plugin for interaction accessibility for end-users
  * with physical impairments which require screen-renders, keyboard navigation, etc.
  *
- * Do not instanciate this plugin directly. It is available from the `renderer.plugins` property.
+ * Do not instantiate this plugin directly. It is available from the `renderer.plugins` property.
  * See {@link PIXI.CanvasRenderer#plugins} or {@link PIXI.WebGLRenderer#plugins}.
  * @namespace PIXI.accessibility
  */

--- a/src/core/renderers/canvas/CanvasRenderer.js
+++ b/src/core/renderers/canvas/CanvasRenderer.js
@@ -304,7 +304,7 @@ export default class CanvasRenderer extends SystemRenderer
  * Collection of installed plugins.
  * @name PIXI.CanvasRenderer#plugins
  * @type {object}
- * @readOnly
+ * @readonly
  * @property {PIXI.accessibility.AccessibilityManager} accessibility Support tabbing interactive elements.
  * @property {PIXI.extract.CanvasExtract} extract Extract image data from renderer.
  * @property {PIXI.interaction.InteractionManager} interaction Handles mouse, touch and pointer events.

--- a/src/core/renderers/canvas/CanvasRenderer.js
+++ b/src/core/renderers/canvas/CanvasRenderer.js
@@ -301,7 +301,8 @@ export default class CanvasRenderer extends SystemRenderer
 }
 
 /**
- * Collection of installed plugins.
+ * Collection of installed plugins. These are included by default in PIXI, but can be excluded
+ * by creating a custom build.
  * @name PIXI.CanvasRenderer#plugins
  * @type {object}
  * @readonly

--- a/src/core/renderers/canvas/CanvasRenderer.js
+++ b/src/core/renderers/canvas/CanvasRenderer.js
@@ -300,4 +300,23 @@ export default class CanvasRenderer extends SystemRenderer
     }
 }
 
+/**
+ * Collection of installed plugins.
+ * @name PIXI.CanvasRenderer#plugins
+ * @type {object}
+ * @readOnly
+ * @property {PIXI.accessibility.AccessibilityManager} accessibility Support tabbing interactive elements.
+ * @property {PIXI.extract.CanvasExtract} extract Extract image data from renderer.
+ * @property {PIXI.interaction.InteractionManager} interaction Handles mouse, touch and pointer events.
+ * @property {PIXI.prepare.CanvasPrepare} prepare Pre-render display objects.
+ */
+
+/**
+ * Adds a plugin to the renderer.
+ *
+ * @method PIXI.CanvasRenderer#registerPlugin
+ * @param {string} pluginName - The name of the plugin.
+ * @param {Function} ctor - The constructor function or class for the plugin.
+ */
+
 pluginTarget.mixin(CanvasRenderer);

--- a/src/core/renderers/canvas/CanvasRenderer.js
+++ b/src/core/renderers/canvas/CanvasRenderer.js
@@ -302,7 +302,8 @@ export default class CanvasRenderer extends SystemRenderer
 
 /**
  * Collection of installed plugins. These are included by default in PIXI, but can be excluded
- * by creating a custom build.
+ * by creating a custom build. Consult the README for more information about creating custom
+ * builds and excluding plugins.
  * @name PIXI.CanvasRenderer#plugins
  * @type {object}
  * @readonly

--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -707,4 +707,23 @@ export default class WebGLRenderer extends SystemRenderer
     }
 }
 
+/**
+ * Collection of installed plugins.
+ * @name PIXI.WebGLRenderer#plugins
+ * @type {object}
+ * @readOnly
+ * @property {PIXI.accessibility.AccessibilityManager} accessibility Support tabbing interactive elements.
+ * @property {PIXI.extract.WebGLExtract} extract Extract image data from renderer.
+ * @property {PIXI.interaction.InteractionManager} interaction Handles mouse, touch and pointer events.
+ * @property {PIXI.prepare.WebGLPrepare} prepare Pre-render display objects.
+ */
+
+/**
+ * Adds a plugin to the renderer.
+ *
+ * @method PIXI.WebGLRenderer#registerPlugin
+ * @param {string} pluginName - The name of the plugin.
+ * @param {Function} ctor - The constructor function or class for the plugin.
+ */
+
 pluginTarget.mixin(WebGLRenderer);

--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -711,7 +711,7 @@ export default class WebGLRenderer extends SystemRenderer
  * Collection of installed plugins.
  * @name PIXI.WebGLRenderer#plugins
  * @type {object}
- * @readOnly
+ * @readonly
  * @property {PIXI.accessibility.AccessibilityManager} accessibility Support tabbing interactive elements.
  * @property {PIXI.extract.WebGLExtract} extract Extract image data from renderer.
  * @property {PIXI.interaction.InteractionManager} interaction Handles mouse, touch and pointer events.

--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -708,7 +708,9 @@ export default class WebGLRenderer extends SystemRenderer
 }
 
 /**
- * Collection of installed plugins.
+ * Collection of installed plugins. These are included by default in PIXI, but can be excluded
+ * by creating a custom build. Consult the README for more information about creating custom
+ * builds and excluding plugins.
  * @name PIXI.WebGLRenderer#plugins
  * @type {object}
  * @readonly

--- a/src/core/settings.js
+++ b/src/core/settings.js
@@ -2,6 +2,8 @@ import maxRecommendedTextures from './utils/maxRecommendedTextures';
 import canUploadSameBuffer from './utils/canUploadSameBuffer';
 
 /**
+ * User's customizable globals for overriding the default PIXI settings, such
+ * as a renderer's default resolution, framerate, float percision, etc. 
  * @namespace PIXI.settings
  */
 export default {

--- a/src/core/settings.js
+++ b/src/core/settings.js
@@ -3,7 +3,7 @@ import canUploadSameBuffer from './utils/canUploadSameBuffer';
 
 /**
  * User's customizable globals for overriding the default PIXI settings, such
- * as a renderer's default resolution, framerate, float percision, etc. 
+ * as a renderer's default resolution, framerate, float percision, etc.
  * @namespace PIXI.settings
  */
 export default {

--- a/src/core/ticker/index.js
+++ b/src/core/ticker/index.js
@@ -53,7 +53,7 @@ shared.destroy = () =>
 };
 
 /**
- * This namespace contains an API for interacting with PIXI's internal global loop.
+ * This namespace contains an API for interacting with PIXI's internal global update loop.
  *
  * This ticker is used for rendering, {@link PIXI.extras.AnimatedSprite AnimatedSprite},
  * {@link PIXI.interaction.InteractionManager InteractionManager} and many other time-based PIXI systems.

--- a/src/core/ticker/index.js
+++ b/src/core/ticker/index.js
@@ -53,7 +53,7 @@ shared.destroy = () =>
 };
 
 /**
- * This namespaces contains an API for interacting with PIXI's internal global loop.
+ * This namespace contains an API for interacting with PIXI's internal global loop.
  *
  * This ticker is used for rendering, {@link PIXI.extras.AnimatedSprite AnimatedSprite},
  * {@link PIXI.interaction.InteractionManager InteractionManager} and many other time-based PIXI systems.

--- a/src/core/ticker/index.js
+++ b/src/core/ticker/index.js
@@ -53,6 +53,9 @@ shared.destroy = () =>
 };
 
 /**
+ * This namespaces contains an API for interacting with PIXI's internal global loop.
+ *
+ * This ticker is used for rendering, {@link PIXI.extras.AnimatedSprite AnimatedSprite}, {@link PIXI.interaction.InteractionManager InteractionManager} and many other time-based PIXI systems.
  * @namespace PIXI.ticker
  */
 export { shared, Ticker };

--- a/src/core/ticker/index.js
+++ b/src/core/ticker/index.js
@@ -55,7 +55,8 @@ shared.destroy = () =>
 /**
  * This namespaces contains an API for interacting with PIXI's internal global loop.
  *
- * This ticker is used for rendering, {@link PIXI.extras.AnimatedSprite AnimatedSprite}, {@link PIXI.interaction.InteractionManager InteractionManager} and many other time-based PIXI systems.
+ * This ticker is used for rendering, {@link PIXI.extras.AnimatedSprite AnimatedSprite},
+ * {@link PIXI.interaction.InteractionManager InteractionManager} and many other time-based PIXI systems.
  * @namespace PIXI.ticker
  */
 export { shared, Ticker };

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -9,6 +9,7 @@ let nextUid = 0;
 let saidHello = false;
 
 /**
+ * Generalized convenience utilities for PIXI.
  * @namespace PIXI.utils
  */
 export {

--- a/src/extract/canvas/CanvasExtract.js
+++ b/src/extract/canvas/CanvasExtract.js
@@ -8,7 +8,7 @@ const TEMP_RECT = new core.Rectangle();
  * An instance of this class is automatically created by default, and can be found at renderer.plugins.extract
  *
  * @class
- * @memberof PIXI
+ * @memberof PIXI.extract
  */
 export default class CanvasExtract
 {
@@ -21,9 +21,9 @@ export default class CanvasExtract
         /**
          * Collection of methods for extracting data (image, pixels, etc.) from a display object or render texture
          *
-         * @member {PIXI.CanvasExtract} extract
+         * @member {PIXI.extract.CanvasExtract} extract
          * @memberof PIXI.CanvasRenderer#
-         * @see PIXI.CanvasExtract
+         * @see PIXI.extract.CanvasExtract
          */
         renderer.extract = this;
     }

--- a/src/extract/index.js
+++ b/src/extract/index.js
@@ -2,7 +2,7 @@
  * This namespace provides renderer-specific plugins for exporting content from a renderer.
  * For instance, these plugins can be used for saving an Image, Canvas element or for exporting the raw image data (pixels).
  *
- * Do not instanciate these plugins directly. It is available from the `renderer.plugins` property.
+ * Do not instantiate these plugins directly. It is available from the `renderer.plugins` property.
  * See {@link PIXI.CanvasRenderer#plugins} or {@link PIXI.WebGLRenderer#plugins}.
  * @namespace PIXI.extract
  */

--- a/src/extract/index.js
+++ b/src/extract/index.js
@@ -1,2 +1,9 @@
+/**
+ * This namespace provides renderer-specific plugins for exporting content from a renderer.
+ * For instance, these plugins can be used for saving an Image, Canvas element or for exporting the raw image data (pixels).
+ *
+ * Do not instanciate these plugins directly. They are available from the `plugins` renderer property.
+ * @namespace PIXI.extract
+ */
 export { default as webgl } from './webgl/WebGLExtract';
 export { default as canvas } from './canvas/CanvasExtract';

--- a/src/extract/index.js
+++ b/src/extract/index.js
@@ -2,7 +2,8 @@
  * This namespace provides renderer-specific plugins for exporting content from a renderer.
  * For instance, these plugins can be used for saving an Image, Canvas element or for exporting the raw image data (pixels).
  *
- * Do not instanciate these plugins directly. They are available from the `plugins` renderer property.
+ * Do not instanciate these plugins directly. It is available from the `renderer.plugins` property.
+ * See {@link PIXI.CanvasRenderer#plugins} or {@link PIXI.WebGLRenderer#plugins}.
  * @namespace PIXI.extract
  */
 export { default as webgl } from './webgl/WebGLExtract';

--- a/src/extract/webgl/WebGLExtract.js
+++ b/src/extract/webgl/WebGLExtract.js
@@ -9,7 +9,7 @@ const BYTES_PER_PIXEL = 4;
  * An instance of this class is automatically created by default, and can be found at renderer.plugins.extract
  *
  * @class
- * @memberof PIXI
+ * @memberof PIXI.extract
  */
 export default class WebGLExtract
 {
@@ -22,9 +22,9 @@ export default class WebGLExtract
         /**
          * Collection of methods for extracting data (image, pixels, etc.) from a display object or render texture
          *
-         * @member {PIXI.WebGLExtract} extract
+         * @member {PIXI.extract.WebGLExtract} extract
          * @memberof PIXI.WebGLRenderer#
-         * @see PIXI.WebGLExtract
+         * @see PIXI.extract.WebGLExtract
          */
         renderer.extract = this;
     }

--- a/src/extras/index.js
+++ b/src/extras/index.js
@@ -1,4 +1,5 @@
 /**
+ * Additional PIXI DisplayObjects for animation, tiling and bitmap text.
  * @namespace PIXI.extras
  */
 export { default as AnimatedSprite } from './AnimatedSprite';

--- a/src/filters/index.js
+++ b/src/filters/index.js
@@ -1,4 +1,6 @@
 /**
+ * This namespace contains WebGL-only display filters that can be applied
+ * to DisplayObjects using the {@link PIXI.DisplayObject#filters filters} property.
  * @namespace PIXI.filters
  */
 export { default as FXAAFilter } from './fxaa/FXAAFilter';

--- a/src/interaction/index.js
+++ b/src/interaction/index.js
@@ -1,7 +1,8 @@
 /**
  * This namespace contains a renderer plugin for handling mouse, pointer, and touch events.
  *
- * Do not instanciate this plugin directly. It is available from the `plugins` renderer property.
+ * Do not instanciate this plugin directly. It is available from the `renderer.plugins` property.
+ * See {@link PIXI.CanvasRenderer#plugins} or {@link PIXI.WebGLRenderer#plugins}.
  * @namespace PIXI.interaction
  */
 export { default as InteractionData } from './InteractionData';

--- a/src/interaction/index.js
+++ b/src/interaction/index.js
@@ -1,4 +1,7 @@
 /**
+ * This namespace contains a renderer plugin for handling mouse, pointer, and touch events.
+ *
+ * Do not instanciate this plugin directly. It is available from the `plugins` renderer property.
  * @namespace PIXI.interaction
  */
 export { default as InteractionData } from './InteractionData';

--- a/src/interaction/index.js
+++ b/src/interaction/index.js
@@ -1,7 +1,7 @@
 /**
  * This namespace contains a renderer plugin for handling mouse, pointer, and touch events.
  *
- * Do not instanciate this plugin directly. It is available from the `renderer.plugins` property.
+ * Do not instantiate this plugin directly. It is available from the `renderer.plugins` property.
  * See {@link PIXI.CanvasRenderer#plugins} or {@link PIXI.WebGLRenderer#plugins}.
  * @namespace PIXI.interaction
  */

--- a/src/loaders/index.js
+++ b/src/loaders/index.js
@@ -1,4 +1,6 @@
 /**
+ * This namespace contains APIs which extends the {@link https://github.com/englercj/resource-loader resource-loader} module
+ * for loading assets, data, and other resources dynamically.
  * @namespace PIXI.loaders
  */
 export { default as Loader } from './loader';

--- a/src/prepare/index.js
+++ b/src/prepare/index.js
@@ -1,4 +1,8 @@
 /**
+ * The prepare namespace provides renderer-specific plugins for pre-rendering DisplayObjects. These plugins are useful for
+ * asynchronously preparing assets, textures, graphics waiting to be displayed.
+ *
+ * Do not instanciate these plugins directly. They are available from the `plugins` renderer property.
  * @namespace PIXI.prepare
  */
 export { default as webgl } from './webgl/WebGLPrepare';

--- a/src/prepare/index.js
+++ b/src/prepare/index.js
@@ -2,7 +2,7 @@
  * The prepare namespace provides renderer-specific plugins for pre-rendering DisplayObjects. These plugins are useful for
  * asynchronously preparing assets, textures, graphics waiting to be displayed.
  *
- * Do not instanciate these plugins directly. It is available from the `renderer.plugins` property.
+ * Do not instantiate these plugins directly. It is available from the `renderer.plugins` property.
  * See {@link PIXI.CanvasRenderer#plugins} or {@link PIXI.WebGLRenderer#plugins}.
  * @namespace PIXI.prepare
  */

--- a/src/prepare/index.js
+++ b/src/prepare/index.js
@@ -2,7 +2,8 @@
  * The prepare namespace provides renderer-specific plugins for pre-rendering DisplayObjects. These plugins are useful for
  * asynchronously preparing assets, textures, graphics waiting to be displayed.
  *
- * Do not instanciate these plugins directly. They are available from the `plugins` renderer property.
+ * Do not instanciate these plugins directly. It is available from the `renderer.plugins` property.
+ * See {@link PIXI.CanvasRenderer#plugins} or {@link PIXI.WebGLRenderer#plugins}.
  * @namespace PIXI.prepare
  */
 export { default as webgl } from './webgl/WebGLPrepare';


### PR DESCRIPTION
### Added

* Adds documentation for missing namespaces like `PIXI.extract`, `PIXI.extras`, etc.
* Adds documentation for `plugins` on the CanvasRenderer and WebGLRenderer.

### Changed

* Added CanvasExtract and WebGLExtract classes to `PIXI.extract` namespace instead of on the global `PIXI` object (mirrors how `prepare` is documented).
* Disables `hardwrap` JSdoc setting because ESLint enforces a line-length limit.

This addresses #3876

#### Preview

https://pixijs.download/docs/docs/index.html