### PR TITLE
Application loader support

### DIFF
--- a/src/core/Application.js
+++ b/src/core/Application.js
@@ -39,6 +39,7 @@ export default class Application
      * @param {boolean} [options.legacy=false] - If true Pixi will aim to ensure compatibility
      * with older / less advanced devices. If you experience unexplained flickering try setting this to true.
      * @param {boolean} [options.sharedTicker=false] - `true` to use PIXI.ticker.shared, `false` to create new ticker.
+     * @param {boolean} [options.sharedLoader=false] - `true` to use PIXI.loaders.shared, `false` to create new Loader.
      */
     constructor(options, arg2, arg3, arg4, arg5)
     {
@@ -53,10 +54,15 @@ export default class Application
             }, arg3);
         }
 
-        // Set the default options
-        options = Object.assign({
+        /**
+         * The default options, so we mixin functionality later.
+         * @member {object}
+         * @protected
+         */
+        this._options = options = Object.assign({
             sharedTicker: false,
             forceCanvas: false,
+            sharedLoader: false,
         }, options);
 
         /**
@@ -167,5 +173,7 @@ export default class Application
 
         this.renderer.destroy(removeView);
         this.renderer = null;
+
+        this._options = null;
     }
 }

--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -527,6 +527,23 @@ Object.defineProperties(core, {
             return core.settings.RENDER_OPTIONS;
         },
     },
+
+    /**
+     * @static
+     * @constant
+     * @name PIXI.loader
+     * @see PIXI.loaders.shared
+     * @deprecated since version 4.5.0
+     */
+    loader: {
+        enumerable: true,
+        get()
+        {
+            warn('PIXI.loader is deprecated, please used PIXI.loaders.shared');
+
+            return loaders.shared || null;
+        },
+    },
 });
 
 // Move the default properties to settings
@@ -998,67 +1015,73 @@ Object.defineProperty(prepare.webgl, 'UPLOADS_PER_FRAME', {
     },
 });
 
-Object.defineProperties(loaders.Resource.prototype, {
-    isJson: {
-        get()
-        {
-            warn('The isJson property is deprecated, please use `resource.type === Resource.TYPE.JSON`.');
+if (loaders.Loader)
+{
+    const Resource = loaders.Resource;
+    const Loader = loaders.Loader;
 
-            return this.type === loaders.Loader.Resource.TYPE.JSON;
+    Object.defineProperties(Resource.prototype, {
+        isJson: {
+            get()
+            {
+                warn('The isJson property is deprecated, please use `resource.type === Resource.TYPE.JSON`.');
+
+                return this.type === Resource.TYPE.JSON;
+            },
         },
-    },
-    isXml: {
-        get()
-        {
-            warn('The isXml property is deprecated, please use `resource.type === Resource.TYPE.XML`.');
+        isXml: {
+            get()
+            {
+                warn('The isXml property is deprecated, please use `resource.type === Resource.TYPE.XML`.');
 
-            return this.type === loaders.Loader.Resource.TYPE.XML;
+                return this.type === Resource.TYPE.XML;
+            },
         },
-    },
-    isImage: {
-        get()
-        {
-            warn('The isImage property is deprecated, please use `resource.type === Resource.TYPE.IMAGE`.');
+        isImage: {
+            get()
+            {
+                warn('The isImage property is deprecated, please use `resource.type === Resource.TYPE.IMAGE`.');
 
-            return this.type === loaders.Loader.Resource.TYPE.IMAGE;
+                return this.type === Resource.TYPE.IMAGE;
+            },
         },
-    },
-    isAudio: {
-        get()
-        {
-            warn('The isAudio property is deprecated, please use `resource.type === Resource.TYPE.AUDIO`.');
+        isAudio: {
+            get()
+            {
+                warn('The isAudio property is deprecated, please use `resource.type === Resource.TYPE.AUDIO`.');
 
-            return this.type === loaders.Loader.Resource.TYPE.AUDIO;
+                return this.type === Resource.TYPE.AUDIO;
+            },
         },
-    },
-    isVideo: {
-        get()
-        {
-            warn('The isVideo property is deprecated, please use `resource.type === Resource.TYPE.VIDEO`.');
+        isVideo: {
+            get()
+            {
+                warn('The isVideo property is deprecated, please use `resource.type === Resource.TYPE.VIDEO`.');
 
-            return this.type === loaders.Loader.Resource.TYPE.VIDEO;
+                return this.type === Resource.TYPE.VIDEO;
+            },
         },
-    },
-});
+    });
 
-Object.defineProperties(loaders.Loader.prototype, {
-    before: {
-        get()
-        {
-            warn('The before() method is deprecated, please use pre().');
+    Object.defineProperties(Loader.prototype, {
+        before: {
+            get()
+            {
+                warn('The before() method is deprecated, please use pre().');
 
-            return this.pre;
+                return this.pre;
+            },
         },
-    },
-    after: {
-        get()
-        {
-            warn('The after() method is deprecated, please use use().');
+        after: {
+            get()
+            {
+                warn('The after() method is deprecated, please use use().');
 
-            return this.use;
+                return this.use;
+            },
         },
-    },
-});
+    });
+}
 
 /**
  * @name PIXI.interaction.interactiveTarget#defaultCursor

--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -527,23 +527,6 @@ Object.defineProperties(core, {
             return core.settings.RENDER_OPTIONS;
         },
     },
-
-    /**
-     * @static
-     * @constant
-     * @name PIXI.loader
-     * @see PIXI.loaders.shared
-     * @deprecated since version 4.5.0
-     */
-    loader: {
-        enumerable: true,
-        get()
-        {
-            warn('PIXI.loader is deprecated, please used PIXI.loaders.shared');
-
-            return loaders.shared || null;
-        },
-    },
 });
 
 // Move the default properties to settings

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,14 @@ import * as prepare from './prepare';
 import { utils } from './core';
 utils.mixins.performMixins();
 
+/**
+ * Alias for {@link PIXI.loaders.shared}.
+ * @name loader
+ * @memberof PIXI
+ * @type {PIXI.loader.Loader}
+ */
+const loader = loaders.shared || null;
+
 export {
     accessibility,
     extract,
@@ -30,6 +38,7 @@ export {
     mesh,
     particles,
     prepare,
+    loader,
 };
 
 // Always export pixi globally.

--- a/src/index.js
+++ b/src/index.js
@@ -32,16 +32,5 @@ export {
     prepare,
 };
 
-/**
- * A premade instance of the loader that can be used to load resources.
- *
- * @name loader
- * @memberof PIXI
- * @property {PIXI.loaders.Loader}
- */
-const loader = loaders && loaders.Loader ? new loaders.Loader() : null; // check is there in case user excludes loader lib
-
-export { loader };
-
 // Always export pixi globally.
 global.PIXI = exports; // eslint-disable-line

--- a/src/loaders/index.js
+++ b/src/loaders/index.js
@@ -1,7 +1,10 @@
+import Application from '../core/Application';
+import Loader from './loader';
+
 /**
  * @namespace PIXI.loaders
  */
-export { default as Loader } from './loader';
+export { Loader };
 export { default as bitmapFontParser, parse as parseBitmapFontData } from './bitmapFontParser';
 export { default as spritesheetParser, getResourcePath } from './spritesheetParser';
 export { default as textureParser } from './textureParser';
@@ -13,3 +16,55 @@ export { default as textureParser } from './textureParser';
  * @memberof PIXI.loaders
  */
 export { Resource } from 'resource-loader';
+
+/**
+ * A premade instance of the loader that can be used to load resources.
+ * @name shared
+ * @memberof PIXI.loaders
+ * @property {PIXI.loaders.Loader}
+ */
+const shared = new Loader();
+
+shared.destroy = () =>
+{
+    // protect destroying shared loader
+};
+
+export { shared };
+
+// Mixin the loader construction
+const AppPrototype = Application.prototype;
+
+AppPrototype._loader = null;
+
+/**
+ * Loader instance to help with asset loading.
+ * @name PIXI.Application#loader
+ * @type {PIXI.loaders.Loader}
+ */
+Object.defineProperty(AppPrototype, 'loader', {
+    get()
+    {
+        if (!this._loader)
+        {
+            const sharedLoader = this._options.sharedLoader;
+
+            this._loader = sharedLoader ? shared : new Loader();
+        }
+
+        return this._loader;
+    },
+});
+
+// Override the destroy function
+// making sure to destroy the current Loader
+AppPrototype._parentDestroy = AppPrototype.destroy;
+AppPrototype.destroy = function destroy()
+{
+    if (this._loader)
+    {
+        this._loader.destroy();
+        this._loader = null;
+    }
+    this._parentDestroy();
+};

--- a/src/loaders/index.js
+++ b/src/loaders/index.js
@@ -23,7 +23,7 @@ export { Resource } from 'resource-loader';
  * A premade instance of the loader that can be used to load resources.
  * @name shared
  * @memberof PIXI.loaders
- * @property {PIXI.loaders.Loader}
+ * @type {PIXI.loaders.Loader}
  */
 const shared = new Loader();
 

--- a/src/loaders/loader.js
+++ b/src/loaders/loader.js
@@ -90,6 +90,15 @@ export default class Loader extends ResourceLoader
     {
         Loader._pixiMiddleware.push(fn);
     }
+
+    /**
+     * Destroy the loader, removes references.
+     */
+    destroy()
+    {
+        this.removeAllListeners();
+        this.reset();
+    }
 }
 
 // Copy EE3 prototype (mixin)


### PR DESCRIPTION
Adds convenience support for loader to the Application class. 
```js
const app = new PIXI.Application();

// Pause rendering
app.stop(); 

// Load some resources
app.loader
    .add('logo', 'images/logo.png');
    .load(() => {
       app.start(); // resume rendering
    });
```

### Added

* Adds `loader` property the Application class, e.g., `app.loader.load()`
* Adds constructor argument `options.sharedLoader` to Application to opt-in to using the shared Loader.
* Adds `PIXI.loaders.shared` as an alias for `PIXI.loader` (conforms to Ticker usage `PIXI.ticker.shared`).

### Fixed

* Fixes issue when excluding the loaders module `npm run dist — -e loaders` (deprecations were throwing issues for deprecated Resource, e.g. 'isJson`, etc).