### PR TITLE
Change set tint implementation on BitmapText

### DIFF
--- a/src/extras/BitmapText.js
+++ b/src/extras/BitmapText.js
@@ -326,7 +326,7 @@ export default class BitmapText extends core.Container
 
     set tint(value) // eslint-disable-line require-jsdoc
     {
-        this._font.tint = (typeof value === 'number' && value >= 0) ? value : 0xFFFFFF;
+        this._font.tint = value;
 
         this.dirty = true;
     }


### PR DESCRIPTION
When using bitmaptext and trying to edit the tint of an already created bitmaptext like this:
        ` this.myCustomTextObject().getCustomPixiText().tint="0x021c4a";`
There's no way of changing the color, it doesn't matter if the color is passed like 0x021c4a or #021c4a, or trying other colors, it always gets the 0xFFFFFF color of the tint function assigned:

```
set tint(value) // eslint-disable-line require-jsdoc
    {
        this._font.tint = (typeof value === 'number' && value >= 0) ? value : 0xFFFFFF;

        this.dirty = true;
    }
```

On my project I've modified the pixi library with the below change, and now it's updating correctly the color of the bitmaptext, so I suggest to apply this change on the pixi library for all users not to suffer this problem:

```
set tint(value) // eslint-disable-line require-jsdoc
    {
        this._font.tint =value;

        this.dirty = true;
    }
```