### PR TITLE
Documents events for DisplayObject, renderers, Texture and BaseTexture

### DIFF
--- a/src/core/display/DisplayObject.js
+++ b/src/core/display/DisplayObject.js
@@ -13,7 +13,6 @@ import { Rectangle } from '../math';
  *
  * @class
  * @extends EventEmitter
- * @mixes PIXI.interaction.interactiveTarget
  * @memberof PIXI
  */
 export default class DisplayObject extends EventEmitter

--- a/src/core/display/DisplayObject.js
+++ b/src/core/display/DisplayObject.js
@@ -126,16 +126,14 @@ export default class DisplayObject extends EventEmitter
         /**
          * Fired when this DisplayObject is added to a Container.
          *
-         * @event added
-         * @memberof PIXI.DisplayObject#
+         * @event PIXI.DisplayObject#added
          * @param {PIXI.Container} container - The container added to.
          */
 
         /**
          * Fired when this DisplayObject is removed from a Container.
          *
-         * @event removed
-         * @memberof PIXI.DisplayObject#
+         * @event PIXI.DisplayObject#removed
          * @param {PIXI.Container} container - The container removed from.
          */
     }

--- a/src/core/display/DisplayObject.js
+++ b/src/core/display/DisplayObject.js
@@ -122,6 +122,22 @@ export default class DisplayObject extends EventEmitter
          * @readonly
          */
         this._destroyed = false;
+
+        /**
+         * Fired when this DisplayObject is added to a Container.
+         *
+         * @event added
+         * @memberof PIXI.DisplayObject#
+         * @param {PIXI.Container} container - The container added to.
+         */
+
+        /**
+         * Fired when this DisplayObject is removed from a Container.
+         *
+         * @event removed
+         * @memberof PIXI.DisplayObject#
+         * @param {PIXI.Container} container - The container removed from.
+         */
     }
 
     /**

--- a/src/core/renderers/canvas/CanvasRenderer.js
+++ b/src/core/renderers/canvas/CanvasRenderer.js
@@ -102,15 +102,13 @@ export default class CanvasRenderer extends SystemRenderer
         /**
          * Fired after rendering finishes.
          *
-         * @event postrender
-         * @memberof PIXI.CanvasRenderer#
+         * @event PIXI.CanvasRenderer#postrender
          */
 
         /**
          * Fired before rendering starts.
          *
-         * @event prerender
-         * @memberof PIXI.CanvasRenderer#
+         * @event PIXI.CanvasRenderer#prerender
          */
     }
 

--- a/src/core/renderers/canvas/CanvasRenderer.js
+++ b/src/core/renderers/canvas/CanvasRenderer.js
@@ -98,6 +98,20 @@ export default class CanvasRenderer extends SystemRenderer
         this.renderingToScreen = false;
 
         this.resize(this.options.width, this.options.height);
+
+        /**
+         * Fired after rendering finishes.
+         *
+         * @event postrender
+         * @memberof PIXI.CanvasRenderer#
+         */
+
+        /**
+         * Fired before rendering starts.
+         *
+         * @event prerender
+         * @memberof PIXI.CanvasRenderer#
+         */
     }
 
     /**

--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -185,6 +185,28 @@ export default class WebGLRenderer extends SystemRenderer
         this._nextTextureLocation = 0;
 
         this.setBlendMode(0);
+
+        /**
+         * Fired after rendering finishes.
+         *
+         * @event postrender
+         * @memberof PIXI.WebGLRenderer#
+         */
+
+        /**
+         * Fired before rendering starts.
+         *
+         * @event prerender
+         * @memberof PIXI.WebGLRenderer#
+         */
+
+        /**
+         * Fired when the WebGL context is set.
+         *
+         * @event context
+         * @memberof PIXI.WebGLRenderer#
+         * @param {WebGLRenderingContext} gl - WebGL context.
+         */
     }
 
     /**

--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -189,22 +189,19 @@ export default class WebGLRenderer extends SystemRenderer
         /**
          * Fired after rendering finishes.
          *
-         * @event postrender
-         * @memberof PIXI.WebGLRenderer#
+         * @event PIXI.WebGLRenderer#postrender
          */
 
         /**
          * Fired before rendering starts.
          *
-         * @event prerender
-         * @memberof PIXI.WebGLRenderer#
+         * @event PIXI.WebGLRenderer#prerender
          */
 
         /**
          * Fired when the WebGL context is set.
          *
-         * @event context
-         * @memberof PIXI.WebGLRenderer#
+         * @event PIXI.WebGLRenderer#context
          * @param {WebGLRenderingContext} gl - WebGL context.
          */
     }

--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -217,6 +217,7 @@ export default class BaseTexture extends EventEmitter
          * @protected
          * @event loaded
          * @memberof PIXI.BaseTexture#
+         * @param {PIXI.BaseTexture} baseTexture - Resource loaded.
          */
 
         /**
@@ -225,13 +226,32 @@ export default class BaseTexture extends EventEmitter
          * @protected
          * @event error
          * @memberof PIXI.BaseTexture#
+         * @param {PIXI.BaseTexture} baseTexture - Resource errored.
+         */
+
+        /**
+         * Fired when BaseTexture is updated.
+         *
+         * @protected
+         * @event update
+         * @memberof PIXI.BaseTexture#
+         * @param {PIXI.BaseTexture} baseTexture - Instance of texture being updated.
+         */
+
+        /**
+         * Fired when BaseTexture is destroyed.
+         *
+         * @protected
+         * @event dispose
+         * @memberof PIXI.BaseTexture#
+         * @param {PIXI.BaseTexture} baseTexture - Instance of texture being destroyed.
          */
     }
 
     /**
      * Updates the texture on all the webgl renderers, this also assumes the src has changed.
      *
-     * @fires update
+     * @fires PIXI.BaseTexture#update
      */
     update()
     {
@@ -524,7 +544,7 @@ export default class BaseTexture extends EventEmitter
      *
      * @param  {string} svgString SVG source as string
      *
-     * @fires loaded
+     * @fires PIXI.BaseTexture#loaded
      */
     _loadSvgSourceUsingString(svgString)
     {
@@ -617,6 +637,7 @@ export default class BaseTexture extends EventEmitter
      * This means you can still use the texture later which will upload it to GPU
      * memory again.
      *
+     * @fires PIXI.BaseTexture#dispose
      */
     dispose()
     {

--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -215,8 +215,7 @@ export default class BaseTexture extends EventEmitter
          * Fired when a not-immediately-available source finishes loading.
          *
          * @protected
-         * @event loaded
-         * @memberof PIXI.BaseTexture#
+         * @event PIXI.BaseTexture#loaded
          * @param {PIXI.BaseTexture} baseTexture - Resource loaded.
          */
 
@@ -224,8 +223,7 @@ export default class BaseTexture extends EventEmitter
          * Fired when a not-immediately-available source fails to load.
          *
          * @protected
-         * @event error
-         * @memberof PIXI.BaseTexture#
+         * @event PIXI.BaseTexture#error
          * @param {PIXI.BaseTexture} baseTexture - Resource errored.
          */
 
@@ -233,8 +231,7 @@ export default class BaseTexture extends EventEmitter
          * Fired when BaseTexture is updated.
          *
          * @protected
-         * @event update
-         * @memberof PIXI.BaseTexture#
+         * @event PIXI.BaseTexture#update
          * @param {PIXI.BaseTexture} baseTexture - Instance of texture being updated.
          */
 
@@ -242,8 +239,7 @@ export default class BaseTexture extends EventEmitter
          * Fired when BaseTexture is destroyed.
          *
          * @protected
-         * @event dispose
-         * @memberof PIXI.BaseTexture#
+         * @event PIXI.BaseTexture#dispose
          * @param {PIXI.BaseTexture} baseTexture - Instance of texture being destroyed.
          */
     }

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -144,8 +144,7 @@ export default class Texture extends EventEmitter
         /**
          * Fired when the texture is updated. This happens if the frame or the baseTexture is updated.
          *
-         * @event update
-         * @memberof PIXI.Texture#
+         * @event PIXI.Texture#update
          * @protected
          * @param {PIXI.Texture} texture - Instance of texture being updated.
          */

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -147,6 +147,7 @@ export default class Texture extends EventEmitter
          * @event update
          * @memberof PIXI.Texture#
          * @protected
+         * @param {PIXI.Texture} texture - Instance of texture being updated.
          */
 
         this._updateID = 0;

--- a/src/interaction/InteractionData.js
+++ b/src/interaction/InteractionData.js
@@ -29,8 +29,11 @@ export default class InteractionData
 
         /**
          * When passed to an event handler, this will be the original DOM Event that was captured
-         *
-         * @member {Event}
+         * 
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent
+         * @member {MouseEvent|TouchEvent|PointerEvent}
          */
         this.originalEvent = null;
 

--- a/src/interaction/InteractionData.js
+++ b/src/interaction/InteractionData.js
@@ -29,7 +29,7 @@ export default class InteractionData
 
         /**
          * When passed to an event handler, this will be the original DOM Event that was captured
-         * 
+         *
          * @see https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent
          * @see https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent
          * @see https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -357,6 +357,7 @@ export default class InteractionManager extends EventEmitter
          * Fired when the operating system cancels a pointer event
          *
          * @event PIXI.interaction.InteractionManager#pointercancel
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
          */
 
         /**
@@ -413,6 +414,7 @@ export default class InteractionManager extends EventEmitter
          * Fired when the operating system cancels a touch
          *
          * @event PIXI.interaction.InteractionManager#touchcancel
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
          */
 
         /**
@@ -550,6 +552,7 @@ export default class InteractionManager extends EventEmitter
          * DisplayObject's `interactive` property must be set to `true` to fire event.
          *
          * @event PIXI.DisplayObject#pointercancel
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
          */
 
         /**
@@ -614,6 +617,7 @@ export default class InteractionManager extends EventEmitter
          * DisplayObject's `interactive` property must be set to `true` to fire event.
          *
          * @event PIXI.DisplayObject#touchcancel
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
          */
 
         /**

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -256,54 +256,48 @@ export default class InteractionManager extends EventEmitter
          * Fired when a pointer device button (usually a mouse left-button) is pressed on the display
          * object.
          *
-         * @event mousedown
-         * @type {PIXI.interaction.InteractionData}
-         * @memberof PIXI.interaction.InteractionManager#
+         * @event PIXI.interaction.InteractionManager#mousedown
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
          */
 
         /**
          * Fired when a pointer device secondary button (usually a mouse right-button) is pressed
          * on the display object.
          *
-         * @event rightdown
-         * @type {PIXI.interaction.InteractionData}
-         * @memberof PIXI.interaction.InteractionManager#
+         * @event PIXI.interaction.InteractionManager#rightdown
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
          */
 
         /**
          * Fired when a pointer device button (usually a mouse left-button) is released over the display
          * object.
          *
-         * @event mouseup
-         * @type {PIXI.interaction.InteractionData}
-         * @memberof PIXI.interaction.InteractionManager#
+         * @event PIXI.interaction.InteractionManager#mouseup
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
          */
 
         /**
          * Fired when a pointer device secondary button (usually a mouse right-button) is released
          * over the display object.
          *
-         * @event rightup
-         * @type {PIXI.interaction.InteractionData}
-         * @memberof PIXI.interaction.InteractionManager#
+         * @event PIXI.interaction.InteractionManager#rightup
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
          */
 
         /**
          * Fired when a pointer device button (usually a mouse left-button) is pressed and released on
          * the display object.
          *
-         * @event click
-         * @type {PIXI.interaction.InteractionData}
-         * @memberof PIXI.interaction.InteractionManager#
+         * @event PIXI.interaction.InteractionManager#click
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
          */
 
         /**
          * Fired when a pointer device secondary button (usually a mouse right-button) is pressed
          * and released on the display object.
          *
-         * @event rightclick
-         * @type {PIXI.interaction.InteractionData}
-         * @memberof PIXI.interaction.InteractionManager#
+         * @event PIXI.interaction.InteractionManager#rightclick
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
          */
 
         /**
@@ -311,9 +305,8 @@ export default class InteractionManager extends EventEmitter
          * display object that initially registered a
          * [mousedown]{@link PIXI.interaction.InteractionManager#event:mousedown}.
          *
-         * @event mouseupoutside
-         * @type {PIXI.interaction.InteractionData}
-         * @memberof PIXI.interaction.InteractionManager#
+         * @event PIXI.interaction.InteractionManager#mouseupoutside
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
          */
 
         /**
@@ -321,145 +314,127 @@ export default class InteractionManager extends EventEmitter
          * outside the display object that initially registered a
          * [rightdown]{@link PIXI.interaction.InteractionManager#event:rightdown}.
          *
-         * @event rightupoutside
-         * @type {PIXI.interaction.InteractionData}
-         * @memberof PIXI.interaction.InteractionManager#
+         * @event PIXI.interaction.InteractionManager#rightupoutside
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
          */
 
         /**
          * Fired when a pointer device (usually a mouse) is moved while over the display object
          *
-         * @event mousemove
-         * @type {PIXI.interaction.InteractionData}
-         * @memberof PIXI.interaction.InteractionManager#
+         * @event PIXI.interaction.InteractionManager#mousemove
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
          */
 
         /**
          * Fired when a pointer device (usually a mouse) is moved onto the display object
          *
-         * @event mouseover
-         * @type {PIXI.interaction.InteractionData}
-         * @memberof PIXI.interaction.InteractionManager#
+         * @event PIXI.interaction.InteractionManager#mouseover
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
          */
 
         /**
          * Fired when a pointer device (usually a mouse) is moved off the display object
          *
-         * @event mouseout
-         * @type {PIXI.interaction.InteractionData}
-         * @memberof PIXI.interaction.InteractionManager#
+         * @event PIXI.interaction.InteractionManager#mouseout
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
          */
 
         /**
          * Fired when a pointer device button is pressed on the display object.
          *
-         * @event pointerdown
-         * @type {PIXI.interaction.InteractionData}
-         * @memberof PIXI.interaction.InteractionManager#
+         * @event PIXI.interaction.InteractionManager#pointerdown
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
          */
 
         /**
          * Fired when a pointer device button is released over the display object.
          *
-         * @event pointerup
-         * @type {PIXI.interaction.InteractionData}
-         * @memberof PIXI.interaction.InteractionManager#
+         * @event PIXI.interaction.InteractionManager#pointerup
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
          */
 
         /**
          * Fired when the operating system cancels a pointer event
          *
-         * @event pointercancel
-         * @memberof PIXI.interaction.InteractionManager#
+         * @event PIXI.interaction.InteractionManager#pointercancel
          */
 
         /**
          * Fired when a pointer device button is pressed and released on the display object.
          *
-         * @event pointertap
-         * @type {PIXI.interaction.InteractionData}
-         * @memberof PIXI.interaction.InteractionManager#
+         * @event PIXI.interaction.InteractionManager#pointertap
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
          */
 
         /**
          * Fired when a pointer device button is released outside the display object that initially
          * registered a [pointerdown]{@link PIXI.interaction.InteractionManager#event:pointerdown}.
          *
-         * @event pointerupoutside
-         * @type {PIXI.interaction.InteractionData}
-         * @memberof PIXI.interaction.InteractionManager#
+         * @event PIXI.interaction.InteractionManager#pointerupoutside
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
          */
 
         /**
          * Fired when a pointer device is moved while over the display object
          *
-         * @event pointermove
-         * @type {PIXI.interaction.InteractionData}
-         * @memberof PIXI.interaction.InteractionManager#
+         * @event PIXI.interaction.InteractionManager#pointermove
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
          */
 
         /**
          * Fired when a pointer device is moved onto the display object
          *
-         * @event pointerover
-         * @type {PIXI.interaction.InteractionData}
-         * @memberof PIXI.interaction.InteractionManager#
+         * @event PIXI.interaction.InteractionManager#pointerover
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
          */
 
         /**
          * Fired when a pointer device is moved off the display object
          *
-         * @event pointerout
-         * @type {PIXI.interaction.InteractionData}
-         * @memberof PIXI.interaction.InteractionManager#
+         * @event PIXI.interaction.InteractionManager#pointerout
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
          */
 
         /**
          * Fired when a touch point is placed on the display object.
          *
-         * @event touchstart
-         * @type {PIXI.interaction.InteractionData}
-         * @memberof PIXI.interaction.InteractionManager#
+         * @event PIXI.interaction.InteractionManager#touchstart
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
          */
 
         /**
          * Fired when a touch point is removed from the display object.
          *
-         * @event touchend
-         * @type {PIXI.interaction.InteractionData}
-         * @memberof PIXI.interaction.InteractionManager#
+         * @event PIXI.interaction.InteractionManager#touchend
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
          */
 
         /**
          * Fired when the operating system cancels a touch
          *
-         * @event touchcancel
-         * @memberof PIXI.interaction.InteractionManager#
+         * @event PIXI.interaction.InteractionManager#touchcancel
          */
 
         /**
          * Fired when a touch point is placed and removed from the display object.
          *
-         * @event tap
-         * @type {PIXI.interaction.InteractionData}
-         * @memberof PIXI.interaction.InteractionManager#
+         * @event PIXI.interaction.InteractionManager#tap
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
          */
 
         /**
          * Fired when a touch point is removed outside of the display object that initially
          * registered a [touchstart]{@link PIXI.interaction.InteractionManager#event:touchstart}.
          *
-         * @event touchendoutside
-         * @type {PIXI.interaction.InteractionData}
-         * @memberof PIXI.interaction.InteractionManager#
+         * @event PIXI.interaction.InteractionManager#PIXI.interaction.InteractionManager#touchendoutside
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
          */
 
         /**
          * Fired when a touch point is moved along the display object.
          *
-         * @event touchmove
-         * @type {PIXI.interaction.InteractionData}
-         * @memberof PIXI.interaction.InteractionManager#
+         * @event PIXI.interaction.InteractionManager#touchmove
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
          */
     }
 

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -644,36 +644,6 @@ export default class InteractionManager extends EventEmitter
          * @event PIXI.DisplayObject#touchmove
          * @param {PIXI.interaction.InteractionData} event - Interaction data
          */
-
-        /**
-         * Enable interaction events for the DisplayObject. Touch, pointer and mouse
-         * events will not be emitted unless `interactive` is set to `true`.
-         *
-         * @name PIXI.DisplayObject#interactive
-         * @type {boolean}
-         * @default false
-         */
-
-        /**
-         * Optional hit-area to define for a DisplayObject. If `interactive` is set to `true`
-         * and this property is set, it will be used for determining bounds in triggering interaction events.
-         *
-         * @example
-         * const sprite = new Sprite(texture);
-         * sprite.interactive = true;
-         * sprite.hitArea = new PIXI.Rectangle(0, 0, 100, 100);
-         * @name PIXI.DisplayObject#hitArea
-         * @type {PIXI.Rectangle|PIXI.Circle|PIXI.Ellipse|PIXI.Polygon|PIXI.RoundedRectangle}
-         */
-
-        /**
-         * Enable interaction events for children of this Container. Touch, pointer and mouse
-         * events will not be emitted for any of the children unless `interactiveChildren` is set to `true`.
-         *
-         * @name PIXI.Container#interactiveChildren
-         * @type {boolean}
-         * @default false
-         */
     }
 
     /**

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -426,7 +426,7 @@ export default class InteractionManager extends EventEmitter
          * Fired when a touch point is removed outside of the display object that initially
          * registered a [touchstart]{@link PIXI.interaction.InteractionManager#event:touchstart}.
          *
-         * @event PIXI.interaction.InteractionManager#PIXI.interaction.InteractionManager#touchendoutside
+         * @event PIXI.interaction.InteractionManager#touchendoutside
          * @param {PIXI.interaction.InteractionData} event - Interaction data
          */
 
@@ -435,6 +435,240 @@ export default class InteractionManager extends EventEmitter
          *
          * @event PIXI.interaction.InteractionManager#touchmove
          * @param {PIXI.interaction.InteractionData} event - Interaction data
+         */
+
+        /**
+         * Fired when a pointer device button (usually a mouse left-button) is pressed on the display.
+         * object. DisplayObject's `interactive` property must be set to `true` to fire event.
+         *
+         * @event PIXI.DisplayObject#mousedown
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
+         */
+
+        /**
+         * Fired when a pointer device secondary button (usually a mouse right-button) is pressed
+         * on the display object. DisplayObject's `interactive` property must be set to `true` to fire event.
+         *
+         * @event PIXI.DisplayObject#rightdown
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
+         */
+
+        /**
+         * Fired when a pointer device button (usually a mouse left-button) is released over the display
+         * object. DisplayObject's `interactive` property must be set to `true` to fire event.
+         *
+         * @event PIXI.DisplayObject#mouseup
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
+         */
+
+        /**
+         * Fired when a pointer device secondary button (usually a mouse right-button) is released
+         * over the display object. DisplayObject's `interactive` property must be set to `true` to fire event.
+         *
+         * @event PIXI.DisplayObject#rightup
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
+         */
+
+        /**
+         * Fired when a pointer device button (usually a mouse left-button) is pressed and released on
+         * the display object. DisplayObject's `interactive` property must be set to `true` to fire event.
+         *
+         * @event PIXI.DisplayObject#click
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
+         */
+
+        /**
+         * Fired when a pointer device secondary button (usually a mouse right-button) is pressed
+         * and released on the display object. DisplayObject's `interactive` property must be set to `true` to fire event.
+         *
+         * @event PIXI.DisplayObject#rightclick
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
+         */
+
+        /**
+         * Fired when a pointer device button (usually a mouse left-button) is released outside the
+         * display object that initially registered a
+         * [mousedown]{@link PIXI.DisplayObject#event:mousedown}.
+         * DisplayObject's `interactive` property must be set to `true` to fire event.
+         *
+         * @event PIXI.DisplayObject#mouseupoutside
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
+         */
+
+        /**
+         * Fired when a pointer device secondary button (usually a mouse right-button) is released
+         * outside the display object that initially registered a
+         * [rightdown]{@link PIXI.DisplayObject#event:rightdown}.
+         * DisplayObject's `interactive` property must be set to `true` to fire event.
+         *
+         * @event PIXI.DisplayObject#rightupoutside
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
+         */
+
+        /**
+         * Fired when a pointer device (usually a mouse) is moved while over the display object.
+         * DisplayObject's `interactive` property must be set to `true` to fire event.
+         *
+         * @event PIXI.DisplayObject#mousemove
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
+         */
+
+        /**
+         * Fired when a pointer device (usually a mouse) is moved onto the display object.
+         * DisplayObject's `interactive` property must be set to `true` to fire event.
+         *
+         * @event PIXI.DisplayObject#mouseover
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
+         */
+
+        /**
+         * Fired when a pointer device (usually a mouse) is moved off the display object.
+         * DisplayObject's `interactive` property must be set to `true` to fire event.
+         *
+         * @event PIXI.DisplayObject#mouseout
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
+         */
+
+        /**
+         * Fired when a pointer device button is pressed on the display object.
+         * DisplayObject's `interactive` property must be set to `true` to fire event.
+         *
+         * @event PIXI.DisplayObject#pointerdown
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
+         */
+
+        /**
+         * Fired when a pointer device button is released over the display object.
+         * DisplayObject's `interactive` property must be set to `true` to fire event.
+         *
+         * @event PIXI.DisplayObject#pointerup
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
+         */
+
+        /**
+         * Fired when the operating system cancels a pointer event.
+         * DisplayObject's `interactive` property must be set to `true` to fire event.
+         *
+         * @event PIXI.DisplayObject#pointercancel
+         */
+
+        /**
+         * Fired when a pointer device button is pressed and released on the display object.
+         * DisplayObject's `interactive` property must be set to `true` to fire event.
+         *
+         * @event PIXI.DisplayObject#pointertap
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
+         */
+
+        /**
+         * Fired when a pointer device button is released outside the display object that initially
+         * registered a [pointerdown]{@link PIXI.DisplayObject#event:pointerdown}.
+         * DisplayObject's `interactive` property must be set to `true` to fire event.
+         *
+         * @event PIXI.DisplayObject#pointerupoutside
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
+         */
+
+        /**
+         * Fired when a pointer device is moved while over the display object.
+         * DisplayObject's `interactive` property must be set to `true` to fire event.
+         *
+         * @event PIXI.DisplayObject#pointermove
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
+         */
+
+        /**
+         * Fired when a pointer device is moved onto the display object.
+         * DisplayObject's `interactive` property must be set to `true` to fire event.
+         *
+         * @event PIXI.DisplayObject#pointerover
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
+         */
+
+        /**
+         * Fired when a pointer device is moved off the display object.
+         * DisplayObject's `interactive` property must be set to `true` to fire event.
+         *
+         * @event PIXI.DisplayObject#pointerout
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
+         */
+
+        /**
+         * Fired when a touch point is placed on the display object.
+         * DisplayObject's `interactive` property must be set to `true` to fire event.
+         *
+         * @event PIXI.DisplayObject#touchstart
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
+         */
+
+        /**
+         * Fired when a touch point is removed from the display object.
+         * DisplayObject's `interactive` property must be set to `true` to fire event.
+         *
+         * @event PIXI.DisplayObject#touchend
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
+         */
+
+        /**
+         * Fired when the operating system cancels a touch.
+         * DisplayObject's `interactive` property must be set to `true` to fire event.
+         *
+         * @event PIXI.DisplayObject#touchcancel
+         */
+
+        /**
+         * Fired when a touch point is placed and removed from the display object.
+         * DisplayObject's `interactive` property must be set to `true` to fire event.
+         *
+         * @event PIXI.DisplayObject#tap
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
+         */
+
+        /**
+         * Fired when a touch point is removed outside of the display object that initially
+         * registered a [touchstart]{@link PIXI.DisplayObject#event:touchstart}.
+         * DisplayObject's `interactive` property must be set to `true` to fire event.
+         *
+         * @event PIXI.DisplayObject#touchendoutside
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
+         */
+
+        /**
+         * Fired when a touch point is moved along the display object.
+         * DisplayObject's `interactive` property must be set to `true` to fire event.
+         *
+         * @event PIXI.DisplayObject#touchmove
+         * @param {PIXI.interaction.InteractionData} event - Interaction data
+         */
+
+        /**
+         * Enable interaction events for the DisplayObject. Touch, pointer and mouse
+         * events will not be emitted unless `interactive` is set to `true`.
+         *
+         * @name PIXI.DisplayObject#interactive
+         * @type {boolean}
+         * @default false
+         */
+
+        /**
+         * Optional hit-area to define for a DisplayObject. If `interactive` is set to `true`
+         * and this property is set, it will be used for determining bounds in triggering interaction events.
+         *
+         * @example
+         * const sprite = new Sprite(texture);
+         * sprite.interactive = true;
+         * sprite.hitArea = new PIXI.Rectangle(0, 0, 100, 100);
+         * @name PIXI.DisplayObject#hitArea
+         * @type {PIXI.Rectangle|PIXI.Circle|PIXI.Ellipse|PIXI.Polygon|PIXI.RoundedRectangle}
+         */
+
+        /**
+         * Enable interaction events for children of this Container. Touch, pointer and mouse
+         * events will not be emitted for any of the children unless `interactiveChildren` is set to `true`.
+         *
+         * @name PIXI.Container#interactiveChildren
+         * @type {boolean}
+         * @default false
          */
     }
 

--- a/src/interaction/interactiveTarget.js
+++ b/src/interaction/interactiveTarget.js
@@ -2,7 +2,7 @@
  * Default property values of interactive objects
  * Used by {@link PIXI.interaction.InteractionManager} to automatically give all DisplayObjects these properties
  *
- * @mixin
+ * @private
  * @name interactiveTarget
  * @memberof PIXI.interaction
  * @example
@@ -14,12 +14,6 @@
  *      );
  */
 export default {
-    /**
-     * @see PIXI.interaction.interactiveTarget#interactive
-     * @name PIXI.DisplayObject#interactive
-     * @type {boolean}
-     * @default false
-     */
 
     /**
      * Enable interaction events for the DisplayObject. Touch, pointer and mouse
@@ -32,31 +26,18 @@ export default {
      *    //handle event
      * });
      * @member {boolean}
-     * @memberof PIXI.interaction.interactiveTarget#
+     * @memberof PIXI.DisplayObject#
      */
     interactive: false,
 
     /**
-     * @see PIXI.interaction.interactiveTarget#interactiveChildren
-     * @name PIXI.Container#interactiveChildren
-     * @type {boolean}
-     * @default false
-     */
-
-    /**
      * Determines if the children to the displayObject can be clicked/touched
-     * Setting this to false allows pixi to bypass a recursive hitTest function
+     * Setting this to false allows pixi to bypass a recursive `hitTest` function
      *
      * @member {boolean}
-     * @memberof PIXI.interaction.interactiveTarget#
+     * @memberof PIXI.Container#
      */
     interactiveChildren: true,
-
-    /**
-     * @see PIXI.interaction.interactiveTarget#hitArea
-     * @name PIXI.DisplayObject#hitArea
-     * @type {PIXI.Rectangle|PIXI.Circle|PIXI.Ellipse|PIXI.Polygon|PIXI.RoundedRectangle}
-     */
 
     /**
      * Interaction shape. Children will be hit first, then this shape will be checked.
@@ -67,15 +48,9 @@ export default {
      * sprite.interactive = true;
      * sprite.hitArea = new PIXI.Rectangle(0, 0, 100, 100);
      * @member {PIXI.Rectangle|PIXI.Circle|PIXI.Ellipse|PIXI.Polygon|PIXI.RoundedRectangle}
-     * @memberof PIXI.interaction.interactiveTarget#
+     * @memberof PIXI.DisplayObject#
      */
     hitArea: null,
-
-    /**
-     * @see PIXI.interaction.interactiveTarget#buttonMode
-     * @name PIXI.DisplayObject#buttonMode
-     * @type {boolean}
-     */
 
     /**
      * If enabled, the mouse cursor use the pointer behavior when hovered over the displayObject if it is interactive
@@ -86,7 +61,7 @@ export default {
      * sprite.interactive = true;
      * sprite.buttonMode = true;
      * @member {boolean}
-     * @memberof PIXI.interaction.interactiveTarget#
+     * @memberof PIXI.DisplayObject#
      */
     get buttonMode()
     {
@@ -105,12 +80,6 @@ export default {
     },
 
     /**
-     * @see PIXI.interaction.interactiveTarget#cursor
-     * @name PIXI.DisplayObject#cursor
-     * @type {string}
-     */
-
-    /**
      * This defines what cursor mode is used when the mouse cursor
      * is hovered over the displayObject.
      *
@@ -121,21 +90,15 @@ export default {
      * @see https://developer.mozilla.org/en/docs/Web/CSS/cursor
      *
      * @member {string}
-     * @memberof PIXI.interaction.interactiveTarget#
+     * @memberof PIXI.DisplayObject#
      */
     cursor: null,
-
-    /**
-     * @see PIXI.interaction.interactiveTarget#trackedPointers
-     * @name PIXI.DisplayObject#trackedPointers
-     * @type {Map<number, InteractionTrackingData>}
-     */
 
     /**
      * Internal set of all active pointers, by identifier
      *
      * @member {Map<number, InteractionTrackingData>}
-     * @memberof PIXI.interaction.interactiveTarget#
+     * @memberof PIXI.DisplayObject#
      * @private
      */
     get trackedPointers()

--- a/src/interaction/interactiveTarget.js
+++ b/src/interaction/interactiveTarget.js
@@ -20,7 +20,7 @@ export default {
      * @type {boolean}
      * @default false
      */
-        
+
     /**
      * Enable interaction events for the DisplayObject. Touch, pointer and mouse
      * events will not be emitted unless `interactive` is set to `true`.
@@ -57,7 +57,7 @@ export default {
      * @name PIXI.DisplayObject#hitArea
      * @type {PIXI.Rectangle|PIXI.Circle|PIXI.Ellipse|PIXI.Polygon|PIXI.RoundedRectangle}
      */
-     
+
     /**
      * Interaction shape. Children will be hit first, then this shape will be checked.
      * Setting this will cause this shape to be checked in hit tests rather than the displayObject's bounds.

--- a/src/interaction/interactiveTarget.js
+++ b/src/interaction/interactiveTarget.js
@@ -15,12 +15,33 @@
  */
 export default {
     /**
-     * Determines if the displayObject be clicked/touched
+     * @see PIXI.interaction.interactiveTarget#interactive
+     * @name PIXI.DisplayObject#interactive
+     * @type {boolean}
+     * @default false
+     */
+        
+    /**
+     * Enable interaction events for the DisplayObject. Touch, pointer and mouse
+     * events will not be emitted unless `interactive` is set to `true`.
      *
+     * @example
+     * const sprite = new PIXI.Sprite(texture);
+     * sprite.interactive = true;
+     * sprite.on('tap', (event) => {
+     *    //handle event
+     * });
      * @member {boolean}
      * @memberof PIXI.interaction.interactiveTarget#
      */
     interactive: false,
+
+    /**
+     * @see PIXI.interaction.interactiveTarget#interactiveChildren
+     * @name PIXI.Container#interactiveChildren
+     * @type {boolean}
+     * @default false
+     */
 
     /**
      * Determines if the children to the displayObject can be clicked/touched
@@ -32,18 +53,38 @@ export default {
     interactiveChildren: true,
 
     /**
+     * @see PIXI.interaction.interactiveTarget#hitArea
+     * @name PIXI.DisplayObject#hitArea
+     * @type {PIXI.Rectangle|PIXI.Circle|PIXI.Ellipse|PIXI.Polygon|PIXI.RoundedRectangle}
+     */
+     
+    /**
      * Interaction shape. Children will be hit first, then this shape will be checked.
      * Setting this will cause this shape to be checked in hit tests rather than the displayObject's bounds.
      *
+     * @example
+     * const sprite = new PIXI.Sprite(texture);
+     * sprite.interactive = true;
+     * sprite.hitArea = new PIXI.Rectangle(0, 0, 100, 100);
      * @member {PIXI.Rectangle|PIXI.Circle|PIXI.Ellipse|PIXI.Polygon|PIXI.RoundedRectangle}
      * @memberof PIXI.interaction.interactiveTarget#
      */
     hitArea: null,
 
     /**
+     * @see PIXI.interaction.interactiveTarget#buttonMode
+     * @name PIXI.DisplayObject#buttonMode
+     * @type {boolean}
+     */
+
+    /**
      * If enabled, the mouse cursor use the pointer behavior when hovered over the displayObject if it is interactive
      * Setting this changes the 'cursor' property to `'pointer'`.
      *
+     * @example
+     * const sprite = new PIXI.Sprite(texture);
+     * sprite.interactive = true;
+     * sprite.buttonMode = true;
      * @member {boolean}
      * @memberof PIXI.interaction.interactiveTarget#
      */
@@ -64,15 +105,31 @@ export default {
     },
 
     /**
+     * @see PIXI.interaction.interactiveTarget#cursor
+     * @name PIXI.DisplayObject#cursor
+     * @type {string}
+     */
+
+    /**
      * This defines what cursor mode is used when the mouse cursor
      * is hovered over the displayObject.
      *
+     * @example
+     * const sprite = new PIXI.Sprite(texture);
+     * sprite.interactive = true;
+     * sprite.cursor = 'wait';
      * @see https://developer.mozilla.org/en/docs/Web/CSS/cursor
      *
      * @member {string}
      * @memberof PIXI.interaction.interactiveTarget#
      */
     cursor: null,
+
+    /**
+     * @see PIXI.interaction.interactiveTarget#trackedPointers
+     * @name PIXI.DisplayObject#trackedPointers
+     * @type {Map<number, InteractionTrackingData>}
+     */
 
     /**
      * Internal set of all active pointers, by identifier


### PR DESCRIPTION
Addresses #3920 

### Added

* Adds additional event documentation including parameters for:
  * Texture
  * BaseTexture
  * DisplayObject
  * WebGLRenderer
  * CanvasRenderer

#### Demo

https://pixijs.download/event-docs/docs/index.html