### PR TITLE
Fix destroyed textures throwing errors when destroyed again.

### DIFF
--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -834,7 +834,7 @@ export default class BaseTexture extends EventEmitter
                 return baseTextureFromCache;
             }
         }
-        else
+        else if (baseTexture && baseTexture.textureCacheIds)
         {
             for (let i = 0; i < baseTexture.textureCacheIds.length; ++i)
             {

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -517,7 +517,7 @@ export default class Texture extends EventEmitter
                 return textureFromCache;
             }
         }
-        else
+        else if (texture && texture.textureCacheIds)
         {
             for (let i = 0; i < texture.textureCacheIds.length; ++i)
             {

--- a/test/core/BaseTexture.js
+++ b/test/core/BaseTexture.js
@@ -101,4 +101,12 @@ describe('BaseTexture', function ()
         expect(PIXI.utils.BaseTextureCache[NAME]).to.equal(undefined);
         expect(PIXI.utils.BaseTextureCache[NAME2]).to.equal(baseTexture);
     });
+
+    it('destroying a destroyed BaseTexture should not throw an error', function ()
+    {
+        const baseTexture = new PIXI.BaseTexture();
+
+        baseTexture.destroy();
+        baseTexture.destroy();
+    });
 });

--- a/test/core/Texture.js
+++ b/test/core/Texture.js
@@ -127,4 +127,12 @@ describe('PIXI.Texture', function ()
         expect(PIXI.utils.TextureCache[NAME]).to.equal(undefined);
         expect(PIXI.utils.TextureCache[NAME2]).to.equal(texture);
     });
+
+    it('destroying a destroyed texture should not throw an error', function ()
+    {
+        const texture = new PIXI.Texture(new PIXI.BaseTexture());
+
+        texture.destroy(true);
+        texture.destroy(true);
+    });
 });


### PR DESCRIPTION
Prevents errors from being thrown when one attempts to remove a destroyed `Texture` from the texture cache. This is likely to happen when recursively destroying a display tree where a texture is shared, among other possible scenarios.