### PR TITLE
Fix not respecting target of mouseup events.

### DIFF
--- a/src/core/ticker/TickerListener.js
+++ b/src/core/ticker/TickerListener.js
@@ -91,12 +91,12 @@ export default class TickerListener
             this.fn(deltaTime);
         }
 
+        const redirect = this.next;
+
         if (this.once)
         {
-            this.destroy();
+            this.destroy(true);
         }
-
-        const redirect = this.next;
 
         // Soft-destroying should remove
         // the next reference

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -1217,6 +1217,10 @@ export default class InteractionManager extends EventEmitter
 
         const eventLen = events.length;
 
+        // if the event wasn't targeting our canvas, then consider it to be pointerupoutside
+        // in all cases (unless it was a pointercancel)
+        const eventAppend = originalEvent.target !== this.interactionDOMElement ? 'outside' : '';
+
         for (let i = 0; i < eventLen; i++)
         {
             const event = events[i];
@@ -1227,19 +1231,20 @@ export default class InteractionManager extends EventEmitter
 
             interactionEvent.data.originalEvent = originalEvent;
 
-            this.processInteractive(interactionEvent, this.renderer._lastObjectRendered, func, true);
+            // perform hit testing for events targeting our canvas or cancel events
+            this.processInteractive(interactionEvent, this.renderer._lastObjectRendered, func, cancelled || !eventAppend);
 
-            this.emit(cancelled ? 'pointercancel' : 'pointerup', interactionEvent);
+            this.emit(cancelled ? 'pointercancel' : `pointerup${eventAppend}`, interactionEvent);
 
             if (event.pointerType === 'mouse')
             {
                 const isRightButton = event.button === 2 || event.which === 3;
 
-                this.emit(isRightButton ? 'rightup' : 'mouseup', interactionEvent);
+                this.emit(isRightButton ? `rightup${eventAppend}` : `mouseup${eventAppend}`, interactionEvent);
             }
             else if (event.pointerType === 'touch')
             {
-                this.emit(cancelled ? 'touchcancel' : 'touchend', interactionEvent);
+                this.emit(cancelled ? 'touchcancel' : `touchend${eventAppend}`, interactionEvent);
                 this.releaseInteractionDataForPointerId(event.pointerId, interactionData);
             }
         }

--- a/test/core/Ticker.js
+++ b/test/core/Ticker.js
@@ -150,6 +150,32 @@ describe('PIXI.ticker.Ticker', function ()
         expect(this.length()).to.equal(length);
     });
 
+    it('should remove once listener in a stack', function ()
+    {
+        const length = this.length();
+        const listener1 = sinon.spy();
+        const listener2 = sinon.spy();
+        const listener3 = sinon.spy();
+
+        shared.add(listener1, null, PIXI.UPDATE_PRIORITY.HIGH);
+        shared.addOnce(listener2, null, PIXI.UPDATE_PRIORITY.NORMAL);
+        shared.add(listener3, null, PIXI.UPDATE_PRIORITY.LOW);
+
+        shared.update();
+
+        expect(this.length()).to.equal(length + 2);
+
+        shared.update();
+
+        expect(listener1.calledTwice).to.be.true;
+        expect(listener2.calledOnce).to.be.true;
+        expect(listener3.calledTwice).to.be.true;
+
+        shared.remove(listener1).remove(listener3);
+
+        expect(this.length()).to.equal(length);
+    });
+
     it('should call inserted item with a lower priority', function ()
     {
         const length = this.length();

--- a/test/interaction/InteractionManager.js
+++ b/test/interaction/InteractionManager.js
@@ -71,6 +71,25 @@ describe('PIXI.interaction.InteractionManager', function ()
             expect(eventSpy).to.have.been.called;
         });
 
+        it('should call mouseupoutside handler on mouseup on different elements', function ()
+        {
+            const stage = new PIXI.Container();
+            const graphics = new PIXI.Graphics();
+            const eventSpy = sinon.spy();
+            const pointer = this.pointer = new MockPointer(stage);
+
+            stage.addChild(graphics);
+            graphics.beginFill(0xFFFFFF);
+            graphics.drawRect(0, 0, 50, 50);
+            graphics.interactive = true;
+            graphics.on('mouseupoutside', eventSpy);
+
+            pointer.mousedown(10, 10);
+            pointer.mouseup(10, 10, false);
+
+            expect(eventSpy).to.have.been.called;
+        });
+
         it('should call mouseover handler', function ()
         {
             const stage = new PIXI.Container();

--- a/test/interaction/MockPointer.js
+++ b/test/interaction/MockPointer.js
@@ -99,6 +99,7 @@ class MockPointer
             });
         }
 
+        Object.defineProperty(mouseEvent, 'target', { value: this.renderer.view });
         this.setPosition(x, y);
         this.render();
         // mouseOverRenderer state should be correct, so mouse position to view rect
@@ -148,6 +149,8 @@ class MockPointer
             preventDefault: sinon.stub(),
         });
 
+        Object.defineProperty(mouseEvent, 'target', { value: this.renderer.view });
+
         this.setPosition(x, y);
         this.render();
         this.interaction.onPointerDown(mouseEvent);
@@ -156,14 +159,20 @@ class MockPointer
     /**
      * @param {number} x - pointer x position
      * @param {number} y - pointer y position
+     * @param {boolean} [onCanvas=true] - if the event happend on the Canvas element or not
      */
-    mouseup(x, y)
+    mouseup(x, y, onCanvas = true)
     {
         const mouseEvent = new MouseEvent('mouseup', {
             clientX: x,
             clientY: y,
             preventDefault: sinon.stub(),
         });
+
+        if (onCanvas)
+        {
+            Object.defineProperty(mouseEvent, 'target', { value: this.renderer.view });
+        }
 
         this.setPosition(x, y);
         this.render();
@@ -195,6 +204,8 @@ class MockPointer
             ],
         });
 
+        Object.defineProperty(touchEvent, 'target', { value: this.renderer.view });
+
         this.setPosition(x, y);
         this.render();
         this.interaction.onPointerDown(touchEvent);
@@ -214,6 +225,8 @@ class MockPointer
             ],
         });
 
+        Object.defineProperty(touchEvent, 'target', { value: this.renderer.view });
+
         this.setPosition(x, y);
         this.render();
         this.interaction.onPointerUp(touchEvent);
@@ -232,6 +245,8 @@ class MockPointer
                 new Touch({ identifier: identifier || 0, target: this.renderer.view }),
             ],
         });
+
+        Object.defineProperty(touchEvent, 'target', { value: this.renderer.view });
 
         this.setPosition(x, y);
         this.render();


### PR DESCRIPTION
Fixes #3466, which was also reported in #3790.
The issue was not looking at the event target on our window listeners for `mouseup`/`pointerup`. This change looks at that and emits `mouseupoutside`/`pointerupoutside` as appropriate.

For the MockPointer changes, it turns out that `target` is not a parameter for Events, and is a read only property. It is configurable, however, which is why I am setting the target in a roundabout way.