### PR TITLE
Fix #3199 by honoring alpha

### DIFF
--- a/src/filters/noise/NoiseFilter.js
+++ b/src/filters/noise/NoiseFilter.js
@@ -28,22 +28,22 @@ export default class NoiseFilter extends core.Filter
             readFileSync(join(__dirname, './noise.frag'), 'utf8')
         );
 
-        this.noise = 0.5;
+        this.noise = Math.random();
     }
 
     /**
-     * The amount of noise to apply.
+     * The amount of noise to apply, this value should be in the range (0, 1].
      *
      * @member {number}
      * @default 0.5
      */
     get noise()
     {
-        return this.uniforms.noise;
+        return this.uniforms.uNoise;
     }
 
     set noise(value) // eslint-disable-line require-jsdoc
     {
-        this.uniforms.noise = value;
+        this.uniforms.uNoise = value;
     }
 }

--- a/src/filters/noise/NoiseFilter.js
+++ b/src/filters/noise/NoiseFilter.js
@@ -17,7 +17,8 @@ import { join } from 'path';
 export default class NoiseFilter extends core.Filter
 {
     /**
-     *
+     * @param {number} noise - The noise intensity, should be a normalized value in the range [0, 1].
+     * @param {number} seed - A random seed for the noise generation. Default is `Math.random()`.
      */
     constructor(noise = 0.5, seed = Math.random())
     {

--- a/src/filters/noise/NoiseFilter.js
+++ b/src/filters/noise/NoiseFilter.js
@@ -28,7 +28,8 @@ export default class NoiseFilter extends core.Filter
             readFileSync(join(__dirname, './noise.frag'), 'utf8')
         );
 
-        this.noise = Math.random();
+        this.noise = 0.5;
+        this.seed = Math.random();
     }
 
     /**
@@ -45,5 +46,20 @@ export default class NoiseFilter extends core.Filter
     set noise(value) // eslint-disable-line require-jsdoc
     {
         this.uniforms.uNoise = value;
+    }
+
+    /**
+     * A seed value to apply to the random noise generation. `Math.random()` is a good value to use.
+     *
+     * @member {number}
+     */
+    get seed()
+    {
+        return this.uniforms.uSeed;
+    }
+
+    set seed(value) // eslint-disable-line require-jsdoc
+    {
+        this.uniforms.uSeed = value;
     }
 }

--- a/src/filters/noise/NoiseFilter.js
+++ b/src/filters/noise/NoiseFilter.js
@@ -19,7 +19,7 @@ export default class NoiseFilter extends core.Filter
     /**
      *
      */
-    constructor()
+    constructor(noise = 0.5, seed = Math.random())
     {
         super(
             // vertex shader
@@ -28,8 +28,8 @@ export default class NoiseFilter extends core.Filter
             readFileSync(join(__dirname, './noise.frag'), 'utf8')
         );
 
-        this.noise = 0.5;
-        this.seed = Math.random();
+        this.noise = noise;
+        this.seed = seed;
     }
 
     /**

--- a/src/filters/noise/noise.frag
+++ b/src/filters/noise/noise.frag
@@ -3,7 +3,7 @@ precision highp float;
 varying vec2 vTextureCoord;
 varying vec4 vColor;
 
-uniform float noise;
+uniform float uNoise;
 uniform sampler2D uSampler;
 
 float rand(vec2 co)
@@ -15,11 +15,5 @@ void main()
 {
     vec4 color = texture2D(uSampler, vTextureCoord);
 
-    float diff = (rand(gl_FragCoord.xy) - 0.5) * noise;
-
-    color.r += diff;
-    color.g += diff;
-    color.b += diff;
-
-    gl_FragColor = color;
+    gl_FragColor = vec4(color.rgb * rand(gl_FragCoord.xy * uNoise), color.a);
 }

--- a/src/filters/noise/noise.frag
+++ b/src/filters/noise/noise.frag
@@ -4,6 +4,7 @@ varying vec2 vTextureCoord;
 varying vec4 vColor;
 
 uniform float uNoise;
+uniform float uSeed;
 uniform sampler2D uSampler;
 
 float rand(vec2 co)
@@ -14,6 +15,20 @@ float rand(vec2 co)
 void main()
 {
     vec4 color = texture2D(uSampler, vTextureCoord);
+    float randomValue = rand(gl_FragCoord.xy * uSeed);
+    float diff = (randomValue - 0.5) * uNoise;
 
-    gl_FragColor = vec4(color.rgb * rand(gl_FragCoord.xy * uNoise), color.a);
+    // Un-premultiply alpha before applying the color matrix. See issue #3539.
+    if (color.a > 0.0) {
+        color.rgb /= color.a;
+    }
+
+    color.r += diff;
+    color.g += diff;
+    color.b += diff;
+
+    // Premultiply alpha again.
+    color.rgb *= color.a;
+
+    gl_FragColor = color;
 }


### PR DESCRIPTION
Proposed to fix #3199, as an alternative to #3941.

Using this test code:

```js
'use strict';

const app = new PIXI.Application({
    backgroundColor: 0x006600,
    width: 512,
    height: 512,
    view: document.getElementById('view'),
});

const graphic = new PIXI.Graphics()
    .beginFill(0xff0000)
    .drawCircle(256, 256, 200);

graphic.filters = [new PIXI.filters.NoiseFilter()];

app.stage.addChild(graphic);
```

Produces this output:

![image](https://cloud.githubusercontent.com/assets/944497/25076095/cdcc3264-22d2-11e7-9560-ebb54a72339a.png)