### PR TITLE
Fix #3252, add an interpolation value for the color matrix result

### DIFF
--- a/src/filters/colormatrix/ColorMatrixFilter.js
+++ b/src/filters/colormatrix/ColorMatrixFilter.js
@@ -36,6 +36,8 @@ export default class ColorMatrixFilter extends core.Filter
             0, 1, 0, 0, 0,
             0, 0, 1, 0, 0,
             0, 0, 0, 1, 0];
+
+        this.interpolation = 1;
     }
 
     /**
@@ -574,6 +576,26 @@ export default class ColorMatrixFilter extends core.Filter
     set matrix(value) // eslint-disable-line require-jsdoc
     {
         this.uniforms.m = value;
+    }
+
+    /**
+     * The interpolation value to use when mixing the original and resultant colors.
+     *
+     * When the value is 0, the original color is used without modification.
+     * When the value is 1, the result color is used.
+     * When in the range (0, 1) the color is interpolated between the original and result by this amount.
+     *
+     * @member {number}
+     * @default 1
+     */
+    get interpolation()
+    {
+        return this.uniforms.uInterpolation;
+    }
+
+    set interpolation(value) // eslint-disable-line require-jsdoc
+    {
+        this.uniforms.uInterpolation = value;
     }
 }
 

--- a/src/filters/colormatrix/colorMatrix.frag
+++ b/src/filters/colormatrix/colorMatrix.frag
@@ -1,15 +1,24 @@
 varying vec2 vTextureCoord;
 uniform sampler2D uSampler;
 uniform float m[20];
+uniform float uInterpolation;
 
 void main(void)
 {
     vec4 c = texture2D(uSampler, vTextureCoord);
+
+    if (uInterpolation == 0.0) {
+        gl_FragColor = c;
+        return;
+    }
+
     // Un-premultiply alpha before applying the color matrix. See issue #3539.
     if (c.a > 0.0) {
       c.rgb /= c.a;
     }
+
     vec4 result;
+
     result.r = (m[0] * c.r);
         result.r += (m[1] * c.g);
         result.r += (m[2] * c.b);
@@ -34,8 +43,10 @@ void main(void)
        result.a += (m[18] * c.a);
        result.a += m[19];
 
-    // Premultiply alpha again.
-    result.rgb *= result.a;
+    vec3 rgb = mix(c.rgb, result.rgb, uInterpolation);
 
-    gl_FragColor = result;
+    // Premultiply alpha again.
+    rgb *= result.a;
+
+    gl_FragColor = vec4(rgb, result.a);
 }


### PR DESCRIPTION
Add an interpolation value that allows you to interpolate between a texel's original color and the result of applying the color matrix.

This should fix #3252 where the user wanted to easily define a scale of sepia to apply.