### PR TITLE
Stops TickListener 'this.fn is not a function' error

### DIFF
--- a/src/core/ticker/TickerListener.js
+++ b/src/core/ticker/TickerListener.js
@@ -82,13 +82,16 @@ export default class TickerListener
      */
     emit(deltaTime)
     {
-        if (this.context)
+        if (this.fn)
         {
-            this.fn.call(this.context, deltaTime);
-        }
-        else
-        {
-            this.fn(deltaTime);
+            if (this.context)
+            {
+                this.fn.call(this.context, deltaTime);
+            }
+            else
+            {
+                this.fn(deltaTime);
+            }
         }
 
         const redirect = this.next;


### PR DESCRIPTION
Fixes: https://github.com/pixijs/pixi.js/issues/3936

I believe the edge case may be because I have a ticker that does not have autoStart turned on.
Instead I manually call .update() on it.