### PR TITLE
Fixes order adding of ticker listeners with same priority

### DIFF
--- a/src/core/ticker/Ticker.js
+++ b/src/core/ticker/Ticker.js
@@ -243,7 +243,7 @@ export default class Ticker
             // Go from highest to lowest priority
             while (current)
             {
-                if (listener.priority >= current.priority)
+                if (listener.priority > current.priority)
                 {
                     listener.connect(previous);
                     break;

--- a/test/core/Ticker.js
+++ b/test/core/Ticker.js
@@ -150,6 +150,30 @@ describe('PIXI.ticker.Ticker', function ()
         expect(this.length()).to.equal(length);
     });
 
+    it('should call when adding same priority', function ()
+    {
+        const length = this.length();
+        const listener1 = sinon.spy();
+        const listener2 = sinon.spy();
+        const listener3 = sinon.spy();
+
+        shared.add(listener1)
+            .add(listener2)
+            .add(listener3);
+
+        shared.update();
+
+        expect(this.length()).to.equal(length + 3);
+
+        sinon.assert.callOrder(listener1, listener2, listener3);
+
+        shared.remove(listener1)
+            .remove(listener2)
+            .remove(listener3);
+
+        expect(this.length()).to.equal(length);
+    });
+
     it('should remove once listener in a stack', function ()
     {
         const length = this.length();


### PR DESCRIPTION
### Fixed

* When adding a new ticker handler, should be added to the end of handlers with the same priority instead of the beginning. This is compatible with the old EventEmitter approach which uses `push` not `unshift`.