### PR TITLE
Make Interaction events closer to Browser behavior

### DIFF
--- a/src/interaction/InteractionData.js
+++ b/src/interaction/InteractionData.js
@@ -43,6 +43,104 @@ export default class InteractionData
          * @member {number}
          */
         this.identifier = null;
+
+        /**
+         * Indicates whether or not the pointer device that created the event is the primary pointer.
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/isPrimary
+         * @type {Boolean}
+         */
+        this.isPrimary = false;
+
+        /**
+         * Indicates which button was pressed on the mouse or pointer device to trigger the event.
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
+         * @type {number}
+         */
+        this.button = 0;
+
+        /**
+         * Indicates which buttons are pressed on the mouse or pointer device when the event is triggered.
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
+         * @type {number}
+         */
+        this.buttons = 0;
+
+        /**
+         * The width of the pointer's contact along the x-axis, measured in CSS pixels.
+         * radiusX of TouchEvents will be represented by this value.
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/width
+         * @type {number}
+         */
+        this.width = 0;
+
+        /**
+         * The height of the pointer's contact along the y-axis, measured in CSS pixels.
+         * radiusY of TouchEvents will be represented by this value.
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/height
+         * @type {number}
+         */
+        this.height = 0;
+
+        /**
+         * The angle, in degrees, between the pointer device and the screen.
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/tiltX
+         * @type {number}
+         */
+        this.tiltX = 0;
+
+        /**
+         * The angle, in degrees, between the pointer device and the screen.
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/tiltY
+         * @type {number}
+         */
+        this.tiltY = 0;
+
+        /**
+         * The type of pointer that triggered the event.
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/pointerType
+         * @type {string}
+         */
+        this.pointerType = null;
+
+        /**
+         * Pressure applied by the pointing device during the event. A Touch's force property
+         * will be represented by this value.
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/pressure
+         * @type {number}
+         */
+        this.pressure = 0;
+
+        /**
+         * From TouchEvents (not PointerEvents triggered by touches), the rotationAngle of the Touch.
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/Touch/rotationAngle
+         * @type {number}
+         */
+        this.rotationAngle = 0;
+
+        /**
+         * Twist of a stylus pointer.
+         * @see https://w3c.github.io/pointerevents/#pointerevent-interface
+         * @type {number}
+         */
+        this.twist = 0;
+
+        /**
+         * Barrel pressure on a stylus pointer.
+         * @see https://w3c.github.io/pointerevents/#pointerevent-interface
+         * @type {number}
+         */
+        this.tangentialPressure = 0;
+    }
+
+    /**
+     * The unique identifier of the pointer. It will be the same as `identifier`.
+     * @readonly
+     * @member {number}
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/pointerId
+     */
+    get pointerId()
+    {
+        return this.identifier;
     }
 
     /**
@@ -60,5 +158,45 @@ export default class InteractionData
     getLocalPosition(displayObject, point, globalPos)
     {
         return displayObject.worldTransform.applyInverse(globalPos || this.global, point);
+    }
+
+    /**
+     * Copies properties from normalized event data.
+     *
+     * @param {Touch|MouseEvent|PointerEvent} event The normalized event data
+     * @private
+     */
+    _copyEvent(event)
+    {
+        // isPrimary should only change on touchstart/pointerdown, so we don't want to overwrite
+        // it with "false" on later events when our shim for it on touch events might not be
+        // accurate
+        if (event.isPrimary)
+        {
+            this.isPrimary = true;
+        }
+        this.button = event.button;
+        this.buttons = event.buttons;
+        this.width = event.width;
+        this.height = event.height;
+        this.tiltX = event.tiltX;
+        this.tiltY = event.tiltY;
+        this.pointerType = event.pointerType;
+        this.pressure = event.pressure;
+        this.rotationAngle = event.rotationAngle;
+        this.twist = event.twist || 0;
+        this.tangentialPressure = event.tangentialPressure || 0;
+    }
+
+    /**
+     * Resets the data for pooling.
+     *
+     * @private
+     */
+    _reset()
+    {
+        // isPrimary is the only property that we really need to reset - everything else is
+        // guaranteed to be overwritten
+        this.isPrimary = false;
     }
 }

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -732,7 +732,6 @@ export default class InteractionManager extends EventEmitter
             window.addEventListener('pointercancel', this.onPointerCancel, true);
             window.addEventListener('pointerup', this.onPointerUp, true);
         }
-
         else
         {
             window.document.addEventListener('mousemove', this.onPointerMove, true);
@@ -740,14 +739,17 @@ export default class InteractionManager extends EventEmitter
             this.interactionDOMElement.addEventListener('mouseout', this.onPointerOut, true);
             this.interactionDOMElement.addEventListener('mouseover', this.onPointerOver, true);
             window.addEventListener('mouseup', this.onPointerUp, true);
+        }
 
-            if (this.supportsTouchEvents)
-            {
-                this.interactionDOMElement.addEventListener('touchstart', this.onPointerDown, true);
-                this.interactionDOMElement.addEventListener('touchcancel', this.onPointerCancel, true);
-                this.interactionDOMElement.addEventListener('touchend', this.onPointerUp, true);
-                this.interactionDOMElement.addEventListener('touchmove', this.onPointerMove, true);
-            }
+        // always look directly for touch events so that we can provide original data
+        // In a future version we should change this to being just a fallback and rely solely on
+        // PointerEvents whenever available
+        if (this.supportsTouchEvents)
+        {
+            this.interactionDOMElement.addEventListener('touchstart', this.onPointerDown, true);
+            this.interactionDOMElement.addEventListener('touchcancel', this.onPointerCancel, true);
+            this.interactionDOMElement.addEventListener('touchend', this.onPointerUp, true);
+            this.interactionDOMElement.addEventListener('touchmove', this.onPointerMove, true);
         }
 
         this.eventsAdded = true;
@@ -793,14 +795,14 @@ export default class InteractionManager extends EventEmitter
             this.interactionDOMElement.removeEventListener('mouseout', this.onPointerOut, true);
             this.interactionDOMElement.removeEventListener('mouseover', this.onPointerOver, true);
             window.removeEventListener('mouseup', this.onPointerUp, true);
+        }
 
-            if (this.supportsTouchEvents)
-            {
-                this.interactionDOMElement.removeEventListener('touchstart', this.onPointerDown, true);
-                this.interactionDOMElement.removeEventListener('touchcancel', this.onPointerCancel, true);
-                this.interactionDOMElement.removeEventListener('touchend', this.onPointerUp, true);
-                this.interactionDOMElement.removeEventListener('touchmove', this.onPointerMove, true);
-            }
+        if (this.supportsTouchEvents)
+        {
+            this.interactionDOMElement.removeEventListener('touchstart', this.onPointerDown, true);
+            this.interactionDOMElement.removeEventListener('touchcancel', this.onPointerCancel, true);
+            this.interactionDOMElement.removeEventListener('touchend', this.onPointerUp, true);
+            this.interactionDOMElement.removeEventListener('touchmove', this.onPointerMove, true);
         }
 
         this.interactionDOMElement = null;
@@ -1116,6 +1118,9 @@ export default class InteractionManager extends EventEmitter
      */
     onPointerDown(originalEvent)
     {
+        // if we support touch events, then only use those for touch events, not pointer events
+        if (this.supportsTouchEvents && originalEvent.pointerType === 'touch') return;
+
         const events = this.normalizeToPointerData(originalEvent);
 
         /**
@@ -1258,6 +1263,9 @@ export default class InteractionManager extends EventEmitter
      */
     onPointerCancel(event)
     {
+        // if we support touch events, then only use those for touch events, not pointer events
+        if (this.supportsTouchEvents && event.pointerType === 'touch') return;
+
         this.onPointerComplete(event, true, this.processPointerCancel);
     }
 
@@ -1294,6 +1302,9 @@ export default class InteractionManager extends EventEmitter
      */
     onPointerUp(event)
     {
+        // if we support touch events, then only use those for touch events, not pointer events
+        if (this.supportsTouchEvents && event.pointerType === 'touch') return;
+
         this.onPointerComplete(event, false, this.processPointerUp);
     }
 
@@ -1393,6 +1404,9 @@ export default class InteractionManager extends EventEmitter
      */
     onPointerMove(originalEvent)
     {
+        // if we support touch events, then only use those for touch events, not pointer events
+        if (this.supportsTouchEvents && originalEvent.pointerType === 'touch') return;
+
         const events = this.normalizeToPointerData(originalEvent);
 
         if (events[0].pointerType === 'mouse')
@@ -1472,6 +1486,9 @@ export default class InteractionManager extends EventEmitter
      */
     onPointerOut(originalEvent)
     {
+        // if we support touch events, then only use those for touch events, not pointer events
+        if (this.supportsTouchEvents && originalEvent.pointerType === 'touch') return;
+
         const events = this.normalizeToPointerData(originalEvent);
 
         // Only mouse and pointer can call onPointerOut, so events will always be length 1

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -1155,9 +1155,10 @@ export default class InteractionManager extends EventEmitter
             {
                 this.emit('touchstart', interactionEvent);
             }
-            else if (event.pointerType === 'mouse')
+            // emit a mouse event for "pen" pointers, the way a browser would emit a fallback event
+            else if (event.pointerType === 'mouse' || event.pointerType === 'pen')
             {
-                const isRightButton = event.button === 2 || event.which === 3;
+                const isRightButton = event.button === 2;
 
                 this.emit(isRightButton ? 'rightdown' : 'mousedown', this.eventData);
             }
@@ -1174,8 +1175,7 @@ export default class InteractionManager extends EventEmitter
      */
     processPointerDown(interactionEvent, displayObject, hit)
     {
-        const e = interactionEvent.data.originalEvent;
-
+        const data = interactionEvent.data;
         const id = interactionEvent.data.identifier;
 
         if (hit)
@@ -1186,13 +1186,13 @@ export default class InteractionManager extends EventEmitter
             }
             this.dispatchEvent(displayObject, 'pointerdown', interactionEvent);
 
-            if (e.type === 'touchstart' || e.pointerType === 'touch')
+            if (data.pointerType === 'touch')
             {
                 this.dispatchEvent(displayObject, 'touchstart', interactionEvent);
             }
-            else if (e.type === 'mousedown' || e.pointerType === 'mouse')
+            else if (data.pointerType === 'mouse' || data.pointerType === 'pen')
             {
-                const isRightButton = e.button === 2 || e.which === 3;
+                const isRightButton = data.button === 2;
 
                 if (isRightButton)
                 {
@@ -1241,9 +1241,9 @@ export default class InteractionManager extends EventEmitter
 
             this.emit(cancelled ? 'pointercancel' : `pointerup${eventAppend}`, interactionEvent);
 
-            if (event.pointerType === 'mouse')
+            if (event.pointerType === 'mouse' || event.pointerType === 'pen')
             {
-                const isRightButton = event.button === 2 || event.which === 3;
+                const isRightButton = event.button === 2;
 
                 this.emit(isRightButton ? `rightup${eventAppend}` : `mouseup${eventAppend}`, interactionEvent);
             }
@@ -1278,7 +1278,7 @@ export default class InteractionManager extends EventEmitter
      */
     processPointerCancel(interactionEvent, displayObject)
     {
-        const e = interactionEvent.data.originalEvent;
+        const data = interactionEvent.data;
 
         const id = interactionEvent.data.identifier;
 
@@ -1287,7 +1287,7 @@ export default class InteractionManager extends EventEmitter
             delete displayObject.trackedPointers[id];
             this.dispatchEvent(displayObject, 'pointercancel', interactionEvent);
 
-            if (e.type === 'touchcancel' || e.pointerType === 'touch')
+            if (data.pointerType === 'touch')
             {
                 this.dispatchEvent(displayObject, 'touchcancel', interactionEvent);
             }
@@ -1318,20 +1318,20 @@ export default class InteractionManager extends EventEmitter
      */
     processPointerUp(interactionEvent, displayObject, hit)
     {
-        const e = interactionEvent.data.originalEvent;
+        const data = interactionEvent.data;
 
         const id = interactionEvent.data.identifier;
 
         const trackingData = displayObject.trackedPointers[id];
 
-        const isTouch = (e.type === 'touchend' || e.pointerType === 'touch');
+        const isTouch = data.pointerType === 'touch';
 
-        const isMouse = (e.type.indexOf('mouse') === 0 || e.pointerType === 'mouse');
+        const isMouse = (data.pointerType === 'mouse' || data.pointerType === 'pen');
 
         // Mouse only
         if (isMouse)
         {
-            const isRightButton = e.button === 2 || e.which === 3;
+            const isRightButton = data.button === 2;
 
             const flags = InteractionTrackingData.FLAGS;
 
@@ -1438,7 +1438,7 @@ export default class InteractionManager extends EventEmitter
             );
             this.emit('pointermove', interactionEvent);
             if (event.pointerType === 'touch') this.emit('touchmove', interactionEvent);
-            if (event.pointerType === 'mouse') this.emit('mousemove', interactionEvent);
+            if (event.pointerType === 'mouse' || event.pointerType === 'pen') this.emit('mousemove', interactionEvent);
         }
 
         if (events[0].pointerType === 'mouse')
@@ -1459,11 +1459,11 @@ export default class InteractionManager extends EventEmitter
      */
     processPointerMove(interactionEvent, displayObject, hit)
     {
-        const e = interactionEvent.data.originalEvent;
+        const data = interactionEvent.data;
 
-        const isTouch = (e.type === 'touchmove' || e.pointerType === 'touch');
+        const isTouch = data.pointerType === 'touch';
 
-        const isMouse = (e.type === 'mousemove' || e.pointerType === 'mouse');
+        const isMouse = (data.pointerType === 'mouse' || data.pointerType === 'pen');
 
         if (isMouse)
         {
@@ -1509,7 +1509,7 @@ export default class InteractionManager extends EventEmitter
         this.processInteractive(interactionEvent, this.renderer._lastObjectRendered, this.processPointerOverOut, false);
 
         this.emit('pointerout', interactionEvent);
-        if (event.pointerType === 'mouse')
+        if (event.pointerType === 'mouse' || event.pointerType === 'pen')
         {
             this.emit('mouseout', interactionEvent);
         }
@@ -1531,11 +1531,11 @@ export default class InteractionManager extends EventEmitter
      */
     processPointerOverOut(interactionEvent, displayObject, hit)
     {
-        const e = interactionEvent.data.originalEvent;
+        const data = interactionEvent.data;
 
         const id = interactionEvent.data.identifier;
 
-        const isMouse = (e.type === 'mouseover' || e.type === 'mouseout' || e.pointerType === 'mouse');
+        const isMouse = (data.pointerType === 'mouse' || data.pointerType === 'pen');
 
         let trackingData = displayObject.trackedPointers[id];
 
@@ -1607,7 +1607,7 @@ export default class InteractionManager extends EventEmitter
         }
 
         this.emit('pointerover', interactionEvent);
-        if (event.pointerType === 'mouse')
+        if (event.pointerType === 'mouse' || event.pointerType === 'pen')
         {
             this.emit('mouseover', interactionEvent);
         }

--- a/test/interaction/InteractionManager.js
+++ b/test/interaction/InteractionManager.js
@@ -1298,4 +1298,34 @@ describe('PIXI.interaction.InteractionManager', function ()
             expect(hit).to.equal(behind);
         });
     });
+
+    describe('InteractionData properties', function ()
+    {
+        it('isPrimary should be set for first touch only', function ()
+        {
+            const stage = new PIXI.Container();
+            const graphics = new PIXI.Graphics();
+            const pointer = this.pointer = new MockPointer(stage);
+
+            stage.addChild(graphics);
+            graphics.beginFill(0xFFFFFF);
+            graphics.drawRect(0, 0, 50, 50);
+            graphics.interactive = true;
+
+            pointer.touchstart(10, 10, 1);
+            expect(pointer.interaction.activeInteractionData[1]).to.exist;
+            expect(pointer.interaction.activeInteractionData[1].isPrimary,
+                    'first touch should be primary on touch start').to.be.true;
+            pointer.touchstart(13, 9, 2);
+            expect(pointer.interaction.activeInteractionData[2].isPrimary,
+                    'second touch should not be primary').to.be.false;
+            pointer.touchmove(10, 20, 1);
+            expect(pointer.interaction.activeInteractionData[1].isPrimary,
+                    'first touch should still be primary after move').to.be.true;
+            pointer.touchend(10, 10, 1);
+            pointer.touchmove(13, 29, 2);
+            expect(pointer.interaction.activeInteractionData[2].isPrimary,
+                    'second touch should still not be primary after first is done').to.be.false;
+        });
+    });
 });

--- a/test/interaction/InteractionManager.js
+++ b/test/interaction/InteractionManager.js
@@ -1441,4 +1441,61 @@ describe('PIXI.interaction.InteractionManager', function ()
                     'second touch should still not be primary after first is done').to.be.false;
         });
     });
+
+    describe('mouse events from pens', function ()
+    {
+        it('should call mousedown handler', function ()
+        {
+            const stage = new PIXI.Container();
+            const graphics = new PIXI.Graphics();
+            const eventSpy = sinon.spy();
+            const pointer = this.pointer = new MockPointer(stage, null, null, true);
+
+            stage.addChild(graphics);
+            graphics.beginFill(0xFFFFFF);
+            graphics.drawRect(0, 0, 50, 50);
+            graphics.interactive = true;
+            graphics.on('mousedown', eventSpy);
+
+            pointer.pendown(10, 10);
+
+            expect(eventSpy).to.have.been.calledOnce;
+        });
+
+        it('should call mousemove handler', function ()
+        {
+            const stage = new PIXI.Container();
+            const graphics = new PIXI.Graphics();
+            const eventSpy = sinon.spy();
+            const pointer = this.pointer = new MockPointer(stage, null, null, true);
+
+            stage.addChild(graphics);
+            graphics.beginFill(0xFFFFFF);
+            graphics.drawRect(0, 0, 50, 50);
+            graphics.interactive = true;
+            graphics.on('mousemove', eventSpy);
+
+            pointer.penmove(10, 10);
+
+            expect(eventSpy).to.have.been.calledOnce;
+        });
+
+        it('should call mouseup handler', function ()
+        {
+            const stage = new PIXI.Container();
+            const graphics = new PIXI.Graphics();
+            const eventSpy = sinon.spy();
+            const pointer = this.pointer = new MockPointer(stage, null, null, true);
+
+            stage.addChild(graphics);
+            graphics.beginFill(0xFFFFFF);
+            graphics.drawRect(0, 0, 50, 50);
+            graphics.interactive = true;
+            graphics.on('mouseup', eventSpy);
+
+            pointer.penup(10, 10);
+
+            expect(eventSpy).to.have.been.calledOnce;
+        });
+    });
 });

--- a/test/interaction/InteractionManager.js
+++ b/test/interaction/InteractionManager.js
@@ -128,6 +128,95 @@ describe('PIXI.interaction.InteractionManager', function ()
         });
     });
 
+    describe('touch vs pointer', function ()
+    {
+        it('should call touchstart and pointerdown when touch event and pointer supported', function ()
+        {
+            const stage = new PIXI.Container();
+            const graphics = new PIXI.Graphics();
+            const touchSpy = sinon.spy(function touchListen() { /* noop */ });
+            const pointerSpy = sinon.spy(function pointerListen() { /* noop */ });
+            const pointer = this.pointer = new MockPointer(stage, null, null, true);
+
+            stage.addChild(graphics);
+            graphics.beginFill(0xFFFFFF);
+            graphics.drawRect(0, 0, 50, 50);
+            graphics.interactive = true;
+            graphics.on('touchstart', touchSpy);
+            graphics.on('pointerdown', pointerSpy);
+
+            pointer.touchstart(10, 10);
+
+            expect(touchSpy).to.have.been.calledOnce;
+            expect(pointerSpy).to.have.been.calledOnce;
+        });
+
+        it('should not call touchstart or pointerdown when pointer event and touch supported', function ()
+        {
+            const stage = new PIXI.Container();
+            const graphics = new PIXI.Graphics();
+            const touchSpy = sinon.spy(function touchListen() { /* noop */ });
+            const pointerSpy = sinon.spy(function pointerListen() { /* noop */ });
+            const pointer = this.pointer = new MockPointer(stage, null, null, true);
+
+            stage.addChild(graphics);
+            graphics.beginFill(0xFFFFFF);
+            graphics.drawRect(0, 0, 50, 50);
+            graphics.interactive = true;
+            graphics.on('touchstart', touchSpy);
+            graphics.on('pointerdown', pointerSpy);
+
+            pointer.touchstart(10, 10, 0, true);
+
+            expect(touchSpy).to.not.have.been.called;
+            expect(pointerSpy).to.not.have.been.called;
+        });
+
+        it('should call touchstart and pointerdown when touch event and pointer not supported', function ()
+        {
+            const stage = new PIXI.Container();
+            const graphics = new PIXI.Graphics();
+            const touchSpy = sinon.spy(function touchListen() { /* noop */ });
+            const pointerSpy = sinon.spy(function pointerListen() { /* noop */ });
+            const pointer = this.pointer = new MockPointer(stage, null, null, false);
+
+            stage.addChild(graphics);
+            graphics.beginFill(0xFFFFFF);
+            graphics.drawRect(0, 0, 50, 50);
+            graphics.interactive = true;
+            graphics.on('touchstart', touchSpy);
+            graphics.on('pointerdown', pointerSpy);
+
+            pointer.touchstart(10, 10);
+
+            expect(touchSpy).to.have.been.calledOnce;
+            expect(pointerSpy).to.have.been.calledOnce;
+        });
+
+        it('should call touchstart and pointerdown when pointer event and touch not supported', function ()
+        {
+            const stage = new PIXI.Container();
+            const graphics = new PIXI.Graphics();
+            const touchSpy = sinon.spy(function touchListen() { /* noop */ });
+            const pointerSpy = sinon.spy(function pointerListen() { /* noop */ });
+            const pointer = this.pointer = new MockPointer(stage, null, null, true);
+
+            pointer.interaction.supportsTouchEvents = false;
+
+            stage.addChild(graphics);
+            graphics.beginFill(0xFFFFFF);
+            graphics.drawRect(0, 0, 50, 50);
+            graphics.interactive = true;
+            graphics.on('touchstart', touchSpy);
+            graphics.on('pointerdown', pointerSpy);
+
+            pointer.touchstart(10, 10, 0, true);
+
+            expect(touchSpy).to.have.been.calledOnce;
+            expect(pointerSpy).to.have.been.calledOnce;
+        });
+    });
+
     describe('add/remove events', function ()
     {
         let stub;
@@ -283,13 +372,37 @@ describe('PIXI.interaction.InteractionManager', function ()
             expect(element.removeEventListener).to.have.been.calledWith('mouseover');
         });
 
-        it('should add and remove touch events to element', function ()
+        it('should add and remove touch events to element without pointer events', function ()
         {
             const manager = new PIXI.interaction.InteractionManager(sinon.stub());
             const element = { style: {}, addEventListener: sinon.stub(), removeEventListener: sinon.stub() };
 
             manager.interactionDOMElement = element;
             manager.supportsPointerEvents = false;
+            manager.supportsTouchEvents = true;
+
+            manager.addEvents();
+
+            expect(element.addEventListener).to.have.been.calledWith('touchstart');
+            expect(element.addEventListener).to.have.been.calledWith('touchcancel');
+            expect(element.addEventListener).to.have.been.calledWith('touchend');
+            expect(element.addEventListener).to.have.been.calledWith('touchmove');
+
+            manager.removeEvents();
+
+            expect(element.removeEventListener).to.have.been.calledWith('touchstart');
+            expect(element.removeEventListener).to.have.been.calledWith('touchcancel');
+            expect(element.removeEventListener).to.have.been.calledWith('touchend');
+            expect(element.removeEventListener).to.have.been.calledWith('touchmove');
+        });
+
+        it('should add and remove touch events to element with pointer events', function ()
+        {
+            const manager = new PIXI.interaction.InteractionManager(sinon.stub());
+            const element = { style: {}, addEventListener: sinon.stub(), removeEventListener: sinon.stub() };
+
+            manager.interactionDOMElement = element;
+            manager.supportsPointerEvents = true;
             manager.supportsTouchEvents = true;
 
             manager.addEvents();

--- a/test/interaction/MockPointer.js
+++ b/test/interaction/MockPointer.js
@@ -30,6 +30,7 @@ class MockPointer
             this.createdPointerEvent = true;
         }
 
+        this.activeTouches = [];
         this.stage = stage;
         this.renderer = new PIXI.CanvasRenderer(width || 100, height || 100);
         this.renderer.sayHello = () => { /* empty */ };
@@ -197,11 +198,13 @@ class MockPointer
      */
     touchstart(x, y, identifier)
     {
+        const touch = new Touch({ identifier: identifier || 0, target: this.renderer.view });
+
+        this.activeTouches.push(touch);
         const touchEvent = new TouchEvent('touchstart', {
             preventDefault: sinon.stub(),
-            changedTouches: [
-                new Touch({ identifier: identifier || 0, target: this.renderer.view }),
-            ],
+            changedTouches: [touch],
+            touches: this.activeTouches,
         });
 
         Object.defineProperty(touchEvent, 'target', { value: this.renderer.view });
@@ -216,13 +219,41 @@ class MockPointer
      * @param {number} y - pointer y position
      * @param {number} [identifier] - pointer id
      */
+    touchmove(x, y, identifier)
+    {
+        const touch = new Touch({ identifier: identifier || 0, target: this.renderer.view });
+        const touchEvent = new TouchEvent('touchmove', {
+            preventDefault: sinon.stub(),
+            changedTouches: [touch],
+            touches: this.activeTouches,
+        });
+
+        this.setPosition(x, y);
+        this.render();
+        this.interaction.onPointerMove(touchEvent);
+    }
+
+    /**
+     * @param {number} x - pointer x position
+     * @param {number} y - pointer y position
+     * @param {number} [identifier] - pointer id
+     */
     touchend(x, y, identifier)
     {
+        const touch = new Touch({ identifier: identifier || 0, target: this.renderer.view });
+
+        for (let i = 0; i < this.activeTouches.length; ++i)
+        {
+            if (this.activeTouches[i].identifier === touch.identifier)
+            {
+                this.activeTouches.splice(i, 1);
+                break;
+            }
+        }
         const touchEvent = new TouchEvent('touchend', {
             preventDefault: sinon.stub(),
-            changedTouches: [
-                new Touch({ identifier: identifier || 0, target: this.renderer.view }),
-            ],
+            changedTouches: [touch],
+            touches: this.activeTouches,
         });
 
         Object.defineProperty(touchEvent, 'target', { value: this.renderer.view });
@@ -239,11 +270,20 @@ class MockPointer
      */
     touchleave(x, y, identifier)
     {
+        const touch = new Touch({ identifier: identifier || 0, target: this.renderer.view });
+
+        for (let i = 0; i < this.activeTouches.length; ++i)
+        {
+            if (this.activeTouches[i].identifier === touch.identifier)
+            {
+                this.activeTouches.splice(i, 1);
+                break;
+            }
+        }
         const touchEvent = new TouchEvent('touchleave', {
             preventDefault: sinon.stub(),
-            changedTouches: [
-                new Touch({ identifier: identifier || 0, target: this.renderer.view }),
-            ],
+            changedTouches: [touch],
+            touches: this.activeTouches,
         });
 
         Object.defineProperty(touchEvent, 'target', { value: this.renderer.view });


### PR DESCRIPTION
Makes the event behavior of InteractionManager closer to that of standard browser behavior with:

* Expose event properties on `InteractionData` (originally from #3890)
* If TouchEvents are supported, use those instead of PointerEvents for touch based events - Fixes #3886
* Emit mouse events on pointer events from a pen device. - Fixes #3867
    * A browser would emit a fallback mouse event on those pointer events, which we were not doing.

Also does a little simplification/cleanup of how we were detecting pointer types and right clicks to determine what events to emit.