### PR TITLE
Removes deprecation warnings with TextMetrics usage

### DIFF
--- a/src/prepare/BasePrepare.js
+++ b/src/prepare/BasePrepare.js
@@ -436,10 +436,7 @@ function calculateTextStyle(helper, item)
     {
         const font = item.toFontString();
 
-        if (!core.TextMetrics._fonts[font])
-        {
-            core.TextMetrics.measureFont(font);
-        }
+        core.TextMetrics.measureFont(font);
 
         return true;
     }

--- a/src/prepare/BasePrepare.js
+++ b/src/prepare/BasePrepare.js
@@ -434,11 +434,11 @@ function calculateTextStyle(helper, item)
 {
     if (item instanceof core.TextStyle)
     {
-        const font = core.Text.getFontStyle(item);
+        const font = item.toFontString();
 
-        if (!core.Text.fontPropertiesCache[font])
+        if (!core.TextMetrics._fonts[font])
         {
-            core.Text.calculateFontProperties(font);
+            core.TextMetrics.measureFont(font);
         }
 
         return true;


### PR DESCRIPTION
### Fixed

* Internally, the prepare plugin was still using the old Text API. This PR fixes #3968

**v4.5.1** (with warnings) https://jsfiddle.net/bs05a3t8/
**fix-text-prepare** (without warnings) https://jsfiddle.net/bs05a3t8/1/
