### PR TITLE
Take into account baseTexture resolution when registering a BitmapText.

### DIFF
--- a/src/extras/BitmapText.js
+++ b/src/extras/BitmapText.js
@@ -469,10 +469,11 @@ export default class BitmapText extends core.Container
         const data = {};
         const info = xml.getElementsByTagName('info')[0];
         const common = xml.getElementsByTagName('common')[0];
+		const res = texture.baseTexture.resolution || 1;
 
         data.font = info.getAttribute('face');
         data.size = parseInt(info.getAttribute('size'), 10);
-        data.lineHeight = parseInt(common.getAttribute('lineHeight'), 10);
+        data.lineHeight = parseInt(common.getAttribute('lineHeight'), 10) / res;
         data.chars = {};
 
         // parse letters
@@ -484,16 +485,16 @@ export default class BitmapText extends core.Container
             const charCode = parseInt(letter.getAttribute('id'), 10);
 
             const textureRect = new core.Rectangle(
-                parseInt(letter.getAttribute('x'), 10) + texture.frame.x,
-                parseInt(letter.getAttribute('y'), 10) + texture.frame.y,
-                parseInt(letter.getAttribute('width'), 10),
-                parseInt(letter.getAttribute('height'), 10)
+                parseInt(letter.getAttribute('x'), 10) / res + texture.frame.x / res,
+                parseInt(letter.getAttribute('y'), 10) / res + texture.frame.y / res,
+                parseInt(letter.getAttribute('width'), 10) / res,
+                parseInt(letter.getAttribute('height'), 10) / res
             );
 
             data.chars[charCode] = {
-                xOffset: parseInt(letter.getAttribute('xoffset'), 10),
-                yOffset: parseInt(letter.getAttribute('yoffset'), 10),
-                xAdvance: parseInt(letter.getAttribute('xadvance'), 10),
+                xOffset: parseInt(letter.getAttribute('xoffset'), 10) / res,
+                yOffset: parseInt(letter.getAttribute('yoffset'), 10) / res,
+                xAdvance: parseInt(letter.getAttribute('xadvance'), 10) / res,
                 kerning: {},
                 texture: new core.Texture(texture.baseTexture, textureRect),
 
@@ -506,9 +507,9 @@ export default class BitmapText extends core.Container
         for (let i = 0; i < kernings.length; i++)
         {
             const kerning = kernings[i];
-            const first = parseInt(kerning.getAttribute('first'), 10);
-            const second = parseInt(kerning.getAttribute('second'), 10);
-            const amount = parseInt(kerning.getAttribute('amount'), 10);
+            const first = parseInt(kerning.getAttribute('first'), 10) / res;
+            const second = parseInt(kerning.getAttribute('second'), 10) / res;
+            const amount = parseInt(kerning.getAttribute('amount'), 10) / res;
 
             if (data.chars[second])
             {

--- a/src/extras/BitmapText.js
+++ b/src/extras/BitmapText.js
@@ -469,7 +469,7 @@ export default class BitmapText extends core.Container
         const data = {};
         const info = xml.getElementsByTagName('info')[0];
         const common = xml.getElementsByTagName('common')[0];
-		const res = texture.baseTexture.resolution || 1;
+        const res = texture.baseTexture.resolution || PIXI.settings.RESOLUTION;
 
         data.font = info.getAttribute('face');
         data.size = parseInt(info.getAttribute('size'), 10);

--- a/src/extras/BitmapText.js
+++ b/src/extras/BitmapText.js
@@ -486,8 +486,8 @@ export default class BitmapText extends core.Container
             const charCode = parseInt(letter.getAttribute('id'), 10);
 
             const textureRect = new core.Rectangle(
-                parseInt(letter.getAttribute('x'), 10) / res + (texture.frame.x / res),
-                parseInt(letter.getAttribute('y'), 10) / res + (texture.frame.y / res),
+                (parseInt(letter.getAttribute('x'), 10) / res) + (texture.frame.x / res),
+                (parseInt(letter.getAttribute('y'), 10) / res) + (texture.frame.y / res),
                 parseInt(letter.getAttribute('width'), 10) / res,
                 parseInt(letter.getAttribute('height'), 10) / res
             );

--- a/src/extras/BitmapText.js
+++ b/src/extras/BitmapText.js
@@ -486,8 +486,8 @@ export default class BitmapText extends core.Container
             const charCode = parseInt(letter.getAttribute('id'), 10);
 
             const textureRect = new core.Rectangle(
-                parseInt(letter.getAttribute('x'), 10) / res + texture.frame.x / res,
-                parseInt(letter.getAttribute('y'), 10) / res + texture.frame.y / res,
+                parseInt(letter.getAttribute('x'), 10) / res + (texture.frame.x / res),
+                parseInt(letter.getAttribute('y'), 10) / res + (texture.frame.y / res),
                 parseInt(letter.getAttribute('width'), 10) / res,
                 parseInt(letter.getAttribute('height'), 10) / res
             );

--- a/src/extras/BitmapText.js
+++ b/src/extras/BitmapText.js
@@ -1,5 +1,6 @@
 import * as core from '../core';
 import ObservablePoint from '../core/math/ObservablePoint';
+import settings from '../core/settings';
 
 /**
  * A BitmapText object will create a line or multiple lines of text using bitmap font. To
@@ -469,7 +470,7 @@ export default class BitmapText extends core.Container
         const data = {};
         const info = xml.getElementsByTagName('info')[0];
         const common = xml.getElementsByTagName('common')[0];
-        const res = texture.baseTexture.resolution || PIXI.settings.RESOLUTION;
+        const res = texture.baseTexture.resolution || settings.RESOLUTION;
 
         data.font = info.getAttribute('face');
         data.size = parseInt(info.getAttribute('size'), 10);

--- a/src/extras/index.js
+++ b/src/extras/index.js
@@ -3,6 +3,7 @@
  * @namespace PIXI.extras
  */
 export { default as AnimatedSprite } from './AnimatedSprite';
+export { default as TextureTransform } from './TextureTransform';
 export { default as TilingSprite } from './TilingSprite';
 export { default as TilingSpriteRenderer } from './webgl/TilingSpriteRenderer';
 export { default as BitmapText } from './BitmapText';


### PR DESCRIPTION
When the base texture has a resolution scale other than 1, then the result of the rendered bitmap text becomes a mess. This change allows you to use bitmap fonts with different screen resolutions.