### PR TITLE
Missing lint from travis test

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "watch": "npm run dist -- --watch",
     "watch:lib": "npm run lib -- --watch",
     "watch:lint": "watch \"eslint scripts src test || exit 0\" src",
-    "test": "npm run dist && npm run coverage",
+    "test": "npm run lint && npm run dist && npm run coverage",
     "unit-test": "floss --path test/index.js",
     "unit-test:debug": "npm run unit-test -- --debug",
     "prerenders": "npm --prefix scripts/renders i scripts/renders",

--- a/test/interaction/InteractionManager.js
+++ b/test/interaction/InteractionManager.js
@@ -1215,7 +1215,7 @@ describe('PIXI.interaction.InteractionManager', function ()
             expect(pointer.renderer.view.style.cursor).to.equal('');
         });
 
-        it.only('should use cursor property as css if no style entry', function ()
+        it('should use cursor property as css if no style entry', function ()
         {
             const stage = new PIXI.Container();
             const graphics = new PIXI.Graphics();


### PR DESCRIPTION
Updated to #3984 and #3975, Travis was left out of the lint process and tests were being blocked because of `it.only`

See Travis build process: https://travis-ci.org/pixijs/pixi.js/builds/228835831#L349-L355