### PR TITLE
Add `updateTexture` & some shortcuts in Sprite; Cosmetic

### DIFF
--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -404,6 +404,19 @@ export default class Sprite extends Container
     }
 
     /**
+     * Update texture if the content of texture has changed.
+     * e.g. If texture is based on a canvas , and after the canvas changed, please call this method.
+     */
+    updateTexture()
+    {
+        const baseTexture = this._texture.baseTexture;
+
+        this._onTextureUpdate();
+
+        baseTexture.emit('update', baseTexture);
+    }
+
+    /**
      * Destroys this sprite and optionally its texture and children
      *
      * @param {object|boolean} [options] - Options parameter. A boolean will act as if all options
@@ -590,5 +603,45 @@ export default class Sprite extends Container
                 value.once('update', this._onTextureUpdate, this);
             }
         }
+    }
+
+    /**
+     * The orig of the texture
+     *
+     * @member {PIXI.Rectangle}
+     */
+    get orig()
+    {
+        return this._texture.orig;
+    }
+
+    /**
+     * The frame of the texture
+     *
+     * @member {PIXI.Rectangle}
+     */
+    get frame()
+    {
+        return this._texture.frame;
+    }
+
+    /**
+     * The trim of the texture
+     *
+     * @member {PIXI.Rectangle}
+     */
+    get trim()
+    {
+        return this._texture.trim;
+    }
+
+    /**
+     * The baseTexture of the texture
+     *
+     * @member {PIXI.BaseTexture}
+     */
+    get baseTexture()
+    {
+        return this._texture.baseTexture;
     }
 }

--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -404,19 +404,6 @@ export default class Sprite extends Container
     }
 
     /**
-     * Update texture if the content of texture has changed.
-     * e.g. If texture is based on a canvas , and after the canvas changed, please call this method.
-     */
-    updateTexture()
-    {
-        const baseTexture = this._texture.baseTexture;
-
-        this._onTextureUpdate();
-
-        baseTexture.emit('update', baseTexture);
-    }
-
-    /**
      * Destroys this sprite and optionally its texture and children
      *
      * @param {object|boolean} [options] - Options parameter. A boolean will act as if all options
@@ -603,45 +590,5 @@ export default class Sprite extends Container
                 value.once('update', this._onTextureUpdate, this);
             }
         }
-    }
-
-    /**
-     * The orig of the texture
-     *
-     * @member {PIXI.Rectangle}
-     */
-    get orig()
-    {
-        return this._texture.orig;
-    }
-
-    /**
-     * The frame of the texture
-     *
-     * @member {PIXI.Rectangle}
-     */
-    get frame()
-    {
-        return this._texture.frame;
-    }
-
-    /**
-     * The trim of the texture
-     *
-     * @member {PIXI.Rectangle}
-     */
-    get trim()
-    {
-        return this._texture.trim;
-    }
-
-    /**
-     * The baseTexture of the texture
-     *
-     * @member {PIXI.BaseTexture}
-     */
-    get baseTexture()
-    {
-        return this._texture.baseTexture;
     }
 }

--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -134,6 +134,7 @@ export default class Text extends Sprite
 
         this._font = this._style.toFontString();
 
+        const context = this.context;
         const measured = TextMetrics.measureText(this._text, this._style, this._style.wordWrap, this.canvas);
         const width = measured.width;
         const height = measured.height;
@@ -146,32 +147,32 @@ export default class Text extends Sprite
         this.canvas.width = Math.ceil((width + (style.padding * 2)) * this.resolution);
         this.canvas.height = Math.ceil((height + (style.padding * 2)) * this.resolution);
 
-        this.context.scale(this.resolution, this.resolution);
+        context.scale(this.resolution, this.resolution);
 
-        this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);
+        context.clearRect(0, 0, this.canvas.width, this.canvas.height);
 
-        this.context.font = this._font;
-        this.context.strokeStyle = style.stroke;
-        this.context.lineWidth = style.strokeThickness;
-        this.context.textBaseline = style.textBaseline;
-        this.context.lineJoin = style.lineJoin;
-        this.context.miterLimit = style.miterLimit;
+        context.font = this._font;
+        context.strokeStyle = style.stroke;
+        context.lineWidth = style.strokeThickness;
+        context.textBaseline = style.textBaseline;
+        context.lineJoin = style.lineJoin;
+        context.miterLimit = style.miterLimit;
 
         let linePositionX;
         let linePositionY;
 
         if (style.dropShadow)
         {
-            this.context.shadowBlur = style.dropShadowBlur;
-            this.context.globalAlpha = style.dropShadowAlpha;
+            context.shadowBlur = style.dropShadowBlur;
+            context.globalAlpha = style.dropShadowAlpha;
 
             if (style.dropShadowBlur > 0)
             {
-                this.context.shadowColor = style.dropShadowColor;
+                context.shadowColor = style.dropShadowColor;
             }
             else
             {
-                this.context.fillStyle = style.dropShadowColor;
+                context.fillStyle = style.dropShadowColor;
             }
 
             const xShadowOffset = Math.cos(style.dropShadowAngle) * style.dropShadowDistance;
@@ -200,24 +201,24 @@ export default class Text extends Sprite
 
                     if (style.stroke && style.strokeThickness)
                     {
-                        this.context.strokeStyle = style.dropShadowColor;
+                        context.strokeStyle = style.dropShadowColor;
                         this.drawLetterSpacing(
                             lines[i],
                             linePositionX + xShadowOffset + style.padding, linePositionY + yShadowOffset + style.padding,
                             true
                         );
-                        this.context.strokeStyle = style.stroke;
+                        context.strokeStyle = style.stroke;
                     }
                 }
             }
         }
 
         // reset the shadow blur and alpha that was set by the drop shadow, for the regular text
-        this.context.shadowBlur = 0;
-        this.context.globalAlpha = 1;
+        context.shadowBlur = 0;
+        context.globalAlpha = 1;
 
         // set canvas text styles
-        this.context.fillStyle = this._generateFillStyle(style, lines);
+        context.fillStyle = this._generateFillStyle(style, lines);
 
         // draw lines line by line
         for (let i = 0; i < lines.length; i++)
@@ -314,29 +315,32 @@ export default class Text extends Sprite
      */
     updateTexture()
     {
+        const canvas = this.canvas;
+
         if (this._style.trim)
         {
-            const trimmed = trimCanvas(this.canvas);
+            const trimmed = trimCanvas(canvas);
 
-            this.canvas.width = trimmed.width;
-            this.canvas.height = trimmed.height;
+            canvas.width = trimmed.width;
+            canvas.height = trimmed.height;
             this.context.putImageData(trimmed.data, 0, 0);
         }
 
         const texture = this._texture;
         const style = this._style;
         const padding = style.trim ? 0 : style.padding;
+        const baseTexture = texture.baseTexture;
 
-        texture.baseTexture.hasLoaded = true;
-        texture.baseTexture.resolution = this.resolution;
+        baseTexture.hasLoaded = true;
+        baseTexture.resolution = this.resolution;
 
-        texture.baseTexture.realWidth = this.canvas.width;
-        texture.baseTexture.realHeight = this.canvas.height;
-        texture.baseTexture.width = this.canvas.width / this.resolution;
-        texture.baseTexture.height = this.canvas.height / this.resolution;
-        texture.trim.width = texture._frame.width = this.canvas.width / this.resolution;
-        texture.trim.height = texture._frame.height = this.canvas.height / this.resolution;
+        baseTexture.realWidth = canvas.width;
+        baseTexture.realHeight = canvas.height;
+        baseTexture.width = canvas.width / this.resolution;
+        baseTexture.height = canvas.height / this.resolution;
 
+        texture.trim.width = texture._frame.width = canvas.width / this.resolution;
+        texture.trim.height = texture._frame.height = canvas.height / this.resolution;
         texture.trim.x = -padding;
         texture.trim.y = -padding;
 
@@ -346,7 +350,7 @@ export default class Text extends Sprite
         // call sprite onTextureUpdate to update scale if _width or _height were set
         this._onTextureUpdate();
 
-        texture.baseTexture.emit('update', texture.baseTexture);
+        baseTexture.emit('update', baseTexture);
 
         this.dirty = false;
     }


### PR DESCRIPTION
* Add `updateText`.  If a sprite is created by a canvas ,  when the canvas's changed , user could call `updateText` for updating sprite.
* Add some shortcuts for accessing  some properties of sprite._texture.
* Cosmetic Text. Just define some local vars for accessing properties of `this` , for DRY.