### PR TITLE
fix changing textures to a 1 frame animation bug

### DIFF
--- a/src/extras/AnimatedSprite.js
+++ b/src/extras/AnimatedSprite.js
@@ -348,6 +348,8 @@ export default class AnimatedSprite extends core.Sprite
                 this._durations.push(value[i].time);
             }
         }
+        this.gotoAndStop(0);
+        this.updateTexture();
     }
 
     /**


### PR DESCRIPTION
Trying to change the animation textures in an extras.AnimatedSprite to a 1 frame animation, the textures are not refreshed. Here is an example:
[jsfiddle](https://jsfiddle.net/gazzell/jochsbru/)

I solved it forcing to go to frame 0 and updating the textures on the textures setter:
[jsfiddle-solution](https://jsfiddle.net/gazzell/wgn8eLep/2/)