### PR TITLE
Improvements to where and how gradients can be applied to Text

### DIFF
--- a/src/core/const.js
+++ b/src/core/const.js
@@ -302,12 +302,14 @@ export const TRANSFORM_MODE = {
  * @name TEXT_GRADIENT
  * @memberof PIXI
  * @type {object}
- * @property {number} LINEAR_VERTICAL Vertical gradient
- * @property {number} LINEAR_HORIZONTAL Linear gradient
+ * @property {number} LINEAR_VERTICAL Vertical gradient; maintains same gradient look over each line
+ * @property {number} LINEAR_HORIZONTAL Horizontal gradient
+ * @property {number} LINEAR_VERTICAL_NOREPEAT Vertical gradient; gradient applies over all lines; each will look different
  */
 export const TEXT_GRADIENT = {
     LINEAR_VERTICAL: 0,
     LINEAR_HORIZONTAL: 1,
+    LINEAR_VERTICAL_NOREPEAT: 2,
 };
 
 /**

--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -151,8 +151,22 @@ export default class Text extends Sprite
 
         context.clearRect(0, 0, this.canvas.width, this.canvas.height);
 
+        const fillStyle = this._generateColorStyle(
+            lines,
+            style.fill,
+            style.fillGradientType,
+            style.fillGradientStops
+        );
+
+        const strokeStyle = this._generateColorStyle(
+            lines,
+            style.stroke,
+            style.strokeGradientType,
+            style.strokeGradientStops
+        );
+
         context.font = this._font;
-        context.strokeStyle = style.stroke;
+        context.strokeStyle = strokeStyle;
         context.lineWidth = style.strokeThickness;
         context.textBaseline = style.textBaseline;
         context.lineJoin = style.lineJoin;
@@ -218,7 +232,7 @@ export default class Text extends Sprite
         context.globalAlpha = 1;
 
         // set canvas text styles
-        context.fillStyle = this._generateFillStyle(style, lines);
+        context.fillStyle = fillStyle;
 
         // draw lines line by line
         for (let i = 0; i < lines.length; i++)
@@ -429,21 +443,24 @@ export default class Text extends Sprite
      * Generates the fill style. Can automatically generate a gradient based on the fill style being an array
      *
      * @private
-     * @param {object} style - The style.
      * @param {string[]} lines - The lines of text.
+     * @param {string|string[]|number|number[]|CanvasGradient|CanvasPattern} color - A canvas
+     *  fillstyle that will be used on the text
+     * @param {number} gradientType - The type/direction of the gradient
+     * @param {number[]} gradientStops - The stop points (numbers between 0 and 1) for the gradient
      * @return {string|number|CanvasGradient} The fill style
      */
-    _generateFillStyle(style, lines)
+    _generateColorStyle(lines, color, gradientType, gradientStops)
     {
-        if (!Array.isArray(style.fill))
+        if (!Array.isArray(color))
         {
-            return style.fill;
+            return color;
         }
 
         // cocoon on canvas+ cannot generate textures, so use the first colour instead
         if (navigator.isCocoonJS)
         {
-            return style.fill[0];
+            return color[0];
         }
 
         // the gradient will be evenly spaced out according to how large the array is.
@@ -457,76 +474,90 @@ export default class Text extends Sprite
         const height = this.canvas.height / this.resolution;
 
         // make a copy of the style settings, so we can manipulate them later
-        const fill = style.fill.slice();
-        const fillGradientStops = style.fillGradientStops.slice();
+        const colorArray = color.slice();
+        const gradientStopsArray = gradientStops.slice();
 
         // wanting to evenly distribute the fills. So an array of 4 colours should give fills of 0.25, 0.5 and 0.75
-        if (!fillGradientStops.length)
+        if (!gradientStopsArray.length)
         {
-            const lengthPlus1 = fill.length + 1;
+            const lengthPlus1 = colorArray.length + 1;
 
             for (let i = 1; i < lengthPlus1; ++i)
             {
-                fillGradientStops.push(i / lengthPlus1);
+                gradientStopsArray.push(i / lengthPlus1);
             }
         }
 
         // stop the bleeding of the last gradient on the line above to the top gradient of the this line
         // by hard defining the first gradient colour at point 0, and last gradient colour at point 1
-        fill.unshift(style.fill[0]);
-        fillGradientStops.unshift(0);
+        colorArray.unshift(color[0]);
+        gradientStopsArray.unshift(0);
 
-        fill.push(style.fill[style.fill.length - 1]);
-        fillGradientStops.push(1);
+        colorArray.push(color[color.length - 1]);
+        gradientStopsArray.push(1);
 
-        if (style.fillGradientType === TEXT_GRADIENT.LINEAR_VERTICAL)
+        if (gradientType === TEXT_GRADIENT.LINEAR_VERTICAL)
         {
+            // We want this gradient setting to be repeated over each individual line.
+            // This differs from LINEAR_VERTICAL_NOREPEAT as this setting make each line have the same vertical gradient.
+            // ['#FF0000', '#00FF00', '#0000FF'] over 2 lines would create stops at 0.125, 0.25, 0.375, 0.625, 0.75, 0.875
+
             // start the gradient at the top center of the canvas, and end at the bottom middle of the canvas
             gradient = this.context.createLinearGradient(width / 2, 0, width / 2, height);
 
-            // we need to repeat the gradient so that each individual line of text has the same vertical gradient effect
-            // ['#FF0000', '#00FF00', '#0000FF'] over 2 lines would create stops at 0.125, 0.25, 0.375, 0.625, 0.75, 0.875
-            totalIterations = (fill.length + 1) * lines.length;
+            totalIterations = (colorArray.length + 1) * lines.length;
             currentIteration = 0;
             for (let i = 0; i < lines.length; i++)
             {
                 currentIteration += 1;
-                for (let j = 0; j < fill.length; j++)
+                for (let j = 0; j < colorArray.length; j++)
                 {
-                    if (typeof fillGradientStops[j] === 'number')
+                    if (typeof gradientStopsArray[j] === 'number')
                     {
-                        stop = (fillGradientStops[j] / lines.length) + (i / lines.length);
+                        stop = (gradientStopsArray[j] / lines.length) + (i / lines.length);
                     }
                     else
                     {
                         stop = currentIteration / totalIterations;
                     }
-                    gradient.addColorStop(stop, fill[j]);
+                    gradient.addColorStop(stop, colorArray[j]);
                     currentIteration++;
                 }
             }
         }
         else
         {
-            // start the gradient at the center left of the canvas, and end at the center right of the canvas
-            gradient = this.context.createLinearGradient(0, height / 2, width, height / 2);
+            if (gradientType === TEXT_GRADIENT.LINEAR_VERTICAL_NOREPEAT)
+            {
+                // We want this gradient to just work once over all of the lines.
+                // This differs from LINEAR_VERTICAL as this setting will mean a different gradient color over each line
 
-            // can just evenly space out the gradients in this case, as multiple lines makes no difference
-            // to an even left to right gradient
-            totalIterations = fill.length + 1;
+                // start the gradient at the top center of the canvas, and end at the bottom middle of the canvas
+                gradient = this.context.createLinearGradient(width / 2, 0, width / 2, height);
+            }
+            else if (gradientType === TEXT_GRADIENT.LINEAR_HORIZONTAL)
+            {
+                // Can just evenly space out the gradients in this case, as multiple lines makes no difference
+                // to an even left to right gradient
+
+                // start the gradient at the center left of the canvas, and end at the center right of the canvas
+                gradient = this.context.createLinearGradient(0, height / 2, width, height / 2);
+            }
+
+            totalIterations = colorArray.length + 1;
             currentIteration = 1;
 
-            for (let i = 0; i < fill.length; i++)
+            for (let i = 0; i < colorArray.length; i++)
             {
-                if (typeof fillGradientStops[i] === 'number')
+                if (typeof gradientStopsArray[i] === 'number')
                 {
-                    stop = fillGradientStops[i];
+                    stop = gradientStopsArray[i];
                 }
                 else
                 {
                     stop = currentIteration / totalIterations;
                 }
-                gradient.addColorStop(stop, fill[i]);
+                gradient.addColorStop(stop, colorArray[i]);
                 currentIteration++;
             }
         }

--- a/src/core/text/TextStyle.js
+++ b/src/core/text/TextStyle.js
@@ -27,6 +27,8 @@ const defaultStyle = {
     miterLimit: 10,
     padding: 0,
     stroke: 'black',
+    strokeGradientType: TEXT_GRADIENT.LINEAR_VERTICAL,
+    strokeGradientStops: [],
     strokeThickness: 0,
     textBaseline: 'alphabetic',
     trim: false,
@@ -78,8 +80,13 @@ export default class TextStyle
      *      or increase the spikiness of rendered text.
      * @param {number} [style.padding=0] - Occasionally some fonts are cropped. Adding some padding will prevent this from
      *     happening by adding padding to all sides of the text.
-     * @param {string|number} [style.stroke='black'] - A canvas fillstyle that will be used on the text stroke
-     *  e.g 'blue', '#FCFF00'
+     * @param {string|string[]|number|number[]|CanvasGradient|CanvasPattern} [style.stroke='black'] - A canvas
+     *  fillstyle that will be used on the text stroke e.g 'blue', '#FCFF00'. Can be an array to create a gradient
+     *  eg ['#000000','#FFFFFF']
+     * @param {number} [style.strokeGradientType=PIXI.TEXT_GRADIENT.LINEAR_VERTICAL] - If stroke is an array of colours
+     *  to create a gradient, this can change the type/direction of the gradient. See {@link PIXI.TEXT_GRADIENT}
+     * @param {number[]} [style.strokeGradientStops] - If strike is an array of colours to create a gradient, this array can set
+     * the stop points (numbers between 0 and 1) for the color, overriding the default behaviour of evenly spacing them.
      * @param {number} [style.strokeThickness=0] - A number that represents the thickness of the stroke.
      *  Default is 0 (no stroke)
      * @param {boolean} [style.trim=false] - Trim transparent borders
@@ -405,6 +412,32 @@ export default class TextStyle
         if (this._stroke !== outputColor)
         {
             this._stroke = outputColor;
+            this.styleID++;
+        }
+    }
+
+    get strokeGradientType()
+    {
+        return this._strokeGradientType;
+    }
+    set strokeGradientType(strokeGradientType)
+    {
+        if (this._strokeGradientType !== strokeGradientType)
+        {
+            this._strokeGradientType = strokeGradientType;
+            this.styleID++;
+        }
+    }
+
+    get strokeGradientStops()
+    {
+        return this._strokeGradientStops;
+    }
+    set strokeGradientStops(strokeGradientStops)
+    {
+        if (!areArraysEqual(this._strokeGradientStops,strokeGradientStops))
+        {
+            this._strokeGradientStops = strokeGradientStops;
             this.styleID++;
         }
     }


### PR DESCRIPTION
Allows the stroke to be a gradient as well as fill - http://stackoverflow.com/questions/43897689/how-to-apply-gradient-stroke-in-pixi-js
New gradient style, LINEAR_VERTICAL_NOREPEAT, which doesn't try to repeat the gradient on multiline to text to make each line match in style - http://stackoverflow.com/questions/43897341/how-to-apply-different-gradients-to-same-text-in-pixi-js

Demo: https://jsfiddle.net/themoonrat/d3roaLmf/ (clear I'm not artist with those chosen colours... )