### PR TITLE
Fix context restore.

### DIFF
--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -223,6 +223,9 @@ export default class WebGLRenderer extends SystemRenderer
 
         const maxTextures = gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS);
 
+        this._activeShader = null;
+        this._activeVao = null;
+
         this.boundTextures = new Array(maxTextures);
         this.emptyTextures = new Array(maxTextures);
 
@@ -674,8 +677,8 @@ export default class WebGLRenderer extends SystemRenderer
      */
     handleContextRestored()
     {
-        this._initContext();
         this.textureManager.removeAll();
+        this._initContext();
     }
 
     /**


### PR DESCRIPTION
Context restore didnt work properly.

Please add this to any of [examples](https://pixijs.github.io/examples/#/basics/basic.js)

```js
setTimeout(function() {
const ext = app.renderer.gl.getExtension('WEBGL_lose_context');
ext.loseContext();
setTimeout(function () {
    ext.restoreContext();
}, 1000);
}, 3000);
```

And then try it with [the fix](https://pixijs.github.io/examples/?v=fix-context-restore#/basics/basic.js)