### PR TITLE
premultiply blendModes, critical for compressed textures.

### DIFF
--- a/src/core/const.js
+++ b/src/core/const.js
@@ -104,6 +104,9 @@ export const BLEND_MODES = {
     SATURATION:     14,
     COLOR:          15,
     LUMINOSITY:     16,
+    NORMAL_NPM:     17,
+    ADD_NPM:        18,
+    SCREEN_NPM:     19,
 };
 
 /**

--- a/src/core/renderers/canvas/utils/mapCanvasBlendModesToPixi.js
+++ b/src/core/renderers/canvas/utils/mapCanvasBlendModesToPixi.js
@@ -53,6 +53,10 @@ export default function mapCanvasBlendModesToPixi(array = [])
         array[BLEND_MODES.COLOR] = 'source-over';
         array[BLEND_MODES.LUMINOSITY] = 'source-over';
     }
+    // not-premultiplied, only for webgl
+    array[BLEND_MODES.NORMAL_NPM] = array[BLEND_MODES.NORMAL];
+    array[BLEND_MODES.ADD_NPM] = array[BLEND_MODES.ADD];
+    array[BLEND_MODES.SCREEN_NPM] = array[BLEND_MODES.SCREEN];
 
     return array;
 }

--- a/src/core/renderers/webgl/WebGLState.js
+++ b/src/core/renderers/webgl/WebGLState.js
@@ -155,7 +155,16 @@ export default class WebGLState
 
         this.activeState[BLEND_FUNC] = value;
 
-        this.gl.blendFunc(this.blendModes[value][0], this.blendModes[value][1]);
+        const mode = this.blendModes[value];
+
+        if (mode.length === 2)
+        {
+            this.gl.blendFunc(mode[0], mode[1]);
+        }
+        else
+        {
+            this.gl.blendFuncSeparate(mode[0], mode[1], mode[2], mode[3]);
+        }
     }
 
     /**

--- a/src/core/renderers/webgl/utils/mapWebGLBlendModesToPixi.js
+++ b/src/core/renderers/webgl/utils/mapWebGLBlendModesToPixi.js
@@ -32,5 +32,10 @@ export default function mapWebGLBlendModesToPixi(gl, array = [])
     array[BLEND_MODES.COLOR] = [gl.ONE, gl.ONE_MINUS_SRC_ALPHA];
     array[BLEND_MODES.LUMINOSITY] = [gl.ONE, gl.ONE_MINUS_SRC_ALPHA];
 
+    // not-premultiplied blend modes
+    array[BLEND_MODES.NORMAL_NPM] = [gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA];
+    array[BLEND_MODES.ADD_NPM] = [gl.SRC_ALPHA, gl.DST_ALPHA, gl.ONE, gl.DST_ALPHA];
+    array[BLEND_MODES.SCREEN_NPM] = [gl.SRC_ALPHA, gl.ONE_MINUS_SRC_COLOR, gl.ONE, gl.ONE_MINUS_SRC_COLOR];
+
     return array;
 }

--- a/src/core/sprites/webgl/SpriteRenderer.js
+++ b/src/core/sprites/webgl/SpriteRenderer.js
@@ -5,6 +5,7 @@ import generateMultiTextureShader from './generateMultiTextureShader';
 import checkMaxIfStatmentsInShader from '../../renderers/webgl/utils/checkMaxIfStatmentsInShader';
 import Buffer from './BatchBuffer';
 import settings from '../../settings';
+import { correctBlendMode, premultiplyTint } from '../../utils';
 import glCore from 'pixi-gl-core';
 import bitTwiddle from 'bit-twiddle';
 
@@ -226,7 +227,7 @@ export default class SpriteRenderer extends ObjectRenderer
         let currentGroup = groups[0];
         let vertexData;
         let uvs;
-        let blendMode = sprites[0].blendMode;
+        let blendMode = correctBlendMode(sprites[0].blendMode, sprites[0]._texture.baseTexture.premultipliedAlpha);
 
         currentGroup.textureCount = 0;
         currentGroup.start = 0;
@@ -251,10 +252,12 @@ export default class SpriteRenderer extends ObjectRenderer
 
             nextTexture = sprite._texture.baseTexture;
 
-            if (blendMode !== sprite.blendMode)
+            const spriteBlendMode = correctBlendMode(blendMode, nextTexture);
+
+            if (blendMode !== spriteBlendMode)
             {
                 // finish a group..
-                blendMode = sprite.blendMode;
+                blendMode = spriteBlendMode;
 
                 // force the batch to break!
                 currentTexture = null;
@@ -362,10 +365,13 @@ export default class SpriteRenderer extends ObjectRenderer
             uint32View[index + 7] = uvs[1];
             uint32View[index + 12] = uvs[2];
             uint32View[index + 17] = uvs[3];
-
             /* eslint-disable max-len */
-            uint32View[index + 3] = uint32View[index + 8] = uint32View[index + 13] = uint32View[index + 18] = sprite._tintRGB + (Math.min(sprite.worldAlpha, 1) * 255 << 24);
+            const alpha = Math.min(sprite.worldAlpha, 1.0);
+            // we dont call extra function if alpha is 1.0, that's faster
+            const argb = alpha < 1.0 && nextTexture.premultipliedAlpha ? premultiplyTint(sprite._tintRGB, alpha)
+                : sprite._tintRGB + (alpha * 255 << 24);
 
+            uint32View[index + 3] = uint32View[index + 8] = uint32View[index + 13] = uint32View[index + 18] = argb;
             float32View[index + 4] = float32View[index + 9] = float32View[index + 14] = float32View[index + 19] = nextTexture._virtalBoundId;
             /* eslint-enable max-len */
 

--- a/src/core/sprites/webgl/SpriteRenderer.js
+++ b/src/core/sprites/webgl/SpriteRenderer.js
@@ -5,7 +5,7 @@ import generateMultiTextureShader from './generateMultiTextureShader';
 import checkMaxIfStatmentsInShader from '../../renderers/webgl/utils/checkMaxIfStatmentsInShader';
 import Buffer from './BatchBuffer';
 import settings from '../../settings';
-import { correctBlendMode, premultiplyTint } from '../../utils';
+import { premultiplyBlendMode, premultiplyTint } from '../../utils';
 import glCore from 'pixi-gl-core';
 import bitTwiddle from 'bit-twiddle';
 
@@ -227,7 +227,8 @@ export default class SpriteRenderer extends ObjectRenderer
         let currentGroup = groups[0];
         let vertexData;
         let uvs;
-        let blendMode = correctBlendMode(sprites[0].blendMode, sprites[0]._texture.baseTexture.premultipliedAlpha);
+        let blendMode = premultiplyBlendMode[
+            Number(sprites[0]._texture.baseTexture.premultipliedAlpha)][sprites[0].blendMode];
 
         currentGroup.textureCount = 0;
         currentGroup.start = 0;
@@ -252,7 +253,7 @@ export default class SpriteRenderer extends ObjectRenderer
 
             nextTexture = sprite._texture.baseTexture;
 
-            const spriteBlendMode = correctBlendMode(sprite.blendMode, nextTexture.premultipliedAlpha);
+            const spriteBlendMode = premultiplyBlendMode[Number(nextTexture.premultipliedAlpha)][sprite.blendMode];
 
             if (blendMode !== spriteBlendMode)
             {

--- a/src/core/sprites/webgl/SpriteRenderer.js
+++ b/src/core/sprites/webgl/SpriteRenderer.js
@@ -252,7 +252,7 @@ export default class SpriteRenderer extends ObjectRenderer
 
             nextTexture = sprite._texture.baseTexture;
 
-            const spriteBlendMode = correctBlendMode(sprite.blendMode, nextTexture);
+            const spriteBlendMode = correctBlendMode(sprite.blendMode, nextTexture.premultipliedAlpha);
 
             if (blendMode !== spriteBlendMode)
             {

--- a/src/core/sprites/webgl/SpriteRenderer.js
+++ b/src/core/sprites/webgl/SpriteRenderer.js
@@ -252,7 +252,7 @@ export default class SpriteRenderer extends ObjectRenderer
 
             nextTexture = sprite._texture.baseTexture;
 
-            const spriteBlendMode = correctBlendMode(blendMode, nextTexture);
+            const spriteBlendMode = correctBlendMode(sprite.blendMode, nextTexture);
 
             if (blendMode !== spriteBlendMode)
             {

--- a/src/core/sprites/webgl/SpriteRenderer.js
+++ b/src/core/sprites/webgl/SpriteRenderer.js
@@ -228,7 +228,7 @@ export default class SpriteRenderer extends ObjectRenderer
         let vertexData;
         let uvs;
         let blendMode = premultiplyBlendMode[
-            Number(sprites[0]._texture.baseTexture.premultipliedAlpha)][sprites[0].blendMode];
+            sprites[0]._texture.baseTexture.premultipliedAlpha ? 1 : 0][sprites[0].blendMode];
 
         currentGroup.textureCount = 0;
         currentGroup.start = 0;

--- a/src/core/sprites/webgl/texture.vert
+++ b/src/core/sprites/webgl/texture.vert
@@ -15,5 +15,5 @@ void main(void){
 
     vTextureCoord = aTextureCoord;
     vTextureId = aTextureId;
-    vColor = vec4(aColor.rgb * aColor.a, aColor.a);
+    vColor = aColor;
 }

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -1,4 +1,4 @@
-import { DATA_URI, URL_FILE_EXTENSION, SVG_SIZE, VERSION } from '../const';
+import { DATA_URI, URL_FILE_EXTENSION, SVG_SIZE, VERSION, BLEND_MODES } from '../const';
 import settings from '../settings';
 import EventEmitter from 'eventemitter3';
 import pluginTarget from './pluginTarget';
@@ -396,4 +396,140 @@ export function clearTextureCache()
     {
         delete BaseTextureCache[key];
     }
+}
+
+/**
+ * changes blendMode according to texture format
+ *
+ * @memberof PIXI.utils
+ * @function correctBlendMode
+ * @param {number} blendMode supposed blend mode
+ * @param {boolean} premultiplied  whether source is premultiplied
+ * @returns {number} true blend mode for this texture
+ */
+export function correctBlendMode(blendMode, premultiplied)
+{
+    if (premultiplied)
+    {
+        if (blendMode < BLEND_MODES.NORMAL_NPM)
+        {
+            return blendMode;
+        }
+        if (blendMode === BLEND_MODES.NORMAL_NPM)
+        {
+            return BLEND_MODES.NORMAL;
+        }
+        if (blendMode === BLEND_MODES.ADD_NPM)
+        {
+            return BLEND_MODES.ADD;
+        }
+        if (blendMode === BLEND_MODES.SCREEN_NPM)
+        {
+            return BLEND_MODES.SCREEN;
+        }
+    }
+    else
+    {
+        if (blendMode > BLEND_MODES.SCREEN)
+        {
+            return blendMode;
+        }
+        if (blendMode === BLEND_MODES.NORMAL)
+        {
+            return BLEND_MODES.NORMAL_NPM;
+        }
+        if (blendMode === BLEND_MODES.ADD)
+        {
+            return BLEND_MODES.ADD_NPM;
+        }
+        if (blendMode === BLEND_MODES.SCREEN)
+        {
+            return BLEND_MODES.SCREEN_NPM;
+        }
+    }
+
+    return blendMode;
+}
+
+/**
+ * premultiplies tint
+ *
+ * @param {number} tint integet RGB
+ * @param {number} alpha floating point alpha (0.0-1.0)
+ * @returns {number} tint multiplied by alpha
+ */
+export function premultiplyTint(tint, alpha)
+{
+    if (alpha === 1.0)
+    {
+        return (alpha * 255 << 24) + tint;
+    }
+    if (alpha === 0.0)
+    {
+        return 0;
+    }
+    let R = ((tint >> 16) & 0xFF);
+    let G = ((tint >> 8) & 0xFF);
+    let B = (tint & 0xFF);
+
+    R = ((R * alpha) + 0.5) | 0;
+    G = ((G * alpha) + 0.5) | 0;
+    B = ((B * alpha) + 0.5) | 0;
+
+    return (alpha * 255 << 24) + (R << 16) + (G << 8) + B;
+}
+
+/**
+ * combines rgb and alpha to out array
+ *
+ * @param {Float32Array|number[]} rgb input rgb
+ * @param {number} alpha alpha param
+ * @param {Float32Array} [out] output
+ * @param {boolean} [premultiply=true] do premultiply it
+ * @returns {Float32Array} vec4 rgba
+ */
+export function premultiplyRgba(rgb, alpha, out, premultiply)
+{
+    out = out || new Float32Array(4);
+    if (premultiply || premultiply === undefined)
+    {
+        out[0] = rgb[0] * alpha;
+        out[1] = rgb[1] * alpha;
+        out[2] = rgb[2] * alpha;
+    }
+    else
+    {
+        out[0] = rgb[0];
+        out[1] = rgb[1];
+        out[2] = rgb[2];
+    }
+    out[3] = alpha;
+
+    return out;
+}
+
+/**
+ * converts integer tint and float alpha to vec4 form, premultiplies by default
+ *
+ * @param {number} tint input tint
+ * @param {number} alpha alpha param
+ * @param {Float32Array} [out] output
+ * @param {boolean} [premultiply=true] do premultiply it
+ * @returns {Float32Array} vec4 rgba
+ */
+export function premultiplyTintToRgba(tint, alpha, out, premultiply)
+{
+    out = out || new Float32Array(4);
+    out[0] = ((tint >> 16) & 0xFF);
+    out[1] = ((tint >> 8) & 0xFF);
+    out[2] = (tint & 0xFF);
+    if (premultiply || premultiply === undefined)
+    {
+        out[0] *= alpha;
+        out[1] *= alpha;
+        out[2] *= alpha;
+    }
+    out[3] = alpha;
+
+    return out;
 }

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -5,7 +5,7 @@ import pluginTarget from './pluginTarget';
 import * as mixins from './mixin';
 import * as isMobile from 'ismobilejs';
 import removeItems from 'remove-array-items';
-import * as mapPremultipliedBlendModes from './mapPremultipliedBlendModes';
+import mapPremultipliedBlendModes from './mapPremultipliedBlendModes';
 
 let nextUid = 0;
 let saidHello = false;

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -1,10 +1,11 @@
-import { DATA_URI, URL_FILE_EXTENSION, SVG_SIZE, VERSION, BLEND_MODES } from '../const';
+import { DATA_URI, URL_FILE_EXTENSION, SVG_SIZE, VERSION } from '../const';
 import settings from '../settings';
 import EventEmitter from 'eventemitter3';
 import pluginTarget from './pluginTarget';
 import * as mixins from './mixin';
 import * as isMobile from 'ismobilejs';
 import removeItems from 'remove-array-items';
+import * as premultiplyBlendMode from './premultiplyBlendMode';
 
 let nextUid = 0;
 let saidHello = false;
@@ -60,6 +61,12 @@ export {
      */
     pluginTarget,
     mixins,
+
+    /**
+     * @memberof PIXI.utils
+     * @type {Array<number[]>} maps premultiply flag and blendMode to adjusted blendMode
+     */
+    premultiplyBlendMode,
 };
 
 /**
@@ -409,46 +416,7 @@ export function clearTextureCache()
  */
 export function correctBlendMode(blendMode, premultiplied)
 {
-    if (premultiplied)
-    {
-        if (blendMode < BLEND_MODES.NORMAL_NPM)
-        {
-            return blendMode;
-        }
-        if (blendMode === BLEND_MODES.NORMAL_NPM)
-        {
-            return BLEND_MODES.NORMAL;
-        }
-        if (blendMode === BLEND_MODES.ADD_NPM)
-        {
-            return BLEND_MODES.ADD;
-        }
-        if (blendMode === BLEND_MODES.SCREEN_NPM)
-        {
-            return BLEND_MODES.SCREEN;
-        }
-    }
-    else
-    {
-        if (blendMode > BLEND_MODES.SCREEN)
-        {
-            return blendMode;
-        }
-        if (blendMode === BLEND_MODES.NORMAL)
-        {
-            return BLEND_MODES.NORMAL_NPM;
-        }
-        if (blendMode === BLEND_MODES.ADD)
-        {
-            return BLEND_MODES.ADD_NPM;
-        }
-        if (blendMode === BLEND_MODES.SCREEN)
-        {
-            return BLEND_MODES.SCREEN_NPM;
-        }
-    }
-
-    return blendMode;
+    return premultiplyBlendMode[Number(premultiplied)][blendMode];
 }
 
 /**

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -417,7 +417,7 @@ export const premultiplyBlendMode = mapPremultipliedBlendModes();
  */
 export function correctBlendMode(blendMode, premultiplied)
 {
-    return premultiplyBlendMode[Number(premultiplied)][blendMode];
+    return premultiplyBlendMode[premultiplied ? 1 : 0][blendMode];
 }
 
 /**

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -5,7 +5,7 @@ import pluginTarget from './pluginTarget';
 import * as mixins from './mixin';
 import * as isMobile from 'ismobilejs';
 import removeItems from 'remove-array-items';
-import * as premultiplyBlendMode from './premultiplyBlendMode';
+import * as mapPremultipliedBlendModes from './mapPremultipliedBlendModes';
 
 let nextUid = 0;
 let saidHello = false;
@@ -61,12 +61,6 @@ export {
      */
     pluginTarget,
     mixins,
-
-    /**
-     * @memberof PIXI.utils
-     * @type {Array<number[]>} maps premultiply flag and blendMode to adjusted blendMode
-     */
-    premultiplyBlendMode,
 };
 
 /**
@@ -404,6 +398,13 @@ export function clearTextureCache()
         delete BaseTextureCache[key];
     }
 }
+
+/**
+ * @memberof PIXI.utils
+ * @const premultiplyBlendMode
+ * @type {Array<number[]>} maps premultiply flag and blendMode to adjusted blendMode
+ */
+export const premultiplyBlendMode = mapPremultipliedBlendModes();
 
 /**
  * changes blendMode according to texture format

--- a/src/core/utils/mapPremultipliedBlendModes.js
+++ b/src/core/utils/mapPremultipliedBlendModes.js
@@ -4,13 +4,13 @@ import { BLEND_MODES } from '../const';
  * Corrects pixi blend, takes premultiplied alpha into account
  *
  * @memberof PIXI
- * @function mapWebGLPremultipliedBlendModesToPixi
+ * @function mapPremultipliedBlendModes
  * @private
  * @param {Array<number[]>} [array] - The array to output into.
  * @return {Array<number[]>} Mapped modes.
  */
 
-function mapWebGLPremultipliedBlendModesToPixi()
+export default function mapPremultipliedBlendModes()
 {
     const pm = [];
     const npm = [];
@@ -36,5 +36,3 @@ function mapWebGLPremultipliedBlendModesToPixi()
 
     return array;
 }
-
-export default mapWebGLPremultipliedBlendModesToPixi();

--- a/src/core/utils/premultiplyBlendMode.js
+++ b/src/core/utils/premultiplyBlendMode.js
@@ -1,0 +1,40 @@
+import { BLEND_MODES } from '../const';
+
+/**
+ * Corrects pixi blend, takes premultiplied alpha into account
+ *
+ * @memberof PIXI
+ * @function mapWebGLPremultipliedBlendModesToPixi
+ * @private
+ * @param {Array<number[]>} [array] - The array to output into.
+ * @return {Array<number[]>} Mapped modes.
+ */
+
+function mapWebGLPremultipliedBlendModesToPixi()
+{
+    const pm = [];
+    const npm = [];
+
+    for (let i = 0; i < 32; i++)
+    {
+        pm[i] = i;
+        npm[i] = i;
+    }
+
+    pm[BLEND_MODES.NORMAL_NPM] = BLEND_MODES.NORMAL;
+    pm[BLEND_MODES.ADD_NPM] = BLEND_MODES.ADD;
+    pm[BLEND_MODES.SCREEN_NPM] = BLEND_MODES.SCREEN;
+
+    npm[BLEND_MODES.NORMAL] = BLEND_MODES.NORMAL_NPM;
+    npm[BLEND_MODES.ADD] = BLEND_MODES.ADD_NPM;
+    npm[BLEND_MODES.SCREEN] = BLEND_MODES.SCREEN_NPM;
+
+    const array = [];
+
+    array.push(npm);
+    array.push(pm);
+
+    return array;
+}
+
+export default mapWebGLPremultipliedBlendModesToPixi();

--- a/src/extras/webgl/TilingSpriteRenderer.js
+++ b/src/extras/webgl/TilingSpriteRenderer.js
@@ -4,7 +4,6 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 
 const tempMat = new core.Matrix();
-const tempArray = new Float32Array(4);
 
 /**
  * WebGL renderer plugin for tiling sprites
@@ -141,17 +140,13 @@ export default class TilingSpriteRenderer extends core.ObjectRenderer
         }
 
         shader.uniforms.uTransform = tempMat.toArray(true);
-
-        const color = tempArray;
-
-        core.utils.hex2rgb(ts.tint, color);
-        color[3] = ts.worldAlpha;
-        shader.uniforms.uColor = color;
+        shader.uniforms.uColor = core.utils.premultiplyTint(ts.tint, ts.worldAlpha,
+            shader.uniforms.uColor, baseTex.premultiplyAlpha);
         shader.uniforms.translationMatrix = ts.transform.worldTransform.toArray(true);
 
         shader.uniforms.uSampler = renderer.bindTexture(tex);
 
-        renderer.setBlendMode(ts.blendMode);
+        renderer.setBlendMode(core.utils.correctBlendMode(ts.blendMode, baseTex.premultiplyAlpha));
 
         quad.vao.draw(this.renderer.gl.TRIANGLES, 6, 0);
     }

--- a/src/mesh/webgl/MeshRenderer.js
+++ b/src/mesh/webgl/MeshRenderer.js
@@ -118,8 +118,9 @@ export default class MeshRenderer extends core.ObjectRenderer
             }
         }
         glData.shader.uniforms.translationMatrix = mesh.worldTransform.toArray(true);
-        glData.shader.uniforms.alpha = mesh.worldAlpha;
-        glData.shader.uniforms.tint = mesh.tintRgb;
+
+        glData.shader.uniforms.uColor = core.utils.premultiplyRgba(mesh._tintRgb,
+            mesh.worldAlpha, texture.baseTexture.premultiplyAlpha);
 
         const drawMode = mesh.drawMode === Mesh.DRAW_MODES.TRIANGLE_MESH ? gl.TRIANGLE_STRIP : gl.TRIANGLES;
 

--- a/src/mesh/webgl/MeshRenderer.js
+++ b/src/mesh/webgl/MeshRenderer.js
@@ -104,7 +104,7 @@ export default class MeshRenderer extends core.ObjectRenderer
 
         glData.shader.uniforms.uSampler = renderer.bindTexture(texture);
 
-        renderer.state.setBlendMode(mesh.blendMode);
+        renderer.state.setBlendMode(core.utils.correctBlendMode(mesh.blendMode, texture.baseTexture.premultiplyAlpha));
 
         if (glData.shader.uniforms.uTransform)
         {

--- a/src/mesh/webgl/mesh.frag
+++ b/src/mesh/webgl/mesh.frag
@@ -1,10 +1,9 @@
 varying vec2 vTextureCoord;
-uniform float alpha;
-uniform vec3 tint;
+uniform vec4 uColor;
 
 uniform sampler2D uSampler;
 
 void main(void)
 {
-    gl_FragColor = texture2D(uSampler, vTextureCoord) * vec4(tint * alpha, alpha);
+    gl_FragColor = texture2D(uSampler, vTextureCoord) * uColor;
 }

--- a/src/particles/ParticleContainer.js
+++ b/src/particles/ParticleContainer.js
@@ -131,8 +131,8 @@ export default class ParticleContainer extends core.Container
          * @member {number}
          * @default 0xFFFFFF
          */
-        this._tint = null;
-        this._tintRGB = [];
+        this._tint = 0;
+        this.tintRgb = new Float32Array(4);
         this.tint = 0xFFFFFF;
     }
 
@@ -180,7 +180,7 @@ export default class ParticleContainer extends core.Container
     set tint(value) // eslint-disable-line require-jsdoc
     {
         this._tint = value;
-        hex2rgb(value, this._tintRGB);
+        hex2rgb(value, this.tintRgb);
     }
 
     /**

--- a/src/particles/webgl/ParticleRenderer.js
+++ b/src/particles/webgl/ParticleRenderer.js
@@ -142,8 +142,10 @@ export default class ParticleRenderer extends core.ObjectRenderer
             buffers = container._glBuffers[renderer.CONTEXT_UID] = this.generateBuffers(container);
         }
 
+        const baseTexture = children[0]._texture.baseTexture;
+
         // if the uvs have not updated then no point rendering just yet!
-        this.renderer.setBlendMode(container.blendMode);
+        this.renderer.setBlendMode(core.utils.correctBlendMode(container.blendMode, baseTexture.premultiplyAlpha));
 
         const gl = renderer.gl;
 
@@ -152,12 +154,11 @@ export default class ParticleRenderer extends core.ObjectRenderer
         m.prepend(renderer._activeRenderTarget.projectionMatrix);
 
         this.shader.uniforms.projectionMatrix = m.toArray(true);
-        this.shader.uniforms.uAlpha = container.worldAlpha;
-        this.shader.uniforms.tint = container._tintRGB;
+
+        this.shader.uniforms.uColor = core.utils.premultiplyRgba(container._tintRgb,
+            container.worldAlpha, baseTexture.premultiplyAlpha);
 
         // make sure the texture is bound..
-        const baseTexture = children[0]._texture.baseTexture;
-
         this.shader.uniforms.uSampler = renderer.bindTexture(baseTexture);
 
         // now lets upload and render the buffers..

--- a/src/particles/webgl/ParticleShader.js
+++ b/src/particles/webgl/ParticleShader.js
@@ -48,11 +48,10 @@ export default class ParticleShader extends Shader
                 'varying float vColor;',
 
                 'uniform sampler2D uSampler;',
-                'uniform float uAlpha;',
-                'uniform vec3 tint;',
+                'uniform vec4 uColor;',
 
                 'void main(void){',
-                '  vec4 color = texture2D(uSampler, vTextureCoord) * vColor * vec4(tint * uAlpha, uAlpha);',
+                '  vec4 color = texture2D(uSampler, vTextureCoord) * vColor * uColor;',
                 '  if (color.a == 0.0) discard;',
                 '  gl_FragColor = color;',
                 '}',


### PR DESCRIPTION
We have "premultipliedAlpha" field in BaseTexture from the beginning of times. But we do not respect it. It was ok, but some time ago both me and @bigtimebuddy started to use compressed textures.

There are no compressed formats with premultiplied alpha in WebGL, DXT1,3,5 are supported, while DXT2,4 aren't.

Example: 

Current version of pixi: https://pixijs.github.io/examples/#/textures/not-premultiplied-alpha.js
This branch: https://pixijs.github.io/examples/?v=dev-blendmodes-premultiply#/textures/not-premultiplied-alpha.js

Please read 
https://www.cgdirector.com/straight-alpha-vs-premultiplied-alpha/ 
http://www.adriancourreges.com/blog/2017/05/09/beware-of-transparent-pixels/
to understand the problem.

Later, I hope we'll be able to add compressed textures as childs of BaseTexture.