### PR TITLE
fix for issue #4043: CORS not working with PIXI.Sprite.fromImage

### DIFF
--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -683,6 +683,10 @@ export default class BaseTexture extends EventEmitter
             {
                 image.crossOrigin = determineCrossOrigin(imageUrl);
             }
+            else if (crossorigin)
+            {
+                image.crossOrigin = typeof crossorigin === 'string' ? crossorigin : 'anonymous';
+            }
 
             baseTexture = new BaseTexture(image, scaleMode);
             baseTexture.imageUrl = imageUrl;

--- a/test/core/BaseTexture.js
+++ b/test/core/BaseTexture.js
@@ -102,11 +102,20 @@ describe('BaseTexture', function ()
         expect(PIXI.utils.BaseTextureCache[NAME2]).to.equal(baseTexture);
     });
 
-    it('destroying a destroyed BaseTexture should not throw an error', function ()
+    it('should not throw an error destroying a destroyed BaseTexture', function ()
     {
         const baseTexture = new PIXI.BaseTexture();
 
         baseTexture.destroy();
         baseTexture.destroy();
+    });
+
+    it('should set source.crossOrigin to anonymous if explicitly set', function ()
+    {
+        cleanCache();
+
+        const baseTexture = PIXI.BaseTexture.fromImage(URL, true);
+
+        expect(baseTexture.source.crossOrigin).to.equal('anonymous');
     });
 });


### PR DESCRIPTION
- added fix suggested by @englercj 
- added test coverage

```
test results before fix (with new test added):

341 passing (1s)
  1 failing

  1) PIXI BaseTexture should set source.crossOrigin to anonymous if explicitly set:
     AssertionError: expected null to equal 'anonymous'
      at Context.<anonymous> (/Users/eddie.reesman/Development/eddie-github/pixi.js/test/core/BaseTexture.js:119:51)
at runCallback (timers.js:651:20)

test results after fix:

342 passing (1s)
```