### PR TITLE
Fix for repeated letters on wordWrapped bitmap text

### DIFF
--- a/src/extras/BitmapText.js
+++ b/src/extras/BitmapText.js
@@ -144,6 +144,7 @@ export default class BitmapText extends core.Container
         let line = 0;
         let lastSpace = -1;
         let lastSpaceWidth = 0;
+        let spacesRemoved = 0;
         let maxLineHeight = 0;
 
         for (let i = 0; i < this.text.length; i++)
@@ -170,9 +171,10 @@ export default class BitmapText extends core.Container
 
             if (lastSpace !== -1 && this.maxWidth > 0 && pos.x * scale > this.maxWidth)
             {
-                core.utils.removeItems(chars, lastSpace, i - lastSpace);
+                core.utils.removeItems(chars, lastSpace - spacesRemoved, i - lastSpace);
                 i = lastSpace;
                 lastSpace = -1;
+                ++spacesRemoved;
 
                 lineWidths.push(lastSpaceWidth);
                 maxLineWidth = Math.max(maxLineWidth, lastSpaceWidth);


### PR DESCRIPTION
Record how many spaces have already been removed when resetting the index for a new line of text after hitting the maxWidth limit

Fixes https://github.com/pixijs/pixi.js/issues/4063