### PR TITLE
Text drop shadow is now the right colour, even with blur enabled

### DIFF
--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -163,16 +163,13 @@ export default class Text extends Sprite
 
         if (style.dropShadow)
         {
-            context.shadowBlur = style.dropShadowBlur;
+            context.fillStyle = style.dropShadowColor;
             context.globalAlpha = style.dropShadowAlpha;
+            context.shadowBlur = style.dropShadowBlur;
 
             if (style.dropShadowBlur > 0)
             {
                 context.shadowColor = style.dropShadowColor;
-            }
-            else
-            {
-                context.fillStyle = style.dropShadowColor;
             }
 
             const xShadowOffset = Math.cos(style.dropShadowAngle) * style.dropShadowDistance;


### PR DESCRIPTION
Fixes: https://github.com/pixijs/pixi.js/issues/3960

Don't see why it was set to ignore the shadow colour before when blur was enabled... that behaviour goes back to v3 days. But it feels like incorrect behaviour to me which this PR fixes