### PR TITLE
Changes the default dropShadowColor in TextStyle

### DIFF
--- a/src/core/text/TextStyle.js
+++ b/src/core/text/TextStyle.js
@@ -11,7 +11,7 @@ const defaultStyle = {
     dropShadowAlpha: 1,
     dropShadowAngle: Math.PI / 6,
     dropShadowBlur: 0,
-    dropShadowColor: '#000000',
+    dropShadowColor: 'black',
     dropShadowDistance: 5,
     fill: 'black',
     fillGradientType: TEXT_GRADIENT.LINEAR_VERTICAL,
@@ -53,7 +53,7 @@ export default class TextStyle
      * @param {number} [style.dropShadowAlpha=1] - Set alpha for the drop shadow
      * @param {number} [style.dropShadowAngle=Math.PI/6] - Set a angle of the drop shadow
      * @param {number} [style.dropShadowBlur=0] - Set a shadow blur radius
-     * @param {string} [style.dropShadowColor='#000000'] - A fill style to be used on the dropshadow e.g 'red', '#00FF00'
+     * @param {string} [style.dropShadowColor='black'] - A fill style to be used on the dropshadow e.g 'red', '#00FF00'
      * @param {number} [style.dropShadowDistance=5] - Set a distance of the drop shadow
      * @param {string|string[]|number|number[]|CanvasGradient|CanvasPattern} [style.fill='black'] - A canvas
      *  fillstyle that will be used on the text e.g 'red', '#00FF00'. Can be an array to create a gradient


### PR DESCRIPTION
Makes the default value of TextStyle's `dropShadowColor` be consistent with `fill` and `stroke` colors. Uses `black` instead of `#000000`.

Would like to fix this to provide more consistent defaults in https://github.com/pixijs/pixi-text-style