### PR TITLE
Remove duplicated base url from loader path in the bitmapFontParser

### DIFF
--- a/src/loaders/bitmapFontParser.js
+++ b/src/loaders/bitmapFontParser.js
@@ -55,11 +55,11 @@ export default function ()
                 {
                     xmlUrl += '/';
                 }
-
-                // remove baseUrl from xmlUrl
-                xmlUrl = xmlUrl.replace(this.baseUrl, '');
             }
         }
+
+        // remove baseUrl from xmlUrl
+        xmlUrl = xmlUrl.replace(this.baseUrl, '');
 
         // if there is an xmlUrl now, it needs a trailing slash. Ensure that it does if the string isn't empty.
         if (xmlUrl && xmlUrl.charAt(xmlUrl.length - 1) !== '/')


### PR DESCRIPTION
### Problem
If loader baseUrl exists, added baseUrl twice to the texture path.

font.xml
```xml
<?xml version='1.0'?>
   <font>
       <pages>
            <page id='0' file='font.png'/>
       </pages>
```

application code
```js
PIXI.loader.baseUrl = '/assets/';
PIXI.loader
  .add(['font.xml'])
  .load();
```
↓
GET /assets//assets/font.png 404 NotFound

### Solusion
Fix the issue https://github.com/pixijs/pixi.js/issues/3510