### PR TITLE
Standardizes how name is represented globally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,11 +30,11 @@ To setup for making changes you will need to take a few steps, we've outlined th
 1. Ensure you have node.js installed. You can download node.js from [nodejs.org][node]. Because
 pixi uses modern JS features, you will need a modern version of node. v4+ is recommended.
 
-2. Fork the [PixiJS][pixi] repository, if you are unsure how to do this GitHub has a guides
+2. Fork the **[pixi.js][pixi]** repository, if you are unsure how to do this GitHub has a guides
 for the [command line][fork-cli] and for the [GitHub Client][fork-gui].
 
 3. Next, run `npm install` from within your clone of your fork. That will install dependencies
-necessary to build PixiJS
+necessary to build PixiJS.
 
 
 ### Making a Change
@@ -61,7 +61,7 @@ bug if it ever happens again. This prevents regressions from sneaking in.
 ### Submitting Your Change
 
 After you have made and tested your change, commit and push it to your fork. Then, open a Pull Request
-from your fork to the main PixiJS repository on the branch you used in the `Making a Change` section of this document.
+from your fork to the main **pixi.js** repository on the branch you used in the `Making a Change` section of this document.
 
 ## Quickie Code Style Guide
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,13 @@
 # How to contribute
 
-It is essential to the development of pixi.js that the community is empowered
+It is essential to the development of PixiJS that the community is empowered
 to make changes and get them into the library. Here are some guidelines to make
 that process silky smooth for all involved.
 
 ## Reporting issues
 
 To report a bug, request a feature, or even ask a question, make use of the GitHub Issues
-section for [pixi.js][issues]. When submitting an issue please take the following steps:
+section for [PixiJS][issues]. When submitting an issue please take the following steps:
 
 1. **Seach for existing issues.** Your question or bug may have already been answered or fixed,
 be sure to search the issues first before putting in a duplicate issue.
@@ -30,11 +30,11 @@ To setup for making changes you will need to take a few steps, we've outlined th
 1. Ensure you have node.js installed. You can download node.js from [nodejs.org][node]. Because
 pixi uses modern JS features, you will need a modern version of node. v4+ is recommended.
 
-2. Fork the [pixi.js][pixi] repository, if you are unsure how to do this GitHub has a guides
+2. Fork the [PixiJS][pixi] repository, if you are unsure how to do this GitHub has a guides
 for the [command line][fork-cli] and for the [GitHub Client][fork-gui].
 
 3. Next, run `npm install` from within your clone of your fork. That will install dependencies
-necessary to build pixi.js
+necessary to build PixiJS
 
 
 ### Making a Change
@@ -54,14 +54,14 @@ one of the above branches.
 
 ### Testing Your Change
 
-You can test your change by using the automated tests packaged with pixi.js. You can run these tests
+You can test your change by using the automated tests packaged with PixiJS. You can run these tests
 by running `npm test` from the command line. If you fix a bug please add a test that will catch that
 bug if it ever happens again. This prevents regressions from sneaking in.
 
 ### Submitting Your Change
 
 After you have made and tested your change, commit and push it to your fork. Then, open a Pull Request
-from your fork to the main pixi.js repository on the branch you used in the `Making a Change` section of this document.
+from your fork to the main PixiJS repository on the branch you used in the `Making a Change` section of this document.
 
 ## Quickie Code Style Guide
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The aim of this project is to provide a fast lightweight 2D library that works
 across all devices. The PixiJS renderer allows everyone to enjoy the power of
 hardware acceleration without prior knowledge of WebGL. Also, it's fast. Really fast.
 
-If you want to keep up to date with the latest pixi.js news then feel free to follow us on twitter
+If you want to keep up to date with the latest PixiJS news then feel free to follow us on twitter
 ([@doormat23](https://twitter.com/doormat23), [@rolnaaba](https://twitter.com/rolnaaba), [@bigtimebuddy](https://twitter.com/bigtimebuddy), [@ivanpopelyshev](https://twitter.com/ivanpopelyshev))
 and we will keep you posted! You can also check back on [our site](http://www.goodboydigital.com/blog)
 as any breakthroughs will be posted up there too!
@@ -31,7 +31,7 @@ PixiJS has full [WebGL](https://en.wikipedia.org/wiki/WebGL) support and seamles
 ### Learn ###
 - Website: Find out more about PixiJS on the [offical website](http://www.pixijs.com/).
 - Getting started: Check out @kittykatattack's comprehensive [tutorial](https://github.com/kittykatattack/learningPixi).
-- Examples: Get stuck right in and play around with pixi code and features right [here](http://pixijs.github.io/examples/)!
+- Examples: Get stuck right in and play around with PixiJS code and features right [here](http://pixijs.github.io/examples/)!
 - Docs: Get to know the PixiJS API by checking out the [docs](https://pixijs.github.io/docs/).
 - Wiki: Other misc tutorials and resources are [on the Wiki](https://github.com/pixijs/pixi.js/wiki/Resources).
 
@@ -84,7 +84,7 @@ those last 2 examples and allowing us to share the source code :)
 
 ### Contribute ###
 
-Want to be part of the pixi.js project? Great! All are welcome! We will get there quicker
+Want to be part of the PixiJS project? Great! All are welcome! We will get there quicker
 together :) Whether you find a bug, have a great feature request or you fancy owning a task
 from the road map above feel free to get in touch.
 
@@ -149,9 +149,9 @@ PIXI.loader.add('bunny', 'bunny.png').load(function(loader, resources) {
 
 ### How to build ###
 
-Note that for most users you don't need to build this project. If all you want is to use pixi, then
+Note that for most users you don't need to build this project. If all you want is to use PixiJS, then
 just download one of our [prebuilt releases](https://github.com/pixijs/pixi.js/releases). Really
-the only time you should need to build pixi.js is if you are developing it.
+the only time you should need to build PixiJS is if you are developing it.
 
 If you don't already have Node.js and NPM, go install them. Then, in the folder where you have cloned
 the repository, install the build dependencies using npm:
@@ -167,7 +167,7 @@ $> npm run dist
 ```
 
 This will create a minified version at `dist/pixi.min.js` and a non-minified version at `dist/pixi.js`
-with all the plugins in the pixi.js project.
+with all the plugins in the PixiJS project.
 
 If there are specific plugins you don't want, say "interaction" or "extras", you can exclude those:
 
@@ -189,7 +189,7 @@ The docs can be generated using npm:
 $> npm run docs
 ```
 
-The documentation uses [Jaguar.js](https://github.com/davidshimjs/jaguarjs-jsdoc) and the jsdoc format, the configuration file can be found at [scripts/jsdoc.conf.json](scripts/jsdoc.conf.json)
+The documentation uses [Jaguar.js](https://github.com/pixijs/jaguarjs-jsdoc) and the jsdoc format, the configuration file can be found at [scripts/jsdoc.conf.json](scripts/jsdoc.conf.json)
 
 ### License ###
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Pixi.js — A 2D JavaScript Renderer
+PixiJS — A 2D JavaScript Renderer
 =============
 
 ![pixi.js logo](http://www.goodboydigital.com/pixijs/pixiV4_wide_full.jpg)
@@ -10,7 +10,7 @@ Pixi.js — A 2D JavaScript Renderer
 [![Build Status](https://travis-ci.org/pixijs/pixi.js.svg?branch=dev)](https://travis-ci.org/pixijs/pixi.js)
 
 The aim of this project is to provide a fast lightweight 2D library that works
-across all devices. The Pixi renderer allows everyone to enjoy the power of
+across all devices. The PixiJS renderer allows everyone to enjoy the power of
 hardware acceleration without prior knowledge of WebGL. Also, it's fast. Really fast.
 
 If you want to keep up to date with the latest pixi.js news then feel free to follow us on twitter
@@ -18,34 +18,34 @@ If you want to keep up to date with the latest pixi.js news then feel free to fo
 and we will keep you posted! You can also check back on [our site](http://www.goodboydigital.com/blog)
 as any breakthroughs will be posted up there too!
 
-**Your support helps us make Pixi.js even better. Make your pledge on [Patreon](https://www.patreon.com/user?u=2384552&ty=h&u=2384552) and we'll love you forever!**
+**Your support helps us make PixiJS even better. Make your pledge on [Patreon](https://www.patreon.com/user?u=2384552&ty=h&u=2384552) and we'll love you forever!**
 
-### What to Use Pixi.js for and When to Use It
+### What to Use PixiJS for and When to Use It
 
-Pixi.js is a rendering library that will allow you to create rich, interactive graphics, cross platform applications, and games without having to dive into the WebGL API or deal with browser and device compatibility.
+PixiJS is a rendering library that will allow you to create rich, interactive graphics, cross platform applications, and games without having to dive into the WebGL API or deal with browser and device compatibility.
 
-Pixi.js has full [WebGL](https://en.wikipedia.org/wiki/WebGL) support and seamlessly falls back to HTML5's [canvas](https://en.wikipedia.org/wiki/Canvas_element) if needed. As a framework, Pixi.js is a fantastic tool for authoring interactive content, *especially with the move away from Adobe Flash in recent years*. Use it for your graphics rich, interactive websites, applications, and HTML5 games.  Out of the box cross-platform compatibility and graceful degradation mean you have less work to do and have more fun doing it! If you want to create polished and refined experiences relatively quickly, without delving into dense, low level code, all while avoiding the headaches of browser inconsistencies, then sprinkle your next project with some Pixi.js magic!
+PixiJS has full [WebGL](https://en.wikipedia.org/wiki/WebGL) support and seamlessly falls back to HTML5's [canvas](https://en.wikipedia.org/wiki/Canvas_element) if needed. As a framework, PixiJS is a fantastic tool for authoring interactive content, *especially with the move away from Adobe Flash in recent years*. Use it for your graphics rich, interactive websites, applications, and HTML5 games.  Out of the box cross-platform compatibility and graceful degradation mean you have less work to do and have more fun doing it! If you want to create polished and refined experiences relatively quickly, without delving into dense, low level code, all while avoiding the headaches of browser inconsistencies, then sprinkle your next project with some PixiJS magic!
 
 **Boost your development and feel free to use your imagination!**
 
 ### Learn ###
-- Website: Find out more about Pixi on the [offical website](http://www.pixijs.com/).
+- Website: Find out more about PixiJS on the [offical website](http://www.pixijs.com/).
 - Getting started: Check out @kittykatattack's comprehensive [tutorial](https://github.com/kittykatattack/learningPixi).
 - Examples: Get stuck right in and play around with pixi code and features right [here](http://pixijs.github.io/examples/)!
-- Docs: Get to know the Pixi API by checking out the [docs](https://pixijs.github.io/docs/).
+- Docs: Get to know the PixiJS API by checking out the [docs](https://pixijs.github.io/docs/).
 - Wiki: Other misc tutorials and resources are [on the Wiki](https://github.com/pixijs/pixi.js/wiki/Resources).
 
 ### Community ###
 - Forums: Check out the [forum](http://www.html5gamedevs.com/forum/15-pixijs/) and [Stackoverflow](http://stackoverflow.com/search?q=pixi.js), both friendly places to ask your pixi questions.
 - Inspiration: Check out the [gallery](http://www.pixijs.com/gallery) to see some of the amazing things people have created!
-- Chat: You can join us on [Gitter](https://gitter.im/pixijs/pixi.js) To chat about Pixi. We also now have a Slack channel. If you would like to join it please Send me an email (mat@goodboydigital.com) and I will invite you in.
+- Chat: You can join us on [Gitter](https://gitter.im/pixijs/pixi.js) To chat about PixiJS. We also now have a Slack channel. If you would like to join it please Send me an email (mat@goodboydigital.com) and I will invite you in.
 
 
 ### Setup ###
 
-It's easy to get started with Pixi.js! Simply download a [prebuilt build](https://github.com/pixijs/pixi.js/wiki/FAQs#where-can-i-get-a-build)!
+It's easy to get started with PixiJS! Simply download a [prebuilt build](https://github.com/pixijs/pixi.js/wiki/FAQs#where-can-i-get-a-build)!
 
-Alternatively, Pixi.js can be installed with [npm](https://docs.npmjs.com/getting-started/what-is-npm) or simply using a content delivery network (CDN) URL to embed Pixi.js directly on your HTML page.
+Alternatively, PixiJS can be installed with [npm](https://docs.npmjs.com/getting-started/what-is-npm) or simply using a content delivery network (CDN) URL to embed PixiJS directly on your HTML page.
 
 _Note: After v4.5.0, support for the [Bower](https://bower.io) package manager has been dropped. Please see the [release notes](https://github.com/pixijs/pixi.js/releases/tag/v4.5.0) for more information._
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pixi.js",
   "version": "4.5.3",
-  "description": "Pixi.js is a fast lightweight 2D library that works across all devices.",
+  "description": "PixiJS is a fast lightweight 2D library that works across all devices.",
   "author": "Mat Groves",
   "contributors": [
     "Ivan Popelyshev <ivan.popelyshev@gmail.com>",

--- a/scripts/jsdoc.conf.json
+++ b/scripts/jsdoc.conf.json
@@ -22,9 +22,9 @@
         "default"       : {
             "outputSourceFiles" : true
         },
-        "applicationName": "PIXI",
+        "applicationName": "PixiJS",
         "footer"        : "Made with ♥ by Goodboy Digital (goodboydigital.com)",
-        "copyright"     : "PIXI Copyright © 2013-2016 Mat Groves.",
+        "copyright"     : "PixiJS Copyright © 2013-2016 Mat Groves.",
         "disqus": "",
         "googleAnalytics": "",
         "openGraph": {
@@ -35,9 +35,9 @@
             "url": ""
         },
         "meta": {
-            "title": "",
-            "description": "",
-            "keyword": ""
+            "title": "PixiJS API Documentation",
+            "description": "Documentation for PixiJS library",
+            "keyword": "docs, documentation, pixi, pixijs, renderer, html5, javascript, jsdoc"
         },
         "linenums"      : true
     },

--- a/src/accessibility/AccessibilityManager.js
+++ b/src/accessibility/AccessibilityManager.js
@@ -45,7 +45,7 @@ export default class AccessibilityManager
             this.createTouchHook();
         }
 
-        // first we create a div that will sit over the pixi element. This is where the div overlays will go.
+        // first we create a div that will sit over the PixiJS element. This is where the div overlays will go.
         const div = document.createElement('div');
 
         div.style.width = `${DIV_TOUCH_SIZE}px`;
@@ -56,7 +56,7 @@ export default class AccessibilityManager
         div.style.zIndex = DIV_TOUCH_ZINDEX;
 
         /**
-         * This is the dom element that will sit over the pixi element. This is where the div overlays will go.
+         * This is the dom element that will sit over the PixiJS element. This is where the div overlays will go.
          *
          * @type {HTMLElement}
          * @private

--- a/src/core/Application.js
+++ b/src/core/Application.js
@@ -40,7 +40,7 @@ export default class Application
      *  (shown if not transparent).
      * @param {boolean} [options.clearBeforeRender=true] - This sets if the renderer will clear the canvas or
      *   not before the new render pass.
-     * @param {boolean} [options.roundPixels=false] - If true Pixi will Math.floor() x/y values when rendering,
+     * @param {boolean} [options.roundPixels=false] - If true PixiJS will Math.floor() x/y values when rendering,
      *  stopping pixel interpolation.
      * @param {boolean} [options.forceFXAA=false] - forces FXAA antialiasing to be used over native.
      *  FXAA is faster, but may not always look as great **webgl only**

--- a/src/core/autoDetectRenderer.js
+++ b/src/core/autoDetectRenderer.js
@@ -24,7 +24,7 @@ import WebGLRenderer from './renderers/webgl/WebGLRenderer';
  *   not before the new render pass.
  * @param {number} [options.resolution=1] - The resolution / device pixel ratio of the renderer, retina would be 2
  * @param {boolean} [options.forceCanvas=false] - prevents selection of WebGL renderer, even if such is present
- * @param {boolean} [options.roundPixels=false] - If true Pixi will Math.floor() x/y values when rendering,
+ * @param {boolean} [options.roundPixels=false] - If true PixiJS will Math.floor() x/y values when rendering,
  *  stopping pixel interpolation.
  * @param {boolean} [options.forceFXAA=false] - forces FXAA antialiasing to be used over native.
  *  FXAA is faster, but may not always look as great **webgl only**

--- a/src/core/const.js
+++ b/src/core/const.js
@@ -183,7 +183,7 @@ export const WRAP_MODES = {
 /**
  * The gc modes that are supported by pixi.
  *
- * The {@link PIXI.settings.GC_MODE} Garbage Collection mode for pixi textures is AUTO
+ * The {@link PIXI.settings.GC_MODE} Garbage Collection mode for PixiJS textures is AUTO
  * If set to GC_MODE, the renderer will occasionally check textures usage. If they are not
  * used for a specified period of time they will be removed from the GPU. They will of course
  * be uploaded again when they are required. This is a silent behind the scenes process that

--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -66,7 +66,7 @@ export default class Container extends DisplayObject
         }
         else
         {
-            // if the child has a parent then lets remove it as Pixi objects can only exist in one place
+            // if the child has a parent then lets remove it as PixiJS objects can only exist in one place
             if (child.parent)
             {
                 child.parent.removeChild(child);

--- a/src/core/graphics/canvas/CanvasGraphicsRenderer.js
+++ b/src/core/graphics/canvas/CanvasGraphicsRenderer.js
@@ -5,7 +5,7 @@ import { SHAPES } from '../../const';
  * @author Mat Groves
  *
  * Big thanks to the very clever Matt DesLauriers <mattdesl> https://github.com/mattdesl/
- * for creating the original pixi version!
+ * for creating the original PixiJS version!
  * Also a thanks to https://github.com/bchevalier for tweaking the tint and alpha so that they
  * now share 4 bytes on the vertex buffer
  *

--- a/src/core/math/Matrix.js
+++ b/src/core/math/Matrix.js
@@ -1,7 +1,7 @@
 import Point from './Point';
 
 /**
- * The pixi Matrix class as an object, which makes it a lot faster,
+ * The PixiJS Matrix class as an object, which makes it a lot faster,
  * here is a representation of it :
  * | a | b | tx|
  * | c | d | ty|

--- a/src/core/renderers/SystemRenderer.js
+++ b/src/core/renderers/SystemRenderer.js
@@ -9,8 +9,8 @@ import EventEmitter from 'eventemitter3';
 const tempMatrix = new Matrix();
 
 /**
- * The SystemRenderer is the base for a Pixi Renderer. It is extended by the {@link PIXI.CanvasRenderer}
- * and {@link PIXI.WebGLRenderer} which can be used for rendering a Pixi scene.
+ * The SystemRenderer is the base for a PixiJS Renderer. It is extended by the {@link PIXI.CanvasRenderer}
+ * and {@link PIXI.WebGLRenderer} which can be used for rendering a PixiJS scene.
  *
  * @abstract
  * @class
@@ -37,7 +37,7 @@ export default class SystemRenderer extends EventEmitter
      *      not before the new render pass.
      * @param {number} [options.backgroundColor=0x000000] - The background color of the rendered area
      *  (shown if not transparent).
-     * @param {boolean} [options.roundPixels=false] - If true Pixi will Math.floor() x/y values when rendering,
+     * @param {boolean} [options.roundPixels=false] - If true PixiJS will Math.floor() x/y values when rendering,
      *  stopping pixel interpolation.
      */
     constructor(system, options, arg2, arg3)
@@ -130,8 +130,8 @@ export default class SystemRenderer extends EventEmitter
 
         /**
          * This sets if the CanvasRenderer will clear the canvas or not before the new render pass.
-         * If the scene is NOT transparent Pixi will use a canvas sized fillRect operation every
-         * frame to set the canvas background color. If the scene is transparent Pixi will use clearRect
+         * If the scene is NOT transparent PixiJS will use a canvas sized fillRect operation every
+         * frame to set the canvas background color. If the scene is transparent PixiJS will use clearRect
          * to clear the canvas every frame. Disable this by setting this to false. For example if
          * your game has a canvas filling background image you often don't need this set.
          *
@@ -141,7 +141,7 @@ export default class SystemRenderer extends EventEmitter
         this.clearBeforeRender = options.clearBeforeRender;
 
         /**
-         * If true Pixi will Math.floor() x/y values when rendering, stopping pixel interpolation.
+         * If true PixiJS will Math.floor() x/y values when rendering, stopping pixel interpolation.
          * Handy for crisp pixel art and speed on legacy devices.
          *
          * @member {boolean}

--- a/src/core/renderers/canvas/CanvasRenderer.js
+++ b/src/core/renderers/canvas/CanvasRenderer.js
@@ -312,7 +312,7 @@ export default class CanvasRenderer extends SystemRenderer
         super.resize(screenWidth, screenHeight);
 
         // reset the scale mode.. oddly this seems to be reset when the canvas is resized.
-        // surely a browser bug?? Let pixi fix that for you..
+        // surely a browser bug?? Let PixiJS fix that for you..
         if (this.smoothProperty)
         {
             this.rootContext[this.smoothProperty] = (settings.SCALE_MODE === SCALE_MODES.LINEAR);

--- a/src/core/renderers/canvas/CanvasRenderer.js
+++ b/src/core/renderers/canvas/CanvasRenderer.js
@@ -34,7 +34,7 @@ export default class CanvasRenderer extends SystemRenderer
      *      not before the new render pass.
      * @param {number} [options.backgroundColor=0x000000] - The background color of the rendered area
      *  (shown if not transparent).
-     * @param {boolean} [options.roundPixels=false] - If true Pixi will Math.floor() x/y values when rendering,
+     * @param {boolean} [options.roundPixels=false] - If true PixiJS will Math.floor() x/y values when rendering,
      *  stopping pixel interpolation.
      */
     constructor(options, arg2, arg3)

--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -48,11 +48,11 @@ export default class WebGLRenderer extends SystemRenderer
      *  preserveDrawingBuffer to `true`.
      * @param {boolean} [options.preserveDrawingBuffer=false] - enables drawing buffer preservation,
      *  enable this if you need to call toDataUrl on the webgl context.
-     * @param {boolean} [options.roundPixels=false] - If true Pixi will Math.floor() x/y values when
+     * @param {boolean} [options.roundPixels=false] - If true PixiJS will Math.floor() x/y values when
      *  rendering, stopping pixel interpolation.
      * @param {number} [options.backgroundColor=0x000000] - The background color of the rendered area
      *  (shown if not transparent).
-     * @param {boolean} [options.legacy=false] - If true Pixi will aim to ensure compatibility
+     * @param {boolean} [options.legacy=false] - If true PixiJS will aim to ensure compatibility
      * with older / less advanced devices. If you experiance unexplained flickering try setting this to true.
      */
     constructor(options, arg2, arg3)

--- a/src/core/renderers/webgl/filters/Filter.js
+++ b/src/core/renderers/webgl/filters/Filter.js
@@ -89,7 +89,7 @@ export default class Filter
         this.enabled = true;
 
         /**
-         * If enabled, pixi will fit the filter area into boundaries for better performance.
+         * If enabled, PixiJS will fit the filter area into boundaries for better performance.
          * Switch it off if it does not work for specific shader.
          *
          * @member {boolean}

--- a/src/core/renderers/webgl/managers/BlendModeManager.js
+++ b/src/core/renderers/webgl/managers/BlendModeManager.js
@@ -23,7 +23,7 @@ export default class BlendModeManager extends WebGLManager
     /**
      * Sets-up the given blendMode from WebGL's point of view.
      *
-     * @param {number} blendMode - the blendMode, should be a Pixi const, such as
+     * @param {number} blendMode - the blendMode, should be a PixiJS const, such as
      *  `PIXI.BLEND_MODES.ADD`. See {@link PIXI.BLEND_MODES} for possible values.
      * @return {boolean} Returns if the blend mode was changed.
      */

--- a/src/core/renderers/webgl/managers/FilterManager.js
+++ b/src/core/renderers/webgl/managers/FilterManager.js
@@ -263,7 +263,7 @@ export default class FilterManager extends WebGLManager
         const tex = this.renderer.emptyTextures[0];
 
         this.renderer.boundTextures[0] = tex;
-        // this syncs the pixi filters  uniforms with glsl uniforms
+        // this syncs the PixiJS filters  uniforms with glsl uniforms
         this.syncUniforms(shader, filter);
 
         renderer.state.setBlendMode(filter.blendMode);
@@ -287,7 +287,7 @@ export default class FilterManager extends WebGLManager
         const uniformData = filter.uniformData;
         const uniforms = filter.uniforms;
 
-        // 0 is reserved for the pixi texture so we start at 1!
+        // 0 is reserved for the PixiJS texture so we start at 1!
         let textureCount = 1;
         let currentState;
 
@@ -354,7 +354,7 @@ export default class FilterManager extends WebGLManager
             }
             else if (uniformData[i].type === 'mat3')
             {
-                // check if its pixi matrix..
+                // check if its PixiJS matrix..
                 if (uniforms[i].a !== undefined)
                 {
                     shader.uniforms[i] = uniforms[i].toArray(true);

--- a/src/core/sprites/canvas/CanvasSpriteRenderer.js
+++ b/src/core/sprites/canvas/CanvasSpriteRenderer.js
@@ -9,7 +9,7 @@ const canvasRenderWorldTransform = new Matrix();
  * @author Mat Groves
  *
  * Big thanks to the very clever Matt DesLauriers <mattdesl> https://github.com/mattdesl/
- * for creating the original pixi version!
+ * for creating the original PixiJS version!
  * Also a thanks to https://github.com/bchevalier for tweaking the tint and alpha so that they now
  * share 4 bytes on the vertex buffer
  *

--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -22,7 +22,7 @@ const defaultDestroyOptions = {
  * A Text can be created directly from a string and a style object
  *
  * ```js
- * let text = new PIXI.Text('This is a pixi text',{fontFamily : 'Arial', fontSize: 24, fill : 0xff1010, align : 'center'});
+ * let text = new PIXI.Text('This is a PixiJS text',{fontFamily : 'Arial', fontSize: 24, fill : 0xff1010, align : 'center'});
  * ```
  *
  * @class

--- a/src/core/textures/BaseRenderTexture.js
+++ b/src/core/textures/BaseRenderTexture.js
@@ -2,7 +2,7 @@ import BaseTexture from './BaseTexture';
 import settings from '../settings';
 
 /**
- * A BaseRenderTexture is a special texture that allows any Pixi display object to be rendered to it.
+ * A BaseRenderTexture is a special texture that allows any PixiJS display object to be rendered to it.
  *
  * __Hint__: All DisplayObjects (i.e. Sprites) that render to a BaseRenderTexture should be preloaded
  * otherwise black rectangles will be drawn instead.

--- a/src/core/textures/RenderTexture.js
+++ b/src/core/textures/RenderTexture.js
@@ -2,7 +2,7 @@ import BaseRenderTexture from './BaseRenderTexture';
 import Texture from './Texture';
 
 /**
- * A RenderTexture is a special texture that allows any Pixi display object to be rendered to it.
+ * A RenderTexture is a special texture that allows any PixiJS display object to be rendered to it.
  *
  * __Hint__: All DisplayObjects (i.e. Sprites) that render to a RenderTexture should be preloaded
  * otherwise black rectangles will be drawn instead.

--- a/src/core/textures/VideoBaseTexture.js
+++ b/src/core/textures/VideoBaseTexture.js
@@ -6,7 +6,7 @@ import { UPDATE_PRIORITY } from '../const';
 /**
  * A texture of a [playing] Video.
  *
- * Video base textures mimic Pixi BaseTexture.from.... method in their creation process.
+ * Video base textures mimic PixiJS BaseTexture.from.... method in their creation process.
  *
  * This can be used in several ways, such as:
  *
@@ -201,7 +201,7 @@ export default class VideoBaseTexture extends BaseTexture
     }
 
     /**
-     * Mimic Pixi BaseTexture.from.... method.
+     * Mimic PixiJS BaseTexture.from.... method.
      *
      * @static
      * @param {HTMLVideoElement} video - Video to create texture from

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -263,7 +263,7 @@ export function sayHello(type)
     if (navigator.userAgent.toLowerCase().indexOf('chrome') > -1)
     {
         const args = [
-            `\n %c %c %c Pixi.js ${VERSION} - ✰ ${type} ✰  %c  %c  http://www.pixijs.com/  %c %c ♥%c♥%c♥ \n\n`,
+            `\n %c %c %c PixiJS ${VERSION} - ✰ ${type} ✰  %c  %c  http://www.pixijs.com/  %c %c ♥%c♥%c♥ \n\n`,
             'background: #ff66a5; padding:5px 0;',
             'background: #ff66a5; padding:5px 0;',
             'color: #ff66a5; background: #030307; padding:5px 0;',
@@ -279,7 +279,7 @@ export function sayHello(type)
     }
     else if (window.console)
     {
-        window.console.log(`Pixi.js ${VERSION} - ${type} - http://www.pixijs.com/`);
+        window.console.log(`PixiJS ${VERSION} - ${type} - http://www.pixijs.com/`);
     }
 
     saidHello = true;
@@ -400,9 +400,10 @@ export function clearTextureCache()
 }
 
 /**
+ * maps premultiply flag and blendMode to adjusted blendMode
  * @memberof PIXI.utils
  * @const premultiplyBlendMode
- * @type {Array<number[]>} maps premultiply flag and blendMode to adjusted blendMode
+ * @type {Array<number[]>}
  */
 export const premultiplyBlendMode = mapPremultipliedBlendModes();
 

--- a/src/core/utils/mapPremultipliedBlendModes.js
+++ b/src/core/utils/mapPremultipliedBlendModes.js
@@ -1,7 +1,7 @@
 import { BLEND_MODES } from '../const';
 
 /**
- * Corrects pixi blend, takes premultiplied alpha into account
+ * Corrects PixiJS blend, takes premultiplied alpha into account
  *
  * @memberof PIXI
  * @function mapPremultipliedBlendModes

--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -67,14 +67,14 @@ export default function deprecation(core)
          * @name AssetLoader
          * @memberof PIXI
          * @see PIXI.loaders.Loader
-         * @throws {ReferenceError} The loader system was overhauled in pixi v3,
+         * @throws {ReferenceError} The loader system was overhauled in PixiJS v3,
          * please see the new PIXI.loaders.Loader class.
          * @deprecated since version 3.0.0
          */
         AssetLoader: {
             get()
             {
-                throw new ReferenceError('The loader system was overhauled in pixi v3, '
+                throw new ReferenceError('The loader system was overhauled in PixiJS v3, '
                     + 'please see the new PIXI.loaders.Loader class.');
             },
         },

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,6 @@ if (typeof deprecation === 'function')
     deprecation(exports);
 }
 
-// Always export pixi globally.
+// Always export PixiJS globally.
 global.PIXI = exports; // eslint-disable-line
 

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -121,7 +121,7 @@ export default class InteractionManager extends EventEmitter
          * is over the object.
          * Setting to true will make things work more in line with how the DOM verison works.
          * Setting to false can make things easier for things like dragging
-         * It is currently set to false as this is how pixi used to work. This will be set to true in
+         * It is currently set to false as this is how PixiJS used to work. This will be set to true in
          * future versions of pixi.
          *
          * @member {boolean}
@@ -944,7 +944,7 @@ export default class InteractionManager extends EventEmitter
     }
 
     /**
-     * Maps x and y coords from a DOM object and maps them correctly to the pixi view. The
+     * Maps x and y coords from a DOM object and maps them correctly to the PixiJS view. The
      * resulting value is stored in the point. This takes into account the fact that the DOM
      * element could be scaled and positioned anywhere on the screen.
      *
@@ -1031,7 +1031,7 @@ export default class InteractionManager extends EventEmitter
 
         // ** FREE TIP **! If an object is not interactive or has no buttons in it
         // (such as a game scene!) set interactiveChildren to false for that displayObject.
-        // This will allow pixi to completely ignore and bypass checking the displayObjects children.
+        // This will allow PixiJS to completely ignore and bypass checking the displayObjects children.
         if (displayObject.interactiveChildren && displayObject.children)
         {
             const children = displayObject.children;

--- a/src/interaction/interactiveTarget.js
+++ b/src/interaction/interactiveTarget.js
@@ -32,7 +32,7 @@ export default {
 
     /**
      * Determines if the children to the displayObject can be clicked/touched
-     * Setting this to false allows pixi to bypass a recursive `hitTest` function
+     * Setting this to false allows PixiJS to bypass a recursive `hitTest` function
      *
      * @member {boolean}
      * @memberof PIXI.Container#

--- a/src/loaders/loader.js
+++ b/src/loaders/loader.js
@@ -10,7 +10,7 @@ import bitmapFontParser from './bitmapFontParser';
  * The new loader, extends Resource Loader by Chad Engler: https://github.com/englercj/resource-loader
  *
  * ```js
- * const loader = PIXI.loader; // pixi exposes a premade instance for you to use.
+ * const loader = PIXI.loader; // PixiJS exposes a premade instance for you to use.
  * //or
  * const loader = new PIXI.loaders.Loader(); // you can also create your own if you want
  *
@@ -81,7 +81,7 @@ export default class Loader extends ResourceLoader
     }
 
     /**
-     * Adds a default middleware to the pixi loader.
+     * Adds a default middleware to the PixiJS loader.
      *
      * @static
      * @param {Function} fn - The middleware to add.

--- a/src/particles/webgl/ParticleBuffer.js
+++ b/src/particles/webgl/ParticleBuffer.js
@@ -5,7 +5,7 @@ import createIndicesForQuads from '../../core/utils/createIndicesForQuads';
  * @author Mat Groves
  *
  * Big thanks to the very clever Matt DesLauriers <mattdesl> https://github.com/mattdesl/
- * for creating the original pixi version!
+ * for creating the original PixiJS version!
  * Also a thanks to https://github.com/bchevalier for tweaking the tint and alpha so that
  * they now share 4 bytes on the vertex buffer
  *

--- a/src/particles/webgl/ParticleRenderer.js
+++ b/src/particles/webgl/ParticleRenderer.js
@@ -6,7 +6,7 @@ import ParticleBuffer from './ParticleBuffer';
  * @author Mat Groves
  *
  * Big thanks to the very clever Matt DesLauriers <mattdesl> https://github.com/mattdesl/
- * for creating the original pixi version!
+ * for creating the original PixiJS version!
  * Also a thanks to https://github.com/bchevalier for tweaking the tint and alpha so that they now
  * share 4 bytes on the vertex buffer
  *


### PR DESCRIPTION
## Overview

This is a _cosmetic_ change that removes all the variations of "PixiJS" and create a consistent way of naming this project. This takes a cue from the logo (with a capital "P", "J" and "S"). The additional variations of the name muddy trying to build a cohesive brand.

**Correct:** `PixiJS` 

**Incorrect:** `pixi`, `Pixi`, `Pixi.js`, `pixijs`

**Exceptions:**
* `PIXI` _when referring to window object_
* `pixi.js` _when referring to bundle file, repository or npm package_

### Fixed
* Fixed a minor JSDoc issue with `premultiplyBlendMode`
* Adds missing fields from the JSDoc output, including "title" and "description"