### PR TITLE
Fix context throwing null TypeError

### DIFF
--- a/src/core/renderers/canvas/utils/canUseNewCanvasBlendModes.js
+++ b/src/core/renderers/canvas/utils/canUseNewCanvasBlendModes.js
@@ -13,7 +13,11 @@ function createColoredCanvas(color)
     canvas.height = 1;
 
     const context = canvas.getContext('2d');
-
+    if(!context)
+    {
+     return canvas;   
+    }
+    
     context.fillStyle = color;
     context.fillRect(0, 0, 6, 1);
 
@@ -41,7 +45,11 @@ export default function canUseNewCanvasBlendModes()
     canvas.height = 1;
 
     const context = canvas.getContext('2d');
-
+    if(!context)
+    {
+        return false;
+    }
+    
     context.globalCompositeOperation = 'multiply';
     context.drawImage(magenta, 0, 0);
     context.drawImage(yellow, 2, 0);

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -621,7 +621,11 @@ function createWhiteTexture()
     canvas.height = 10;
 
     const context = canvas.getContext('2d');
-
+    if(!context) 
+    {
+     return new Texture(new BaseTexture());   
+    }
+    
     context.fillStyle = 'white';
     context.fillRect(0, 0, 10, 10);
 


### PR DESCRIPTION
When unit testing components that import PIXI the context ends up being null, 

```
TypeError: Cannot set property 'fillStyle' of null

      at createColoredCanvas (node_modules/pixi.js/lib/core/renderers/canvas/utils/canUseNewCanvasBlendModes.js:20:23)
      at canUseNewCanvasBlendModes (node_modules/pixi.js/lib/core/renderers/canvas/utils/canUseNewCanvasBlendModes.js:36:19)
      at Object.<anonymous> (node_modules/pixi.js/lib/core/sprites/canvas/CanvasTinter.js:220:61)
      at Object.<anonymous> (node_modules/pixi.js/lib/core/sprites/canvas/CanvasSpriteRenderer.js:13:21)
      at Object.<anonymous> (node_modules/pixi.js/lib/core/index.js:102:29)
      at Object.<anonymous> (node_modules/pixi.js/lib/index.js:18:13
```