### PR TITLE
Graphics drawPolygon Documentation Fix

### DIFF
--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -651,7 +651,7 @@ export default class Graphics extends Container
     /**
      * Draws a polygon using the given path.
      *
-     * @param {number[]|PIXI.Point[]} path - The path data used to construct the polygon.
+     * @param {number[]|PIXI.Point[]|PIXI.Polygon} path - The path data used to construct the polygon.
      * @return {PIXI.Graphics} This Graphics object. Good for chaining method calls
      */
     drawPolygon(path)


### PR DESCRIPTION
Hey -

Just a tiny fix. Visual Studio Code pointed this out in some code I was writing, the drawPolygon method accepts a PIXI.Polygon, but the doc string doesn't include it.

Cheers
-Courtland
