### PR TITLE
Don't remove textures if they've been replaced in the cache

### DIFF
--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -521,7 +521,11 @@ export default class Texture extends EventEmitter
         {
             for (let i = 0; i < texture.textureCacheIds.length; ++i)
             {
-                delete TextureCache[texture.textureCacheIds[i]];
+                // Check that texture matches the one being passed in before deleting it from the cache.
+                if (TextureCache[texture.textureCacheIds[i]] === texture)
+                {
+                    delete TextureCache[texture.textureCacheIds[i]];
+                }
             }
 
             texture.textureCacheIds.length = 0;

--- a/test/core/Texture.js
+++ b/test/core/Texture.js
@@ -108,6 +108,25 @@ describe('PIXI.Texture', function ()
         expect(PIXI.utils.TextureCache[NAME2]).to.equal(texture);
     });
 
+    it('should not remove Texture from cache if Texture instance has been replaced', function ()
+    {
+        cleanCache();
+
+        const texture = new PIXI.Texture(new PIXI.BaseTexture());
+        const texture2 = new PIXI.Texture(new PIXI.BaseTexture());
+
+        PIXI.Texture.addToCache(texture, NAME);
+        expect(texture.textureCacheIds.indexOf(NAME)).to.equal(0);
+        expect(PIXI.utils.TextureCache[NAME]).to.equal(texture);
+        PIXI.Texture.addToCache(texture2, NAME);
+        expect(texture2.textureCacheIds.indexOf(NAME)).to.equal(0);
+        expect(PIXI.utils.TextureCache[NAME]).to.equal(texture2);
+        PIXI.Texture.removeFromCache(texture);
+        expect(texture.textureCacheIds.indexOf(NAME)).to.equal(-1);
+        expect(texture2.textureCacheIds.indexOf(NAME)).to.equal(0);
+        expect(PIXI.utils.TextureCache[NAME]).to.equal(texture2);
+    });
+
     it('destroying a destroyed texture should not throw an error', function ()
     {
         const texture = new PIXI.Texture(new PIXI.BaseTexture());


### PR DESCRIPTION
Ran into an issue where a texture was replaced in the cache by a new texture with the same name, and was removed unintentionally, causing an error: `The frameID 'line1' does not exist in texture cache.` @andrewstart suggested this fix, making sure the texture to be removed is the same texture as the one passed into `removeFromCache()`