### PR TITLE
A display object can no longer be interactive if it has no alpha

### DIFF
--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -990,7 +990,7 @@ export default class InteractionManager extends EventEmitter
      */
     processInteractive(interactionEvent, displayObject, func, hitTest, interactive)
     {
-        if (!displayObject || !displayObject.visible)
+        if (!displayObject || !displayObject.visible || !displayObject.alpha)
         {
             return false;
         }


### PR DESCRIPTION
So, had a little bug on my game where I was seeing the 'hand' icon indicating it was hovering over something with interactive = true and buttonMode = true - but there was nothing there! And clicking on it made a button (which is usually in that location) callback occur. Turns out, that to make that button disappear, I'd tweened the alpha out, and the interaction manager only checks for if visible is true or not.

Considering the feel of the code felt "if it cannot be seen, it shouldn't be interactive" I've added an additional check to not check interactivity if a component has no alpha. Not sure how others feel about this, or the potential side effects it could have if people may have relied on this behaviour?