### PR TITLE
Support OffscreenCanvas

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,8 @@
     },
     "globals": {
         "global": false,
-        "__VERSION__": false
+        "__VERSION__": false,
+        "OffscreenCanvas": false
     },
     "parserOptions": {
         "ecmaVersion": 6,

--- a/src/core/Application.js
+++ b/src/core/Application.js
@@ -29,7 +29,7 @@ export default class Application
      * @param {object} [options] - The optional renderer parameters
      * @param {number} [options.width=800] - the width of the renderers view
      * @param {number} [options.height=600] - the height of the renderers view
-     * @param {HTMLCanvasElement} [options.view] - the canvas to use as a view, optional
+     * @param {HTMLCanvasElement|OffscreenCanvas} [options.view] - the canvas to use as a view, optional
      * @param {boolean} [options.transparent=false] - If the render view is transparent, default false
      * @param {boolean} [options.antialias=false] - sets antialias (only applicable in chrome at the moment)
      * @param {boolean} [options.preserveDrawingBuffer=false] - enables drawing buffer preservation, enable this if you
@@ -146,7 +146,7 @@ export default class Application
 
     /**
      * Reference to the renderer's canvas element.
-     * @member {HTMLCanvasElement}
+     * @member {HTMLCanvasElement|OffscreenCanvas}
      * @readonly
      */
     get view()

--- a/src/core/autoDetectRenderer.js
+++ b/src/core/autoDetectRenderer.js
@@ -13,7 +13,7 @@ import WebGLRenderer from './renderers/webgl/WebGLRenderer';
  * @param {object} [options] - The optional renderer parameters
  * @param {number} [options.width=800] - the width of the renderers view
  * @param {number} [options.height=600] - the height of the renderers view
- * @param {HTMLCanvasElement} [options.view] - the canvas to use as a view, optional
+ * @param {HTMLCanvasElement|OffscreenCanvas} [options.view] - the canvas to use as a view, optional
  * @param {boolean} [options.transparent=false] - If the render view is transparent, default false
  * @param {boolean} [options.antialias=false] - sets antialias (only applicable in chrome at the moment)
  * @param {boolean} [options.preserveDrawingBuffer=false] - enables drawing buffer preservation, enable this if you

--- a/src/core/renderers/SystemRenderer.js
+++ b/src/core/renderers/SystemRenderer.js
@@ -25,7 +25,7 @@ export default class SystemRenderer extends EventEmitter
      * @param {object} [options] - The optional renderer parameters
      * @param {number} [options.width=800] - the width of the screen
      * @param {number} [options.height=600] - the height of the screen
-     * @param {HTMLCanvasElement} [options.view] - the canvas to use as a view, optional
+     * @param {HTMLCanvasElement|OffscreenCanvas} [options.view] - the canvas to use as a view, optional
      * @param {boolean} [options.transparent=false] - If the render view is transparent, default false
      * @param {boolean} [options.autoResize=false] - If the render view is automatically resized, default false
      * @param {boolean} [options.antialias=false] - sets antialias (only applicable in chrome at the moment)

--- a/src/core/renderers/canvas/CanvasRenderer.js
+++ b/src/core/renderers/canvas/CanvasRenderer.js
@@ -22,7 +22,7 @@ export default class CanvasRenderer extends SystemRenderer
      * @param {object} [options] - The optional renderer parameters
      * @param {number} [options.width=800] - the width of the screen
      * @param {number} [options.height=600] - the height of the screen
-     * @param {HTMLCanvasElement} [options.view] - the canvas to use as a view, optional
+     * @param {HTMLCanvasElement|OffscreenCanvas} [options.view] - the canvas to use as a view, optional
      * @param {boolean} [options.transparent=false] - If the render view is transparent, default false
      * @param {boolean} [options.autoResize=false] - If the render view is automatically resized, default false
      * @param {boolean} [options.antialias=false] - sets antialias (only applicable in chrome at the moment)

--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -34,7 +34,7 @@ export default class WebGLRenderer extends SystemRenderer
      * @param {object} [options] - The optional renderer parameters
      * @param {number} [options.width=800] - the width of the screen
      * @param {number} [options.height=600] - the height of the screen
-     * @param {HTMLCanvasElement} [options.view] - the canvas to use as a view, optional
+     * @param {HTMLCanvasElement|OffscreenCanvas} [options.view] - the canvas to use as a view, optional
      * @param {boolean} [options.transparent=false] - If the render view is transparent, default false
      * @param {boolean} [options.autoResize=false] - If the render view is automatically resized, default false
      * @param {boolean} [options.antialias=false] - sets antialias. If not available natively then FXAA

--- a/src/core/settings.js
+++ b/src/core/settings.js
@@ -100,7 +100,7 @@ export default {
      * @constant
      * @memberof PIXI.settings
      * @type {object}
-     * @property {HTMLCanvasElement} view=null
+     * @property {HTMLCanvasElement|OffscreenCanvas} view=null
      * @property {number} resolution=1
      * @property {boolean} antialias=false
      * @property {boolean} forceFXAA=false

--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -439,7 +439,8 @@ export default class Sprite extends Container
      * The source can be - frame id, image url, video url, canvas element, video element, base texture
      *
      * @static
-     * @param {number|string|PIXI.BaseTexture|HTMLCanvasElement|HTMLVideoElement} source Source to create texture from
+     * @param {number|string|PIXI.BaseTexture|HTMLCanvasElement|HTMLVideoElement|OffscreenCanvas}
+           source Source to create texture from
      * @return {PIXI.Sprite} The newly created sprite
      */
     static from(source)

--- a/src/core/sprites/canvas/CanvasTinter.js
+++ b/src/core/sprites/canvas/CanvasTinter.js
@@ -14,7 +14,7 @@ const CanvasTinter = {
      * @memberof PIXI.CanvasTinter
      * @param {PIXI.Sprite} sprite - the sprite to tint
      * @param {number} color - the color to use to tint the sprite with
-     * @return {HTMLCanvasElement} The tinted canvas
+     * @return {HTMLCanvasElement|OffscreenCanvas} The tinted canvas
      */
     getTintedTexture: (sprite, color) =>
     {
@@ -73,7 +73,7 @@ const CanvasTinter = {
      * @memberof PIXI.CanvasTinter
      * @param {PIXI.Texture} texture - the texture to tint
      * @param {number} color - the color to use to tint the sprite with
-     * @param {HTMLCanvasElement} canvas - the current canvas
+     * @param {HTMLCanvasElement|OffscreenCanvas} canvas - the current canvas
      */
     tintWithMultiply: (texture, color, canvas) =>
     {
@@ -130,7 +130,7 @@ const CanvasTinter = {
      * @memberof PIXI.CanvasTinter
      * @param {PIXI.Texture} texture - the texture to tint
      * @param {number} color - the color to use to tint the sprite with
-     * @param {HTMLCanvasElement} canvas - the current canvas
+     * @param {HTMLCanvasElement|OffscreenCanvas} canvas - the current canvas
      */
     tintWithOverlay(texture, color, canvas)
     {
@@ -174,7 +174,7 @@ const CanvasTinter = {
      * @memberof PIXI.CanvasTinter
      * @param {PIXI.Texture} texture - the texture to tint
      * @param {number} color - the color to use to tint the sprite with
-     * @param {HTMLCanvasElement} canvas - the current canvas
+     * @param {HTMLCanvasElement|OffscreenCanvas} canvas - the current canvas
      */
     tintWithPerPixel: (texture, color, canvas) =>
     {
@@ -286,7 +286,7 @@ CanvasTinter.tintMethod = CanvasTinter.canUseMultiply ? CanvasTinter.tintWithMul
  * @callback tintMethodFunctionType
  * @param texture {PIXI.Texture} the texture to tint
  * @param color {number} the color to use to tint the sprite with
- * @param canvas {HTMLCanvasElement} the current canvas
+ * @param canvas {HTMLCanvasElement|OffscreenCanvas} the current canvas
  */
 
 export default CanvasTinter;

--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -17,7 +17,7 @@ import bitTwiddle from 'bit-twiddle';
 export default class BaseTexture extends EventEmitter
 {
     /**
-     * @param {HTMLImageElement|HTMLCanvasElement} [source] - the source object of the texture.
+     * @param {HTMLImageElement|HTMLCanvasElement|OffscreenCanvas} [source] - the source object of the texture.
      * @param {number} [scaleMode=PIXI.settings.SCALE_MODE] - See {@link PIXI.SCALE_MODES} for possible values
      * @param {number} [resolution=1] - The resolution / device pixel ratio of the texture
      */
@@ -107,7 +107,7 @@ export default class BaseTexture extends EventEmitter
          * TODO: Make this a setter that calls loadSource();
          *
          * @readonly
-         * @member {HTMLImageElement|HTMLCanvasElement}
+         * @member {HTMLImageElement|HTMLCanvasElement|OffscreenCanvas}
          */
         this.source = null; // set in loadSource, if at all
 
@@ -302,7 +302,7 @@ export default class BaseTexture extends EventEmitter
      *     }
      *
      * @protected
-     * @param {HTMLImageElement|HTMLCanvasElement} source - the source object of the texture.
+     * @param {HTMLImageElement|HTMLCanvasElement|OffscreenCanvas} source - the source object of the texture.
      */
     loadSource(source)
     {
@@ -711,7 +711,7 @@ export default class BaseTexture extends EventEmitter
      * Helper function that creates a base texture from the given canvas element.
      *
      * @static
-     * @param {HTMLCanvasElement} canvas - The canvas element source of the texture
+     * @param {HTMLCanvasElement|OffscreenCanvas} canvas - The canvas element source of the texture
      * @param {number} scaleMode - See {@link PIXI.SCALE_MODES} for possible values
      * @param {string} [origin='canvas'] - A string origin of who created the base texture
      * @return {PIXI.BaseTexture} The new base texture.
@@ -739,7 +739,7 @@ export default class BaseTexture extends EventEmitter
      * The source can be - image url, image element, canvas element.
      *
      * @static
-     * @param {string|HTMLImageElement|HTMLCanvasElement} source - The source to create base texture from.
+     * @param {string|HTMLImageElement|HTMLCanvasElement|OffscreenCanvas} source - The source to create base texture from.
      * @param {number} [scaleMode=PIXI.settings.SCALE_MODE] - See {@link PIXI.SCALE_MODES} for possible values
      * @param {number} [sourceScale=(auto)] - Scale for the original image, used with Svg images.
      * @return {PIXI.BaseTexture} The new base texture.
@@ -773,7 +773,7 @@ export default class BaseTexture extends EventEmitter
 
             return baseTexture;
         }
-        else if (source instanceof HTMLCanvasElement)
+        else if (source instanceof HTMLCanvasElement || source instanceof OffscreenCanvas)
         {
             return BaseTexture.fromCanvas(source, scaleMode);
         }

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -330,7 +330,7 @@ export default class Texture extends EventEmitter
      * Helper function that creates a new Texture based on the given canvas element.
      *
      * @static
-     * @param {HTMLCanvasElement} canvas - The canvas element source of the texture
+     * @param {HTMLCanvasElement|OffscreenCanvas} canvas - The canvas element source of the texture
      * @param {number} [scaleMode=PIXI.settings.SCALE_MODE] - See {@link PIXI.SCALE_MODES} for possible values
      * @param {string} [origin='canvas'] - A string origin of who created the base texture
      * @return {PIXI.Texture} The newly created texture
@@ -376,7 +376,7 @@ export default class Texture extends EventEmitter
      * The source can be - frame id, image url, video url, canvas element, video element, base texture
      *
      * @static
-     * @param {number|string|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement|PIXI.BaseTexture}
+     * @param {number|string|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement|OffscreenCanvas|PIXI.BaseTexture}
      *        source - Source to create texture from
      * @return {PIXI.Texture} The newly created texture
      */
@@ -415,6 +415,10 @@ export default class Texture extends EventEmitter
         {
             return Texture.fromVideo(source);
         }
+        else if (source instanceof OffscreenCanvas)
+        {
+            return Texture.fromCanvas(source, settings.SCALE_MODE, 'OffscreenCanvas');
+        }
         else if (source instanceof BaseTexture)
         {
             return new Texture(source);
@@ -428,7 +432,7 @@ export default class Texture extends EventEmitter
      * Create a texture from a source and add to the cache.
      *
      * @static
-     * @param {HTMLImageElement|HTMLCanvasElement} source - The input source.
+     * @param {HTMLImageElement|HTMLCanvasElement|OffscreenCanvas} source - The input source.
      * @param {String} imageUrl - File name of texture, for cache and resolving resolution.
      * @param {String} [name] - Human readible name for the texture cache. If no name is
      *        specified, only `imageUrl` will be used as the cache ID.

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -1,7 +1,7 @@
 import { DATA_URI, URL_FILE_EXTENSION, SVG_SIZE, VERSION } from '../const';
 import settings from '../settings';
 import EventEmitter from 'eventemitter3';
-import pluginTarget from './pluginTarget';
+import * as PluginTarget from './pluginTarget';
 import * as mixins from './mixin';
 import * as isMobile from 'ismobilejs';
 import removeItems from 'remove-array-items';
@@ -54,14 +54,21 @@ export {
      * @type {EventEmitter}
      */
     EventEmitter,
-    /**
-     * @memberof PIXI.utils
-     * @function pluginTarget
-     * @type {mixin}
-     */
-    pluginTarget,
     mixins,
 };
+
+/**
+ * @memberof PIXI.utils
+ * @class UnsupportedPluginTargetError
+ */
+export const UnsupportedPluginTargetError = PluginTarget.UnsupportedTargetError;
+
+/**
+ * @memberof PIXI.utils
+ * @function pluginTarget
+ * @type {mixin}
+ */
+export const { pluginTarget } = PluginTarget;
 
 /**
  * Gets the next unique identifier

--- a/src/core/utils/trimCanvas.js
+++ b/src/core/utils/trimCanvas.js
@@ -4,7 +4,7 @@
  * @memberof PIXI
  * @function trimCanvas
  * @private
- * @param {HTMLCanvasElement} canvas - the canvas to trim
+ * @param {HTMLCanvasElement|OffscreenCanvas} canvas - the canvas to trim
  * @returns {object} Trim data
  */
 export default function trimCanvas(canvas)

--- a/src/extras/TilingSprite.js
+++ b/src/extras/TilingSprite.js
@@ -347,7 +347,8 @@ export default class TilingSprite extends core.Sprite
      * The source can be - frame id, image url, video url, canvas element, video element, base texture
      *
      * @static
-     * @param {number|string|PIXI.BaseTexture|HTMLCanvasElement|HTMLVideoElement} source - Source to create texture from
+     * @param {number|string|PIXI.BaseTexture|HTMLCanvasElement|HTMLVideoElement|OffscreenCanvas}
+           source - Source to create texture from
      * @param {number} width - the width of the tiling sprite
      * @param {number} height - the height of the tiling sprite
      * @return {PIXI.Texture} The newly created texture

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -42,6 +42,11 @@ export default class InteractionManager extends EventEmitter
      */
     constructor(renderer, options)
     {
+        if (!(renderer.view instanceof HTMLCanvasElement))
+        {
+            throw new core.utils.UnsupportedPluginTargetError();
+        }
+
         super();
 
         options = options || {};

--- a/test/interaction/InteractionManager.js
+++ b/test/interaction/InteractionManager.js
@@ -233,7 +233,7 @@ describe('PIXI.interaction.InteractionManager', function ()
 
         it('should add and remove pointer events to document', function ()
         {
-            const manager = new PIXI.interaction.InteractionManager(sinon.stub());
+            const manager = new PIXI.interaction.InteractionManager({ view: document.createElement('canvas') });
             const addSpy = sinon.spy(window.document, 'addEventListener');
             const removeSpy = sinon.spy(window.document, 'removeEventListener');
 
@@ -256,7 +256,7 @@ describe('PIXI.interaction.InteractionManager', function ()
 
         it('should add and remove pointer events to window', function ()
         {
-            const manager = new PIXI.interaction.InteractionManager(sinon.stub());
+            const manager = new PIXI.interaction.InteractionManager({ view: document.createElement('canvas') });
             const addSpy = sinon.spy(window, 'addEventListener');
             const removeSpy = sinon.spy(window, 'removeEventListener');
 
@@ -281,7 +281,7 @@ describe('PIXI.interaction.InteractionManager', function ()
 
         it('should add and remove pointer events to element', function ()
         {
-            const manager = new PIXI.interaction.InteractionManager(sinon.stub());
+            const manager = new PIXI.interaction.InteractionManager({ view: document.createElement('canvas') });
             const element = { style: {}, addEventListener: sinon.stub(), removeEventListener: sinon.stub() };
 
             manager.interactionDOMElement = element;
@@ -304,7 +304,7 @@ describe('PIXI.interaction.InteractionManager', function ()
 
         it('should add and remove mouse events to document', function ()
         {
-            const manager = new PIXI.interaction.InteractionManager(sinon.stub());
+            const manager = new PIXI.interaction.InteractionManager({ view: document.createElement('canvas') });
             const addSpy = sinon.spy(window.document, 'addEventListener');
             const removeSpy = sinon.spy(window.document, 'removeEventListener');
 
@@ -327,7 +327,7 @@ describe('PIXI.interaction.InteractionManager', function ()
 
         it('should add and remove mouse events to window', function ()
         {
-            const manager = new PIXI.interaction.InteractionManager(sinon.stub());
+            const manager = new PIXI.interaction.InteractionManager({ view: document.createElement('canvas') });
             const addSpy = sinon.spy(window, 'addEventListener');
             const removeSpy = sinon.spy(window, 'removeEventListener');
 
@@ -350,7 +350,7 @@ describe('PIXI.interaction.InteractionManager', function ()
 
         it('should add and remove mouse events to element', function ()
         {
-            const manager = new PIXI.interaction.InteractionManager(sinon.stub());
+            const manager = new PIXI.interaction.InteractionManager({ view: document.createElement('canvas') });
             const element = { style: {}, addEventListener: sinon.stub(), removeEventListener: sinon.stub() };
 
             manager.interactionDOMElement = element;
@@ -374,7 +374,7 @@ describe('PIXI.interaction.InteractionManager', function ()
 
         it('should add and remove touch events to element without pointer events', function ()
         {
-            const manager = new PIXI.interaction.InteractionManager(sinon.stub());
+            const manager = new PIXI.interaction.InteractionManager({ view: document.createElement('canvas') });
             const element = { style: {}, addEventListener: sinon.stub(), removeEventListener: sinon.stub() };
 
             manager.interactionDOMElement = element;
@@ -398,7 +398,7 @@ describe('PIXI.interaction.InteractionManager', function ()
 
         it('should add and remove touch events to element with pointer events', function ()
         {
-            const manager = new PIXI.interaction.InteractionManager(sinon.stub());
+            const manager = new PIXI.interaction.InteractionManager({ view: document.createElement('canvas') });
             const element = { style: {}, addEventListener: sinon.stub(), removeEventListener: sinon.stub() };
 
             manager.interactionDOMElement = element;
@@ -1513,5 +1513,11 @@ describe('PIXI.interaction.InteractionManager', function ()
 
             expect(eventSpy).to.have.been.calledOnce;
         });
+    });
+
+    it('should throw UnsupportedError when the view is not a canvas element', function ()
+    {
+        expect(() => new PIXI.interaction.InteractionManager({ view: {} }))
+            .to.throw(PIXI.utils.UnsupportedPluginTargetError);
     });
 });


### PR DESCRIPTION
The target of `InteractionManager` could be an `OffscreenCanvas`, which does not have features required by the plugin.
Notify the lack of the feature to the plugin initializer and let it ignore the exception.
Now `OffscreenCanvas` is supported throughout PixiJS. Update documents accordingly.