### PR TITLE
Set initial lastTime to -1

### DIFF
--- a/src/core/ticker/Ticker.js
+++ b/src/core/ticker/Ticker.js
@@ -81,9 +81,9 @@ export default class Ticker
          * this value will have a precision of 1 µs.
          *
          * @member {number}
-         * @default 0
+         * @default -1
          */
-        this.lastTime = 0;
+        this.lastTime = -1;
 
         /**
          * Factor of current {@link PIXI.ticker.Ticker#deltaTime}.


### PR DESCRIPTION
`update` method could have 0 as timestamp, but the frame would be ignored because the initial `lastTime` is 0. Let it have a negative value.