### PR TITLE
Add Google Analytics to Documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2013-2016 Mathew Groves, Chad Engler
+Copyright (c) 2013-2017 Mathew Groves, Chad Engler
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/scripts/jsdoc.conf.json
+++ b/scripts/jsdoc.conf.json
@@ -24,9 +24,9 @@
         },
         "applicationName": "PixiJS",
         "footer"        : "Made with ♥ by Goodboy Digital (goodboydigital.com)",
-        "copyright"     : "PixiJS Copyright © 2013-2016 Mat Groves.",
+        "copyright"     : "PixiJS Copyright © 2013-2017 Mat Groves.",
         "disqus": "",
-        "googleAnalytics": "",
+        "googleAnalytics": "UA-103772589-5",
         "openGraph": {
             "title": "",
             "type": "website",


### PR DESCRIPTION
## Overview

Implement Google Analytics for documentation as a way to understand which APIs are most used, browsed for, looked up. Also, as a way to understand the traffic relationships between Github/Wiki and Docs.