### PR TITLE
Pins jsdoc to 3.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "floss": "^2.0.1",
     "jaguarjs-jsdoc": "^1.0.1",
     "js-md5": "^0.4.1",
-    "jsdoc": "^3.4.2",
+    "jsdoc": "3.4.3",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "parallelshell": "^2.0.0",


### PR DESCRIPTION
It appears that **jsdoc** 3.5.x introduced a bug with how events are documented which is not rendering any of our DisplayObject or InteractiveManager events.

**release branch:** (has events) http://pixijs.download/release/docs/PIXI.DisplayObject.html
**dev branch:** (no events) http://pixijs.download/dev/docs/PIXI.DisplayObject.html
**bug-jsdoc branch:** (has events again) http://pixijs.download/bug-jsdoc/docs/PIXI.DisplayObject.html

### Related Issue
https://github.com/jsdoc3/jsdoc/issues/1425

### Original Reference
http://www.html5gamedevs.com/topic/32395-docs-missing-events/