### PR TITLE
Improving SVG handling in Spritesheets with sourceScale support

### DIFF
--- a/src/core/textures/Spritesheet.js
+++ b/src/core/textures/Spritesheet.js
@@ -151,6 +151,7 @@ export default class Spritesheet
     {
         let frameIndex = initialFrameIndex;
         const maxFrames = Spritesheet.BATCH_SIZE;
+        const sourceScale = this.baseTexture.sourceScale;
 
         while (frameIndex - initialFrameIndex < maxFrames && frameIndex < this._frameKeys.length)
         {
@@ -164,26 +165,26 @@ export default class Spritesheet
                 const orig = new Rectangle(
                     0,
                     0,
-                    this._frames[i].sourceSize.w / this.resolution,
-                    this._frames[i].sourceSize.h / this.resolution
+                    Math.floor(this._frames[i].sourceSize.w * sourceScale) / this.resolution,
+                    Math.floor(this._frames[i].sourceSize.h * sourceScale) / this.resolution
                 );
 
                 if (this._frames[i].rotated)
                 {
                     frame = new Rectangle(
-                        rect.x / this.resolution,
-                        rect.y / this.resolution,
-                        rect.h / this.resolution,
-                        rect.w / this.resolution
+                        Math.floor(rect.x * sourceScale) / this.resolution,
+                        Math.floor(rect.y * sourceScale) / this.resolution,
+                        Math.floor(rect.h * sourceScale) / this.resolution,
+                        Math.floor(rect.w * sourceScale) / this.resolution
                     );
                 }
                 else
                 {
                     frame = new Rectangle(
-                        rect.x / this.resolution,
-                        rect.y / this.resolution,
-                        rect.w / this.resolution,
-                        rect.h / this.resolution
+                        Math.floor(rect.x * sourceScale) / this.resolution,
+                        Math.floor(rect.y * sourceScale) / this.resolution,
+                        Math.floor(rect.w * sourceScale) / this.resolution,
+                        Math.floor(rect.h * sourceScale) / this.resolution
                     );
                 }
 
@@ -191,10 +192,10 @@ export default class Spritesheet
                 if (this._frames[i].trimmed)
                 {
                     trim = new Rectangle(
-                        this._frames[i].spriteSourceSize.x / this.resolution,
-                        this._frames[i].spriteSourceSize.y / this.resolution,
-                        rect.w / this.resolution,
-                        rect.h / this.resolution
+                        Math.floor(this._frames[i].spriteSourceSize.x * sourceScale) / this.resolution,
+                        Math.floor(this._frames[i].spriteSourceSize.y * sourceScale) / this.resolution,
+                        Math.floor(rect.w * sourceScale) / this.resolution,
+                        Math.floor(rect.h * sourceScale) / this.resolution
                     );
                 }
 

--- a/test/core/Spritesheet.js
+++ b/test/core/Spritesheet.js
@@ -12,12 +12,14 @@ describe('PIXI.Spritesheet', function ()
             spritesheet.parse(function (textures)
             {
                 const id = 'goldmine_10_5.png';
+                const width = Math.floor(spritesheet.data.frames[id].frame.w * spritesheet.baseTexture.sourceScale);
+                const height = Math.floor(spritesheet.data.frames[id].frame.h * spritesheet.baseTexture.sourceScale);
 
                 expect(Object.keys(textures).length).to.equal(1);
                 expect(Object.keys(spritesheet.textures).length).to.equal(1);
                 expect(textures[id]).to.be.an.instanceof(PIXI.Texture);
-                expect(textures[id].width).to.equal(spritesheet.data.frames[id].frame.w / spritesheet.resolution);
-                expect(textures[id].height).to.equal(spritesheet.data.frames[id].frame.h / spritesheet.resolution);
+                expect(textures[id].width).to.equal(width / spritesheet.resolution);
+                expect(textures[id].height).to.equal(height / spritesheet.resolution);
                 expect(textures[id].textureCacheIds.indexOf(id)).to.equal(0);
                 spritesheet.destroy(true);
                 expect(spritesheet.textures).to.be.null;
@@ -66,6 +68,19 @@ describe('PIXI.Spritesheet', function ()
 
             this.validate(spritesheet, done);
         };
+    });
+
+    it('should create instance with BaseTexture source scale', function (done)
+    {
+        const data = require(path.resolve(this.resources, 'building1.json')); // eslint-disable-line global-require
+        const baseTexture = new PIXI.BaseTexture.fromImage(data.meta.image, undefined, undefined, 1.5);
+        const spritesheet = new PIXI.Spritesheet(baseTexture, data);
+
+        expect(data).to.be.an.object;
+        expect(data.meta.image).to.equal('building1.png');
+        expect(spritesheet.resolution).to.equal(0.5);
+
+        this.validate(spritesheet, done);
     });
 
     it('should create instance with filename resolution', function (done)


### PR DESCRIPTION
Spritesheets no longer work properly if your using the `sourceScale` feature introduced in #2614.

This fix multiplies the size by the BaseTexture's sourceScale.

Note: My only concern is Math.floor. It works, however, it's easy to see why it could become a problem. Not sure how else to fix this. sourceScale uses [Math.round](https://github.com/pixijs/pixi.js/commit/4bcacc57bb764782cb307f10ee2048f7d4a4fddd#diff-2820734d8d9cebcd6dd6120421612e81R512) to ensure a clean width/height. I can't use Math.round here because multiple frames could end up being wider or higher than it's baseTexture.

Suggestions?

