### PR TITLE
Fix texture's frame dimension error report

### DIFF
--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -562,7 +562,8 @@ export default class Texture extends EventEmitter
             const errorX = `X: ${x} + ${width} = ${x + width} > ${this.baseTexture.width}`;
             const errorY = `Y: ${y} + ${height} = ${y + height} > ${this.baseTexture.height}`;
 
-            throw new Error(`Texture Error: frame does not fit inside the base Texture dimensions: ${errorX} ${relationship} ${errorY}`);
+            throw new Error('Texture Error: frame does not fit inside the base Texture dimensions: '
+                + `${errorX} ${relationship} ${errorY}`);
         }
 
         // this.valid = width && height && this.baseTexture.source && this.baseTexture.hasLoaded;

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -552,15 +552,20 @@ export default class Texture extends EventEmitter
 
         this.noFrame = false;
 
-        if (frame.x + frame.width > this.baseTexture.width || frame.y + frame.height > this.baseTexture.height)
+        const { x, y, width, height } = frame;
+        const xNotFit = x + width > this.baseTexture.width;
+        const yNotFit = y + height > this.baseTexture.height;
+
+        if (xNotFit || yNotFit)
         {
-            throw new Error('Texture Error: frame does not fit inside the base Texture dimensions: '
-                + `X: ${frame.x} + ${frame.width} = ${frame.x + frame.width} > ${this.baseTexture.width} `
-                + `Y: ${frame.y} + ${frame.height} = ${frame.y + frame.height} > ${this.baseTexture.height}`);
+            const errorX = xNotFit ? `X: ${x} + ${width} = ${x + width} > ${this.baseTexture.width} ` : '';
+            const errorY = yNotFit ? `Y: ${y} + ${height} = ${y + height} > ${this.baseTexture.height}` : '';
+
+            throw new Error(`Texture Error: frame does not fit inside the base Texture dimensions: ${errorX}${errorY}`);
         }
 
-        // this.valid = frame && frame.width && frame.height && this.baseTexture.source && this.baseTexture.hasLoaded;
-        this.valid = frame && frame.width && frame.height && this.baseTexture.hasLoaded;
+        // this.valid = width && height && this.baseTexture.source && this.baseTexture.hasLoaded;
+        this.valid = width && height && this.baseTexture.hasLoaded;
 
         if (!this.trim && !this.rotate)
         {

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -558,10 +558,11 @@ export default class Texture extends EventEmitter
 
         if (xNotFit || yNotFit)
         {
-            const errorX = xNotFit ? `X: ${x} + ${width} = ${x + width} > ${this.baseTexture.width} ` : '';
-            const errorY = yNotFit ? `Y: ${y} + ${height} = ${y + height} > ${this.baseTexture.height}` : '';
+            const relationship = xNotFit && yNotFit ? 'and' : 'or';
+            const errorX = `X: ${x} + ${width} = ${x + width} > ${this.baseTexture.width}`;
+            const errorY = `Y: ${y} + ${height} = ${y + height} > ${this.baseTexture.height}`;
 
-            throw new Error(`Texture Error: frame does not fit inside the base Texture dimensions: ${errorX}${errorY}`);
+            throw new Error(`Texture Error: frame does not fit inside the base Texture dimensions: ${errorX} ${relationship} ${errorY}`);
         }
 
         // this.valid = width && height && this.baseTexture.source && this.baseTexture.hasLoaded;


### PR DESCRIPTION
What's the error: 
The error will tell you both X and Y are wrong if you only one of them has incorrect value:
For example, set the height to `Number.MAX_VALUE`, then:
![image](https://user-images.githubusercontent.com/10692276/30027504-a4b066fa-91c4-11e7-83fa-f240043be458.png)

Why change `frame && frame.width ...` to `frame.width ...`?
If `frame == undefined`, it already breaks during  `if (frame.x + frame.width > this.baseTexture.width || frame.y + frame.height > this.baseTexture.height)` :)