### PR TITLE
filters can survive context loss

### DIFF
--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -127,6 +127,19 @@ export default class WebGLRenderer extends SystemRenderer
          */
         this.currentRenderer = this.emptyRenderer;
 
+        /**
+         * Manages textures
+         * @member {PIXI.TextureManager}
+         */
+        this.textureManager = null;
+
+        /**
+         * Manages the filters.
+         *
+         * @member {PIXI.FilterManager}
+         */
+        this.filterManager = null;
+
         this.initPlugins();
 
         /**
@@ -178,12 +191,6 @@ export default class WebGLRenderer extends SystemRenderer
 
         this._initContext();
 
-        /**
-         * Manages the filters.
-         *
-         * @member {PIXI.FilterManager}
-         */
-        this.filterManager = new FilterManager(this);
         // map some webGL blend and drawmodes..
         this.drawModes = mapWebGLDrawModesToPixi(this.gl);
 
@@ -236,6 +243,7 @@ export default class WebGLRenderer extends SystemRenderer
 
         // create a texture manager...
         this.textureManager = new TextureManager(this);
+        this.filterManager = new FilterManager(this);
         this.textureGC = new TextureGarbageCollector(this);
 
         this.state.resetToDefault();
@@ -683,6 +691,7 @@ export default class WebGLRenderer extends SystemRenderer
     handleContextRestored()
     {
         this.textureManager.removeAll();
+        this.filterManager.destroy(true);
         this._initContext();
     }
 

--- a/src/core/renderers/webgl/managers/FilterManager.js
+++ b/src/core/renderers/webgl/managers/FilterManager.js
@@ -49,6 +49,8 @@ export default class FilterManager extends WebGLManager
         this.pool = {};
 
         this.filterData = null;
+
+        this.managedFilters = [];
     }
 
     /**
@@ -231,6 +233,8 @@ export default class FilterManager extends WebGLManager
             {
                 shader = filter.glShaders[renderer.CONTEXT_UID] = new Shader(this.gl, filter.vertexSrc, filter.fragmentSrc);
             }
+
+            this.managedFilters.push(filter);
 
             // TODO - this only needs to be done once?
             renderer.bindVao(null);
@@ -488,11 +492,32 @@ export default class FilterManager extends WebGLManager
     /**
      * Destroys this Filter Manager.
      *
+     * @param {boolean} contextLost context was lost, do not free shaders
+     *
      */
-    destroy()
+    destroy(contextLost)
     {
+        const renderer = this.renderer;
+        const filters = this.managedFilters;
+
+        for (let i = 0; i < filters.length; i++)
+        {
+            if (!contextLost)
+            {
+                filters[i].glShaders[renderer.CONTEXT_UID].destroy();
+            }
+            delete filters[i].glShaders[renderer.CONTEXT_UID];
+        }
+
         this.shaderCache = {};
-        this.emptyPool();
+        if (!contextLost)
+        {
+            this.emptyPool();
+        }
+        else
+        {
+            this.pool = {};
+        }
     }
 
     /**

--- a/src/core/renderers/webgl/managers/FilterManager.js
+++ b/src/core/renderers/webgl/managers/FilterManager.js
@@ -492,10 +492,10 @@ export default class FilterManager extends WebGLManager
     /**
      * Destroys this Filter Manager.
      *
-     * @param {boolean} contextLost context was lost, do not free shaders
+     * @param {boolean} [contextLost=false] context was lost, do not free shaders
      *
      */
-    destroy(contextLost)
+    destroy(contextLost = false)
     {
         const renderer = this.renderer;
         const filters = this.managedFilters;


### PR DESCRIPTION
I believe that PIXI v4 is LTS, so I backported solution from my fork.

Its not fixed in v5: https://github.com/pixijs/pixi.js/blob/next/src/core/renderers/webgl/systems/FilterSystem.js

It is fixed in my v5 fork: https://github.com/gameofbombs/gobi/blob/master/src/pixi/renderers/systems/ShaderSystem.ts

To test the feature put this code in any of pixi examples that has filters, and see if it survives after context is lost. With my patch there are no errors/warnings in console at all.

```js
function loseContext() {
	var gl = app.renderer.gl;
	var ext = gl;
	if (!ext.loseContext) {
		ext = gl.getExtension('WEBGL_lose_context');
	}
	ext.loseContext();
	setTimeout(function () {
		ext.restoreContext();
	}, 1000);
}

setTimeout(loseContext, 2000);
```