### PR TITLE
AnimatedSprite.prototype.update: plz add arg this to .onComplete()

### DIFF
--- a/src/core/renderers/webgl/filters/filterTransforms.js
+++ b/src/core/renderers/webgl/filters/filterTransforms.js
@@ -40,36 +40,13 @@ export function calculateNormalizedScreenSpaceMatrix(outputMatrix, filterArea, t
 // this will map the filter coord so that a texture can be used based on the transform of a sprite
 export function calculateSpriteMatrix(outputMatrix, filterArea, textureSize, sprite)
 {
-    const worldTransform = sprite.worldTransform.copy(Matrix.TEMP_MATRIX);
     const texture = sprite._texture.baseTexture;
-
-    // TODO unwrap?
-    const mappedMatrix = outputMatrix.identity();
-
-    // scale..
-    const ratio = textureSize.height / textureSize.width;
-
-    mappedMatrix.translate(filterArea.x / textureSize.width, filterArea.y / textureSize.height);
-
-    mappedMatrix.scale(1, ratio);
-
-    const translateScaleX = (textureSize.width / texture.width);
-    const translateScaleY = (textureSize.height / texture.height);
-
-    worldTransform.tx /= texture.width * translateScaleX;
-
-    // this...?  free beer for anyone who can explain why this makes sense!
-    worldTransform.ty /= texture.width * translateScaleX;
-    // worldTransform.ty /= texture.height * translateScaleY;
+    const mappedMatrix = outputMatrix.set(textureSize.width, 0, 0, textureSize.height, filterArea.x, filterArea.y);
+    const worldTransform = sprite.worldTransform.copy(Matrix.TEMP_MATRIX);
 
     worldTransform.invert();
     mappedMatrix.prepend(worldTransform);
-
-    // apply inverse scale..
-    mappedMatrix.scale(1, 1 / ratio);
-
-    mappedMatrix.scale(translateScaleX, translateScaleY);
-
+    mappedMatrix.scale(1.0 / texture.width, 1.0 / texture.height);
     mappedMatrix.translate(sprite.anchor.x, sprite.anchor.y);
 
     return mappedMatrix;

--- a/src/core/renderers/webgl/managers/FilterManager.js
+++ b/src/core/renderers/webgl/managers/FilterManager.js
@@ -327,7 +327,9 @@ export default class FilterManager extends WebGLManager
         // TODO Cacheing layer..
         for (const i in uniformData)
         {
-            if (uniformData[i].type.toLowerCase() === 'sampler2d' && uniforms[i] !== 0)
+            const type = uniformData[i].type.toLowerCase();
+
+            if (type === 'sampler2d' && uniforms[i] !== 0)
             {
                 if (uniforms[i].baseTexture)
                 {
@@ -352,7 +354,7 @@ export default class FilterManager extends WebGLManager
 
                 textureCount++;
             }
-            else if (uniformData[i].type.toLowerCase() === 'mat3')
+            else if (type === 'mat3')
             {
                 // check if its PixiJS matrix..
                 if (uniforms[i].a !== undefined)
@@ -364,7 +366,7 @@ export default class FilterManager extends WebGLManager
                     shader.uniforms[i] = uniforms[i];
                 }
             }
-            else if (uniformData[i].type.toLowerCase() === 'vec2')
+            else if (type === 'vec2')
             {
                 // check if its a point..
                 if (uniforms[i].x !== undefined)
@@ -380,7 +382,7 @@ export default class FilterManager extends WebGLManager
                     shader.uniforms[i] = uniforms[i];
                 }
             }
-            else if (uniformData[i].type.toLowerCase() === 'float')
+            else if (type === 'float')
             {
                 if (shader.uniforms.data[i].value !== uniformData[i])
                 {

--- a/src/core/renderers/webgl/managers/FilterManager.js
+++ b/src/core/renderers/webgl/managers/FilterManager.js
@@ -327,7 +327,7 @@ export default class FilterManager extends WebGLManager
         // TODO Cacheing layer..
         for (const i in uniformData)
         {
-            if (uniformData[i].type === 'sampler2D' && uniforms[i] !== 0)
+            if (uniformData[i].type.toLowerCase() === 'sampler2d' && uniforms[i] !== 0)
             {
                 if (uniforms[i].baseTexture)
                 {
@@ -352,7 +352,7 @@ export default class FilterManager extends WebGLManager
 
                 textureCount++;
             }
-            else if (uniformData[i].type === 'mat3')
+            else if (uniformData[i].type.toLowerCase() === 'mat3')
             {
                 // check if its PixiJS matrix..
                 if (uniforms[i].a !== undefined)
@@ -364,7 +364,7 @@ export default class FilterManager extends WebGLManager
                     shader.uniforms[i] = uniforms[i];
                 }
             }
-            else if (uniformData[i].type === 'vec2')
+            else if (uniformData[i].type.toLowerCase() === 'vec2')
             {
                 // check if its a point..
                 if (uniforms[i].x !== undefined)
@@ -380,7 +380,7 @@ export default class FilterManager extends WebGLManager
                     shader.uniforms[i] = uniforms[i];
                 }
             }
-            else if (uniformData[i].type === 'float')
+            else if (uniformData[i].type.toLowerCase() === 'float')
             {
                 if (shader.uniforms.data[i].value !== uniformData[i])
                 {

--- a/src/core/textures/Spritesheet.js
+++ b/src/core/textures/Spritesheet.js
@@ -151,6 +151,7 @@ export default class Spritesheet
     {
         let frameIndex = initialFrameIndex;
         const maxFrames = Spritesheet.BATCH_SIZE;
+        const sourceScale = this.baseTexture.sourceScale;
 
         while (frameIndex - initialFrameIndex < maxFrames && frameIndex < this._frameKeys.length)
         {
@@ -164,26 +165,26 @@ export default class Spritesheet
                 const orig = new Rectangle(
                     0,
                     0,
-                    this._frames[i].sourceSize.w / this.resolution,
-                    this._frames[i].sourceSize.h / this.resolution
+                    Math.floor(this._frames[i].sourceSize.w * sourceScale) / this.resolution,
+                    Math.floor(this._frames[i].sourceSize.h * sourceScale) / this.resolution
                 );
 
                 if (this._frames[i].rotated)
                 {
                     frame = new Rectangle(
-                        rect.x / this.resolution,
-                        rect.y / this.resolution,
-                        rect.h / this.resolution,
-                        rect.w / this.resolution
+                        Math.floor(rect.x * sourceScale) / this.resolution,
+                        Math.floor(rect.y * sourceScale) / this.resolution,
+                        Math.floor(rect.h * sourceScale) / this.resolution,
+                        Math.floor(rect.w * sourceScale) / this.resolution
                     );
                 }
                 else
                 {
                     frame = new Rectangle(
-                        rect.x / this.resolution,
-                        rect.y / this.resolution,
-                        rect.w / this.resolution,
-                        rect.h / this.resolution
+                        Math.floor(rect.x * sourceScale) / this.resolution,
+                        Math.floor(rect.y * sourceScale) / this.resolution,
+                        Math.floor(rect.w * sourceScale) / this.resolution,
+                        Math.floor(rect.h * sourceScale) / this.resolution
                     );
                 }
 
@@ -191,10 +192,10 @@ export default class Spritesheet
                 if (this._frames[i].trimmed)
                 {
                     trim = new Rectangle(
-                        this._frames[i].spriteSourceSize.x / this.resolution,
-                        this._frames[i].spriteSourceSize.y / this.resolution,
-                        rect.w / this.resolution,
-                        rect.h / this.resolution
+                        Math.floor(this._frames[i].spriteSourceSize.x * sourceScale) / this.resolution,
+                        Math.floor(this._frames[i].spriteSourceSize.y * sourceScale) / this.resolution,
+                        Math.floor(rect.w * sourceScale) / this.resolution,
+                        Math.floor(rect.h * sourceScale) / this.resolution
                     );
                 }
 

--- a/src/extras/TilingSprite.js
+++ b/src/extras/TilingSprite.js
@@ -56,6 +56,15 @@ export default class TilingSprite extends core.Sprite
         this._canvasPattern = null;
 
         /**
+         * flag indicating the texture has changed but hasn't
+         * been updated yet
+         *
+         * @member {boolean}
+         * @private
+         */
+        this._textureDirtyFlag = true;
+
+        /**
          * transform that is applied to UV to get the texture coords
          *
          * @member {PIXI.extras.TextureTransform}
@@ -136,6 +145,7 @@ export default class TilingSprite extends core.Sprite
         {
             this.uvTransform.texture = this._texture;
         }
+        this._textureDirtyFlag = true;
     }
 
     /**
@@ -159,6 +169,7 @@ export default class TilingSprite extends core.Sprite
 
         renderer.setObjectRenderer(renderer.plugins[this.pluginName]);
         renderer.plugins[this.pluginName].render(this);
+        this._textureDirtyFlag = false;
     }
 
     /**
@@ -185,8 +196,7 @@ export default class TilingSprite extends core.Sprite
         const modY = ((this.tilePosition.y / this.tileScale.y) % texture._frame.height) * baseTextureResolution;
 
         // create a nice shiny pattern!
-        // TODO this needs to be refreshed if texture changes..
-        if (!this._canvasPattern)
+        if (this._textureDirtyFlag)
         {
             // cut an object from a spritesheet..
             const tempCanvas = new core.CanvasRenderTarget(texture._frame.width,
@@ -210,6 +220,7 @@ export default class TilingSprite extends core.Sprite
                     -texture._frame.x * baseTextureResolution, -texture._frame.y * baseTextureResolution);
             }
             this._canvasPattern = tempCanvas.context.createPattern(tempCanvas.canvas, 'repeat');
+            this._textureDirtyFlag = false;
         }
 
         // set context state..

--- a/test/core/Spritesheet.js
+++ b/test/core/Spritesheet.js
@@ -12,12 +12,14 @@ describe('PIXI.Spritesheet', function ()
             spritesheet.parse(function (textures)
             {
                 const id = 'goldmine_10_5.png';
+                const width = Math.floor(spritesheet.data.frames[id].frame.w * spritesheet.baseTexture.sourceScale);
+                const height = Math.floor(spritesheet.data.frames[id].frame.h * spritesheet.baseTexture.sourceScale);
 
                 expect(Object.keys(textures).length).to.equal(1);
                 expect(Object.keys(spritesheet.textures).length).to.equal(1);
                 expect(textures[id]).to.be.an.instanceof(PIXI.Texture);
-                expect(textures[id].width).to.equal(spritesheet.data.frames[id].frame.w / spritesheet.resolution);
-                expect(textures[id].height).to.equal(spritesheet.data.frames[id].frame.h / spritesheet.resolution);
+                expect(textures[id].width).to.equal(width / spritesheet.resolution);
+                expect(textures[id].height).to.equal(height / spritesheet.resolution);
                 expect(textures[id].textureCacheIds.indexOf(id)).to.equal(0);
                 spritesheet.destroy(true);
                 expect(spritesheet.textures).to.be.null;
@@ -66,6 +68,19 @@ describe('PIXI.Spritesheet', function ()
 
             this.validate(spritesheet, done);
         };
+    });
+
+    it('should create instance with BaseTexture source scale', function (done)
+    {
+        const data = require(path.resolve(this.resources, 'building1.json')); // eslint-disable-line global-require
+        const baseTexture = new PIXI.BaseTexture.fromImage(data.meta.image, undefined, undefined, 1.5);
+        const spritesheet = new PIXI.Spritesheet(baseTexture, data);
+
+        expect(data).to.be.an.object;
+        expect(data.meta.image).to.equal('building1.png');
+        expect(spritesheet.resolution).to.equal(0.5);
+
+        this.validate(spritesheet, done);
     });
 
     it('should create instance with filename resolution', function (done)


### PR DESCRIPTION
Hi guys, would it be possible to add to an next update.
pass arg **this** on the **this.onComplete();**

ex:
```javascript
if (this._currentTime < 0 && !this.loop) {
            this.gotoAndStop(0);

            if (this.onComplete) {
                this.onComplete(this);
            }
        } else if.....
```
in pixi.js v4.5.4  is at line: 29901

I'm writing a plugin now or wish bind(this) but keep the arg this of current motion.
I could make the modification, but the code is very long and will take too much space in my plugin, only for a modification.

here the context why i need it 
thanks

```javascript
animationControler.prototype.addMotionContext_Winks = function(motion,motionCall,frames,luck) { //var .addMotionContext_Winks('idl1','winks1',0,80)
    var _motion = this.getChildAt(this._motionsLists[motion]);
    var _motionCall = this.getChildAt(this._motionsLists[motionCall]);
    var luck = luck || 50;
    var MotionContext = function(frame,ran){
        if(frame===frames && ran<luck){
            _motion.renderable = false; // stop scenes rendering current motion
            _motionCall.loop = false; // linear force no loop
            _motionCall.gotoAndPlay(0); //ex: 'winks1'
            _motionCall.renderable = true;
            return true;
        };
        return false;
    }.bind(this);

    _motionCall.onComplete = function(aaa){ // maybe use _motionContext than .onComplete (need check)
        console.log('complettt need arg this : ', aaa);
        console.log('this: ', this);
    }.bind(this);
    
    var ranKey = Math.random().toString(36).substring(7); // generate random memoryKey register context
    _motion._motionContexts['_Linear'+frames+'_'+motionCall+'id_'+ranKey] = MotionContext;
};
```