### PR TITLE
fix NineSlice with resolution

### DIFF
--- a/src/mesh/NineSlicePlane.js
+++ b/src/mesh/NineSlicePlane.js
@@ -172,8 +172,8 @@ export default class NineSlicePlane extends Plane
 
         const base = this._texture.baseTexture;
         const textureSource = base.source;
-        const w = base.width;
-        const h = base.height;
+        const w = base.width * base.resolution;
+        const h = base.height * base.resolution;
 
         this.drawSegment(context, textureSource, w, h, 0, 1, 10, 11);
         this.drawSegment(context, textureSource, w, h, 2, 3, 12, 13);


### PR DESCRIPTION
Somehow, we didn't use resolution for NineSlicePlane canvas version, and fix is easy. However I dont have fiddle for it, people just reported this problem and solution to me. 

Theoretically, that's how it suppose to work.