### PR TITLE
Upgrade jaguarjs-jsdoc Template

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "resource-loader": "^2.0.9"
   },
   "devDependencies": {
+    "@pixi/jsdoc-template": "^2.0.0",
     "babel-cli": "^6.18.0",
     "babel-plugin-static-fs": "^1.1.0",
     "babel-plugin-version-inline": "^1.0.0",
@@ -75,7 +76,6 @@
     "electron": "^1.4.15",
     "eslint": "^3.5.0",
     "floss": "^2.0.1",
-    "jaguarjs-jsdoc": "^1.0.1",
     "js-md5": "^0.4.1",
     "jsdoc": "3.4.3",
     "minimist": "^1.2.0",

--- a/scripts/jsdoc.conf.json
+++ b/scripts/jsdoc.conf.json
@@ -51,6 +51,6 @@
         "private"       : false,
         "lenient"       : true,
         "destination"   : "./docs",
-        "template"      : "./node_modules/jaguarjs-jsdoc"
+        "template"      : "./node_modules/@pixi/jsdoc-template"
     }
 }


### PR DESCRIPTION
Forked [jaguarjs-jsdoc](https://github.com/pixijs/jaguarjs-jsdoc) to [@pixi/jsdoc-template](https://github.com/pixijs/pixi-jsdoc-template) which adds a bunch of improvements to the existing docs template:
- Fixes bugs in search
- Changes colors to match website/examples/etc
- Better spacing for improved legibility
- Deep-links next to each API
- Responsive layout to display better on large mobile devices

**Existing Docs**: https://pixijs.download/release/docs/PIXI.CanvasRenderer.html
![screen shot 2017-09-18 at 4 58 35 pm](https://user-images.githubusercontent.com/864393/30564291-8dcef9fa-9c92-11e7-8632-09bbb049f4a2.png)


**New Template**: https://pixijs.download/new-jsdoc-template/docs/PIXI.CanvasRenderer.html
![screen shot 2017-09-18 at 4 58 43 pm](https://user-images.githubusercontent.com/864393/30564295-90449186-9c92-11e7-8def-d76e2fdd0106.png)
