### PR TITLE
Force base render textures to be whole pixels to fix error in IE

### DIFF
--- a/src/core/textures/BaseRenderTexture.js
+++ b/src/core/textures/BaseRenderTexture.js
@@ -54,8 +54,8 @@ export default class BaseRenderTexture extends BaseTexture
 
         this.resolution = resolution || settings.RESOLUTION;
 
-        this.width = width;
-        this.height = height;
+        this.width = Math.ceil(width);
+        this.height = Math.ceil(height);
 
         this.realWidth = this.width * this.resolution;
         this.realHeight = this.height * this.resolution;
@@ -95,6 +95,9 @@ export default class BaseRenderTexture extends BaseTexture
      */
     resize(width, height)
     {
+        width = Math.ceil(width);
+        height = Math.ceil(height);
+
         if (width === this.width && height === this.height)
         {
             return;

--- a/src/core/textures/RenderTexture.js
+++ b/src/core/textures/RenderTexture.js
@@ -97,6 +97,9 @@ export default class RenderTexture extends Texture
      */
     resize(width, height, doNotResizeBaseTexture)
     {
+        width = Math.ceil(width);
+        height = Math.ceil(height);
+
         // TODO - could be not required..
         this.valid = (width > 0 && height > 0);
 


### PR DESCRIPTION
I have a bit of code that takes a texture rendered by PIXI.Text, then creates a rope from it to create curved text. I then put that to a renderTexture to be used by sprites.
However, on IE 11 only, (WebGL in IE in fact), the texture just looks bizarre. I've created a fiddle that shows normal text (top), rope (left) then the sprite using a generated texture (right). I've forced some crazy resolution values to help replicate the issue.
By using Math.ceil on width and height of created render textures, the issue goes away. I think this is safe, since regular textures you upload with sprites couldn't be a fraction of a pixel wide, so why should created textures?

https://jsfiddle.net/themoonrat/71hadj49/

In case the fiddle doesn't work for you (remember, IE 11 WebGL only), here's how it looks to me in Chrome
![chrome](https://user-images.githubusercontent.com/1528426/30664531-f2c1d56c-9e45-11e7-9015-add63ea86a1f.jpg)

And then in IE
![ie11jpg](https://user-images.githubusercontent.com/1528426/30664541-fb50963c-9e45-11e7-860f-972d9f2be4c9.jpg)
