### PR TITLE
Consistent Canvas State after render()

### DIFF
--- a/src/core/renderers/canvas/CanvasRenderer.js
+++ b/src/core/renderers/canvas/CanvasRenderer.js
@@ -199,7 +199,8 @@ export default class CanvasRenderer extends SystemRenderer
             // displayObject.hitArea = //TODO add a temp hit area
         }
 
-        context.setTransform(1, 0, 0, 1, 0, 0);
+        context.save();
+        setTransform(1, 0, 0, 1, 0, 0);
         context.globalAlpha = 1;
         this._activeBlendMode = BLEND_MODES.NORMAL;
         context.globalCompositeOperation = this.blendModes[BLEND_MODES.NORMAL];
@@ -227,6 +228,8 @@ export default class CanvasRenderer extends SystemRenderer
             // TODO: implement background for CanvasRenderTarget or RenderTexture?
             // }
         }
+        
+        context.restore();
 
         // TODO RENDER TARGET STUFF HERE..
         const tempContext = this.context;

--- a/src/core/renderers/canvas/CanvasRenderer.js
+++ b/src/core/renderers/canvas/CanvasRenderer.js
@@ -228,7 +228,7 @@ export default class CanvasRenderer extends SystemRenderer
             // TODO: implement background for CanvasRenderTarget or RenderTexture?
             // }
         }
-        
+
         context.restore();
 
         // TODO RENDER TARGET STUFF HERE..


### PR DESCRIPTION
Save and Restore canvas state so transform, style changes etc aren't propagated outside of render()