### PR TITLE
Allow texture to be null when create a new Mesh.

### DIFF
--- a/src/mesh/Mesh.js
+++ b/src/mesh/Mesh.js
@@ -28,6 +28,7 @@ export default class Mesh extends core.Container
          * The texture of the Mesh
          *
          * @member {PIXI.Texture}
+         * @default PIXI.Texture.EMPTY
          * @private
          */
         this._texture = texture || Texture.EMPTY;

--- a/src/mesh/Mesh.js
+++ b/src/mesh/Mesh.js
@@ -29,11 +29,11 @@ export default class Mesh extends core.Container
          * @member {PIXI.Texture}
          * @private
          */
-        this._texture = texture;
+        this._texture = texture || PIXI.texture.EMPTY;
 
-        if (texture && !texture.baseTexture.hasLoaded)
+        if (!this._texture.baseTexture.hasLoaded)
         {
-            texture.once('update', this._onTextureUpdate, this);
+            this._texture.once('update', this._onTextureUpdate, this);
         }
 
         /**

--- a/src/mesh/Mesh.js
+++ b/src/mesh/Mesh.js
@@ -31,7 +31,7 @@ export default class Mesh extends core.Container
          */
         this._texture = texture;
 
-        if (!texture.baseTexture.hasLoaded)
+        if (texture && !texture.baseTexture.hasLoaded)
         {
             texture.once('update', this._onTextureUpdate, this);
         }
@@ -58,8 +58,10 @@ export default class Mesh extends core.Container
             100, 100,
             0, 100]);
 
-        /*
-         * @member {Uint16Array} An array containing the indices of the vertices
+        /**
+         * An array containing the indices of the vertices
+         *
+         * @member {Uint16Array}
          */
         //  TODO auto generate this based on draw mode!
         this.indices = indices || new Uint16Array([0, 1, 3, 2]);

--- a/src/mesh/Mesh.js
+++ b/src/mesh/Mesh.js
@@ -2,7 +2,6 @@ import * as core from '../core';
 import Texture from '../core/textures/Texture';
 import { default as TextureTransform } from '../extras/TextureTransform';
 
-
 const tempPoint = new core.Point();
 const tempPolygon = new core.Polygon();
 

--- a/src/mesh/Mesh.js
+++ b/src/mesh/Mesh.js
@@ -1,5 +1,7 @@
 import * as core from '../core';
+import Texture from '../core/textures/Texture';
 import { default as TextureTransform } from '../extras/TextureTransform';
+
 
 const tempPoint = new core.Point();
 const tempPolygon = new core.Polygon();
@@ -29,7 +31,7 @@ export default class Mesh extends core.Container
          * @member {PIXI.Texture}
          * @private
          */
-        this._texture = texture || PIXI.texture.EMPTY;
+        this._texture = texture || Texture.EMPTY;
 
         if (!this._texture.baseTexture.hasLoaded)
         {


### PR DESCRIPTION
Sometimes, user would pass `null` as  argument `texture` when call `new Mesh()`