### PR TITLE
[WIP] Node.JS support

### DIFF
--- a/src/accessibility/AccessibilityManager.js
+++ b/src/accessibility/AccessibilityManager.js
@@ -480,7 +480,15 @@ export default class AccessibilityManager
         this.children = null;
         this.renderer = null;
     }
+
+    static isSupported () {
+        return typeof document !== 'undefined'
+    }
 }
 
-core.WebGLRenderer.registerPlugin('accessibility', AccessibilityManager);
-core.CanvasRenderer.registerPlugin('accessibility', AccessibilityManager);
+if (AccessibilityManager.isSupported())
+{
+    core.WebGLRenderer.registerPlugin('accessibility', AccessibilityManager);
+    core.CanvasRenderer.registerPlugin('accessibility', AccessibilityManager);
+}
+

--- a/src/core/renderers/SystemRenderer.js
+++ b/src/core/renderers/SystemRenderer.js
@@ -5,6 +5,7 @@ import settings from '../settings';
 import Container from '../display/Container';
 import RenderTexture from '../textures/RenderTexture';
 import EventEmitter from 'eventemitter3';
+import createCanvas from '../utils/createCanvas';
 
 const tempMatrix = new Matrix();
 
@@ -89,7 +90,7 @@ export default class SystemRenderer extends EventEmitter
          *
          * @member {HTMLCanvasElement}
          */
-        this.view = options.view || document.createElement('canvas');
+        this.view = options.view || createCanvas();
 
         /**
          * The resolution / device pixel ratio of the renderer

--- a/src/core/renderers/webgl/WebGLRenderer.js
+++ b/src/core/renderers/webgl/WebGLRenderer.js
@@ -79,8 +79,11 @@ export default class WebGLRenderer extends SystemRenderer
         this.handleContextLost = this.handleContextLost.bind(this);
         this.handleContextRestored = this.handleContextRestored.bind(this);
 
-        this.view.addEventListener('webglcontextlost', this.handleContextLost, false);
-        this.view.addEventListener('webglcontextrestored', this.handleContextRestored, false);
+        if (typeof this.view.addEventListener !== 'undefined')
+        {
+            this.view.addEventListener('webglcontextlost', this.handleContextLost, false);
+            this.view.addEventListener('webglcontextrestored', this.handleContextRestored, false);
+        }
 
         /**
          * The options passed in to create a new webgl context.
@@ -706,8 +709,11 @@ export default class WebGLRenderer extends SystemRenderer
         this.destroyPlugins();
 
         // remove listeners
-        this.view.removeEventListener('webglcontextlost', this.handleContextLost);
-        this.view.removeEventListener('webglcontextrestored', this.handleContextRestored);
+        if (typeof this.view.addEventListener !== 'undefined')
+        {
+            this.view.removeEventListener('webglcontextlost', this.handleContextLost);
+            this.view.removeEventListener('webglcontextrestored', this.handleContextRestored);
+        }
 
         this.textureManager.destroy();
 

--- a/src/core/renderers/webgl/filters/Filter.js
+++ b/src/core/renderers/webgl/filters/Filter.js
@@ -183,7 +183,7 @@ export default class Filter
 
             'void main(void){',
             '   vec4 masky = texture2D(filterSampler, vFilterCoord);',
-            '   vec4 sample = texture2D(uSampler, vTextureCoord);',
+            '   vec4 _sample = texture2D(uSampler, vTextureCoord);',
             '   vec4 color;',
             '   if(mod(vFilterCoord.x, 1.0) > 0.5)',
             '   {',
@@ -194,8 +194,8 @@ export default class Filter
             '     color = vec4(0.0, 1.0, 0.0, 1.0);',
             '   }',
             // '   gl_FragColor = vec4(mod(vFilterCoord.x, 1.5), vFilterCoord.y,0.0,1.0);',
-            '   gl_FragColor = mix(sample, masky, 0.5);',
-            '   gl_FragColor *= sample.a;',
+            '   gl_FragColor = mix(_sample, masky, 0.5);',
+            '   gl_FragColor *= _sample.a;',
             '}',
         ].join('\n');
     }

--- a/src/core/text/TextMetrics.js
+++ b/src/core/text/TextMetrics.js
@@ -1,3 +1,5 @@
+import createCanvas from '../utils/createCanvas'
+
 /**
  * The TextMetrics object represents the measurement of a block of text with a specified style.
  *
@@ -298,9 +300,7 @@ export default class TextMetrics
  * @property {number} fontSize - Font size from ascent to descent
  */
 
-const canvas = document.createElement('canvas');
-
-canvas.width = canvas.height = 10;
+const canvas = createCanvas(10, 10);
 
 /**
  * Cached canvas element for measuring text

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -4,6 +4,7 @@ import TextureUvs from './TextureUvs';
 import EventEmitter from 'eventemitter3';
 import { Rectangle } from '../math';
 import { TextureCache, getResolutionOfUrl } from '../utils';
+import createCanvas from '../utils/createCanvas';
 import settings from '../settings';
 
 /**
@@ -626,10 +627,7 @@ export default class Texture extends EventEmitter
 
 function createWhiteTexture()
 {
-    const canvas = document.createElement('canvas');
-
-    canvas.width = 10;
-    canvas.height = 10;
+    const canvas = createCanvas(10, 10);
 
     const context = canvas.getContext('2d');
 

--- a/src/core/utils/canUploadSameBuffer.js
+++ b/src/core/utils/canUploadSameBuffer.js
@@ -3,6 +3,8 @@ export default function canUploadSameBuffer()
 	// Uploading the same buffer multiple times in a single frame can cause perf issues.
 	// Apparent on IOS so only check for that at the moment
 	// this check may become more complex if this issue pops up elsewhere.
+    if (typeof navigator === 'undefined') return true
+
     const ios = !!navigator.platform && (/iPad|iPhone|iPod/).test(navigator.platform);
 
     return !ios;

--- a/src/core/utils/createCanvas.js
+++ b/src/core/utils/createCanvas.js
@@ -1,0 +1,15 @@
+export default function createCanvas(width = 300, height = 150)
+{
+  let canvas;
+  if (typeof document !== 'undefined') {
+    canvas = document.createElement('canvas');
+  } else {
+    try {
+      const { Canvas } = require('canvas');
+      canvas = new Canvas(width, height);
+    } catch (e) {
+      console.log(e)
+    }
+  }
+  return canvas;
+}

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -297,18 +297,32 @@ export function isWebGLSupported()
 {
     const contextOptions = { stencil: true, failIfMajorPerformanceCaveat: true };
 
+    let headlessGL = null
     try
     {
-        if (!window.WebGLRenderingContext)
+        headlessGL = require('gl')
+    }
+    catch (e) {}
+
+    try
+    {
+        if (!root.WebGLRenderingContext && !headlessGL)
         {
             return false;
         }
 
-        const canvas = document.createElement('canvas');
-        let gl = canvas.getContext('webgl', contextOptions) || canvas.getContext('experimental-webgl', contextOptions);
+        let gl
+        if (headlessGL !== null)
+        {
+            gl = headlessGL(100, 100)
+        }
+        else
+        {
+            const canvas = document.createElement('canvas');
+            gl = canvas.getContext('webgl', contextOptions) || canvas.getContext('experimental-webgl', contextOptions);
+        }
 
         const success = !!(gl && gl.getContextAttributes().stencil);
-
         if (gl)
         {
             const loseContext = gl.getExtension('WEBGL_lose_context');

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -9,6 +9,7 @@ import mapPremultipliedBlendModes from './mapPremultipliedBlendModes';
 
 let nextUid = 0;
 let saidHello = false;
+const root = typeof window === 'undefined' ? global : window
 
 /**
  * Generalized convenience utilities for PIXI.
@@ -260,7 +261,7 @@ export function sayHello(type)
         return;
     }
 
-    if (navigator.userAgent.toLowerCase().indexOf('chrome') > -1)
+    if (typeof navigator !== 'undefined' && navigator.userAgent.toLowerCase().indexOf('chrome') > -1)
     {
         const args = [
             `\n %c %c %c PixiJS ${VERSION} - ✰ ${type} ✰  %c  %c  http://www.pixijs.com/  %c %c ♥%c♥%c♥ \n\n`,
@@ -275,11 +276,11 @@ export function sayHello(type)
             'color: #ff2424; background: #fff; padding:5px 0;',
         ];
 
-        window.console.log.apply(console, args);
+        root.console.log.apply(console, args);
     }
-    else if (window.console)
+    else if (root.console)
     {
-        window.console.log(`PixiJS ${VERSION} - ${type} - http://www.pixijs.com/`);
+        root.console.log(`PixiJS ${VERSION} - ${type} - http://www.pixijs.com/`);
     }
 
     saidHello = true;

--- a/src/extras/webgl/tilingSprite.frag
+++ b/src/extras/webgl/tilingSprite.frag
@@ -12,6 +12,6 @@ void main(void)
     coord = (uMapCoord * vec3(coord, 1.0)).xy;
     coord = clamp(coord, uClampFrame.xy, uClampFrame.zw);
 
-    vec4 sample = texture2D(uSampler, coord);
-    gl_FragColor = sample * uColor;
+    vec4 _sample = texture2D(uSampler, coord);
+    gl_FragColor = _sample * uColor;
 }

--- a/src/extras/webgl/tilingSprite_simple.frag
+++ b/src/extras/webgl/tilingSprite_simple.frag
@@ -5,6 +5,6 @@ uniform vec4 uColor;
 
 void main(void)
 {
-    vec4 sample = texture2D(uSampler, vTextureCoord);
-    gl_FragColor = sample * uColor;
+    vec4 _sample = texture2D(uSampler, vTextureCoord);
+    gl_FragColor = _sample * uColor;
 }

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -1819,7 +1819,14 @@ export default class InteractionManager extends EventEmitter
 
         this._tempPoint = null;
     }
+
+    static isSupported () {
+        return typeof document !== 'undefined'
+    }
 }
 
-core.WebGLRenderer.registerPlugin('interaction', InteractionManager);
-core.CanvasRenderer.registerPlugin('interaction', InteractionManager);
+if (InteractionManager.isSupported())
+{
+    core.WebGLRenderer.registerPlugin('interaction', InteractionManager);
+    core.CanvasRenderer.registerPlugin('interaction', InteractionManager);
+}

--- a/src/polyfill/index.js
+++ b/src/polyfill/index.js
@@ -2,22 +2,24 @@ import './Object.assign';
 import './requestAnimationFrame';
 import './Math.sign';
 
-if (!window.ArrayBuffer)
+const root = typeof window === 'undefined' ? global : window
+
+if (!root.ArrayBuffer)
 {
-    window.ArrayBuffer = Array;
+    root.ArrayBuffer = Array;
 }
 
-if (!window.Float32Array)
+if (!root.Float32Array)
 {
-    window.Float32Array = Array;
+    root.Float32Array = Array;
 }
 
-if (!window.Uint32Array)
+if (!root.Uint32Array)
 {
-    window.Uint32Array = Array;
+    root.Uint32Array = Array;
 }
 
-if (!window.Uint16Array)
+if (!root.Uint16Array)
 {
-    window.Uint16Array = Array;
+    root.Uint16Array = Array;
 }


### PR DESCRIPTION
I'm currently working on a server-side video rendering solution that is PIXI-backed. I was able to get PIXI v3 working by doing some monkeypatching and browser object mocking, but for v4 I'd like to build the solution into PIXI itself.

For CanvasRenderer I'm using [`node-canvas`](https://github.com/Automattic/node-canvas), for WebGL rendering I'm using [`headless-gl`](https://github.com/stackgl/headless-gl). These two packages are "drop-in" replacements for the browser features, but of course there are some difficulties - e.g. the fact that they're not working together out of the box.

Tasks:
- [X] Avoid usage of `window`, use `global` if present / possible
- [X] Avoid usage of `document.createElement('canvas')` - I created a wrapper called `createCanvas`. Uses `document.createElement` in the browser environment and `new Canvas()` in Node.JS environment
- [X] If `document` is not available, disable interaction handlers / plugins that require the DOM
- [X] Rename `sample` in WebGL shaders, since this seems to be a reserved word on OpenGL ES?
- [ ] Fix resource loading (e.g. `Texture.fromImage`)
- [ ] Modify CanvasRenderer so that it can render using `node-canvas`

Current state: I am now able to perform server-side rendering using WebGLRenderer, [like this](https://gist.github.com/saschagehlich/ada18ce4d7cb73380345e1ebed953345).

This PR requires some more work in `pixi-gl-core`. I'll create a PR for these changes soon and add a link to the PR.