### PR TITLE
Adding "name" as optionnal parameter for all display objects

### DIFF
--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -17,11 +17,11 @@ import DisplayObject from './DisplayObject';
 export default class Container extends DisplayObject
 {
     /**
-     *
+     * @param {string} name - The name of the display object.
      */
-    constructor()
+    constructor(name = null)
     {
-        super();
+        super(name);
 
         /**
          * The array of children of this container.

--- a/src/core/display/DisplayObject.js
+++ b/src/core/display/DisplayObject.js
@@ -18,9 +18,9 @@ import { Rectangle } from '../math';
 export default class DisplayObject extends EventEmitter
 {
     /**
-     *
+     * @param {string} name - The name of the display object.
      */
-    constructor()
+    constructor(name = null)
     {
         super();
 
@@ -121,6 +121,13 @@ export default class DisplayObject extends EventEmitter
          * @readonly
          */
         this._destroyed = false;
+
+        /**
+         * The name of the object, in order to be easily identified when searching for a container or sprite
+         *
+         * @member {string}
+         */
+        this.name = name;
 
         /**
          * Fired when this DisplayObject is added to a Container.

--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -29,10 +29,11 @@ export default class Graphics extends Container
     /**
      *
      * @param {boolean} [nativeLines=false] - If true the lines will be draw using LINES instead of TRIANGLE_STRIP
+     * @param {string} name - The name of the display object.
      */
-    constructor(nativeLines = false)
+    constructor(nativeLines = false, name = null)
     {
-        super();
+        super(name);
 
         /**
          * The alpha value used when filling the Graphics object.

--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -23,10 +23,11 @@ export default class Sprite extends Container
 {
     /**
      * @param {PIXI.Texture} texture - The texture for this sprite
+     * @param {string} name - The name of the display object.
      */
-    constructor(texture)
+    constructor(texture, name = null)
     {
-        super();
+        super(name);
 
         /**
          * The anchor sets the origin point of the texture.

--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -35,8 +35,9 @@ export default class Text extends Sprite
      * @param {string} text - The string that you would like the text to display
      * @param {object|PIXI.TextStyle} [style] - The style parameters
      * @param {HTMLCanvasElement} [canvas] - The canvas element for drawing text
+     * @param {string} name - The name of the display object.
      */
-    constructor(text, style, canvas)
+    constructor(text, style, canvas, name = null)
     {
         canvas = canvas || document.createElement('canvas');
 
@@ -48,7 +49,7 @@ export default class Text extends Sprite
         texture.orig = new Rectangle();
         texture.trim = new Rectangle();
 
-        super(texture);
+        super(texture, name);
 
         // base texture is already automatically added to the cache, now adding the actual texture
         Texture.addToCache(this._texture, this._texture.baseTexture.textureCacheIds[0]);

--- a/src/extras/AnimatedSprite.js
+++ b/src/extras/AnimatedSprite.js
@@ -33,10 +33,11 @@ export default class AnimatedSprite extends core.Sprite
      * @param {PIXI.Texture[]|FrameObject[]} textures - an array of {@link PIXI.Texture} or frame
      *  objects that make up the animation
      * @param {boolean} [autoUpdate=true] - Whether to use PIXI.ticker.shared to auto update animation time.
+     * @param {string} name - The name of the display object.
      */
-    constructor(textures, autoUpdate)
+    constructor(textures, autoUpdate, name = null)
     {
-        super(textures[0] instanceof core.Texture ? textures[0] : textures[0].texture);
+        super(textures[0] instanceof core.Texture ? textures[0] : textures[0].texture, name);
 
         /**
          * @private

--- a/src/extras/TilingSprite.js
+++ b/src/extras/TilingSprite.js
@@ -17,10 +17,11 @@ export default class TilingSprite extends core.Sprite
      * @param {PIXI.Texture} texture - the texture of the tiling sprite
      * @param {number} [width=100] - the width of the tiling sprite
      * @param {number} [height=100] - the height of the tiling sprite
+     * @param {string} name - The name of the display object.
      */
-    constructor(texture, width = 100, height = 100)
+    constructor(texture, width = 100, height = 100, name = null)
     {
-        super(texture);
+        super(texture, name);
 
         /**
          * Tile transform

--- a/src/mesh/Mesh.js
+++ b/src/mesh/Mesh.js
@@ -19,10 +19,11 @@ export default class Mesh extends core.Container
      * @param {Float32Array} [uvs] - if you want to specify the uvs
      * @param {Uint16Array} [indices] - if you want to specify the indices
      * @param {number} [drawMode] - the drawMode, can be any of the Mesh.DRAW_MODES consts
+     * @param {string} name - The name of the display object.
      */
-    constructor(texture, vertices, uvs, indices, drawMode)
+    constructor(texture, vertices, uvs, indices, drawMode, name = null)
     {
-        super();
+        super(name);
 
         /**
          * The texture of the Mesh

--- a/src/mesh/NineSlicePlane.js
+++ b/src/mesh/NineSlicePlane.js
@@ -41,10 +41,11 @@ export default class NineSlicePlane extends Plane
      * @param {int} [topHeight=10] size of the top horizontal bar (C)
      * @param {int} [rightWidth=10] size of the right vertical bar (B)
      * @param {int} [bottomHeight=10] size of the bottom horizontal bar (D)
+     * @param {string} name - The name of the display object.
      */
-    constructor(texture, leftWidth, topHeight, rightWidth, bottomHeight)
+    constructor(texture, leftWidth, topHeight, rightWidth, bottomHeight, name = null)
     {
-        super(texture, 4, 4);
+        super(texture, 4, 4, name);
 
         this._origWidth = texture.orig.width;
         this._origHeight = texture.orig.height;

--- a/src/mesh/Plane.js
+++ b/src/mesh/Plane.js
@@ -21,10 +21,11 @@ export default class Plane extends Mesh
      * @param {PIXI.Texture} texture - The texture to use on the Plane.
      * @param {number} verticesX - The number of vertices in the x-axis
      * @param {number} verticesY - The number of vertices in the y-axis
+     * @param {string} name - The name of the display object.
      */
-    constructor(texture, verticesX, verticesY)
+    constructor(texture, verticesX, verticesY, name = null)
     {
-        super(texture);
+        super(texture, name);
 
         /**
          * Tracker for if the Plane is ready to be drawn. Needed because Mesh ctor can

--- a/src/mesh/Rope.js
+++ b/src/mesh/Rope.js
@@ -20,10 +20,11 @@ export default class Rope extends Mesh
     /**
      * @param {PIXI.Texture} texture - The texture to use on the rope.
      * @param {PIXI.Point[]} points - An array of {@link PIXI.Point} objects to construct this rope.
+     * @param {string} name - The name of the display object.
      */
-    constructor(texture, points)
+    constructor(texture, points, name = null)
     {
-        super(texture);
+        super(texture, name);
 
         /**
          * An array of points that determine the rope

--- a/src/particles/ParticleContainer.js
+++ b/src/particles/ParticleContainer.js
@@ -39,10 +39,11 @@ export default class ParticleContainer extends core.Container
      * @param {number} [batchSize=16384] - Number of particles per batch. If less than maxSize, it uses maxSize instead.
      * @param {boolean} [autoResize=true] If true, container allocates more batches in case
      *  there are more than `maxSize` particles.
+     * @param {string} name - The name of the display object.
      */
-    constructor(maxSize = 1500, properties, batchSize = 16384, autoResize = false)
+    constructor(maxSize = 1500, properties, batchSize = 16384, autoResize = false, name = null)
     {
-        super();
+        super(name);
 
         // Making sure the batch size is valid
         // 65535 is max vertex index in the index buffer (see ParticleRenderer)


### PR DESCRIPTION
Not sure you'll like this pull request or if someone already asked you for this
I'm a fan of smart one liners and having the possibility (optional) to set a name directly when creating a container may simplify writing. It also leads the writers to use names and then potential editors may display interesting names instead of just a Javascript constructor name.

Also gives more sense to "getContainerByName" in extras

You ok with that?

Thanks for your answer!