### PR TITLE
Ensures that text style properties are copied by value, not by reference

### DIFF
--- a/src/core/text/TextStyle.js
+++ b/src/core/text/TextStyle.js
@@ -95,10 +95,7 @@ export default class TextStyle
 
         this.reset();
 
-        for (const key in style)
-        {
-            deepCopyProperty(this, style, key);
-        }
+        deepCopyProperties(this, style, style);
     }
 
     /**
@@ -111,10 +108,7 @@ export default class TextStyle
     {
         const clonedProperties = {};
 
-        for (const key in defaultStyle)
-        {
-            deepCopyProperty(clonedProperties, this, key);
-        }
+        deepCopyProperties(clonedProperties, this, defaultStyle);
 
         return new TextStyle(clonedProperties);
     }
@@ -124,10 +118,7 @@ export default class TextStyle
      */
     reset()
     {
-        for (const key in defaultStyle)
-        {
-            deepCopyProperty(this, defaultStyle, key);
-        }
+        deepCopyProperties(this, defaultStyle, defaultStyle);
     }
 
     /**
@@ -767,16 +758,16 @@ function areArraysEqual(array1, array2)
 /**
  * Utility function to ensure that object properties are copied by value, and not by reference
  *
- * @param {Object} target Target object to copy property into
- * @param {Object} source Source object for the proporty to copy
- * @param {string} prop Property name to copy
+ * @param {Object} target Target object to copy properties into
+ * @param {Object} source Source object for the proporties to copy
+ * @param {string} propertyObj Object containing properties names we want to loop over
  */
-function deepCopyProperty(target, source, prop) {
-    if (Array.isArray(source[prop])) {
-        target[prop] = source[prop].slice();
-    } else if (source[prop] && typeof source[prop] === 'object') {
-        Object.assign(target[prop], source[prop]);
-    } else {
-        target[prop] = source[prop];
+function deepCopyProperties(target, source, propertyObj) {
+    for (const prop in propertyObj) {
+        if (Array.isArray(source[prop])) {
+            target[prop] = source[prop].slice();
+        } else {
+            target[prop] = source[prop];
+        }
     }
 }

--- a/src/core/text/TextStyle.js
+++ b/src/core/text/TextStyle.js
@@ -93,7 +93,15 @@ export default class TextStyle
     {
         this.styleID = 0;
 
-        Object.assign(this, defaultStyle, style);
+        for (const key in defaultStyle)
+        {
+            deepCopyProperty(this, defaultStyle, key);
+        }
+
+        for (const key in style)
+        {
+            deepCopyProperty(this, style, key);
+        }
     }
 
     /**
@@ -108,7 +116,7 @@ export default class TextStyle
 
         for (const key in defaultStyle)
         {
-            clonedProperties[key] = this[key];
+            deepCopyProperty(clonedProperties, this, key);
         }
 
         return new TextStyle(clonedProperties);
@@ -119,7 +127,10 @@ export default class TextStyle
      */
     reset()
     {
-        Object.assign(this, defaultStyle);
+        for (const key in defaultStyle)
+        {
+            deepCopyProperty(this, defaultStyle, key);
+        }
     }
 
     /**
@@ -754,4 +765,21 @@ function areArraysEqual(array1, array2)
     }
 
     return true;
+}
+
+/**
+ * Utility function to ensure that object properties are copied by value, and not by reference
+ *
+ * @param {Object} target Target object to copy property into
+ * @param {Object} source Source object for the proporty to copy
+ * @param {string} prop Property name to copy
+ */
+function deepCopyProperty(target, source, prop) {
+    if (Array.isArray(source[prop])) {
+        target[prop] = source[prop].slice();
+    } else if (source[prop] && typeof source[prop] === 'object') {
+        Object.assign(target[prop], source[prop]);
+    } else {
+        target[prop] = source[prop];
+    }
 }

--- a/src/core/text/TextStyle.js
+++ b/src/core/text/TextStyle.js
@@ -93,10 +93,7 @@ export default class TextStyle
     {
         this.styleID = 0;
 
-        for (const key in defaultStyle)
-        {
-            deepCopyProperty(this, defaultStyle, key);
-        }
+        this.reset();
 
         for (const key in style)
         {

--- a/test/core/TextStyle.js
+++ b/test/core/TextStyle.js
@@ -50,4 +50,14 @@ describe('PIXI.TextStyle', function ()
 
         expect(style.toFontString()).to.have.string('"Georgia","Arial","sans-serif"');
     });
+
+    it('should not shared array / object references between different instances', function ()
+    {
+        const defaultStyle = new PIXI.TextStyle();
+        const style = new PIXI.TextStyle();
+
+        expect(defaultStyle.fillGradientStops.length).to.equal(style.fillGradientStops.length);
+        style.fillGradientStops.push(0);
+        expect(defaultStyle.fillGradientStops.length).to.not.equal(style.fillGradientStops.length);
+    });
 });


### PR DESCRIPTION
Fixes an issue where
```js
const style1= new PIXI.TextStyle();
const style2 = new PIXI.TextStyle();
style1.fillGradientStops.push(0);
```
Because the array is copied by reference (as an `Object.assign` is currently used), 
`style2.fillGradientStops === style1.fillGradientStops`

Which is incorrect. The arrays should be separate instances