### PR TITLE
Removes getTestContext, getBufferType and interleaveTypedArrays from utils

### DIFF
--- a/packages/core/src/geometry/Geometry.js
+++ b/packages/core/src/geometry/Geometry.js
@@ -1,6 +1,7 @@
 import Attribute from './Attribute';
 import Buffer from './Buffer';
-import { interleaveTypedArrays, getBufferType } from '@pixi/utils';
+import interleaveTypedArrays from './utils/interleaveTypedArrays';
+import getBufferType from './utils/getBufferType';
 
 const byteSizeMap = { 5126: 4, 5123: 2, 5121: 1 };
 let UID = 0;

--- a/packages/core/src/geometry/utils/getBufferType.js
+++ b/packages/core/src/geometry/utils/getBufferType.js
@@ -1,0 +1,33 @@
+export default function getBufferType(array)
+{
+    if (array.BYTES_PER_ELEMENT === 4)
+    {
+        if (array instanceof Float32Array)
+        {
+            return 'Float32Array';
+        }
+        else if (array instanceof Uint32Array)
+        {
+            return 'Uint32Array';
+        }
+
+        return 'Int32Array';
+    }
+    else if (array.BYTES_PER_ELEMENT === 2)
+    {
+        if (array instanceof Uint16Array)
+        {
+            return 'Uint16Array';
+        }
+    }
+    else if (array.BYTES_PER_ELEMENT === 1)
+    {
+        if (array instanceof Uint8Array)
+        {
+            return 'Uint8Array';
+        }
+    }
+
+    // TODO map out the rest of the array elements!
+    return null;
+}

--- a/packages/core/src/geometry/utils/interleaveTypedArrays.js
+++ b/packages/core/src/geometry/utils/interleaveTypedArrays.js
@@ -1,0 +1,54 @@
+import getBufferType from './getBufferType';
+
+/* eslint-disable object-shorthand */
+const map = {
+    Float32Array: Float32Array,
+    Uint32Array: Uint32Array,
+    Int32Array: Int32Array,
+    Uint8Array: Uint8Array,
+};
+
+export default function interleaveTypedArrays(arrays, sizes)
+{
+    let outSize = 0;
+    let stride = 0;
+    const views = {};
+
+    for (let i = 0; i < arrays.length; i++)
+    {
+        stride += sizes[i];
+        outSize += arrays[i].length;
+    }
+
+    const buffer = new ArrayBuffer(outSize * 4);
+
+    let out = null;
+    let littleOffset = 0;
+
+    for (let i = 0; i < arrays.length; i++)
+    {
+        const size = sizes[i];
+        const array = arrays[i];
+
+        const type = getBufferType(array);
+
+        if (!views[type])
+        {
+            views[type] = new map[type](buffer);
+        }
+
+        out = views[type];
+
+        for (let j = 0; j < array.length; j++)
+        {
+            const indexStart = ((j / size | 0) * stride) + littleOffset;
+            const index = j % size;
+
+            out[indexStart + index] = array[j];
+        }
+
+        littleOffset += size;
+    }
+
+    return new Float32Array(buffer);
+}

--- a/packages/core/src/shader/Program.js
+++ b/packages/core/src/shader/Program.js
@@ -1,6 +1,7 @@
 import extractUniformsFromSrc from './extractUniformsFromSrc';
 import * as shaderUtils from '../renderers/webgl/systems/shader/shader';
-import { ProgramCache, getTestContext } from '@pixi/utils';
+import { ProgramCache } from '@pixi/utils';
+import getTestContext from './getTestContext';
 import defaultFragment from './defaultProgram.frag';
 import defaultVertex from './defaultProgram.vert';
 

--- a/packages/core/src/shader/getTestContext.js
+++ b/packages/core/src/shader/getTestContext.js
@@ -1,0 +1,48 @@
+import { settings } from '@pixi/settings';
+
+let context = null;
+
+/**
+ * returns a little webGL context to use for program inspection.
+ *
+ * @static
+ * @private
+ * @returns {webGL-context} a gl context to test with
+ */
+export default function getTestContext()
+{
+    if (!context)
+    {
+        const canvas = document.createElement('canvas');
+
+        let gl;
+
+        if (settings.PREFER_WEBGL_2)
+        {
+            gl = canvas.getContext('webgl2', {});
+        }
+
+        if (!gl)
+        {
+            gl = canvas.getContext('webgl', {})
+            || canvas.getContext('experimental-webgl', {});
+
+            if (!gl)
+            {
+                // fail, not able to get a context
+                throw new Error('This browser does not support webGL. Try using the canvas renderer');
+            }
+            else
+            {
+                // for shader testing..
+                gl.getExtension('WEBGL_draw_buffers');
+            }
+        }
+
+        context = gl;
+
+        return gl;
+    }
+
+    return context;
+}

--- a/packages/utils/src/browser/index.js
+++ b/packages/utils/src/browser/index.js
@@ -1,4 +1,3 @@
-export * from './getTestContext';
 export * from './hello';
 export * from './isWebGLSupported';
 export * from './deprecationWarn';

--- a/packages/utils/src/data/index.js
+++ b/packages/utils/src/data/index.js
@@ -1,5 +1,3 @@
 export * from './createIndicesForQuads';
-export * from './getBufferType';
-export * from './interleaveTypedArrays';
 export * from './uid';
 export * from './sign';


### PR DESCRIPTION
_I’m working on a series of incremental changes which remove, reorganize and realign the current utils (aka the “junk drawer” of PixiJS)._

### Changed

* Removes `getTestContext` from utils, add to **core/src/shader**
* Removes `getBufferType` and `interleaveTypedArrays` from utils and moves to **core/src/geometry/utils**