### PR TITLE
Optimization for Build Times with Rollup

### DIFF
--- a/bundles/pixi.js/package.json
+++ b/bundles/pixi.js/package.json
@@ -19,9 +19,9 @@
     "url": "https://github.com/pixijs/pixi.js.git"
   },
   "scripts": {
-    "build": "rollup -cp && rollup -cp -f umd",
-    "build:dev": "rollup -c && rollup -c -f umd",
-    "watch": "rollup -cw -f umd",
+    "build": "rollup -cp --main-format umd",
+    "build:dev": "rollup -c --main-format umd",
+    "watch": "rollup -cw --main-format umd",
     "postversion": "npm run build",
     "test": "tester"
   },

--- a/bundles/pixi.js/package.json
+++ b/bundles/pixi.js/package.json
@@ -19,9 +19,9 @@
     "url": "https://github.com/pixijs/pixi.js.git"
   },
   "scripts": {
-    "build": "rollup -cp --main-format umd",
-    "build:dev": "rollup -c --main-format umd",
-    "watch": "rollup -cw --main-format umd",
+    "build": "rollup -cpb",
+    "build:dev": "rollup -cb",
+    "watch": "rollup -cwb",
     "postversion": "npm run build",
     "test": "tester"
   },

--- a/bundles/pixi.js/package.json
+++ b/bundles/pixi.js/package.json
@@ -68,7 +68,6 @@
     "@internal/tester": "^5.0.0-alpha",
     "buble": "^0.17.0",
     "rimraf": "^2.6.2",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/bundles/pixi.js/rollup.config.js
+++ b/bundles/pixi.js/rollup.config.js
@@ -5,14 +5,14 @@ import * as fs from 'fs';
 // Only support deprecations with UMD format, since this
 // is the version of PixiJS run in the browser directly. ES format
 // will not receive deprecations.
-if (config.output.format === 'umd')
+if (config[0].output.format === 'umd')
 {
     // Rollup exports all the namespaces/classes, in order to
     // deprecates exported classes, we need to add deprecate.js
     // as the outro for the build.
     const buffer = fs.readFileSync('./src/deprecated.js', 'utf8');
 
-    config.outro = buble.transform(buffer).code;
+    config[0].outro = buble.transform(buffer).code;
 }
 
 export default config;

--- a/filters/alpha/package.json
+++ b/filters/alpha/package.json
@@ -34,7 +34,6 @@
   },
   "devDependencies": {
     "@internal/builder": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/filters/alpha/package.json
+++ b/filters/alpha/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "exit 0"

--- a/filters/alpha/rollup.config.js
+++ b/filters/alpha/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/filters/blur/package.json
+++ b/filters/blur/package.json
@@ -34,7 +34,6 @@
   },
   "devDependencies": {
     "@internal/builder": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/filters/blur/package.json
+++ b/filters/blur/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "exit 0"

--- a/filters/blur/rollup.config.js
+++ b/filters/blur/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/filters/color-matrix/package.json
+++ b/filters/color-matrix/package.json
@@ -34,7 +34,6 @@
   },
   "devDependencies": {
     "@internal/builder": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/filters/color-matrix/package.json
+++ b/filters/color-matrix/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "exit 0"

--- a/filters/color-matrix/rollup.config.js
+++ b/filters/color-matrix/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/filters/displacement/package.json
+++ b/filters/displacement/package.json
@@ -34,7 +34,6 @@
   },
   "devDependencies": {
     "@internal/builder": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/filters/displacement/package.json
+++ b/filters/displacement/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "exit 0"

--- a/filters/displacement/rollup.config.js
+++ b/filters/displacement/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/filters/fxaa/package.json
+++ b/filters/fxaa/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "exit 0"

--- a/filters/fxaa/package.json
+++ b/filters/fxaa/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "@internal/builder": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/filters/fxaa/rollup.config.js
+++ b/filters/fxaa/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/filters/noise/package.json
+++ b/filters/noise/package.json
@@ -34,7 +34,6 @@
   },
   "devDependencies": {
     "@internal/builder": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/filters/noise/package.json
+++ b/filters/noise/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "exit 0"

--- a/filters/noise/rollup.config.js
+++ b/filters/noise/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/packages/accessibility/package.json
+++ b/packages/accessibility/package.json
@@ -37,7 +37,6 @@
   "devDependencies": {
     "@internal/builder": "^5.0.0-alpha",
     "@internal/tester": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/packages/accessibility/package.json
+++ b/packages/accessibility/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "tester"

--- a/packages/accessibility/rollup.config.js
+++ b/packages/accessibility/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "tester"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -38,7 +38,6 @@
     "@pixi/utils": "^5.0.0-alpha",
     "@internal/builder": "^5.0.0-alpha",
     "@internal/tester": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/packages/app/rollup.config.js
+++ b/packages/app/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "tester"

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -34,7 +34,6 @@
   "devDependencies": {
     "@internal/builder": "^5.0.0-alpha",
     "@internal/tester": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/packages/constants/rollup.config.js
+++ b/packages/constants/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,7 +45,6 @@
   "devDependencies": {
     "@internal/builder": "^5.0.0-alpha",
     "@internal/tester": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "tester"

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/packages/display/package.json
+++ b/packages/display/package.json
@@ -38,7 +38,6 @@
   "devDependencies": {
     "@internal/builder": "^5.0.0-alpha",
     "@internal/tester": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/packages/display/package.json
+++ b/packages/display/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "tester"

--- a/packages/display/rollup.config.js
+++ b/packages/display/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/packages/extract/package.json
+++ b/packages/extract/package.json
@@ -34,7 +34,6 @@
   },
   "devDependencies": {
     "@internal/builder": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/packages/extract/package.json
+++ b/packages/extract/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "exit 0"

--- a/packages/extract/rollup.config.js
+++ b/packages/extract/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/packages/fragments/package.json
+++ b/packages/fragments/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "exit 0"

--- a/packages/fragments/package.json
+++ b/packages/fragments/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "@internal/builder": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/packages/fragments/rollup.config.js
+++ b/packages/fragments/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/packages/graphics/package.json
+++ b/packages/graphics/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "tester"

--- a/packages/graphics/package.json
+++ b/packages/graphics/package.json
@@ -40,7 +40,6 @@
   "devDependencies": {
     "@internal/builder": "^5.0.0-alpha",
     "@internal/tester": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/packages/graphics/rollup.config.js
+++ b/packages/graphics/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/packages/interaction/package.json
+++ b/packages/interaction/package.json
@@ -40,7 +40,6 @@
     "@pixi/graphics": "^5.0.0-alpha",
     "@internal/builder": "^5.0.0-alpha",
     "@internal/tester": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/packages/interaction/package.json
+++ b/packages/interaction/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "tester"

--- a/packages/interaction/rollup.config.js
+++ b/packages/interaction/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/packages/loaders/package.json
+++ b/packages/loaders/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "tester"

--- a/packages/loaders/package.json
+++ b/packages/loaders/package.json
@@ -40,7 +40,6 @@
   "devDependencies": {
     "@internal/builder": "^5.0.0-alpha",
     "@internal/tester": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/packages/loaders/rollup.config.js
+++ b/packages/loaders/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "tester"

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -31,7 +31,6 @@
   "devDependencies": {
     "@internal/builder": "^5.0.0-alpha",
     "@internal/tester": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/packages/math/rollup.config.js
+++ b/packages/math/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/packages/mesh/package.json
+++ b/packages/mesh/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "exit 0"

--- a/packages/mesh/package.json
+++ b/packages/mesh/package.json
@@ -39,7 +39,6 @@
     "@pixi/loaders": "^5.0.0-alpha",
     "@internal/builder": "^5.0.0-alpha",
     "@internal/tester": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/packages/mesh/rollup.config.js
+++ b/packages/mesh/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/packages/mixin-cache-as-bitmap/package.json
+++ b/packages/mixin-cache-as-bitmap/package.json
@@ -38,7 +38,6 @@
   "devDependencies": {
     "@internal/tester": "^5.0.0-alpha",
     "@internal/builder": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/packages/mixin-cache-as-bitmap/package.json
+++ b/packages/mixin-cache-as-bitmap/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "tester"

--- a/packages/mixin-cache-as-bitmap/rollup.config.js
+++ b/packages/mixin-cache-as-bitmap/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/packages/mixin-get-child-by-name/package.json
+++ b/packages/mixin-get-child-by-name/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "tester"

--- a/packages/mixin-get-child-by-name/package.json
+++ b/packages/mixin-get-child-by-name/package.json
@@ -34,7 +34,6 @@
   "devDependencies": {
     "@internal/tester": "^5.0.0-alpha",
     "@internal/builder": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/packages/mixin-get-child-by-name/rollup.config.js
+++ b/packages/mixin-get-child-by-name/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/packages/mixin-get-global-position/package.json
+++ b/packages/mixin-get-global-position/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "tester"

--- a/packages/mixin-get-global-position/package.json
+++ b/packages/mixin-get-global-position/package.json
@@ -35,7 +35,6 @@
   "devDependencies": {
     "@internal/builder": "^5.0.0-alpha",
     "@internal/tester": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/packages/mixin-get-global-position/rollup.config.js
+++ b/packages/mixin-get-global-position/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/packages/particles/package.json
+++ b/packages/particles/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "exit 0"

--- a/packages/particles/package.json
+++ b/packages/particles/package.json
@@ -38,7 +38,6 @@
   },
   "devDependencies": {
     "@internal/builder": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/packages/particles/rollup.config.js
+++ b/packages/particles/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/packages/polyfill/package.json
+++ b/packages/polyfill/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "exit 0"

--- a/packages/polyfill/package.json
+++ b/packages/polyfill/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "@internal/builder": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/packages/polyfill/rollup.config.js
+++ b/packages/polyfill/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/packages/prepare/package.json
+++ b/packages/prepare/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "tester"

--- a/packages/prepare/package.json
+++ b/packages/prepare/package.json
@@ -39,7 +39,6 @@
   "devDependencies": {
     "@internal/builder": "^5.0.0-alpha",
     "@internal/tester": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/packages/prepare/rollup.config.js
+++ b/packages/prepare/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "tester"

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -34,7 +34,6 @@
   "devDependencies": {
     "@internal/builder": "^5.0.0-alpha",
     "@internal/tester": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/packages/settings/rollup.config.js
+++ b/packages/settings/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/packages/sprite-animated/package.json
+++ b/packages/sprite-animated/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "exit 0"

--- a/packages/sprite-animated/package.json
+++ b/packages/sprite-animated/package.json
@@ -35,7 +35,6 @@
   },
   "devDependencies": {
     "@internal/builder": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/packages/sprite-animated/rollup.config.js
+++ b/packages/sprite-animated/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/packages/sprite-tiling/package.json
+++ b/packages/sprite-tiling/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "tester"

--- a/packages/sprite-tiling/package.json
+++ b/packages/sprite-tiling/package.json
@@ -39,7 +39,6 @@
   "devDependencies": {
     "@internal/builder": "^5.0.0-alpha",
     "@internal/tester": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/packages/sprite-tiling/rollup.config.js
+++ b/packages/sprite-tiling/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/packages/sprite/package.json
+++ b/packages/sprite/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "tester"

--- a/packages/sprite/package.json
+++ b/packages/sprite/package.json
@@ -40,7 +40,6 @@
   "devDependencies": {
     "@internal/builder": "^5.0.0-alpha",
     "@internal/tester": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/packages/sprite/rollup.config.js
+++ b/packages/sprite/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/packages/spritesheet/package.json
+++ b/packages/spritesheet/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "tester"

--- a/packages/spritesheet/package.json
+++ b/packages/spritesheet/package.json
@@ -36,7 +36,6 @@
   "devDependencies": {
     "@internal/builder": "^5.0.0-alpha",
     "@internal/tester": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/packages/spritesheet/rollup.config.js
+++ b/packages/spritesheet/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/packages/text-bitmap/package.json
+++ b/packages/text-bitmap/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "exit 0"

--- a/packages/text-bitmap/package.json
+++ b/packages/text-bitmap/package.json
@@ -38,7 +38,6 @@
   },
   "devDependencies": {
     "@internal/builder": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/packages/text-bitmap/rollup.config.js
+++ b/packages/text-bitmap/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -38,7 +38,6 @@
   "devDependencies": {
     "@internal/builder": "^5.0.0-alpha",
     "@internal/tester": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "tester"

--- a/packages/text/rollup.config.js
+++ b/packages/text/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/packages/ticker/package.json
+++ b/packages/ticker/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "tester"

--- a/packages/ticker/package.json
+++ b/packages/ticker/package.json
@@ -34,7 +34,6 @@
   "devDependencies": {
     "@internal/builder": "^5.0.0-alpha",
     "@internal/tester": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/packages/ticker/rollup.config.js
+++ b/packages/ticker/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -38,7 +38,6 @@
   "devDependencies": {
     "@internal/builder": "^5.0.0-alpha",
     "@internal/tester": "^5.0.0-alpha",
-    "rollup": "^0.50.0",
-    "rollup-watch": "^4.3.1"
+    "rollup": "^0.50.0"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "build:dev": "rollup -c && rollup -c -f cjs",
-    "build": "rollup -cp && rollup -cp -f cjs",
+    "build:dev": "rollup -c",
+    "build": "rollup -cp",
     "watch": "rollup -cw",
     "postversion": "npm run build",
     "test": "tester"

--- a/packages/utils/rollup.config.js
+++ b/packages/utils/rollup.config.js
@@ -1,1 +1,1 @@
-export * from '@internal/builder';
+export { default } from '@internal/builder';

--- a/tools/builder/index.js
+++ b/tools/builder/index.js
@@ -13,16 +13,15 @@ const preprocess = require('rollup-plugin-preprocess').default;
 const pkg = require(path.resolve('./package'));
 const input = 'src/index.js';
 
-const { prod, format } = minimist(process.argv.slice(2), {
-    string: ['main-format'],
-    boolean: ['prod'],
+const { prod, bundle } = minimist(process.argv.slice(2), {
+    boolean: ['prod', 'bundle'],
     default: {
-        'main-format': 'cjs',
         prod: false,
+        bundle: false,
     },
     alias: {
         p: 'prod',
-        format: 'main-format',
+        b: 'bundle',
     },
 });
 
@@ -117,7 +116,7 @@ exports.default = [
         input,
         output: {
             file: pkg.main,
-            format,
+            format: bundle ? 'umd' : 'cjs',
         },
         external,
         sourcemap,


### PR DESCRIPTION
Simple change to optimize the build times overall with Rollup this removes double command line call for each build and takes advantage of any internal Rollup caching and uses less system memory.

Also, removes **rollup-watch** which is no longer needed in Rollup 0.46+

## Results

### `npm run build:dev`

Current: 35s
After PR: 27s
**22% faster**

### `npm run build`

Current: 54s
After PR: 44s
**18% faster**