### PR TITLE
fix bug for adding useless extra blank ahead of the first text line [#4251]

### DIFF
--- a/src/core/text/TextMetrics.js
+++ b/src/core/text/TextMetrics.js
@@ -106,6 +106,7 @@ export default class TextMetrics
         // Greedy wrapping algorithm that will wrap words as the line grows longer
         // than its horizontal bounds.
         let result = '';
+        let firstChar = text.charAt(0);
         const lines = text.split('\n');
         const wordWrapWidth = style.wordWrapWidth;
         const characterCache = {};
@@ -142,8 +143,7 @@ export default class TextMetrics
                         }
                         else
                         {
-                            if (c === 0)
-                            {
+                            if (c === 0 && (j > 0 || firstChar == ' ')) {
                                 result += ' ';
                             }
 

--- a/src/core/text/TextMetrics.js
+++ b/src/core/text/TextMetrics.js
@@ -143,7 +143,8 @@ export default class TextMetrics
                         }
                         else
                         {
-                            if (c === 0 && (j > 0 || firstChar === ' ')) {
+                            if (c === 0 && (j > 0 || firstChar === ' '))
+                            {
                                 result += ' ';
                             }
 

--- a/src/core/text/TextMetrics.js
+++ b/src/core/text/TextMetrics.js
@@ -106,7 +106,7 @@ export default class TextMetrics
         // Greedy wrapping algorithm that will wrap words as the line grows longer
         // than its horizontal bounds.
         let result = '';
-        let firstChar = text.charAt(0);
+        const firstChar = text.charAt(0);
         const lines = text.split('\n');
         const wordWrapWidth = style.wordWrapWidth;
         const characterCache = {};
@@ -143,7 +143,7 @@ export default class TextMetrics
                         }
                         else
                         {
-                            if (c === 0 && (j > 0 || firstChar == ' ')) {
+                            if (c === 0 && (j > 0 || firstChar === ' ')) {
                                 result += ' ';
                             }
 


### PR DESCRIPTION
original code is in a wrong way to add blank character when the style.breakWords is enabled.
see also issue: [#4251](https://github.com/pixijs/pixi.js/issues/4251)