### PR TITLE
fixed ColorMatixFilter documentation issue

### DIFF
--- a/src/filters/colormatrix/ColorMatrixFilter.js
+++ b/src/filters/colormatrix/ColorMatrixFilter.js
@@ -8,7 +8,7 @@ import { join } from 'path';
  * with a new set of RGBA color and alpha values. It's pretty powerful!
  *
  * ```js
- *  let colorMatrix = new PIXI.ColorMatrixFilter();
+ *  let colorMatrix = new PIXI.filters.ColorMatrixFilter();
  *  container.filters = [colorMatrix];
  *  colorMatrix.contrast(2);
  * ```


### PR DESCRIPTION
#4419 On the example for ColorMatrixFilter, it gives this as an example:
`let colorMatrix = new PIXI.ColorMatrixFilter();`

fixed it so it reads:

`let colorMatrix = new PIXI.filters.ColorMatrixFilter();`