### PR TITLE
same textures bound in same places

### DIFF
--- a/src/core/sprites/webgl/SpriteRenderer.js
+++ b/src/core/sprites/webgl/SpriteRenderer.js
@@ -241,9 +241,19 @@ export default class SpriteRenderer extends ObjectRenderer
         // copy textures..
         for (i = 0; i < MAX_TEXTURES; ++i)
         {
-            boundTextures[i] = rendererBoundTextures[i];
-            boundTextures[i]._virtalBoundId = i;
+            const bt = rendererBoundTextures[i];
+
+            if (bt._enabled === TICK)
+            {
+                boundTextures[i] = this.renderer.emptyTextures[i];
+                continue;
+            }
+
+            boundTextures[i] = bt;
+            bt._virtalBoundId = i;
+            bt._enabled = TICK;
         }
+        TICK++;
 
         for (i = 0; i < this.currentIndex; ++i)
         {


### PR DESCRIPTION
A long time I knew the fact that SpriteRenderer wont like same texture bound in two locations.

But every time I thought that none of our plugins use the same textures as SpriteRenderer.

Now, https://github.com/pixijs/pixi-ui https://github.com/gameofbombs/pixi-heaven, https://github.com/pixijs/pixi-projection and possible others (i havent check sdf and neutrino) are forcing textures to be binded in specific locations, and SpriteRenderer wants to use same textures.

Thankfully, v5 Sprite Renderer doesn't have that issue because @GoodBoyDigital dropped the optimization that caused it.

Now, for the sake of plugins, for the sake of users who have `WebGL: INVALID_ENUM: activeTexture: texture unit out of range` that can be explained only by `virtalBoundId=-1` , I want to merge this fix into 4.6.1 .

I dont want to make better algorithm, I just made a fix for algorithm that we use in v4. Better algorithms can be introduced in v5.

I and @cursedcoder tested the fix on a real project.