### PR TITLE
Ensures that the source video is unloaded correctly (v4)

### DIFF
--- a/src/core/textures/VideoBaseTexture.js
+++ b/src/core/textures/VideoBaseTexture.js
@@ -196,6 +196,10 @@ export default class VideoBaseTexture extends BaseTexture
         {
             BaseTexture.removeFromCache(this.source._pixiId);
             delete this.source._pixiId;
+
+            this.source.pause();
+            this.source.src = '';
+            this.source.load();
         }
 
         super.destroy();


### PR DESCRIPTION
Paste the following code into the video example http://pixijs.io/examples/#/basics/video.js
What changes to the example is that on the first click of the button, the video be created and  play, but on the 2nd click, it will destroy the video. The next click creates and plays again, and so on.

What you'll notice is that when you click to destroy, the video disappears, but you still hear the sound of it playing, because the video tag source hasn't properly been dealt with. 

This PR pauses the video and sets it's source to null, to properly destroy it.

```js
var app = new PIXI.Application(800, 600, { transparent: true });
document.body.appendChild(app.view);

// Create play button that can be used to trigger the video
var button = new PIXI.Graphics()
    .beginFill(0x0, 0.5)
    .drawRoundedRect(0, 0, 100, 100, 10)
    .endFill()
    .beginFill(0xffffff)
    .moveTo(36, 30)
    .lineTo(36, 70)
    .lineTo(70, 50);

// Position the button
button.x = (app.renderer.width - button.width) / 2;
button.y = (app.renderer.height - button.height) / 2;

// Enable interactivity on the button
button.interactive = true;
button.buttonMode = true;

// Add to the stage
app.stage.addChild(button);

// Listen for a click/tap event to start playing the video
// this is useful for some mobile platforms. For example:
// ios9 and under cannot render videos in PIXI without a 
// polyfill - https://github.com/bfred-it/iphone-inline-video
// ios10 and above require a click/tap event to render videos 
// that contain audio in PIXI. Videos with no audio track do 
// not have this requirement
button.on('pointertap', onPlayVideo);

showing = false;

var texture;
var videoSprite;

function onPlayVideo() {
    if (videoSprite) {
      videoSprite.destroy(true);
      videoSprite = null;
      texture = null;
    } else {
      // create a video texture from a path
      texture = PIXI.Texture.fromVideo('required/assets/testVideo.mp4');

      // create a new Sprite using the video texture (yes it's that easy)
      videoSprite = new PIXI.Sprite(texture);

      // Stetch the fullscreen
      videoSprite.width = app.renderer.width;
      videoSprite.height = app.renderer.height;

      app.stage.addChild(videoSprite);
      app.stage.addChild(button);
    }
}
```