### PR TITLE
Hdr cubemap support

### DIFF
--- a/src/core/renderers/webgl/systems/ContextSystem.js
+++ b/src/core/renderers/webgl/systems/ContextSystem.js
@@ -116,6 +116,7 @@ export default class ContextSystem extends WebGLSystem
             extensions.depthTexture = gl.getExtension('WEBKIT_WEBGL_depth_texture');
             extensions.floatTexture = gl.getExtension('OES_texture_float');
             extensions.loseContext = gl.getExtension('WEBGL_lose_context');
+            extensions.lodTexture = gl.getExtension('EXT_shader_texture_lod');
 
             extensions.vertexArrayObject = gl.getExtension('OES_vertex_array_object')
                                         || gl.getExtension('MOZ_OES_vertex_array_object')

--- a/src/core/textures/CubeTexture.js
+++ b/src/core/textures/CubeTexture.js
@@ -4,9 +4,9 @@ import { TARGETS } from './../const';
 
 export default class CubeTexture extends Texture
 {
-    constructor(width, height, format)
+    constructor(width, height, format, type)
     {
-        super(null, 0, 1, width, height, format);
+        super(null, 0, 1, width, height, format, type);
 
         this.target = TARGETS.TEXTURE_CUBE_MAP; // gl.TEXTURE_CUBE_MAP
 


### PR DESCRIPTION
Hi,

First of all I'm aware you guys are rebuild a big part on the next branch but just want to share these with you. I've been trying to implement PBR (Physically based rendering) with PIXI.js. Here is a simple example : 
http://dev.goodboydigital.com/client/goodboy/labs/pbr/

For PBR we'll need to have the texture level of detail enabled so you can do 
`vec3 radiance = pow( textureCubeLodEXT( uRadianceMap, lookup, mip ).rgb, vec3( 2.2 ) );`
to get a good radiance texture.

Also we'll need HDR support for Cubemap texture too.

I understand this is a working in progress branch, so this is rather a reminder of a feature will be really nice to have in your future plan.  :)

Thank you,
Wen