### PR TITLE
Region parameter for Renderer.generateTexture()

### DIFF
--- a/src/core/renderers/SystemRenderer.js
+++ b/src/core/renderers/SystemRenderer.js
@@ -244,11 +244,17 @@ export default class SystemRenderer extends EventEmitter
      * @param {PIXI.DisplayObject} displayObject - The displayObject the object will be generated from
      * @param {number} scaleMode - Should be one of the scaleMode consts
      * @param {number} resolution - The resolution / device pixel ratio of the texture being generated
+	 * @param {PIXI.Rectangle} region - The region of the displayObject, that shall be rendered
      * @return {PIXI.Texture} a texture of the graphics object
      */
-    generateTexture(displayObject, scaleMode, resolution)
+    generateTexture(displayObject, scaleMode, resolution, region)
     {
-        const bounds = displayObject.getLocalBounds();
+        let bounds = displayObject.getLocalBounds();
+
+        if (region)
+        {
+            bounds = region;
+        }
 
         const renderTexture = RenderTexture.create(bounds.width | 0, bounds.height | 0, scaleMode, resolution);
 

--- a/src/core/renderers/SystemRenderer.js
+++ b/src/core/renderers/SystemRenderer.js
@@ -244,7 +244,8 @@ export default class SystemRenderer extends EventEmitter
      * @param {PIXI.DisplayObject} displayObject - The displayObject the object will be generated from
      * @param {number} scaleMode - Should be one of the scaleMode consts
      * @param {number} resolution - The resolution / device pixel ratio of the texture being generated
-	 * @param {PIXI.Rectangle} region - The region of the displayObject, that shall be rendered
+     * @param {PIXI.Rectangle} [region] - The region of the displayObject, that shall be rendered,
+     *        if no region is specified, defaults to the local bounds of the displayObject.
      * @return {PIXI.Texture} a texture of the graphics object
      */
     generateTexture(displayObject, scaleMode, resolution, region)

--- a/src/core/renderers/SystemRenderer.js
+++ b/src/core/renderers/SystemRenderer.js
@@ -249,17 +249,12 @@ export default class SystemRenderer extends EventEmitter
      */
     generateTexture(displayObject, scaleMode, resolution, region)
     {
-        let bounds = displayObject.getLocalBounds();
+        region = region || displayObject.getLocalBounds();
 
-        if (region)
-        {
-            bounds = region;
-        }
+        const renderTexture = RenderTexture.create(region.width | 0, region.height | 0, scaleMode, resolution);
 
-        const renderTexture = RenderTexture.create(bounds.width | 0, bounds.height | 0, scaleMode, resolution);
-
-        tempMatrix.tx = -bounds.x;
-        tempMatrix.ty = -bounds.y;
+        tempMatrix.tx = -region.x;
+        tempMatrix.ty = -region.y;
 
         this.render(displayObject, renderTexture, false, tempMatrix, true);
 


### PR DESCRIPTION
Added an optional "region" parameter to Renderer.generateTexture() to only render the specified area.
https://jsfiddle.net/bma73/92os3a0e/17/