### PR TITLE
obserbvable_point: public subscribe

### DIFF
--- a/src/core/math/ObservablePoint.js
+++ b/src/core/math/ObservablePoint.js
@@ -21,6 +21,10 @@ export default class ObservablePoint
 
         this.cb = cb;
         this.scope = scope;
+        this.set = this.set.bind(this);
+        this.runCallbacks = this.runCallbacks.bind(this);
+        this._listeners = [];
+        this._broadcasters = [];
     }
 
     /**
@@ -39,7 +43,7 @@ export default class ObservablePoint
         {
             this._x = _x;
             this._y = _y;
-            this.cb.call(this.scope);
+            this.runCallbacks();
         }
     }
 
@@ -54,7 +58,7 @@ export default class ObservablePoint
         {
             this._x = point.x;
             this._y = point.y;
-            this.cb.call(this.scope);
+            this.runCallbacks();
         }
     }
 
@@ -73,7 +77,7 @@ export default class ObservablePoint
         if (this._x !== value)
         {
             this._x = value;
-            this.cb.call(this.scope);
+            this.runCallbacks();
         }
     }
 
@@ -92,7 +96,143 @@ export default class ObservablePoint
         if (this._y !== value)
         {
             this._y = value;
-            this.cb.call(this.scope);
+            this.runCallbacks();
         }
+    }
+
+    /**
+     * Runs callback passed to the constructor, as well as publicly subscribed callbacks
+     */
+    runCallbacks()
+    {
+        this.cb.call(this.scope);
+        for (let i = 0, j = this._listeners.length; i < j; i++)
+        {
+            this._listeners[i](this._x, this._y);
+        }
+    }
+
+    /**
+     * Every time x | y is changed, subscribed callback will be executed.
+     * @param {Function} callback - executed with x and y arguments
+     * @returns {Number} of currently linked listeners (if unique) or {null} if already added.
+     */
+    addChangeListener(callback)
+    {
+        if (this._listeners.indexOf(callback) < 0)
+        {
+            return this._listeners.push(callback);
+        }
+
+        return null;
+    }
+
+    /**
+     * Stops instance from executing publicly subscribed, specific callback.
+     * @param {Function} callback - previously linked listener
+     * @returns {Number} of currently linked listeners (if succesfully removed)
+     * or {null} if callback wasn't on the list.
+     */
+    removeChangeListener(callback)
+    {
+        const i = this._listeners.indexOf(callback);
+
+        if (i > -1)
+        {
+            this._listeners.splice(i, 1);
+
+            return this._listeners.length;
+        }
+
+        return null;
+    }
+
+    /**
+     * Removes all publicly subscribed listeners. Main callback (passed to constructor) stays.
+     * @returns {ObservablePoint} self
+     */
+    purgeListeners()
+    {
+        this._listeners = [];
+
+        return this;
+    }
+
+    /**
+     * Makes connection opposite to addEventListener. Forces this instance to listen to changes broadcast by
+     * another instance of {ObservablePoint} (passed here as an argument).
+     *
+     * Every change in foreign instance makes this instance to update itself to the foreign instance values (x, y).
+     * E.g:  this.position < -- is - updated - by - (observablePoint) - every time - observablePoint - is - updated -
+     *
+     *
+     * @param {ObservablePoint} observablePoint - foreign instance
+     */
+    linkTo(observablePoint)
+    {
+        if (!(observablePoint instanceof ObservablePoint))
+        {
+            throw new Error('Linking to NOT an ObservablePoint instance');
+        }
+        else if (observablePoint.addChangeListener(this.set) > 0)
+        {
+            if (this._broadcasters.indexOf(observablePoint) < 0)
+            {
+                this._broadcasters.push(observablePoint);
+            }
+        }
+        this.copy(observablePoint);
+    }
+
+    /**
+     * Stops foreign instance of {ObservablePoint} updating this {ObservablePoint}.
+     * If bilateral connection was made, this instance will keep updating foreign instance.
+     * @param {ObservablePoint} observablePoint - foreign instance that
+     * has been passed to this instance through {Function} linkTo.
+     * @returns {ObservablePoint} foreign instance if successful, or {null} if it wasn't on the list.
+     */
+    unlink(observablePoint)
+    {
+        observablePoint.removeChangeListener(this.set);
+        const i = this._broadcasters.indexOf(observablePoint);
+
+        if (i > -1)
+        {
+            return this._broadcasters.splice(i, 1).pop();
+        }
+
+        return null;
+    }
+
+    /**
+     * Stops all foreign instances of {ObservablePoint} updating this object.
+     * Does not cancel bilateral connections.
+     * @returns {ObservablePoint} self
+     */
+    unlinkAll()
+    {
+        while (this._broadcasters.length)
+        {
+            this.unlink(this._broadcasters.pop());
+        }
+
+        return this;
+    }
+
+    /**
+     * Removes all publicly subscribed listeners AND unlinks all foreign instances.
+     * Cancels bilateral links unless foreign instance/s was/were unlinked before.
+     * @returns {ObservablePoint} self
+     */
+    detach()
+    {
+        for (let i = 0, j = this._broadcasters.length; i < j; i++)
+        {
+            this._broadcasters[i].unlink(this);
+        }
+        this.purgeListeners();
+        this.unlinkAll();
+
+        return this;
     }
 }

--- a/test/core/ObservablePoint.js
+++ b/test/core/ObservablePoint.js
@@ -49,5 +49,126 @@ describe('PIXI.ObservablePoint', function ()
         p1.copy(p3);
         expect(p1.y).to.equal(p3.y);
     });
-});
 
+    it('should properly add and remove change listeners', function ()
+    {
+        const cb = sinon.spy();
+        const changeListener1 = sinon.spy();
+        const changeListener2 = sinon.spy();
+        const p1 = new PIXI.ObservablePoint(cb, this, 10, 20);
+
+        p1.addChangeListener(changeListener1);
+        expect(p1._listeners.length).to.equal(1);
+        p1.x += 1;
+        expect(cb.callCount).to.equal(1);
+        expect(changeListener1.calledWith(11, 20)).to.be.true;
+        expect(changeListener1.callCount).to.equal(1);
+
+        p1.set(2, 2);
+        expect(cb.callCount).to.equal(2);
+        expect(changeListener1.callCount).to.equal(2);
+        expect(changeListener1.calledWith(0, 0)).to.be.false;
+        expect(changeListener1.calledWith(2, 2)).to.be.true;
+
+        p1.removeChangeListener(changeListener1);
+        expect(p1._listeners.length).to.equal(0);
+
+        p1.addChangeListener(changeListener1);
+        p1.addChangeListener(changeListener2);
+        expect(p1._listeners.length).to.equal(2);
+
+        p1.y += 2;
+        expect(cb.callCount).to.equal(3);
+        expect(changeListener1.callCount).to.equal(3);
+        expect(changeListener2.callCount).to.equal(1);
+        expect(changeListener1.calledWith(2, 4)).to.be.true;
+        expect(changeListener2.calledWith(2, 4)).to.be.true;
+
+        p1.purgeListeners();
+        p1.y -= 2;
+        expect(p1._listeners.length).to.equal(0);
+        expect(cb.callCount).to.equal(4);
+        expect(changeListener1.callCount).to.equal(3);
+        expect(changeListener2.callCount).to.equal(1);
+    });
+
+    it('should properly link and unlink Observable Points to each other', function ()
+    {
+        const cb1 = sinon.spy();
+        const cb2 = sinon.spy();
+        const p1 = new PIXI.ObservablePoint(cb1, this, 10, 20);
+        const p2 = new PIXI.ObservablePoint(cb2, this, 5, 2);
+
+        p1.linkTo(p2);
+        expect(cb1.callCount).to.equal(1);
+        expect(cb2.callCount).to.equal(0);
+        expect(p1._broadcasters.length).to.equal(1);
+        expect(p2._listeners.length).to.equal(1);
+        expect(p1._listeners.length).to.equal(0);
+        expect(p2._broadcasters.length).to.equal(0);
+        expect(p1.x).to.equal(p2.x);
+        expect(p1.y).to.equal(p2.y);
+
+        p2.set(4, 3);
+        expect(p1.x).to.equal(p2.x);
+        expect(p1.y).to.equal(p2.y);
+        expect(cb1.callCount).to.equal(2);
+        expect(cb2.callCount).to.equal(1);
+
+        p1.x = 10;
+        expect(p1.x).to.equal(10);
+        expect(p2.x).to.equal(4);
+
+        p2.y = 12;
+        expect(p1.x).to.equal(p2.x);
+        expect(p1.y).to.equal(p2.y);
+
+        p1.unlink(p2);
+        expect(p1._broadcasters.length).to.equal(0);
+        expect(p1._listeners.length).to.equal(0);
+        expect(p2._listeners.length).to.equal(0);
+        expect(p2._broadcasters.length).to.equal(0);
+
+        // bilateral linking
+        p1.linkTo(p2);
+        p2.linkTo(p1);
+        expect(p1._broadcasters.length).to.equal(1);
+        expect(p2._listeners.length).to.equal(1);
+        expect(p1._listeners.length).to.equal(1);
+        expect(p2._broadcasters.length).to.equal(1);
+        expect(p1.x).to.equal(p2.x);
+        expect(p1.y).to.equal(p2.y);
+
+        p2.y = 40;
+        expect(p1.x).to.equal(p2.x);
+        expect(p1.y).to.equal(p2.y);
+
+        p1.x = -4;
+        expect(p1.x).to.equal(p2.x);
+        expect(p1.y).to.equal(p2.y);
+
+        p1.unlinkAll();
+        expect(p1._broadcasters.length).to.equal(0);
+        expect(p1._listeners.length).to.equal(1);
+        expect(p2._listeners.length).to.equal(0);
+        expect(p2._broadcasters.length).to.equal(1);
+
+        p2.x = 100;
+        expect(p1.x).to.equal(-4);
+        p1.x = 50;
+        expect(p2.x).to.equal(50);
+
+        p1.linkTo(p2);
+        p2.linkTo(p1);
+        expect(p1._broadcasters.length).to.equal(1);
+        expect(p2._listeners.length).to.equal(1);
+        expect(p1._listeners.length).to.equal(1);
+        expect(p2._broadcasters.length).to.equal(1);
+
+        p1.detach();
+        expect(p1._broadcasters.length).to.equal(0);
+        expect(p1._listeners.length).to.equal(0);
+        expect(p2._listeners.length).to.equal(0);
+        expect(p2._broadcasters.length).to.equal(0);
+    });
+});

--- a/test/core/ObservablePoint.js
+++ b/test/core/ObservablePoint.js
@@ -57,25 +57,20 @@ describe('PIXI.ObservablePoint', function ()
         const changeListener2 = sinon.spy();
         const p1 = new PIXI.ObservablePoint(cb, this, 10, 20);
 
-        p1.addChangeListener(changeListener1);
-        expect(p1._listeners.length).to.equal(1);
+        p1.on('change', changeListener1);
         p1.x += 1;
         expect(cb.callCount).to.equal(1);
-        expect(changeListener1.calledWith(11, 20)).to.be.true;
         expect(changeListener1.callCount).to.equal(1);
+        expect(changeListener1.calledWith(11, 20)).to.be.true;
 
         p1.set(2, 2);
         expect(cb.callCount).to.equal(2);
         expect(changeListener1.callCount).to.equal(2);
-        expect(changeListener1.calledWith(0, 0)).to.be.false;
         expect(changeListener1.calledWith(2, 2)).to.be.true;
 
-        p1.removeChangeListener(changeListener1);
-        expect(p1._listeners.length).to.equal(0);
-
-        p1.addChangeListener(changeListener1);
-        p1.addChangeListener(changeListener2);
-        expect(p1._listeners.length).to.equal(2);
+        p1.off('change', changeListener1);
+        p1.on('change', changeListener1);
+        p1.on('change', changeListener2);
 
         p1.y += 2;
         expect(cb.callCount).to.equal(3);
@@ -84,91 +79,10 @@ describe('PIXI.ObservablePoint', function ()
         expect(changeListener1.calledWith(2, 4)).to.be.true;
         expect(changeListener2.calledWith(2, 4)).to.be.true;
 
-        p1.purgeListeners();
+        p1.removeAllListeners();
         p1.y -= 2;
-        expect(p1._listeners.length).to.equal(0);
         expect(cb.callCount).to.equal(4);
         expect(changeListener1.callCount).to.equal(3);
         expect(changeListener2.callCount).to.equal(1);
-    });
-
-    it('should properly link and unlink Observable Points to each other', function ()
-    {
-        const cb1 = sinon.spy();
-        const cb2 = sinon.spy();
-        const p1 = new PIXI.ObservablePoint(cb1, this, 10, 20);
-        const p2 = new PIXI.ObservablePoint(cb2, this, 5, 2);
-
-        p1.linkTo(p2);
-        expect(cb1.callCount).to.equal(1);
-        expect(cb2.callCount).to.equal(0);
-        expect(p1._broadcasters.length).to.equal(1);
-        expect(p2._listeners.length).to.equal(1);
-        expect(p1._listeners.length).to.equal(0);
-        expect(p2._broadcasters.length).to.equal(0);
-        expect(p1.x).to.equal(p2.x);
-        expect(p1.y).to.equal(p2.y);
-
-        p2.set(4, 3);
-        expect(p1.x).to.equal(p2.x);
-        expect(p1.y).to.equal(p2.y);
-        expect(cb1.callCount).to.equal(2);
-        expect(cb2.callCount).to.equal(1);
-
-        p1.x = 10;
-        expect(p1.x).to.equal(10);
-        expect(p2.x).to.equal(4);
-
-        p2.y = 12;
-        expect(p1.x).to.equal(p2.x);
-        expect(p1.y).to.equal(p2.y);
-
-        p1.unlink(p2);
-        expect(p1._broadcasters.length).to.equal(0);
-        expect(p1._listeners.length).to.equal(0);
-        expect(p2._listeners.length).to.equal(0);
-        expect(p2._broadcasters.length).to.equal(0);
-
-        // bilateral linking
-        p1.linkTo(p2);
-        p2.linkTo(p1);
-        expect(p1._broadcasters.length).to.equal(1);
-        expect(p2._listeners.length).to.equal(1);
-        expect(p1._listeners.length).to.equal(1);
-        expect(p2._broadcasters.length).to.equal(1);
-        expect(p1.x).to.equal(p2.x);
-        expect(p1.y).to.equal(p2.y);
-
-        p2.y = 40;
-        expect(p1.x).to.equal(p2.x);
-        expect(p1.y).to.equal(p2.y);
-
-        p1.x = -4;
-        expect(p1.x).to.equal(p2.x);
-        expect(p1.y).to.equal(p2.y);
-
-        p1.unlinkAll();
-        expect(p1._broadcasters.length).to.equal(0);
-        expect(p1._listeners.length).to.equal(1);
-        expect(p2._listeners.length).to.equal(0);
-        expect(p2._broadcasters.length).to.equal(1);
-
-        p2.x = 100;
-        expect(p1.x).to.equal(-4);
-        p1.x = 50;
-        expect(p2.x).to.equal(50);
-
-        p1.linkTo(p2);
-        p2.linkTo(p1);
-        expect(p1._broadcasters.length).to.equal(1);
-        expect(p2._listeners.length).to.equal(1);
-        expect(p1._listeners.length).to.equal(1);
-        expect(p2._broadcasters.length).to.equal(1);
-
-        p1.detach();
-        expect(p1._broadcasters.length).to.equal(0);
-        expect(p1._listeners.length).to.equal(0);
-        expect(p2._listeners.length).to.equal(0);
-        expect(p2._broadcasters.length).to.equal(0);
     });
 });


### PR DESCRIPTION
More a feature request than issue. Resolves https://github.com/pixijs/pixi.js/issues/4486
Back in the times of PIXI 3.x, it was easy to follow position / scale / anchor / pivot of particular display object in dispersed solutions. Simple assignment `b.position = a.position`, regardless of good practices conduct, allowed to stick and unstick display objects easily.

Re-designed transformation system in PIXI 4.x put kibosh on it, and among other benefits, made tracking/following changes in position, scale, anchor, pivot as easy and faulty as _per frame check_ or _hacky as duck_.

Can we make this transparent and more friendly? 
If pub-sub + link methods are too much, coud we at least give pub sub to ObservablePoint? The code and tests from PR are already split to two sections.