### PR TITLE
Fixes scoping issue with loader middleware

### DIFF
--- a/packages/loaders/src/Loader.js
+++ b/packages/loaders/src/Loader.js
@@ -70,12 +70,12 @@ export default class Loader extends ResourceLoader
 
             if (pre)
             {
-                this.pre(pre.bind(plugin));
+                this.pre(pre);
             }
 
             if (use)
             {
-                this.use(use.bind(plugin));
+                this.use(use);
             }
         }
 

--- a/packages/spritesheet/test/SpritesheetLoader.js
+++ b/packages/spritesheet/test/SpritesheetLoader.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const { Loader, LoaderResource } = require('@pixi/loaders');
 const { Texture, BaseTexture } = require('@pixi/core');
-const { SpritesheetLoader } = require('../');
+const { SpritesheetLoader, Spritesheet } = require('../');
 
 describe('PIXI.SpritesheetLoader', function ()
 {
@@ -11,9 +11,20 @@ describe('PIXI.SpritesheetLoader', function ()
         expect(SpritesheetLoader.use).to.be.a('function');
     });
 
-    it('should install middleware', function ()
+    it('should install middleware', function (done)
     {
         Loader.registerPlugin(SpritesheetLoader);
+
+        const loader = new Loader();
+
+        loader.add('building1', path.join(__dirname, 'resources/building1.json'));
+        loader.load((loader, resources) =>
+        {
+            expect(resources.building1).to.be.instanceof(LoaderResource);
+            expect(resources.building1.spritesheet).to.be.instanceof(Spritesheet);
+            loader.reset();
+            done();
+        });
     });
 
     it('should do nothing if the resource is not JSON', function ()


### PR DESCRIPTION
cc @GoodBoyDigital 

In the loader refactor (#4471) it changed the scope of the middleware function. Fixed and added a unit-test for loading a spritesheet.