### PR TITLE
`trim` shader's source when check precision

### DIFF
--- a/src/core/Shader.js
+++ b/src/core/Shader.js
@@ -14,7 +14,7 @@ function checkPrecision(src, def)
             return copy;
         }
     }
-    else if (src.substring(0, 9) !== 'precision')
+    else if (src.trim().substring(0, 9) !== 'precision')
     {
         return `precision ${def} float;\n${src}`;
     }


### PR DESCRIPTION
Some users like add `one blank line` before & after the source code.
if no trim , `substring(0, 9)` can't work correct.

e.g. : 
```js
    var fragSrc = `
    
        precision mediump float;

        uniform sampler2D uSampler;
        varying vec2 vTextureCoord;

        uniform float uAlpha;
        uniform float uColorMultiplier;
        uniform vec3 uColorOffset;

        void main(void){
          vec4 color = texture2D(uSampler, vTextureCoord) * uAlpha;
          color.rgb *= uColorMultiplier;
          color.rgb += uColorOffset * color.a;

          gl_FragColor = color;
        }

    `;
```