### PR TITLE
Fix bug #4467 : `scale` of ParticleContainer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pixi.js",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "description": "The HTML5 Creation Engine: Create beautiful digital content with the fastest, most flexible 2D WebGL renderer.",
   "author": "Mat Groves",
   "contributors": [

--- a/src/particles/ParticleContainer.js
+++ b/src/particles/ParticleContainer.js
@@ -32,7 +32,7 @@ export default class ParticleContainer extends core.Container
      * @param {number} [maxSize=1500] - The maximum number of particles that can be rendered by the container.
      *  Affects size of allocated buffers.
      * @param {object} [properties] - The properties of children that should be uploaded to the gpu and applied.
-     * @param {boolean} [properties.vertex=false] - When true, vertex be uploaded and applied.
+     * @param {boolean} [properties.vertices=false] - When true, vertices be uploaded and applied.
      *                  if sprite's ` scale/anchor/trim/frame/orig` is dynamic, please set `true`.
      * @param {boolean} [properties.position=true] - When true, position be uploaded and applied.
      * @param {boolean} [properties.rotation=false] - When true, rotation be uploaded and applied.
@@ -157,8 +157,8 @@ export default class ParticleContainer extends core.Container
     {
         if (properties)
         {
-            this._properties[0] = 'vertex' in properties || 'scale' in properties
-                ? !!properties.vertex || !!properties.scale : this._properties[0];
+            this._properties[0] = 'vertices' in properties || 'scale' in properties
+                ? !!properties.vertices || !!properties.scale : this._properties[0];
             this._properties[1] = 'position' in properties ? !!properties.position : this._properties[1];
             this._properties[2] = 'rotation' in properties ? !!properties.rotation : this._properties[2];
             this._properties[3] = 'uvs' in properties ? !!properties.uvs : this._properties[3];

--- a/src/particles/ParticleContainer.js
+++ b/src/particles/ParticleContainer.js
@@ -157,13 +157,13 @@ export default class ParticleContainer extends core.Container
     {
         if (properties)
         {
-            this._properties[0] = 'scale' in properties || 'vertex' in properties
-                ? !!properties.scale || !!properties.vertex : this._properties[0];
+            this._properties[0] = 'vertex' in properties || 'scale' in properties
+                ? !!properties.vertex || !!properties.scale : this._properties[0];
             this._properties[1] = 'position' in properties ? !!properties.position : this._properties[1];
             this._properties[2] = 'rotation' in properties ? !!properties.rotation : this._properties[2];
             this._properties[3] = 'uvs' in properties ? !!properties.uvs : this._properties[3];
-            this._properties[4] = 'alpha' in properties || 'tint' in properties
-                ? !!properties.alpha || !!properties.tint : this._properties[4];
+            this._properties[4] = 'tint' in properties || 'alpha' in properties
+                ? !!properties.tint || !!properties.alpha : this._properties[4];
         }
     }
 

--- a/src/particles/ParticleContainer.js
+++ b/src/particles/ParticleContainer.js
@@ -32,13 +32,14 @@ export default class ParticleContainer extends core.Container
      * @param {number} [maxSize=1500] - The maximum number of particles that can be rendered by the container.
      *  Affects size of allocated buffers.
      * @param {object} [properties] - The properties of children that should be uploaded to the gpu and applied.
-     * @param {boolean} [properties.scale=false] - When true, scale be uploaded and applied.
+     * @param {boolean} [properties.vertex=false] - When true, vertex be uploaded and applied.
+     *                  if sprite's ` scale/anchor/trim/frame/orig` is dynamic, please set `true`.
      * @param {boolean} [properties.position=true] - When true, position be uploaded and applied.
      * @param {boolean} [properties.rotation=false] - When true, rotation be uploaded and applied.
      * @param {boolean} [properties.uvs=false] - When true, uvs be uploaded and applied.
      * @param {boolean} [properties.tint=false] - When true, alpha and tint be uploaded and applied.
      * @param {number} [batchSize=16384] - Number of particles per batch. If less than maxSize, it uses maxSize instead.
-     * @param {boolean} [autoResize=true] If true, container allocates more batches in case
+     * @param {boolean} [autoResize=false] If true, container allocates more batches in case
      *  there are more than `maxSize` particles.
      */
     constructor(maxSize = 1500, properties, batchSize = 16384, autoResize = false)
@@ -156,7 +157,8 @@ export default class ParticleContainer extends core.Container
     {
         if (properties)
         {
-            this._properties[0] = 'scale' in properties ? !!properties.scale : this._properties[0];
+            this._properties[0] = 'scale' in properties || 'vertex' in properties
+                ? !!properties.scale || !!properties.vertex : this._properties[0];
             this._properties[1] = 'position' in properties ? !!properties.position : this._properties[1];
             this._properties[2] = 'rotation' in properties ? !!properties.rotation : this._properties[2];
             this._properties[3] = 'uvs' in properties ? !!properties.uvs : this._properties[3];

--- a/src/particles/webgl/ParticleShader.js
+++ b/src/particles/webgl/ParticleShader.js
@@ -21,7 +21,6 @@ export default class ParticleShader extends Shader
                 'attribute vec4 aColor;',
 
                 'attribute vec2 aPositionCoord;',
-                'attribute vec2 aScale;',
                 'attribute float aRotation;',
 
                 'uniform mat3 projectionMatrix;',


### PR DESCRIPTION
detail at https://github.com/pixijs/pixi.js/issues/4467

1) remove `attribute vec2 aScale;` in the shader source. it's needless. because `scale` has been compute in  ParticleRenderer's `uploadVertices()`. We don't need to upload the scale as attribute to shader.

2) update the document about `properties.scale` in ParticleContainer.
in fact , when sprite's `scale/anchor/trim/frame/orig` changed , users have to set  `scale:true` . 
though that option  named `scale` , but it's not only about `sprite.scale`.

3) change the name from `scale` to `vertices` , and  do polyfill in ParticleContainer's `setProperties()` (like `alpha` & `tint`)