### PR TITLE
Fixing mipmaps and renderTexture

### DIFF
--- a/packages/core/src/renderers/systems/textures/GLTexture.js
+++ b/packages/core/src/renderers/systems/textures/GLTexture.js
@@ -23,5 +23,11 @@ export default class GLTexture
          * @type {number}
          */
         this.dirtyStyleId = -1;
+
+        /**
+         * Whether mip levels has to be generated
+         * @type {boolean}
+         */
+        this.mipmap = false;
     }
 }

--- a/packages/core/src/textures/resources/BaseImageResource.js
+++ b/packages/core/src/textures/resources/BaseImageResource.js
@@ -53,19 +53,21 @@ export default class BaseImageResource extends Resource
     upload(renderer, baseTexture, glTexture, source)
     {
         const gl = renderer.gl;
+        const width = baseTexture.realWidth;
+        const height = baseTexture.realHeight;
 
         source = source || this.source;
 
         gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, baseTexture.premultiplyAlpha);
 
-        if (glTexture.width === baseTexture.width && glTexture.height === baseTexture.height)
+        if (glTexture.width === width && glTexture.height === height)
         {
             gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, baseTexture.format, baseTexture.type, source);
         }
         else
         {
-            glTexture.width = baseTexture.width;
-            glTexture.height = baseTexture.height;
+            glTexture.width = width;
+            glTexture.height = height;
 
             gl.texImage2D(gl.TEXTURE_2D, 0, baseTexture.format, baseTexture.format, baseTexture.type, source);
         }


### PR DESCRIPTION
Yeah, @GoodBoyDigital broke everything :)

1. Fixing mipmaps - there's one more flag in GLTexture: whether or not mipmaps has to be uploaded
2. default renderTexture logic, that is also used in case of async ImageBitmap creation was faulty
3. minor refactor on width/height, also fixed potential resolution bug.