### PR TITLE
Ensure argument type is string for getChildByName

### DIFF
--- a/src/extras/getChildByName.js
+++ b/src/extras/getChildByName.js
@@ -17,6 +17,11 @@ core.DisplayObject.prototype.name = null;
  */
 core.Container.prototype.getChildByName = function getChildByName(name)
 {
+    if ((typeof name) !== 'string')
+    {
+        return null;
+    }
+
     for (let i = 0; i < this.children.length; i++)
     {
         if (this.children[i].name === name)


### PR DESCRIPTION
Added the argument validation for extras/getChildByName.

If user accidentally pass `undefined` as argument, the first unnamed child will be returned unexpectedly since the property `name` is not a default property for `Container` or its ancestors.

If the argument validation is not suit for design policy of pixi.js, I will follow the policy and this pull request should be closed.

Thanks in advance.