### PR TITLE
Update resource-loader version

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "object-assign": "^4.0.1",
     "pixi-gl-core": "^1.1.4",
     "remove-array-items": "^1.0.0",
-    "resource-loader": "^2.0.9"
+    "resource-loader": "^2.1.1"
   },
   "devDependencies": {
     "@pixi/jsdoc-template": "^2.0.0",


### PR DESCRIPTION
Updated resource-loader from v2.0.9 to v2.1.1.

Most important changes are to fix englercj/resource-loader#102 and englercj/resource-loader#106.

Full change logs: [v2.1.0](https://github.com/englercj/resource-loader/releases/tag/v2.1.0), [v2.1.1](https://github.com/englercj/resource-loader/releases/tag/v2.1.1).

