### PR TITLE
README Link Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ _Note: `4.5.1` can be replaced by any [released](https://github.com/pixijs/pixi.
 - [Run Pixie Run](http://work.goodboydigital.com/runpixierun/)
 - [Fight for Everyone](http://www.goodboydigital.com/casestudies/fightforeveryone)
 - [Flash vs HTML](http://flashvhtml.com)
-- [Bunny Demo](http://pixijs.io/bunny-mark)
+- [Bunny Demo](http://www.goodboydigital.com/pixijs/bunnymark)
 - [Storm Brewing](http://www.goodboydigital.com/pixijs/storm)
 - [Render Texture Demo](http://www.goodboydigital.com/pixijs/examples/11)
 - [Primitives Demo](http://www.goodboydigital.com/pixijs/examples/13)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ _Note: `4.5.1` can be replaced by any [released](https://github.com/pixijs/pixi.
 ### Demos ###
 
 - [Filters Demo](http://pixijs.io/pixi-filters/tools/demo/)
-- [Run Pixie Run](http://www.goodboydigital.com/runpixierun)
+- [Run Pixie Run](http://work.goodboydigital.com/runpixierun/)
 - [Fight for Everyone](http://www.goodboydigital.com/casestudies/fightforeveryone)
 - [Flash vs HTML](http://flashvhtml.com)
 - [Bunny Demo](http://pixijs.io/bunny-mark)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 PixiJS — The HTML5 Creation Engine
 =============
 
-![pixi.js logo](http://www.goodboydigital.com/pixijs/pixiV4_wide_full.jpg)
+![pixi.js logo](http://pixijs.download/pixijs-banner.png)
 
 [![Inline docs](http://inch-ci.org/github/pixijs/pixi.js.svg?branch=dev)](http://inch-ci.org/github/pixijs/pixi.js)
 [![Build Status](https://travis-ci.org/pixijs/pixi.js.svg?branch=dev)](https://travis-ci.org/pixijs/pixi.js)
@@ -62,13 +62,12 @@ _Note: `4.5.1` can be replaced by any [released](https://github.com/pixijs/pixi.
 
 ### Demos ###
 
-- [WebGL Filters!](http://pixijs.github.io/pixi-filters/examples/)
+- [Filters Demo](http://pixijs.io/pixi-filters/tools/demo/)
 - [Run pixie run](http://www.goodboydigital.com/runpixierun)
 - [Fight for Everyone](http://www.goodboydigital.com/casestudies/fightforeveryone)
 - [Flash vs HTML](http://flashvhtml.com)
-- [Bunny Demo](http://www.goodboydigital.com/pixijs/bunnymark)
+- [Bunny Demo](http://pixijs.io/bunny-mark)
 - [Storm Brewing](http://www.goodboydigital.com/pixijs/storm)
-- [Filters Demo](http://www.goodboydigital.com/pixijs/examples/15/indexAll.html)
 - [Render Texture Demo](http://www.goodboydigital.com/pixijs/examples/11)
 - [Primitives Demo](http://www.goodboydigital.com/pixijs/examples/13)
 - [Masking Demo](http://www.goodboydigital.com/pixijs/examples/14)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ _Note: `4.5.1` can be replaced by any [released](https://github.com/pixijs/pixi.
 ### Demos ###
 
 - [Filters Demo](http://pixijs.io/pixi-filters/tools/demo/)
-- [Run pixie run](http://www.goodboydigital.com/runpixierun)
+- [Run Pixie Run](http://www.goodboydigital.com/runpixierun)
 - [Fight for Everyone](http://www.goodboydigital.com/casestudies/fightforeveryone)
 - [Flash vs HTML](http://flashvhtml.com)
 - [Bunny Demo](http://pixijs.io/bunny-mark)


### PR DESCRIPTION
## Overview

@GoodBoyDigital and co produced a wonderful new [website](https://www.goodboydigital.com/), however some of the older demo links being hosted on that site are now broken. We are looking for a restore solution, but in the meantime, I updated a few links which were old anyways.

Partially addresses #4571

### Fixed

* Updates the banner image to be image served on S3 bucket
* Changes bunny demo to be the project on GitHub pages
* Changes the filters demo to be the demo on GitHub pages
  