### PR TITLE
Adds pre-commit dependency and hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "prerelease": "npm run clean:build && npm test",
     "release": "lerna publish"
   },
+  "pre-commit": [
+    "lintfix"
+  ],
   "devDependencies": {
     "@pixi/jsdoc-template": "^2.2.0",
     "copyfiles": "^1.2.0",
@@ -34,6 +37,7 @@
     "jsdoc": "^3.4.0",
     "lerna": "^2.4.0",
     "minimist": "^1.2.0",
+    "pre-commit": "^1.2.2",
     "rimraf": "^2.6.2",
     "rollup": "^0.52.0",
     "rollup-plugin-buble": "^0.18.0",


### PR DESCRIPTION
### Added

* Adds **pre-commit** dependency to provide a pre-commit Git hook to fix up linting. This should catch a bunch of basic issues submitting PRs. Easy to opt-out by using `--no-verify` flag with `git commit`.

cc @GoodBoyDigital 