### PR TITLE
Next stage

### DIFF
--- a/packages/app/src/Application.js
+++ b/packages/app/src/Application.js
@@ -1,5 +1,5 @@
 import { settings } from '@pixi/settings';
-import { Container } from '@pixi/display';
+import { Stage } from '@pixi/display';
 import { Renderer } from '@pixi/core';
 import { Ticker, UPDATE_PRIORITY } from '@pixi/ticker';
 
@@ -52,6 +52,7 @@ export default class Application
      *  for devices with dual graphics card **webgl only**
      * @param {boolean} [options.sharedTicker=false] - `true` to use PIXI.Ticker.shared, `false` to create new ticker.
      * @param {boolean} [options.sharedLoader=false] - `true` to use PIXI.Loaders.shared, `false` to create new Loader.
+     * @param {PIXI.Container} {options.stage} - Pass existing stage or container
      */
     constructor(options, arg2, arg3, arg4, arg5)
     {
@@ -88,7 +89,7 @@ export default class Application
          * The root display container that's rendered.
          * @member {PIXI.Container}
          */
-        this.stage = new Container();
+        this.stage = options.stage || new Stage();
 
         /**
          * Internal reference to the ticker
@@ -142,8 +143,9 @@ export default class Application
     /**
      * Render the current stage.
      */
-    render()
+    render(delta)
     {
+        this.stage.animate(delta);
         this.renderer.render(this.stage);
     }
 

--- a/packages/display/src/Container.js
+++ b/packages/display/src/Container.js
@@ -66,24 +66,26 @@ export default class Container extends DisplayObject
         }
         else
         {
+            let newChildStage = this.innerStage ? this : this.parentStage;
+
             // if the child has a parent then lets remove it as PixiJS objects can only exist in one place
             if (child.parent)
             {
-                child.parent.removeChild(child);
+                if (child.parentStage !== newChildStage)
+                {
+                    child.parent.removeChild(child);
+                }
+                else
+                {
+                    child.parent.detachChild(child);
+                    newChildStage = null;
+                }
             }
-
-            child.parent = this;
-            // ensure child transform will be recalculated
-            child.transform._parentID = -1;
-
             this.children.push(child);
 
-            // ensure bounds will be recalculated
-            this._boundsID++;
+            this._innerAddChild(child, newChildStage);
 
-            // TODO - lets either do all callbacks or all events.. not both!
             this.onChildrenChange(this.children.length - 1);
-            child.emit('added', this);
         }
 
         return child;
@@ -103,25 +105,50 @@ export default class Container extends DisplayObject
             throw new Error(`${child}addChildAt: The index ${index} supplied is out of bounds ${this.children.length}`);
         }
 
+        let newChildStage = this.innerStage ? this : this.parentStage;
+
         if (child.parent)
         {
-            child.parent.removeChild(child);
+            if (child.parentStage !== newChildStage)
+            {
+                child.parent.removeChild(child);
+            }
+            else
+            {
+                child.parent.detachChild(child);
+                newChildStage = null;
+            }
         }
 
+        this.children.splice(index, 0, child);
+
+        this._innerAddChild(child, newChildStage);
+
+        this.onChildrenChange(index);
+
+        return child;
+    }
+
+    /**
+     * Inner workings of addChild and addChildAt
+     *
+     * @param child {PIXI.DisplayObject} new child
+     * @param newChildStage {PIXI.Stage} if child needs his stage changed
+     * @private
+     */
+    _innerAddChild(child, newChildStage)
+    {
         child.parent = this;
         // ensure child transform will be recalculated
         child.transform._parentID = -1;
 
-        this.children.splice(index, 0, child);
-
         // ensure bounds will be recalculated
         this._boundsID++;
 
-        // TODO - lets either do all callbacks or all events.. not both!
-        this.onChildrenChange(index);
-        child.emit('added', this);
-
-        return child;
+        if (newChildStage)
+        {
+            newChildStage.innerStage.addSubtree(child);
+        }
     }
 
     /**
@@ -226,17 +253,7 @@ export default class Container extends DisplayObject
 
             if (index === -1) return null;
 
-            child.parent = null;
-            // ensure child transform will be recalculated
-            child.transform._parentID = -1;
-            removeItems(this.children, index, 1);
-
-            // ensure bounds will be recalculated
-            this._boundsID++;
-
-            // TODO - lets either do all callbacks or all events.. not both!
-            this.onChildrenChange(index);
-            child.emit('removed', this);
+            this._innerRemoveChild(index, child, false);
         }
 
         return child;
@@ -252,6 +269,20 @@ export default class Container extends DisplayObject
     {
         const child = this.getChildAt(index);
 
+        this._innerRemoveChild(index, child, false);
+
+        return child;
+    }
+
+    /**
+     * Inner workings of removeChild and removeChildAt
+     * @param index
+     * @param child
+     * @param detach
+     * @private
+     */
+    _innerRemoveChild(index, child, detach)
+    {
         // ensure child transform will be recalculated..
         child.parent = null;
         child.transform._parentID = -1;
@@ -262,7 +293,67 @@ export default class Container extends DisplayObject
 
         // TODO - lets either do all callbacks or all events.. not both!
         this.onChildrenChange(index);
-        child.emit('removed', this);
+
+        const childStage = this.innerStage ? this : this.parentStage;
+
+        if (childStage)
+        {
+            if (detach)
+            {
+                childStage.innerStage.detachSubtree(child);
+            }
+            else
+            {
+                childStage.innerStage.removeSubtree(child);
+            }
+        }
+    }
+
+    /**
+     * Detaches one or more children from the container.
+     * Stage events woould not fire.
+     *
+     * @param {...PIXI.DisplayObject} child - The DisplayObject(s) to remove
+     * @return {PIXI.DisplayObject} The first child that was detached.
+     */
+    detachChild(child)
+    {
+        const argumentsLength = arguments.length;
+
+        // if there is only one argument we can bypass looping through the them
+        if (argumentsLength > 1)
+        {
+            // loop through the arguments property and add all children
+            // use it the right way (.length and [i]) so that this function can still be optimised by JS runtimes
+            for (let i = 0; i < argumentsLength; i++)
+            {
+                this.removeChild(arguments[i]);
+            }
+        }
+        else
+        {
+            const index = this.children.indexOf(child);
+
+            if (index === -1) return null;
+
+            this._innerRemoveChild(index, child, true);
+        }
+
+        return child;
+    }
+
+    /**
+     * Detaches a child from the specified index position.
+     * Stage events woould not fire.
+     *
+     * @param {number} index - The index to get the child from
+     * @return {PIXI.DisplayObject} The child that was detached.
+     */
+    detachChildAt(index)
+    {
+        const child = this.getChildAt(index);
+
+        this._innerRemoveChild(index, child, true);
 
         return child;
     }
@@ -272,9 +363,10 @@ export default class Container extends DisplayObject
      *
      * @param {number} [beginIndex=0] - The beginning position.
      * @param {number} [endIndex=this.children.length] - The ending position. Default value is size of the container.
+     * @param {boolean} [detach=false] - Whether to fire stage events
      * @returns {DisplayObject[]} List of removed children
      */
-    removeChildren(beginIndex = 0, endIndex)
+    removeChildren(beginIndex = 0, endIndex, detach)
     {
         const begin = beginIndex;
         const end = typeof endIndex === 'number' ? endIndex : this.children.length;
@@ -298,9 +390,24 @@ export default class Container extends DisplayObject
 
             this.onChildrenChange(beginIndex);
 
-            for (let i = 0; i < removed.length; ++i)
+            const childStage = this.innerStage ? this : this.parentStage;
+
+            if (childStage)
             {
-                removed[i].emit('removed', this);
+                if (detach)
+                {
+                    for (let i = 0; i < removed.length; ++i)
+                    {
+                        childStage.innerStage.detachSubtree(removed[i]);
+                    }
+                }
+                else
+                {
+                    for (let i = 0; i < removed.length; ++i)
+                    {
+                        childStage.innerStage.removeSubtree(removed[i]);
+                    }
+                }
             }
 
             return removed;

--- a/packages/display/src/DisplayObject.js
+++ b/packages/display/src/DisplayObject.js
@@ -1,6 +1,7 @@
 import EventEmitter from 'eventemitter3';
 import { Rectangle, Transform } from '@pixi/math';
 import Bounds from './Bounds';
+import { uid } from '@pixi/utils';
 // _tempDisplayObjectParent = new DisplayObject();
 
 /**
@@ -19,6 +20,8 @@ export default class DisplayObject extends EventEmitter
     constructor()
     {
         super();
+
+        this.uid = uid();
 
         this.tempDisplayObjectParent = null;
 
@@ -65,6 +68,30 @@ export default class DisplayObject extends EventEmitter
          * @readonly
          */
         this.parent = null;
+
+        /**
+         * Which stage object belongs to
+         *
+         * @member {PIXI.Stage}
+         * @readonly
+         */
+        this.parentStage = null;
+
+        /**
+         * Inner element collection for stage, exists only for Stage
+         *
+         * @member {PIXI.InnerStage}
+         * @readonly
+         */
+        this.innerStage = null;
+
+        /**
+         * Array of children, exists only for Container
+         *
+         * @member {PIXI.DisplayObject[]}
+         * @readonly
+         */
+        this.children = null;
 
         /**
          * The multiplied alpha of the displayObject

--- a/packages/display/src/InnerStage.js
+++ b/packages/display/src/InnerStage.js
@@ -1,0 +1,171 @@
+/**
+ * Inner stage component, handles all operations with sets of DisplayObjects
+ *
+ * @class
+ * @memberof PIXI
+ */
+export default class InnerStage
+{
+    /**
+     *
+     */
+    constructor(stage)
+    {
+        /**
+         * stage this faced belongs to
+         * @member {PIXI.Stage}
+         */
+        this.stage = stage;
+
+        /**
+         * set of attached objects
+         * @type {{}}
+         * @private
+         */
+        this.attachedSet = {};
+
+        /**
+         * set of detached objects
+         * @type {{}}
+         * @private
+         */
+        this.detachedSet = {};
+
+        this.tempQueueStack = [];
+    }
+
+    detachSubtree(subtree)
+    {
+        const aSet = this.attachedSet;
+        const dSet = this.detachedSet;
+        const q = this.tempQueueStack.pop() || [];
+
+        q.length = 0;
+        q.push(subtree);
+        for (let i = 0; i < q.length; i++)
+        {
+            const x = q[i];
+
+            if (x.parentStage !== this)
+            {
+                continue;
+            }
+            dSet[x.uniqId] = x;
+            delete aSet[x.uniqId];
+            if (x.innerStage || !x.children)
+            {
+                continue;
+            }
+            for (let j = 0; j < x.children.length; j++)
+            {
+                q.push(x.children[j]);
+            }
+        }
+        q.length = 0;
+        this.tempQueueStack.push(q);
+    }
+
+    addSubtree(subtree)
+    {
+        const stage = this.stage;
+        const aSet = this.attachedSet;
+        const dSet = this.detachedSet;
+        const q = this.tempQueueStack.pop() || [];
+
+        q.length = 0;
+        q.push(subtree);
+        for (let i = 0; i < q.length; i++)
+        {
+            const x = q[i];
+
+            if (x.parentStage !== this)
+            {
+                if (x.parentStage)
+                {
+                    x.parentStage.innerStage.removeSubtree(x);
+                }
+                x.parentStage = stage;
+                stage.onAdd(x);
+            }
+            else
+            {
+                delete dSet[x.uniqId];
+            }
+            aSet[x.uniqId] = x;
+
+            if (x.innerStage || !x.children)
+            {
+                continue;
+            }
+            for (let j = 0; j < x.children.length; j++)
+            {
+                q.push(x.children[j]);
+            }
+        }
+        q.length = 0;
+        this.tempQueueStack.push(q);
+    }
+
+    removeSubtree(subtree)
+    {
+        const stage = this.stage;
+        const aSet = this.attachedSet;
+        const dSet = this.detachedSet;
+        const q = this.tempQueueStack.pop() || [];
+
+        q.length = 0;
+        q.push(subtree);
+        for (let i = 0; i < q.length; i++)
+        {
+            const x = q[i];
+
+            if (x.parentStage !== stage)
+            {
+                continue;
+            }
+            x.parentStage = null;
+            stage.onRemove(x);
+
+            delete aSet[x.uniqId];
+            delete dSet[x.uniqId];
+
+            if (x.children)
+            {
+                for (let j = 0; j < x.children.length; j++)
+                {
+                    q.push(x.children[j]);
+                }
+            }
+        }
+        q.length = 0;
+        this.tempQueueStack.push(q);
+    }
+
+    flushDetached()
+    {
+        const stage = this.stage;
+        const q = this.detachedSet;
+        let key;
+        let flag = false;
+
+        for (key in q)
+        {
+            flag = true;
+            break;
+        }
+        if (!flag) return;
+
+        this.detachedSet = {};
+
+        for (key in q)
+        {
+            const x = q[key];
+
+            if (x.parentStage === stage)
+            {
+                x.parentStage = null;
+                stage.onRemove(x);
+            }
+        }
+    }
+}

--- a/packages/display/src/Stage.js
+++ b/packages/display/src/Stage.js
@@ -1,0 +1,54 @@
+import Container from './Container';
+import InnerStage from './InnerStage';
+import Runner from 'mini-runner';
+
+/**
+ * Stage is a Container that takes care of add/remove events and animations
+ *
+ * @class
+ * @extends PIXI.Container
+ * @memberof PIXI
+ */
+export default class Stage extends Container
+{
+    /**
+     *
+     */
+    constructor()
+    {
+        super();
+
+        /**
+         * The array of children of this container
+         *
+         * @member {Runner}
+         * @readonly
+         */
+        this.runnerAnimate = new Runner('animate', 1);
+
+        /**
+         * set of attached objects
+         * @type {PIXI.InnerStage}
+         */
+        this.innerStage = new InnerStage(this);
+    }
+
+    onAdd(obj)
+    {
+        this.runnerAnimate.add(obj);
+        obj.emit('added', this);
+    }
+
+    onRemove(obj)
+    {
+        this.runnerAnimate.remove(obj);
+        obj.emit('removed', this);
+    }
+
+    animate(delta)
+    {
+        this.innerStage.flushDetached();
+
+        this.runnerAnimate.run(delta);
+    }
+}

--- a/packages/display/src/index.js
+++ b/packages/display/src/index.js
@@ -1,3 +1,4 @@
 export { default as Bounds } from './Bounds';
 export { default as DisplayObject } from './DisplayObject';
 export { default as Container } from './Container';
+export { default as Stage } from './Stage';

--- a/packages/display/test/Container.js
+++ b/packages/display/test/Container.js
@@ -50,38 +50,6 @@ describe('PIXI.Container', function ()
         });
     });
 
-    describe('events', function ()
-    {
-        it('should trigger "added" and "removed" events on its children', function ()
-        {
-            const container = new Container();
-            const child = new DisplayObject();
-            let triggeredAdded = false;
-            let triggeredRemoved = false;
-
-            child.on('added', (to) =>
-            {
-                triggeredAdded = true;
-                expect(container.children.length).to.be.equals(1);
-                expect(child.parent).to.be.equals(to);
-            });
-            child.on('removed', (from) =>
-            {
-                triggeredRemoved = true;
-                expect(container.children.length).to.be.equals(0);
-                expect(child.parent).to.be.null;
-                expect(container).to.be.equals(from);
-            });
-
-            container.addChild(child);
-            expect(triggeredAdded).to.be.true;
-            expect(triggeredRemoved).to.be.false;
-
-            container.removeChild(child);
-            expect(triggeredRemoved).to.be.true;
-        });
-    });
-
     describe('addChild', function ()
     {
         it('should remove from current parent', function ()

--- a/packages/display/test/Stage.js
+++ b/packages/display/test/Stage.js
@@ -1,0 +1,42 @@
+const { Container, DisplayObject, Stage } = require('../');
+
+describe('PIXI.Stage', function ()
+{
+    describe('events', function ()
+    {
+        it('should trigger "added" and "removed" events on inner children', function ()
+        {
+            const stage = new Stage();
+            const container = new Container();
+            const child = new DisplayObject();
+
+            container.addChild(child);
+
+            let triggeredAdded = false;
+            let triggeredRemoved = false;
+
+            child.on('added', (to) =>
+            {
+                triggeredAdded = true;
+                expect(stage.children.length).to.be.equals(1);
+                expect(container.parent).to.be.equals(stage);
+                expect(child.parentStage).to.be.equals(to);
+            });
+            child.on('removed', (from) =>
+            {
+                triggeredRemoved = true;
+                expect(stage.children.length).to.be.equals(0);
+                expect(container.parent).to.be.null;
+                expect(child.parentStage).to.be.null;
+                expect(stage).to.be.equals(from);
+            });
+
+            stage.addChild(container);
+            expect(triggeredAdded).to.be.true;
+            expect(triggeredRemoved).to.be.false;
+
+            stage.removeChild(container);
+            expect(triggeredRemoved).to.be.true;
+        });
+    });
+});

--- a/packages/display/test/index.js
+++ b/packages/display/test/index.js
@@ -1,4 +1,5 @@
 require('./Container');
 require('./DisplayObject');
+require('./Stage');
 require('./toGlobal');
 require('./toLocal');

--- a/packages/sprite-animated/src/AnimatedSprite.js
+++ b/packages/sprite-animated/src/AnimatedSprite.js
@@ -1,6 +1,5 @@
 import { Texture } from '@pixi/core';
 import { Sprite } from '@pixi/sprite';
-import { Ticker, UPDATE_PRIORITY } from '@pixi/ticker';
 
 /**
  * @typedef PIXI.extras.AnimatedSprite~FrameObject
@@ -34,7 +33,7 @@ export default class AnimatedSprite extends Sprite
     /**
      * @param {PIXI.Texture[]|PIXI.extras.AnimatedSprite~FrameObject[]} textures - an array of {@link PIXI.Texture} or frame
      *  objects that make up the animation
-     * @param {boolean} [autoUpdate=true] - Whether to use PIXI.Ticker.shared to auto update animation time.
+     * @param {boolean} [autoUpdate=true] - Whether to use stage animation update.
      */
     constructor(textures, autoUpdate)
     {
@@ -126,10 +125,6 @@ export default class AnimatedSprite extends Sprite
         }
 
         this.playing = false;
-        if (this._autoUpdate)
-        {
-            Ticker.shared.remove(this.update, this);
-        }
     }
 
     /**
@@ -144,10 +139,6 @@ export default class AnimatedSprite extends Sprite
         }
 
         this.playing = true;
-        if (this._autoUpdate)
-        {
-            Ticker.shared.add(this.update, this, UPDATE_PRIORITY.HIGH);
-        }
     }
 
     /**
@@ -189,7 +180,21 @@ export default class AnimatedSprite extends Sprite
     }
 
     /**
-     * Updates the object transform for rendering.
+     * Updates the animation in case of _autoUpdate
+     *
+     * @private
+     * @param {number} deltaTime - Time since last tick.
+     */
+    animate(deltaTime)
+    {
+        if (this.playing && this._autoUpdate)
+        {
+            this.update(deltaTime);
+        }
+    }
+
+    /**
+     * Updates animation.
      *
      * @private
      * @param {number} deltaTime - Time since last tick.


### PR DESCRIPTION
### Work in progress - more tests, examples.

# Return of the stage

This is colossal PR that was waited too long, people really want correct `added` and `removed` events and a way to track all animations that exist in main stage tree. This is critical for projects that need to free resources and count references to them.

`InnerStage` tracks sets of DisplayObjects and Containers that exist in the stage, some in detached stage. 170 lines of serious algorithm code were always on used-side.

`parentStage` property always points to the stage where the object is registered.

As a default implementation that can be easily changed in plugins and in user-side code, any object that has "animate" method will be called when the time comes. It can be changed both by overriding Stage methods and handling `added` and `removed` events.

There can be nested stages.

`added` and `removed` are fired for whole subtree.

```
var stage = new PIXI.Stage();
var container = new PIXI.Container();
var child = new PIXI.DisplayObject();

container.addChild(child); // nothing
stage.addChild(container); // child is ADDED!
```

Additional way of moving objects in the same stage without firing events: `detachChild`. It exists in cocos2d-x as a flag to `removeChild`, which is not verbose. 

```js
var container1 = new PIXI.Container();
var container2 = new PIXI.Container();
var stage = new PIXI.Stage();

stage.addChild(container1);
stage.addChild(container2);

var child = new PIXI.Container();
container1.addChild(child); //ADDED
container1.detachChild(child);// event doesnt fire
//some calculations
container2.addChild(child); // event doesnt fire because its in the same stage
//some calculations
container2.detachChild(child);

stage.innerStage.flushDetached(); // actual REMOVED
```