### PR TITLE
[next] Windows tests are failing

### DIFF
--- a/packages/core/src/renderers/systems/textures/TextureSystem.js
+++ b/packages/core/src/renderers/systems/textures/TextureSystem.js
@@ -204,13 +204,15 @@ export default class TextureSystem extends WebGLSystem
      */
     destroyTexture(texture, skipRemove)
     {
+        const gl = this.gl;
+
         texture = texture.baseTexture || texture;
 
         if (texture._glTextures[this.renderer.CONTEXT_UID])
         {
             this.unbind(texture);
 
-            texture._glTextures[this.renderer.CONTEXT_UID].texture.destroy();
+            gl.destroyTexture(texture._glTextures[this.renderer.CONTEXT_UID].texture);
             texture.off('dispose', this.destroyTexture, this);
 
             delete texture._glTextures[this.renderer.CONTEXT_UID];

--- a/packages/core/test/ImageResource.js
+++ b/packages/core/test/ImageResource.js
@@ -42,19 +42,7 @@ describe('PIXI.resources.ImageResource', function ()
         expect(resource.width).to.equal(0);
         expect(resource.height).to.equal(0);
         expect(resource.valid).to.be.false;
-        if (this.slugUrl.indexOf('\\') < 0)
-        {
-            // unix
-            expect(resource.url).to.equal(`file://${this.slugUrl}`);
-        }
-        else
-        {
-            // windows
-            const resourceUrl = resource.url.toLowerCase();
-            const windowsUrl = `file:///${this.slugUrl.replace(/\\/g, '/').toLowerCase()}`;
-
-            expect(resourceUrl).to.be.equals(windowsUrl);
-        }
+        expect(resource.url).to.equal(image.src);
 
         resource.destroy();
     });

--- a/packages/core/test/ImageResource.js
+++ b/packages/core/test/ImageResource.js
@@ -42,7 +42,19 @@ describe('PIXI.resources.ImageResource', function ()
         expect(resource.width).to.equal(0);
         expect(resource.height).to.equal(0);
         expect(resource.valid).to.be.false;
-        expect(resource.url).to.equal(`file://${this.slugUrl}`);
+        if (this.slugUrl.indexOf('\\') < 0)
+        {
+            // unix
+            expect(resource.url).to.equal(`file://${this.slugUrl}`);
+        }
+        else
+        {
+            // windows
+            const resourceUrl = resource.url.toLowerCase();
+            const windowsUrl = `file:///${this.slugUrl.replace(/\\/g, '/').toLowerCase()}`;
+
+            expect(resourceUrl).to.be.equals(windowsUrl);
+        }
 
         resource.destroy();
     });

--- a/packages/spritesheet/test/SpritesheetLoader.js
+++ b/packages/spritesheet/test/SpritesheetLoader.js
@@ -91,8 +91,8 @@ describe('PIXI.SpritesheetLoader', function ()
             }
             next();
         })
-            .add(`atlas_crn`, `file://${__dirname}/resources/atlas_crn.json`)
-            .add(`atlas`, `file://${__dirname}/resources/building1.json`)
+            .add(`atlas_crn`, path.join(__dirname, 'resources', 'atlas_crn.json'))
+            .add(`atlas`, path.join(__dirname, 'resources', 'building1.json'))
             .load((loader, resources) =>
             {
                 expect(resources.atlas_image.data).to.be.instanceof(HTMLImageElement);


### PR DESCRIPTION
This is only a partial fix. In windows, `path` resolves `file:///D:\...`

Another test that is failing - https://github.com/pixijs/pixi.js/blob/next/packages/spritesheet/test/SpritesheetLoader.js#L94 , I honestly don't know what to do about that.

Any ideas?