### PR TITLE
Update JSDocs to latest version to fix EISDIR error

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "eslint": "^3.5.0",
     "floss": "^2.0.1",
     "js-md5": "^0.4.1",
-    "jsdoc": "3.4.3",
+    "jsdoc": "3.5.5",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "parallelshell": "^2.0.0",


### PR DESCRIPTION
On my system (macOS High Sierra 10.13.2) the docs failed to build. Updating JSDoc to the latest version fixed the problem.

Previous error output:

```
$ npm run docs

> pixi.js@4.6.2 predocs /Users/himmelattack/Downloads/pixi.js-dev
> rimraf docs/**


> pixi.js@4.6.2 docs /Users/himmelattack/Downloads/pixi.js-dev
> jsdoc -c scripts/jsdoc.conf.json -R README.md

fs.js:1965
  binding.copyFile(src, dest, flags);
          ^

Error: EISDIR: illegal operation on a directory, copyfile '/Users/himmelattack/Downloads/pixi.js-dev/node_modules/@pixi/jsdoc-template/static/fonts/glyphicons-halflings-regular.eot' -> 'docs/fonts'
    at Object.fs.copyFileSync (fs.js:1965:11)
    at /Users/himmelattack/Downloads/pixi.js-dev/node_modules/@pixi/jsdoc-template/publish.js:391:12
    at Array.forEach (<anonymous>)
    at Object.exports.publish (/Users/himmelattack/Downloads/pixi.js-dev/node_modules/@pixi/jsdoc-template/publish.js:388:17)
    at Object.module.exports.cli.generateDocs (/Users/himmelattack/Downloads/pixi.js-dev/node_modules/jsdoc/cli.js:430:39)
    at Object.module.exports.cli.processParseResults (/Users/himmelattack/Downloads/pixi.js-dev/node_modules/jsdoc/cli.js:383:20)
    at module.exports.cli.main (/Users/himmelattack/Downloads/pixi.js-dev/node_modules/jsdoc/cli.js:227:14)
    at Object.module.exports.cli.runCommand (/Users/himmelattack/Downloads/pixi.js-dev/node_modules/jsdoc/cli.js:180:5)
    at /Users/himmelattack/Downloads/pixi.js-dev/node_modules/jsdoc/jsdoc.js:103:9
    at Object.<anonymous> (/Users/himmelattack/Downloads/pixi.js-dev/node_modules/jsdoc/jsdoc.js:104:3)
    at Module._compile (module.js:660:30)
    at Object.Module._extensions..js (module.js:671:10)
    at Module.load (module.js:573:32)
    at tryModuleLoad (module.js:513:12)
    at Function.Module._load (module.js:505:3)
    at Function.Module.runMain (module.js:701:10)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! pixi.js@4.6.2 docs: `jsdoc -c scripts/jsdoc.conf.json -R README.md`
npm ERR! Exit status 1
```