### PR TITLE
[next] Math `copy` inconsistencies

### DIFF
--- a/bundles/pixi.js/src/deprecated.js
+++ b/bundles/pixi.js/src/deprecated.js
@@ -657,4 +657,60 @@ export default function deprecated(PIXI)
 
         return BaseTexture.from(canvas, { scaleMode, resourceOptions });
     };
+
+    /**
+     * @method copy
+     * @static
+     * @memberof PIXI.Point
+     * @deprecated since 5.0.0
+     * @see PIXI.Point.copyFrom
+     */
+    PIXI.Point.prototype.copy = function copy(p)
+    {
+        warn('PIXI.Point.copy has been replaced with PIXI.Point.copyFrom');
+
+        return this.copyFrom(p);
+    };
+
+    /**
+     * @method copy
+     * @static
+     * @memberof PIXI.ObservablePoint
+     * @deprecated since 5.0.0
+     * @see PIXI.ObservablePoint.copyFrom
+     */
+    PIXI.ObservablePoint.prototype.copy = function copy(p)
+    {
+        warn('PIXI.ObservablePoint.copy has been replaced with PIXI.ObservablePoint.copyFrom');
+
+        return this.copyFrom(p);
+    };
+
+    /**
+     * @method copy
+     * @static
+     * @memberof PIXI.Rectangle
+     * @deprecated since 5.0.0
+     * @see PIXI.Rectangle.copyFrom
+     */
+    PIXI.Rectangle.prototype.copy = function copy(p)
+    {
+        warn('PIXI.Rectangle.copy has been replaced with PIXI.Rectangle.copyFrom');
+
+        return this.copyFrom(p);
+    };
+
+    /**
+     * @method copy
+     * @static
+     * @memberof PIXI.Rectangle
+     * @deprecated since 5.0.0
+     * @see PIXI.Matrix.copyTo
+     */
+    PIXI.Matrix.prototype.copy = function copy(p)
+    {
+        warn('PIXI.Matrix.copy has been replaced with PIXI.Matrix.copyTo');
+
+        return this.copyTo(p);
+    };
 }

--- a/bundles/pixi.js/src/deprecated.js
+++ b/bundles/pixi.js/src/deprecated.js
@@ -659,57 +659,49 @@ export default function deprecated(PIXI)
     };
 
     /**
-     * @method copy
-     * @static
-     * @memberof PIXI.Point
+     * @method PIXI.Point#copy
      * @deprecated since 5.0.0
-     * @see PIXI.Point.copyFrom
+     * @see PIXI.Point#copyFrom
      */
     PIXI.Point.prototype.copy = function copy(p)
     {
-        warn('PIXI.Point.copy has been replaced with PIXI.Point.copyFrom');
+        warn('PIXI.Point.copy has been replaced with PIXI.Point#copyFrom');
 
         return this.copyFrom(p);
     };
 
     /**
-     * @method copy
-     * @static
-     * @memberof PIXI.ObservablePoint
+     * @method PIXI.ObservablePoint#copy
      * @deprecated since 5.0.0
-     * @see PIXI.ObservablePoint.copyFrom
+     * @see PIXI.ObservablePoint#copyFrom
      */
     PIXI.ObservablePoint.prototype.copy = function copy(p)
     {
-        warn('PIXI.ObservablePoint.copy has been replaced with PIXI.ObservablePoint.copyFrom');
+        warn('PIXI.ObservablePoint.copy has been replaced with PIXI.ObservablePoint#copyFrom');
 
         return this.copyFrom(p);
     };
 
     /**
-     * @method copy
-     * @static
-     * @memberof PIXI.Rectangle
+     * @method PIXI.Rectangle#copy
      * @deprecated since 5.0.0
-     * @see PIXI.Rectangle.copyFrom
+     * @see PIXI.Rectangle#copyFrom
      */
     PIXI.Rectangle.prototype.copy = function copy(p)
     {
-        warn('PIXI.Rectangle.copy has been replaced with PIXI.Rectangle.copyFrom');
+        warn('PIXI.Rectangle.copy has been replaced with PIXI.Rectangle#copyFrom');
 
         return this.copyFrom(p);
     };
 
     /**
-     * @method copy
-     * @static
-     * @memberof PIXI.Rectangle
+     * @method PIXI.Matrix#copy
      * @deprecated since 5.0.0
-     * @see PIXI.Matrix.copyTo
+     * @see PIXI.Matrix#copyTo
      */
     PIXI.Matrix.prototype.copy = function copy(p)
     {
-        warn('PIXI.Matrix.copy has been replaced with PIXI.Matrix.copyTo');
+        warn('PIXI.Matrix.copy has been replaced with PIXI.Matrix#copyTo');
 
         return this.copyTo(p);
     };

--- a/packages/canvas/canvas-graphics/src/Graphics.js
+++ b/packages/canvas/canvas-graphics/src/Graphics.js
@@ -26,7 +26,7 @@ Graphics.prototype.generateCanvasTexture = function generateCanvasTexture(scaleM
     }
 
     this.transform.updateLocalTransform();
-    this.transform.localTransform.copy(tempMatrix);
+    this.transform.localTransform.copyTo(tempMatrix);
 
     tempMatrix.invert();
 

--- a/packages/canvas/canvas-renderer/src/CanvasRenderer.js
+++ b/packages/canvas/canvas-renderer/src/CanvasRenderer.js
@@ -183,7 +183,7 @@ export default class CanvasRenderer extends AbstractRenderer
 
             if (transform)
             {
-                transform.copy(tempWt);
+                transform.copyTo(tempWt);
 
                 // lets not forget to flag the parent transform as dirty...
                 this._tempDisplayObjectParent.transform._worldID = -1;

--- a/packages/canvas/canvas-sprite/src/CanvasSpriteRenderer.js
+++ b/packages/canvas/canvas-sprite/src/CanvasSpriteRenderer.js
@@ -85,7 +85,7 @@ export default class CanvasSpriteRenderer
 
             if (texture.rotate)
             {
-                wt.copy(canvasRenderWorldTransform);
+                wt.copyTo(canvasRenderWorldTransform);
                 wt = canvasRenderWorldTransform;
                 GroupD8.matrixAppendRotationInv(wt, texture.rotate, dx, dy);
                 // the anchor has already been applied above, so lets set it to zero

--- a/packages/core/src/renderers/filters/filterTransforms.js
+++ b/packages/core/src/renderers/filters/filterTransforms.js
@@ -7,13 +7,9 @@ import { Matrix } from '@pixi/math';
  * @param outputMatrix {Matrix} @alvin
  * @private
  */
-// TODO playing around here.. this is temporary - (will end up in the shader)
 // this returns a matrix that will normalise map filter cords in the filter to screen space
 export function calculateScreenSpaceMatrix(outputMatrix, filterArea, textureSize)
 {
-    // let worldTransform = sprite.worldTransform.copy(Matrix.TEMP_MATRIX),
-    // let texture = {width:1136, height:700};//sprite._texture.baseTexture;
-
     // TODO unwrap?
     const mappedMatrix = outputMatrix.identity();
 
@@ -43,7 +39,7 @@ export function calculateSpriteMatrix(outputMatrix, filterArea, textureSize, spr
 {
     const orig = sprite._texture.orig;
     const mappedMatrix = outputMatrix.set(textureSize.width, 0, 0, textureSize.height, filterArea.x, filterArea.y);
-    const worldTransform = sprite.worldTransform.copy(Matrix.TEMP_MATRIX);
+    const worldTransform = sprite.worldTransform.copyTo(Matrix.TEMP_MATRIX);
 
     worldTransform.invert();
     mappedMatrix.prepend(worldTransform);

--- a/packages/display/src/DisplayObject.js
+++ b/packages/display/src/DisplayObject.js
@@ -480,7 +480,7 @@ export default class DisplayObject extends EventEmitter
 
     set position(value) // eslint-disable-line require-jsdoc
     {
-        this.transform.position.copy(value);
+        this.transform.position.copyFrom(value);
     }
 
     /**
@@ -496,7 +496,7 @@ export default class DisplayObject extends EventEmitter
 
     set scale(value) // eslint-disable-line require-jsdoc
     {
-        this.transform.scale.copy(value);
+        this.transform.scale.copyFrom(value);
     }
 
     /**
@@ -512,7 +512,7 @@ export default class DisplayObject extends EventEmitter
 
     set pivot(value) // eslint-disable-line require-jsdoc
     {
-        this.transform.pivot.copy(value);
+        this.transform.pivot.copyFrom(value);
     }
 
     /**
@@ -528,7 +528,7 @@ export default class DisplayObject extends EventEmitter
 
     set skew(value) // eslint-disable-line require-jsdoc
     {
-        this.transform.skew.copy(value);
+        this.transform.skew.copyFrom(value);
     }
 
     /**

--- a/packages/math/src/Matrix.js
+++ b/packages/math/src/Matrix.js
@@ -454,10 +454,10 @@ export default class Matrix
     /**
      * Changes the values of the given matrix to be the same as the ones in this matrix
      *
-     * @param {PIXI.Matrix} matrix - The matrix to copy from.
+     * @param {PIXI.Matrix} matrix - The matrix to copy to.
      * @return {PIXI.Matrix} The matrix given in parameter with its values updated.
      */
-    copy(matrix)
+    copyTo(matrix)
     {
         matrix.a = this.a;
         matrix.b = this.b;
@@ -467,6 +467,24 @@ export default class Matrix
         matrix.ty = this.ty;
 
         return matrix;
+    }
+
+    /**
+     * Changes the values of the matrix to be the same as the ones in given matrix
+     *
+     * @param {PIXI.Matrix} matrix - The matrix to copy from.
+     * @return {PIXI.Matrix} this
+     */
+    copyFrom(matrix)
+    {
+        this.a = matrix.a;
+        this.b = matrix.b;
+        this.c = matrix.c;
+        this.d = matrix.d;
+        this.tx = matrix.tx;
+        this.ty = matrix.ty;
+
+        return this;
     }
 
     /**

--- a/packages/math/src/ObservablePoint.js
+++ b/packages/math/src/ObservablePoint.js
@@ -44,18 +44,34 @@ export default class ObservablePoint
     }
 
     /**
-     * Copies the data from another point
+     * Copies x and y from the given point
      *
-     * @param {PIXI.Point|PIXI.ObservablePoint} point - point to copy from
+     * @param {PIXI.Point} p - The point to copy from.
+     * @returns Returns itself.
      */
-    copy(point)
+    copyFrom(p)
     {
-        if (this._x !== point.x || this._y !== point.y)
+        if (this._x !== p.x || this._y !== p.y)
         {
-            this._x = point.x;
-            this._y = point.y;
+            this._x = p.x;
+            this._y = p.y;
             this.cb.call(this.scope);
         }
+
+        return this;
+    }
+
+    /**
+     * Copies x and y into the given point
+     *
+     * @param {PIXI.Point} p - The point to copy.
+     * @returns Given point with values updated
+     */
+    copyTo(p)
+    {
+        p.set(this.x, this.y);
+
+        return p;
     }
 
     /**

--- a/packages/math/src/ObservablePoint.js
+++ b/packages/math/src/ObservablePoint.js
@@ -69,7 +69,7 @@ export default class ObservablePoint
      */
     copyTo(p)
     {
-        p.set(this.x, this.y);
+        p.set(this._x, this._y);
 
         return p;
     }

--- a/packages/math/src/Point.js
+++ b/packages/math/src/Point.js
@@ -39,11 +39,27 @@ export default class Point
     /**
      * Copies x and y from the given point
      *
-     * @param {PIXI.Point} p - The point to copy.
+     * @param {PIXI.Point} p - The point to copy from
+     * @returns Returns itself.
      */
-    copy(p)
+    copyFrom(p)
     {
         this.set(p.x, p.y);
+
+        return this;
+    }
+
+    /**
+     * Copies x and y into the given point
+     *
+     * @param {PIXI.Point} p - The point to copy.
+     * @returns Given point with values updated
+     */
+    copyTo(p)
+    {
+        p.set(this.x, this.y);
+
+        return p;
     }
 
     /**

--- a/packages/math/src/shapes/Rectangle.js
+++ b/packages/math/src/shapes/Rectangle.js
@@ -116,10 +116,10 @@ export default class Rectangle
     /**
      * Copies another rectangle to this one.
      *
-     * @param {PIXI.Rectangle} rectangle - The rectangle to copy.
+     * @param {PIXI.Rectangle} rectangle - The rectangle to copy from.
      * @return {PIXI.Rectangle} Returns itself.
      */
-    copy(rectangle)
+    copyFrom(rectangle)
     {
         this.x = rectangle.x;
         this.y = rectangle.y;
@@ -127,6 +127,22 @@ export default class Rectangle
         this.height = rectangle.height;
 
         return this;
+    }
+
+    /**
+     * Copies this rectangle to another one.
+     *
+     * @param {PIXI.Rectangle} rectangle - The rectangle to copy to.
+     * @return {PIXI.Rectangle} Returns given parameter.
+     */
+    copyTo(rectangle)
+    {
+        rectangle.x = this.x;
+        rectangle.y = this.y;
+        rectangle.width = this.width;
+        rectangle.height = this.height;
+
+        return rectangle;
     }
 
     /**

--- a/packages/math/test/ObservablePoint.js
+++ b/packages/math/test/ObservablePoint.js
@@ -42,11 +42,11 @@ describe('PIXI.ObservablePoint', function ()
         const p2 = new ObservablePoint(cb, this, 5, 2);
         const p3 = new ObservablePoint(cb, this, 5, 6);
 
-        p1.copy(p2);
+        p1.copyFrom(p2);
         expect(p1.x).to.equal(p2.x);
         expect(p1.y).to.equal(p2.y);
 
-        p1.copy(p3);
+        p1.copyFrom(p3);
         expect(p1.y).to.equal(p3.y);
     });
 });

--- a/packages/math/test/Point.js
+++ b/packages/math/test/Point.js
@@ -30,7 +30,7 @@ describe('PIXI.Point', function ()
         const p1 = new Point(10, 20);
         const p2 = new Point(2, 5);
 
-        p1.copy(p2);
+        p1.copyFrom(p2);
 
         expect(p1.x).to.equal(2);
         expect(p1.y).to.equal(5);

--- a/packages/math/test/Rectangle.js
+++ b/packages/math/test/Rectangle.js
@@ -45,7 +45,7 @@ describe('PIXI.Rectangle', function ()
         const rect1 = new Rectangle(10, 10, 10, 10);
         const rect2 = new Rectangle(2, 2, 5, 5);
 
-        rect1.copy(rect2);
+        rect1.copyFrom(rect2);
 
         expect(rect1.x).to.equal(2);
         expect(rect1.y).to.equal(2);

--- a/packages/mixin-cache-as-bitmap/src/index.js
+++ b/packages/mixin-cache-as-bitmap/src/index.js
@@ -311,7 +311,7 @@ DisplayObject.prototype._initCachedDisplayObjectCanvas = function _initCachedDis
     // need to set //
     const m = _tempMatrix;
 
-    this.transform.localTransform.copy(m);
+    this.transform.localTransform.copyTo(m);
     m.invert();
 
     m.tx -= bounds.x;

--- a/packages/particles/src/ParticleRenderer.js
+++ b/packages/particles/src/ParticleRenderer.js
@@ -151,7 +151,7 @@ export default class ParticleRenderer extends ObjectRenderer
 
         const gl = renderer.gl;
 
-        const m = container.worldTransform.copy(this.tempMatrix);
+        const m = container.worldTransform.copyTo(this.tempMatrix);
 
         m.prepend(renderer._activeRenderTarget.projectionMatrix);
 

--- a/packages/sprite-tiling/src/TilingSprite.js
+++ b/packages/sprite-tiling/src/TilingSprite.js
@@ -110,7 +110,7 @@ export default class TilingSprite extends Sprite
 
     set tileScale(value) // eslint-disable-line require-jsdoc
     {
-        this.tileTransform.scale.copy(value);
+        this.tileTransform.scale.copyFrom(value);
     }
 
     /**
@@ -125,7 +125,7 @@ export default class TilingSprite extends Sprite
 
     set tilePosition(value) // eslint-disable-line require-jsdoc
     {
-        this.tileTransform.position.copy(value);
+        this.tileTransform.position.copyFrom(value);
     }
 
     /**

--- a/packages/sprite/src/Sprite.js
+++ b/packages/sprite/src/Sprite.js
@@ -532,7 +532,7 @@ export default class Sprite extends Container
 
     set anchor(value) // eslint-disable-line require-jsdoc
     {
-        this._anchor.copy(value);
+        this._anchor.copyFrom(value);
     }
 
     /**

--- a/packages/text-bitmap/src/BitmapText.js
+++ b/packages/text-bitmap/src/BitmapText.js
@@ -378,7 +378,7 @@ export default class BitmapText extends Container
         }
         else
         {
-            this._anchor.copy(value);
+            this._anchor.copyFrom(value);
         }
     }
 


### PR DESCRIPTION
## Overview

Standardizes the use of `copy` methods in Points and Matrix. Resolves a discrepancy between Points and Matrix with how `copy` is being used.

### 🔥   Deprecated

* `PIXI.Point#copy` => `PIXI.Point#copyFrom`
* `PIXI.ObservablePoint#copy` => `PIXI.ObservablePoint#copyFrom`
* `PIXI.Matrix#copy` => `PIXI.Matrix#copyTo`
* `PIXI.Rectangle#copy` => `PIXI.Rectangle#copyFrom`


### 🎁  Added

* `PIXI.Point#copyTo`
* `PIXI.ObservablePoint#copyTo`
* `PIXI.Matrix#copyFrom`
* `PIXI.Rectangle#copyTo`