### PR TITLE
Fixes handling of error when Spritesheet is valid but image is not

### DIFF
--- a/src/loaders/spritesheetParser.js
+++ b/src/loaders/spritesheetParser.js
@@ -31,6 +31,13 @@ export default function ()
         // load the image for this sheet
         this.add(imageResourceName, resourcePath, loadOptions, function onImageLoad(res)
         {
+            if (res.error)
+            {
+                next(res.error);
+
+                return;
+            }
+
             const spritesheet = new Spritesheet(
                 res.texture.baseTexture,
                 resource.data,

--- a/test/loaders/resources/atlas_error.json
+++ b/test/loaders/resources/atlas_error.json
@@ -1,0 +1,17 @@
+{
+    "frames": {
+        "boss1.png": {
+            "frame": {"x":1,"y":1,"w":168,"h":168},
+            "rotated": false,
+            "trimmed": false,
+            "spriteSourceSize": {"x":0,"y":0,"w":168,"h":168},
+            "sourceSize": {"w":168,"h":168}
+        }
+    },
+    "meta": {
+        "image": "invalid.png",
+        "format": "RGBA8888",
+        "size": {"w":170,"h":170},
+        "scale": "1"
+    }
+}

--- a/test/loaders/spritesheetParser.js
+++ b/test/loaders/spritesheetParser.js
@@ -85,6 +85,27 @@ describe('PIXI.loaders.spritesheetParser', function ()
         });
     });
 
+    it('should dispatch an error failing to load spritesheet image', function (done)
+    {
+        const spy = sinon.spy((error, ldr, res) =>
+        {
+            expect(res.name).to.equal('atlas_image');
+            expect(res.error).to.equal(error);
+            expect(error.toString()).to.have.string('Failed to load element using: IMG');
+        });
+        const loader = new PIXI.loaders.Loader();
+
+        loader.add('atlas', path.join(__dirname, 'resources', 'atlas_error.json'));
+        loader.onError.add(spy);
+        loader.load((loader, resources) =>
+        {
+            expect(resources.atlas_image.error).to.be.instanceof(Error);
+            expect(spy.calledOnce).to.be.true;
+            loader.reset();
+            done();
+        });
+    });
+
     it('should build the image url', function ()
     {
         function getResourcePath(url, image)


### PR DESCRIPTION
Fixes #4599

Properly handles situation where image is invalid but spritesheet JSON is not.