### PR TITLE
Support blendModes with NineSlicePlane and CanvasRenderer

### DIFF
--- a/src/mesh/NineSlicePlane.js
+++ b/src/mesh/NineSlicePlane.js
@@ -143,6 +143,7 @@ export default class NineSlicePlane extends Plane
         const context = renderer.context;
 
         context.globalAlpha = this.worldAlpha;
+        renderer.setBlendMode(this.blendMode);
 
         const transform = this.worldTransform;
         const res = renderer.resolution;


### PR DESCRIPTION
That's from Mesh:

```js
renderer.context.globalAlpha = mesh.worldAlpha;
renderer.setBlendMode(mesh.blendMode);
```

blendMode line is missing in NineSlicePlane. I can be a problem if something sets not-normal blendmode before NineSlicePlane is rendered.

Previously in Canvas Mesh: #4535