### PR TITLE
Adds `drawStar` method to Graphics

### DIFF
--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -5,7 +5,7 @@ import GraphicsData from './GraphicsData';
 import Sprite from '../sprites/Sprite';
 import { Matrix, Point, Rectangle, RoundedRectangle, Ellipse, Polygon, Circle } from '../math';
 import { hex2rgb, rgb2hex } from '../utils';
-import { SHAPES, BLEND_MODES } from '../const';
+import { SHAPES, BLEND_MODES, PI_2 } from '../const';
 import Bounds from '../display/Bounds';
 import bezierCurveTo from './utils/bezierCurveTo';
 import CanvasRenderer from '../renderers/canvas/CanvasRenderer';
@@ -481,15 +481,15 @@ export default class Graphics extends Container
 
         if (!anticlockwise && endAngle <= startAngle)
         {
-            endAngle += Math.PI * 2;
+            endAngle += PI_2;
         }
         else if (anticlockwise && startAngle <= endAngle)
         {
-            startAngle += Math.PI * 2;
+            startAngle += PI_2;
         }
 
         const sweep = endAngle - startAngle;
-        const segs = Math.ceil(Math.abs(sweep) / (Math.PI * 2)) * 40;
+        const segs = Math.ceil(Math.abs(sweep) / PI_2) * 40;
 
         if (sweep === 0)
         {
@@ -687,6 +687,40 @@ export default class Graphics extends Container
         this.drawShape(shape);
 
         return this;
+    }
+
+    /**
+     * Draw a star shape with an abitrary number of points.
+     *
+     * @param {number} x - Center X position of the star
+     * @param {number} y - Center Y position of the star
+     * @param {number} points - The number of points of the star, must be > 1
+     * @param {number} radius - The outer radius of the star
+     * @param {number} [innerRadius] - The inner radius between points, default half `radius`
+     * @param {number} [rotation=0] - The rotation of the star in radians, where 0 is vertical
+     * @return {PIXI.Graphics} This Graphics object. Good for chaining method calls
+     */
+    drawStar(x, y, points, radius, innerRadius, rotation = 0)
+    {
+        innerRadius = innerRadius || radius / 2;
+
+        const startAngle = (-1 * Math.PI / 2) + rotation;
+        const len = points * 2;
+        const delta = PI_2 / len;
+        const polygon = [];
+
+        for (let i = 0; i < len; i++)
+        {
+            const r = i % 2 ? innerRadius : radius;
+            const angle = (i * delta) + startAngle;
+
+            polygon.push(
+                x + (r * Math.cos(angle)),
+                y + (r * Math.sin(angle))
+            );
+        }
+
+        return this.drawPolygon(polygon);
     }
 
     /**


### PR DESCRIPTION
## Overview

I was looking at old un-submitted additions to Graphics that I created. This one is a very simple function that allows a user to draw a star shape with an arbitrary number of points with Graphics. This change is pretty light-weight because no new internal Shapes are added; it's rendered as a polygon shape. 

I think the functionality here is pretty small and generalized enough to be useful in Graphics and not as a plugin. Also, I'm making this PR to v4 because it's also an easy merge to v5 as well.

### :gift: Added

* Adds `drawStar` method to Graphics

### ✏️ Changed

* Replaced instances in Graphics of `Math.PI * 2` with the `PI_2` PIXI const

### 🔎 Example

https://jsfiddle.net/bigtimebuddy/08kcovyq/