### PR TITLE
Update mouse position in onPointerMove, when using a pen tablet

### DIFF
--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -1428,7 +1428,7 @@ export default class InteractionManager extends EventEmitter
 
         const events = this.normalizeToPointerData(originalEvent);
 
-        if (events[0].pointerType === 'mouse')
+        if (events[0].pointerType === 'mouse' || events[0].pointerType === 'pen')
         {
             this.didMove = true;
 


### PR DESCRIPTION
Update the mouse position in onPointerMove when using a pen tablet (like a wacom), the same as with a mouse. (Browsers that support Pointer events)