### PR TITLE
added min size restriction for Text canvas

### DIFF
--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -144,8 +144,8 @@ export default class Text extends Sprite
         const maxLineWidth = measured.maxLineWidth;
         const fontProperties = measured.fontProperties;
 
-        this.canvas.width = Math.ceil((width + (style.padding * 2)) * this.resolution);
-        this.canvas.height = Math.ceil((height + (style.padding * 2)) * this.resolution);
+        this.canvas.width = Math.ceil((Math.max(1, width) + (style.padding * 2)) * this.resolution);
+        this.canvas.height = Math.ceil((Math.max(1, height) + (style.padding * 2)) * this.resolution);
 
         context.scale(this.resolution, this.resolution);
 

--- a/test/core/Text.js
+++ b/test/core/Text.js
@@ -115,5 +115,19 @@ describe('PIXI.Text', function ()
 
             expect(text.text).to.equal(' ');
         });
+
+        it('should keep at least 1 pixel for canvas width and height', function ()
+        {
+            const text = new PIXI.Text('');
+
+            text.updateText();
+
+            expect(text.canvas.width).to.be.above(1);
+            expect(text.canvas.height).to.be.above(1);
+
+            text.text = '\n';
+
+            expect(text.canvas.width).to.be.above(1);
+        });
     });
 });


### PR DESCRIPTION
Fix for this issue,  details described in there.
https://github.com/pixijs/pixi.js/issues/4618

This pull request also contains unit test to ensure minimum canvas size.