### PR TITLE
Fix ColorMatrixFilter negative effect

### DIFF
--- a/src/filters/colormatrix/ColorMatrixFilter.js
+++ b/src/filters/colormatrix/ColorMatrixFilter.js
@@ -299,10 +299,10 @@ export default class ColorMatrixFilter extends core.Filter
     negative(multiply)
     {
         const matrix = [
-            -1,  0,  0,  0,  1,
-             0, -1,  0,  0,  1,
-             0,  0, -1,  0,  1,
-             0,  0,  0,  1,  0,
+            -1, 0, 0, 0, 1,
+            0, -1, 0, 0, 1,
+            0, 0, -1, 0, 1,
+            0, 0, 0, 1, 0,
         ];
 
         this._loadMatrix(matrix, multiply);

--- a/src/filters/colormatrix/ColorMatrixFilter.js
+++ b/src/filters/colormatrix/ColorMatrixFilter.js
@@ -299,10 +299,10 @@ export default class ColorMatrixFilter extends core.Filter
     negative(multiply)
     {
         const matrix = [
-            0, 1, 1, 0, 0,
-            1, 0, 1, 0, 0,
-            1, 1, 0, 0, 0,
-            0, 0, 0, 1, 0,
+            -1,  0,  0,  0,  1,
+             0, -1,  0,  0,  1,
+             0,  0, -1,  0,  1,
+             0,  0,  0,  1,  0,
         ];
 
         this._loadMatrix(matrix, multiply);

--- a/src/filters/colormatrix/ColorMatrixFilter.js
+++ b/src/filters/colormatrix/ColorMatrixFilter.js
@@ -299,9 +299,9 @@ export default class ColorMatrixFilter extends core.Filter
     negative(multiply)
     {
         const matrix = [
-            -1, 0, 0, 0, 1,
-            0, -1, 0, 0, 1,
-            0, 0, -1, 0, 1,
+            -1, 0, 0, 1, 0,
+            0, -1, 0, 1, 0,
+            0, 0, -1, 1, 0,
             0, 0, 0, 1, 0,
         ];
 


### PR DESCRIPTION
First off, thanks for PixiJS!

I have been experimenting with `ColorMatrixFilter` and was confused by the `negative` effect: my understanding was that it would invert the RGB colors, but that did not seem to be the case (as simple case try to invert a white shape on a black background); either I'm doing something wrong or the inversion matrix is simply wrong?

Using the matrix:

```
-1  0  0  0  1
 0 -1  0  0  1
 0  0 -1  0  1
 0  0  0  1  0
```

produces negatives for me.

On a related note, I noticed that multiplying effects (using the `multiply` parameter) produces strange results (using both built-in matrices and my own), because of the adjustments done by `_colorMatrix()`. If I multiply effects using `_multiply` and set the resulting matrix myself the result looks good to me (both the matrix and the visual effect).