### PR TITLE
Filter backdrop

### DIFF
--- a/src/core/renderers/webgl/filters/Filter.js
+++ b/src/core/renderers/webgl/filters/Filter.js
@@ -99,6 +99,19 @@ export default class Filter
          * @member {boolean}
          */
         this.autoFit = true;
+
+        /**
+         * If set, filterManager calculates background image and stores location in to specified uniform
+         * @member {string|null}
+         */
+        this.backdropUniformName = null;
+
+        /**
+         * temporary storage for backdrop render texture
+         * @member {PIXI.RenderTexture}
+         * @private
+         */
+        this._backdropRenderTexture = null;
     }
 
     /**

--- a/src/core/renderers/webgl/filters/Filter.js
+++ b/src/core/renderers/webgl/filters/Filter.js
@@ -102,12 +102,14 @@ export default class Filter
 
         /**
          * If set, filterManager calculates background image and stores location in to specified uniform
+         * Backdrop is explained here: https://www.w3.org/TR/compositing-1/#backdropCalc
+         * All those blending modes are possible to implement through this feature
          * @member {string|null}
          */
         this.backdropUniformName = null;
 
         /**
-         * temporary storage for backdrop render texture
+         * Temporary storage for backdrop render texture
          * @member {PIXI.RenderTexture}
          * @private
          */

--- a/src/core/renderers/webgl/filters/Filter.js
+++ b/src/core/renderers/webgl/filters/Filter.js
@@ -111,7 +111,14 @@ export default class Filter
          * @member {PIXI.RenderTexture}
          * @private
          */
-        this._backdropRenderTexture = null;
+        this._backdropRenderTarget = null;
+
+        /**
+         * color that is used to clear renderTarget before filter is applied
+         * RGBA array format
+         * @member {Float32Array}
+         */
+        this.clearColor = null;
     }
 
     /**

--- a/src/core/renderers/webgl/managers/FilterManager.js
+++ b/src/core/renderers/webgl/managers/FilterManager.js
@@ -203,6 +203,15 @@ export default class FilterManager extends WebGLManager
             this.freePotRenderTarget(flop);
         }
 
+        for (let i = 0; i < filters.length; i++)
+        {
+            if (filters[i]._backdropRenderTexture)
+            {
+                this.freePotRenderTarget(filters[i]._backdropRenderTexture);
+                filters[i]._backdropRenderTexture = null;
+            }
+        }
+
         filterData.index--;
 
         if (filterData.index === 0)
@@ -341,7 +350,8 @@ export default class FilterManager extends WebGLManager
 
         if (filter._backdropRenderTexture)
         {
-            shader.uniforms[filter._backdropUniformName] = this.renderer.bindTexture(filter._backdropRenderTexture, textureCount);
+            shader.uniforms[filter._backdropUniformName]
+                = this.renderer.bindTexture(filter._backdropRenderTexture, textureCount);
             textureCount++;
         }
 
@@ -686,5 +696,7 @@ export default class FilterManager extends WebGLManager
 
         renderer.bindTexture(rt, 1, true);
         gl.copyTexSubImage2D(gl.TEXTURE_2D, 0, 0, 0, x1, y1, pixelsWidth, pixelsHeight);
+
+        return rt;
     }
 }

--- a/src/core/renderers/webgl/managers/FilterManager.js
+++ b/src/core/renderers/webgl/managers/FilterManager.js
@@ -279,7 +279,8 @@ export default class FilterManager extends WebGLManager
         if (clear)
         {
             gl.disable(gl.SCISSOR_TEST);
-            renderer.clear(filter.clearColor);// [1, 1, 1, 1]);
+            // TODO - take next filter clear color
+            renderer.clear();// [1, 1, 1, 1]);
             gl.enable(gl.SCISSOR_TEST);
         }
 


### PR DESCRIPTION
Hello, new blendmodes!

Big problem: We cant merge this thing before we get rid of "non-compatible format" error in console. It existed in `pixi-picture` and it exists here, I dont know what's wrong with my implementation :(

### :gift: Added

* `filter.backdropUniformName` if set, filterManager copies backdrop buffer to the filter input, only if current renderTarget is a Framebuffer and not root.
* `filter.clearColor` specifies color to clear filter input.

### 🐛 Example

[JsFiddle](https://jsfiddle.net/Hackerham/xgnq4fc9/5/)

One displacementFilter takes care of two sprites at the same time. Try remove clearColor attribute and see a disaster in the center and around the sprites (filter padding)