### PR TITLE
Replaces PREFER_WEBGL_2 and options.legacy with ENV and PREFER_ENV

### DIFF
--- a/packages/app/src/Application.js
+++ b/packages/app/src/Application.js
@@ -46,8 +46,6 @@ export default class Application
      *  stopping pixel interpolation.
      * @param {boolean} [options.forceFXAA=false] - forces FXAA antialiasing to be used over native.
      *  FXAA is faster, but may not always look as great **webgl only**
-     * @param {boolean} [options.legacy=false] - `true` to ensure compatibility with older / less advanced devices.
-     *  If you experience unexplained flickering try setting this to true. **webgl only**
      * @param {string} [options.powerPreference] - Parameter passed to webgl context, set to "high-performance"
      *  for devices with dual graphics card **webgl only**
      * @param {boolean} [options.sharedTicker=false] - `true` to use PIXI.Ticker.shared, `false` to create new ticker.

--- a/packages/canvas/canvas-renderer/src/autoDetectRenderer.js
+++ b/packages/canvas/canvas-renderer/src/autoDetectRenderer.js
@@ -28,8 +28,6 @@ import CanvasRenderer from './CanvasRenderer';
  *  stopping pixel interpolation.
  * @param {boolean} [options.forceFXAA=false] - forces FXAA antialiasing to be used over native.
  *  FXAA is faster, but may not always look as great **webgl only**
- * @param {boolean} [options.legacy=false] - `true` to ensure compatibility with older / less advanced devices.
- *  If you experience unexplained flickering try setting this to true. **webgl only**
  * @param {string} [options.powerPreference] - Parameter passed to webgl context, set to "high-performance"
  *  for devices with dual graphics card **webgl only**
  * @return {PIXI.Renderer|PIXI.CanvasRenderer} Returns WebGL renderer if available, otherwise CanvasRenderer

--- a/packages/constants/src/index.js
+++ b/packages/constants/src/index.js
@@ -1,4 +1,23 @@
 /**
+ * Different types of environments for WebGL.
+ *
+ * @static
+ * @constant
+ * @memberof PIXI
+ * @name ENV
+ * @type {object}
+ * @property {number} WEBGL_LEGACY - Used for older v1 WebGL devices. PixiJS will aim to ensure compatibility
+ *  with older / less advanced devices. If you experiance unexplained flickering prefer this envionment.
+ * @property {number} WEBGL - Version 1 of WebGL
+ * @property {number} WEBGL2 - Version 2 of WebGL
+ */
+export const ENV = {
+    WEBGL_LEGACY: 0,
+    WEBGL: 1,
+    WEBGL2: 2,
+};
+
+/**
  * Constant to identify the Renderer Type.
  *
  * @static

--- a/packages/core/src/Renderer.js
+++ b/packages/core/src/Renderer.js
@@ -54,8 +54,6 @@ export default class Renderer extends AbstractRenderer
      *  rendering, stopping pixel interpolation.
      * @param {number} [options.backgroundColor=0x000000] - The background color of the rendered area
      *  (shown if not transparent).
-     * @param {boolean} [options.legacy=false] - If true PixiJS will aim to ensure compatibility
-     *  with older / less advanced devices. If you experiance unexplained flickering try setting this to true.
      * @param {string} [options.powerPreference] - Parameter passed to webgl context, set to "high-performance"
      *  for devices with dual graphics card
      */
@@ -74,7 +72,6 @@ export default class Renderer extends AbstractRenderer
         // this will be set by the contextSystem (this.context)
         this.gl = null;
         this.CONTEXT_UID = 0;
-        this.legacy = !!options.legacy;
 
         // TODO legacy!
 

--- a/packages/core/src/context/ContextSystem.js
+++ b/packages/core/src/context/ContextSystem.js
@@ -74,7 +74,7 @@ export default class ContextSystem extends System
     {
         let gl;
 
-        if (settings.PREFER_WEBGL_2)
+        if (settings.PREFER_WEBGL_2 && !this.renderer.legacy)
         {
             gl = canvas.getContext('webgl2', options);
         }

--- a/packages/core/src/context/ContextSystem.js
+++ b/packages/core/src/context/ContextSystem.js
@@ -1,5 +1,6 @@
 import System from '../System';
-import { settings } from '@pixi/settings';
+import { settings } from '../settings';
+import { ENV } from '@pixi/constants';
 
 let CONTEXT_UID = 0;
 
@@ -74,7 +75,7 @@ export default class ContextSystem extends System
     {
         let gl;
 
-        if (settings.PREFER_WEBGL_2 && !this.renderer.legacy)
+        if (settings.PREFER_ENV >= ENV.WEBGL2)
         {
             gl = canvas.getContext('webgl2', options);
         }

--- a/packages/core/src/geometry/GeometrySystem.js
+++ b/packages/core/src/geometry/GeometrySystem.js
@@ -1,5 +1,7 @@
 import System from '../System';
 import GLBuffer from './GLBuffer';
+import { ENV } from '@pixi/constants';
+import { settings } from '../settings';
 
 const byteSizeMap = { 5126: 4, 5123: 2, 5121: 1 };
 
@@ -41,7 +43,7 @@ export default class GeometrySystem extends System
             // webgl 1!
             let nativeVaoExtension = this.renderer.context.extensions.vertexArrayObject;
 
-            if (this.renderer.legacy)
+            if (settings.PREFER_ENV === ENV.WEBGL_LEGACY)
             {
                 nativeVaoExtension = null;
             }

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -1,6 +1,8 @@
 import * as resources from './textures/resources';
 import * as systems from './systems';
 
+import './settings';
+
 export { systems };
 export { resources };
 

--- a/packages/core/src/settings.js
+++ b/packages/core/src/settings.js
@@ -11,7 +11,7 @@ import { ENV } from '@pixi/constants';
  * @static
  * @constant
  * @name PREFER_ENV
- * @memberof PIXI
+ * @memberof PIXI.settings
  * @type {number}
  * @default PIXI.ENV.WEBGL2
  */

--- a/packages/core/src/settings.js
+++ b/packages/core/src/settings.js
@@ -1,0 +1,20 @@
+import { settings } from '@pixi/settings';
+import { ENV } from '@pixi/constants';
+
+/**
+ * The maximum support for using WebGL. If a device does not
+ * support WebGL version, for instance WebGL 2, it will still
+ * attempt to fallback support to WebGL 1. If you want to
+ * explicitly remove feature support to target a more stable
+ * baseline, prefer a lower environment.
+ *
+ * @static
+ * @constant
+ * @name PREFER_ENV
+ * @memberof PIXI
+ * @type {number}
+ * @default PIXI.ENV.WEBGL2
+ */
+settings.PREFER_ENV = ENV.WEBGL2;
+
+export { settings };

--- a/packages/core/src/shader/utils/getTestContext.js
+++ b/packages/core/src/shader/utils/getTestContext.js
@@ -1,4 +1,5 @@
-import { settings } from '@pixi/settings';
+import { settings } from '../../settings';
+import { ENV } from '@pixi/constants';
 
 let context = null;
 
@@ -17,7 +18,7 @@ export default function getTestContext()
 
         let gl;
 
-        if (settings.PREFER_WEBGL_2)
+        if (settings.PREFER_ENV >= ENV.WEBGL2)
         {
             gl = canvas.getContext('webgl2', {});
         }

--- a/packages/core/test/Renderer.js
+++ b/packages/core/test/Renderer.js
@@ -1,4 +1,6 @@
 const { Renderer } = require('../');
+const { settings } = require('@pixi/settings');
+const { ENV } = require('@pixi/constants');
 const { isWebGLSupported, skipHello } = require('@pixi/utils');
 
 skipHello();
@@ -12,7 +14,8 @@ describe('PIXI.Renderer', function ()
 {
     it('setting option legacy should disable VAOs and SPRITE_MAX_TEXTURES', withGL(function ()
     {
-        const renderer = new Renderer({ legacy: true, width: 1, height: 1 });
+        settings.PREFER_ENV = ENV.WEBGL_LEGACY;
+        const renderer = new Renderer(1, 1);
 
         try
         {
@@ -23,6 +26,7 @@ describe('PIXI.Renderer', function ()
         {
             renderer.destroy();
         }
+        settings.PREFER_ENV = ENV.WEBGL2;
     }));
 
     it('should allow clear() to work despite no containers added to the renderer', withGL(function ()

--- a/packages/settings/src/settings.js
+++ b/packages/settings/src/settings.js
@@ -37,16 +37,6 @@ export default {
     RESOLUTION: 1,
 
     /**
-     * Prefer the use of WebGL v2 by default.
-     *
-     * @static
-     * @memberof PIXI.settings
-     * @type {boolean}
-     * @default true
-     */
-    PREFER_WEBGL_2: true,
-
-    /**
      * Default filter resolution.
      *
      * @static

--- a/packages/sprite/src/SpriteRenderer.js
+++ b/packages/sprite/src/SpriteRenderer.js
@@ -7,6 +7,7 @@ import { createIndicesForQuads, premultiplyBlendMode, premultiplyTint } from '@p
 import bitTwiddle from 'bit-twiddle';
 import BatchBuffer from './BatchBuffer';
 import generateMultiTextureShader from './generateMultiTextureShader';
+import { ENV } from '@pixi/constants';
 
 let TICK = 0;
 // const TEXTURE_TICK = 0;
@@ -103,7 +104,7 @@ export default class SpriteRenderer extends ObjectRenderer
     {
         const gl = this.renderer.gl;
 
-        if (this.renderer.legacy)
+        if (settings.PREFER_ENV === ENV.WEBGL_LEGACY)
         {
             this.MAX_TEXTURES = 1;
         }


### PR DESCRIPTION
The following test is breaking locally: `setting option legacy should disable VAOs and SPRITE_MAX_TEXTURES` ~, this will disable WebGL2 if `legacy` is enabled.~

### Added

* Adds `PIXI.ENV` enum which describes the different type of maximum environmental settings that PixiJS will attempt to deal with using WebGL (v1, v2, and v1 legacy)
* Adds `PIXI.settings.PREFER_ENV` which accepts values from `PIXI.ENV`.