### PR TITLE
[next] Improves Use of Minified Bundles

### DIFF
--- a/bundles/pixi.js-legacy/package.json
+++ b/bundles/pixi.js-legacy/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "test": "floss --path test",
-    "postversion": "cd ../.. && npm run build"
+    "build:min": "uglifyjs dist/pixi-legacy.js -c -m -o dist/pixi-legacy.min.js --source-map \"content='dist/pixi-legacy.js.map',includeSources=true,filename='dist/pixi-legacy.min.js.map',url='pixi-legacy.min.js.map'\" --comments \"/pixi.js-legacy - /\""
   },
   "files": [
     "lib/"
@@ -40,6 +40,7 @@
     "@pixi/polyfill": "^5.0.0-alpha"
   },
   "devDependencies": {
-    "floss": "^2.1.3"
+    "floss": "^2.1.3",
+    "uglify-es": "^3.3.9"
   }
 }

--- a/bundles/pixi.js/package.json
+++ b/bundles/pixi.js/package.json
@@ -20,7 +20,8 @@
     "url": "https://github.com/pixijs/pixi.js.git"
   },
   "scripts": {
-    "test": "floss --path test"
+    "test": "floss --path test",
+    "build:min": "uglifyjs dist/pixi.js -c -m -o dist/pixi.min.js --source-map \"content='dist/pixi.js.map',includeSources=true,filename='dist/pixi.min.js.map',url='pixi.min.js.map'\" --comments \"/pixi.js - /\""
   },
   "files": [
     "lib/"
@@ -60,6 +61,7 @@
     "@pixi/utils": "^5.0.0-alpha"
   },
   "devDependencies": {
-    "floss": "^2.1.3"
+    "floss": "^2.1.3",
+    "uglify-es": "^3.3.9"
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.4.0",
+  "lerna": "2.9.0",
   "packages": [
     "bundles/*",
     "packages/*",

--- a/package.json
+++ b/package.json
@@ -3,25 +3,25 @@
   "scripts": {
     "postinstall": "npm run bootstrap",
     "bootstrap": "lerna bootstrap --hoist",
-    "clean:build": "rimraf \"{bundles,packages,packages/canvas,packages/filters}/*/lib\"",
+    "clean:build": "rimraf \"{bundles,packages,packages/canvas,packages/filters}/*/{lib,dist}\"",
     "preclean": "npm run clean:build",
     "clean": "lerna clean",
-    "pretest": "npm run lint && npm run build:dev",
+    "pretest": "npm run lint && npm run build",
     "test": "floss --path test",
     "unit-test": "floss --path test",
     "docs": "jsdoc -c jsdoc.conf.json -R README.md",
     "lint": "eslint *.js test bundles packages tools --ignore-path .gitignore --max-warnings 0",
     "lintfix": "npm run lint -- --fix",
     "prebuild": "npm run clean:build",
-    "build": "npm run build:prod",
-    "build:dev": "rollup -c",
-    "build:prod": "rollup -c --prod",
+    "build:min": "lerna run build:min --concurrency 1 --scope pixi*",
+    "build": "rollup -c",
     "watch": "rollup -cw",
     "lerna": "lerna",
     "predist": "rimraf dist/*",
-    "dist": "npm run docs && npm run build:prod -- --scope \"pixi.js*\"",
+    "dist": "npm run docs && npm run build:min",
     "postdist": "copyfiles -f \"bundles/*/dist/*\" dist",
     "prerelease": "npm run clean:build && npm test",
+    "postversion": "npm run build && npm run build:min",
     "release": "lerna publish"
   },
   "pre-commit": [
@@ -35,7 +35,7 @@
     "floss": "^2.1.3",
     "glob": "^7.1.2",
     "jsdoc": "^3.4.0",
-    "lerna": "^2.4.0",
+    "lerna": "^2.9.0",
     "minimist": "^1.2.0",
     "pre-commit": "^1.2.2",
     "rimraf": "^2.6.2",
@@ -45,8 +45,6 @@
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-replace": "^2.0.0",
     "rollup-plugin-sourcemaps": "^0.4.2",
-    "rollup-plugin-string": "^2.0.2",
-    "rollup-plugin-uglify": "^2.0.1",
-    "uglify-es": "^3.0.25"
+    "rollup-plugin-string": "^2.0.2"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,21 +5,17 @@ import transpile from 'rollup-plugin-buble';
 import resolve from 'rollup-plugin-node-resolve';
 import string from 'rollup-plugin-string';
 import sourcemaps from 'rollup-plugin-sourcemaps';
-import uglify from 'rollup-plugin-uglify';
-import { minify } from 'uglify-es';
 import minimist from 'minimist';
 import commonjs from 'rollup-plugin-commonjs';
 import replace from 'rollup-plugin-replace';
 
 // Support --scope and --ignore globs
 const args = minimist(process.argv.slice(2), {
-    boolean: ['prod', 'bundles'],
+    boolean: ['bundles'],
     default: {
-        prod: false,
         bundles: true,
     },
     alias: {
-        p: 'prod',
         b: 'bundles',
     },
 });
@@ -52,20 +48,6 @@ const plugins = [
     }),
     transpile(),
 ];
-
-if (args.prod)
-{
-    plugins.push(uglify({
-        mangle: true,
-        compress: true,
-        output: {
-            comments(node, comment)
-            {
-                return comment.line === 1;
-            },
-        },
-    }, minify));
-}
 
 const compiled = (new Date()).toUTCString().replace(/GMT/g, 'UTC');
 const sourcemap = true;


### PR DESCRIPTION
### Changes

* Packages are not longer minified, because these libraries are not consumable by the browser directly via `<script>` tag (use for Webpack, etc), users should be responsible for the type of minifying they want. Removing uglify from the Rollup plugins makes the build faster.
* Bundles now generate both minified and unminified browser files, these are also deployed to Travis and published to NPM. Consistent with v4.
   * [**pixi.js**](https://pixijs.download/next-bundle-minification/pixi.js)
   * [**pixi.min.js**](https://pixijs.download/next-bundle-minification/pixi.min.js)
   * [**pixi-legacy.js**](https://pixijs.download/next-bundle-minification/pixi-legacy.js)
   * [**pixi-legacy.min.js**](https://pixijs.download/next-bundle-minification/pixi-legacy.min.js)
* Bumped Lerna to latest for the `postversion` hook available in 2.7+ (will help publishing)