### PR TITLE
Polyfill interactionData buttons property via event.which for Safari browser

### DIFF
--- a/src/interaction/InteractionData.js
+++ b/src/interaction/InteractionData.js
@@ -164,9 +164,8 @@ export default class InteractionData
      * Copies properties from normalized event data.
      *
      * @param {Touch|MouseEvent|PointerEvent} event The normalized event data
-     * @private
      */
-    _copyEvent(event)
+    copyEvent(event)
     {
         // isPrimary should only change on touchstart/pointerdown, so we don't want to overwrite
         // it with "false" on later events when our shim for it on touch events might not be
@@ -176,7 +175,9 @@ export default class InteractionData
             this.isPrimary = true;
         }
         this.button = event.button;
-        this.buttons = event.buttons;
+        // event.buttons is not available in all browsers (ie. Safari), but it does have a non-standard
+        // event.which property instead, which conveys the same information.
+        this.buttons = Number.isInteger(event.buttons) ? event.buttons : event.which;
         this.width = event.width;
         this.height = event.height;
         this.tiltX = event.tiltX;
@@ -190,10 +191,8 @@ export default class InteractionData
 
     /**
      * Resets the data for pooling.
-     *
-     * @private
      */
-    _reset()
+    reset()
     {
         // isPrimary is the only property that we really need to reset - everything else is
         // guaranteed to be overwritten

--- a/src/interaction/InteractionEvent.js
+++ b/src/interaction/InteractionEvent.js
@@ -59,10 +59,8 @@ export default class InteractionEvent
 
     /**
      * Resets the event.
-     *
-     * @private
      */
-    _reset()
+    reset()
     {
         this.stopped = false;
         this.currentTarget = null;

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -1661,7 +1661,7 @@ export default class InteractionManager extends EventEmitter
         }
         // copy properties from the event, so that we can make sure that touch/pointer specific
         // data is available
-        interactionData._copyEvent(event);
+        interactionData.copyEvent(event);
 
         return interactionData;
     }
@@ -1679,7 +1679,7 @@ export default class InteractionManager extends EventEmitter
         if (interactionData)
         {
             delete this.activeInteractionData[pointerId];
-            interactionData._reset();
+            interactionData.reset();
             this.interactionDataPool.push(interactionData);
         }
     }
@@ -1717,7 +1717,7 @@ export default class InteractionManager extends EventEmitter
         }
 
         interactionData.originalEvent = pointerEvent;
-        interactionEvent._reset();
+        interactionEvent.reset();
 
         return interactionEvent;
     }


### PR DESCRIPTION
event.buttons is not supported on Safari: https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
However, it does have a non-standard event.which property, which we can use as a backup to convey the same information.
Also, whilst around here, changed private functions to public in InteractionData; they were clearly not private as they are used externally in InteractionManager.js