### PR TITLE
[next] mask alpha fix

### DIFF
--- a/packages/core/src/filters/spriteMask/SpriteMaskFilter.js
+++ b/packages/core/src/filters/spriteMask/SpriteMaskFilter.js
@@ -52,6 +52,7 @@ export default class SpriteMaskFilter extends Filter
         }
         tex.transform.update();
 
+        this.uniforms.npmAlpha = tex.baseTexture.premultiplyAlpha ? 0.0 : 1.0;
         this.uniforms.mask = tex;
         this.uniforms.otherMatrix = filterManager.calculateSpriteMatrix(this.maskMatrix, maskSprite)
             .prepend(tex.transform.mapCoord);

--- a/packages/core/src/filters/spriteMask/spriteMaskFilter.frag
+++ b/packages/core/src/filters/spriteMask/spriteMaskFilter.frag
@@ -4,6 +4,7 @@ varying vec2 vTextureCoord;
 uniform sampler2D uSampler;
 uniform sampler2D mask;
 uniform float alpha;
+uniform float npmAlpha;
 uniform vec4 maskClamp;
 
 void main(void)
@@ -16,8 +17,10 @@ void main(void)
 
     vec4 original = texture2D(uSampler, vTextureCoord);
     vec4 masky = texture2D(mask, vMaskCoord);
+    float alphaMul = 1.0 - npmAlpha * (1.0 - masky.a);
 
-    original *= (masky.r * masky.a * alpha * clip);
+    original.rgb *= 1.0 - npmAlpha * (1.0 - original.a);
+    original *= (alphaMul * masky.r * alpha * clip);
 
     gl_FragColor = original;
 }

--- a/packages/core/src/filters/spriteMask/spriteMaskFilter.frag
+++ b/packages/core/src/filters/spriteMask/spriteMaskFilter.frag
@@ -19,7 +19,6 @@ void main(void)
     vec4 masky = texture2D(mask, vMaskCoord);
     float alphaMul = 1.0 - npmAlpha * (1.0 - masky.a);
 
-    original.rgb *= 1.0 - npmAlpha * (1.0 - original.a);
     original *= (alphaMul * masky.r * alpha * clip);
 
     gl_FragColor = original;

--- a/packages/core/src/mask/MaskSystem.js
+++ b/packages/core/src/mask/MaskSystem.js
@@ -113,7 +113,7 @@ export default class MaskSystem extends System
         // TODO - may cause issues!
         target.filterArea = maskData.getBounds(true);
 
-        this.renderer.filterSystem.pushFilter(target, alphaMaskFilter);
+        this.renderer.filter.push(target, alphaMaskFilter);
 
         this.alphaMaskIndex++;
     }
@@ -124,7 +124,7 @@ export default class MaskSystem extends System
      */
     popSpriteMask()
     {
-        this.renderer.filterSystem.popFilter();
+        this.renderer.filter.pop();
         this.alphaMaskIndex--;
     }
 

--- a/packages/display/src/DisplayObject.js
+++ b/packages/display/src/DisplayObject.js
@@ -582,6 +582,8 @@ export default class DisplayObject extends EventEmitter
      * PIXI.Graphics or a PIXI.Sprite object. This allows for much faster masking in canvas as it
      * utilises shape clipping. To remove a mask, set this property to null.
      *
+     * For sprite mask both alpha and red channel are used. Black mask is the same as transparent mask.
+     *
      * @todo For the moment, PIXI.CanvasRenderer doesn't support PIXI.Sprite as mask.
      *
      * @member {PIXI.Graphics|PIXI.Sprite}


### PR DESCRIPTION
First, MaskSystem was broken.
Second, I found the problem in SpriteMaskFilter shader that existed in v4.

This line in SpriteMaskFilter shader is wrong for masks that have alpha component, because R is premultiplied.

```glsl
original *= (masky.a * masky.r * alpha * clip);
```

Lets fix it and allow to use NPM textures too.

Current: http://pixijs.io/examples/?v=next#/demos/alpha-mask.js
Fix: http://pixijs.io/examples/?v=next-mask-alpha#/demos/alpha-mask.js
NPM fix: https://jsfiddle.net/Hackerham/6os1us0o/6/