### PR TITLE
[next] blendFuncSeparate fix

### DIFF
--- a/packages/core/src/state/StateSystem.js
+++ b/packages/core/src/state/StateSystem.js
@@ -188,7 +188,17 @@ export default class StateSystem extends System
         }
 
         this.blendMode = value;
-        this.gl.blendFunc(this.blendModes[value][0], this.blendModes[value][1]);
+
+        const mode = this.blendModes[value];
+
+        if (mode.length === 2)
+        {
+            this.gl.blendFunc(mode[0], mode[1]);
+        }
+        else
+        {
+            this.gl.blendFuncSeparate(mode[0], mode[1], mode[2], mode[3]);
+        }
     }
 
     /**

--- a/packages/core/src/state/utils/mapWebGLBlendModesToPixi.js
+++ b/packages/core/src/state/utils/mapWebGLBlendModesToPixi.js
@@ -7,8 +7,8 @@ import { BLEND_MODES } from '@pixi/constants';
  * @function mapWebGLBlendModesToPixi
  * @private
  * @param {WebGLRenderingContext} gl - The rendering context.
- * @param {string[]} [array=[]] - The array to output into.
- * @return {string[]} Mapped modes.
+ * @param {number[][]} [array=[]] - The array to output into.
+ * @return {number[][]} Mapped modes.
  */
 export default function mapWebGLBlendModesToPixi(gl, array = [])
 {


### PR DESCRIPTION
Copy of V4 code:

https://github.com/pixijs/pixi.js/blob/dev/src/core/renderers/webgl/WebGLState.js#L158

This allows to use NPM modes.