### PR TITLE
[next] image bitmap bug

### DIFF
--- a/packages/core/src/textures/resources/ImageResource.js
+++ b/packages/core/src/textures/resources/ImageResource.js
@@ -66,7 +66,7 @@ export default class ImageResource extends BaseImageResource
          * @member {boolean|null}
          * @readonly
          */
-        this.premultiplyAlpha = options.premultiplyAlpha !== 'undefined' ? options.premultiplyAlpha : true;
+        this.premultiplyAlpha = options.premultiplyAlpha !== false;
 
         /**
          * The ImageBitmap element created for HTMLImageElement

--- a/packages/core/src/textures/resources/ImageResource.js
+++ b/packages/core/src/textures/resources/ImageResource.js
@@ -142,9 +142,10 @@ export default class ImageResource extends BaseImageResource
      * Called when we need to convert image into BitmapImage.
      * Can be called multiple times, real promise is cached inside.
      *
+     * @param {PIXI.BaseTexture} baseTexture - BaseTexture for this resource
      * @returns {Promise} cached promise to fill that bitmap
      */
-    process()
+    process(baseTexture)
     {
         if (this._process !== null)
         {
@@ -155,7 +156,11 @@ export default class ImageResource extends BaseImageResource
             return Promise.resolve(this);
         }
 
-        this._process = window.createImageBitmap(this.source)
+        this._process = window.createImageBitmap(this.source,
+            0, 0, this.source.width, this.source.height,
+            {
+                premultiplyAlpha: baseTexture.premultiplyAlpha ? 'premultiply' : 'none',
+            })
             .then((bitmap) =>
             {
                 if (this.destroyed)

--- a/packages/core/src/textures/resources/ImageResource.js
+++ b/packages/core/src/textures/resources/ImageResource.js
@@ -117,7 +117,7 @@ export default class ImageResource extends BaseImageResource
 
                 if (this.createBitmap)
                 {
-                    resolve(this.process());
+                    resolve(this.process(/* baseTexture */));
                 }
                 else
                 {
@@ -191,7 +191,7 @@ export default class ImageResource extends BaseImageResource
             if (!this.bitmap)
             {
                 // yeah, ignore the output
-                this.process();
+                this.process(baseTexture);
                 if (!this.bitmap)
                 {
                     return false;


### PR DESCRIPTION
Chrome ignores webgl texture upload params in favor of createImageBitmap params.

Pixi: https://jsfiddle.net/Hackerham/6os1us0o/113/
WebGL: https://fiddle.jshell.net/sosw339h/36/

Coordinates were added as params because Firefox doesnt like the fact I pass only `options`

Reported: https://bugzilla.mozilla.org/show_bug.cgi?id=1442632