### PR TITLE
Hotfix for rollup-plugin-commonjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^2.6.2",
     "rollup": "^0.52.0",
     "rollup-plugin-buble": "^0.18.0",
-    "rollup-plugin-commonjs": "^8.2.4",
+    "rollup-plugin-commonjs": "8.3.0",
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-replace": "^2.0.0",
     "rollup-plugin-sourcemaps": "^0.4.2",


### PR DESCRIPTION
This is causing next to fail on Travis. Filed related issue here: https://github.com/rollup/rollup-plugin-commonjs/issues/299

### Future Recommendations

* I would like to upgrade to the latest Rollup (which fixes the issue with commonjs) but I found a bug that prevents me from doing that when building the bundles. Rollup is having issues with importing a namespace and using a single class from that namespace. Will try to sort out a bug issue for Rollup. 
* Also, I would like to start checking in shrinkwrap/lock file to **next** to prevent this happening in future. We cannot have external dependencies break us so easily.