### PR TITLE
Repeating deprecation warnings #4443

### DIFF
--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -1,6 +1,10 @@
 // provide method to give a stack track for warnings
 // useful for tracking-down where deprecated methods/properties/classes
 // are being used within the code
+
+// message/stack map - helps to prevent showing deprecation warning if it was already shown
+const shownWarningStacks = {};
+
 function warn(msg)
 {
     // @if DEBUG
@@ -17,21 +21,27 @@ function warn(msg)
         // chop off the stack trace which includes pixi.js internal calls
         stack = stack.split('\n').splice(3).join('\n');
 
-        if (console.groupCollapsed)
+        // don't show warning message if it was already shown
+        if (!shownWarningStacks[msg])
         {
-            console.groupCollapsed(
-                '%cDeprecation Warning: %c%s',
-                'color:#614108;background:#fffbe6',
-                'font-weight:normal;color:#614108;background:#fffbe6',
-                msg
-            );
-            console.warn(stack);
-            console.groupEnd();
-        }
-        else
-        {
-            console.warn('Deprecation Warning: ', msg);
-            console.warn(stack);
+            shownWarningStacks[msg] = stack;
+
+            if (console.groupCollapsed)
+            {
+                console.groupCollapsed(
+                    '%cDeprecation Warning: %c%s',
+                    'color:#614108;background:#fffbe6',
+                    'font-weight:normal;color:#614108;background:#fffbe6',
+                    msg
+                );
+                console.warn(stack);
+                console.groupEnd();
+            }
+            else
+            {
+                console.warn('Deprecation Warning: ', msg);
+                console.warn(stack);
+            }
         }
     }
     /* eslint-enable no-console */

--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -2,7 +2,7 @@
 // useful for tracking-down where deprecated methods/properties/classes
 // are being used within the code
 
-// message/stack map - helps to prevent showing deprecation warning if it was already shown
+// message/stack map - helps to prevent showing same deprecation warning several times
 const shownWarningStacks = {};
 
 function warn(msg)
@@ -22,7 +22,7 @@ function warn(msg)
         stack = stack.split('\n').splice(3).join('\n');
 
         // don't show warning message if it was already shown
-        if (!shownWarningStacks[msg])
+        if (!shownWarningStacks[msg] || shownWarningStacks[msg] !== stack)
         {
             shownWarningStacks[msg] = stack;
 

--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -2,12 +2,20 @@
 // useful for tracking-down where deprecated methods/properties/classes
 // are being used within the code
 
-// message/stack map - helps to prevent showing same deprecation warning several times
-const shownWarningStacks = {};
+// A map of warning messages already fired
+const warnings = {};
 
+// provide method to give a stack track for warnings
+// useful for tracking-down where deprecated methods/properties/classes
+// are being used within the code
 function warn(msg)
 {
-    // @if DEBUG
+    // Ignore duplicat
+    if (warnings[msg])
+    {
+        return;
+    }
+
     /* eslint-disable no-console */
     let stack = new Error().stack;
 
@@ -21,31 +29,26 @@ function warn(msg)
         // chop off the stack trace which includes pixi.js internal calls
         stack = stack.split('\n').splice(3).join('\n');
 
-        // don't show warning message if it was already shown
-        if (!shownWarningStacks[msg] || shownWarningStacks[msg] !== stack)
+        if (console.groupCollapsed)
         {
-            shownWarningStacks[msg] = stack;
-
-            if (console.groupCollapsed)
-            {
-                console.groupCollapsed(
-                    '%cDeprecation Warning: %c%s',
-                    'color:#614108;background:#fffbe6',
-                    'font-weight:normal;color:#614108;background:#fffbe6',
-                    msg
-                );
-                console.warn(stack);
-                console.groupEnd();
-            }
-            else
-            {
-                console.warn('Deprecation Warning: ', msg);
-                console.warn(stack);
-            }
+            console.groupCollapsed(
+                '%cDeprecation Warning: %c%s',
+                'color:#614108;background:#fffbe6',
+                'font-weight:normal;color:#614108;background:#fffbe6',
+                msg
+            );
+            console.warn(stack);
+            console.groupEnd();
+        }
+        else
+        {
+            console.warn('Deprecation Warning: ', msg);
+            console.warn(stack);
         }
     }
     /* eslint-enable no-console */
-    // @endif
+
+    warnings[msg] = true;
 }
 
 export default function deprecation(core)


### PR DESCRIPTION
Added message-stack map to prevent showing multiple warning messages from same place. 
Didn't change anything for case with "IE < 10 and Safari < 6" - should I add separate array to store shown messages for this case?

Fix for issue #4443