### PR TITLE
Fix typo in PIXI.WRAP_MODES docs

### DIFF
--- a/src/core/const.js
+++ b/src/core/const.js
@@ -158,7 +158,7 @@ export const SCALE_MODES = {
 /**
  * The wrap modes that are supported by pixi.
  *
- * The {@link PIXI.settings.WRAP_MODE} wrap mode affects the default wraping mode of future operations.
+ * The {@link PIXI.settings.WRAP_MODE} wrap mode affects the default wrapping mode of future operations.
  * It can be re-assigned to either CLAMP or REPEAT, depending upon suitability.
  * If the texture is non power of two then clamp will be used regardless as webGL can
  * only use REPEAT if the texture is po2.


### PR DESCRIPTION
Noticed this small typo while reading up on http://pixijs.download/dev/docs/PIXI.html#.WRAP_MODES

Changes `wraping` to `wrapping`.