### PR TITLE
[next] Disables release build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,16 +58,16 @@ deploy:
         all_branches: true
         condition: $TRAVIS_TAG
   # Deploy config for latest release
-  - provider: s3
-    access_key_id: $S3_ACCESS_KEY_ID
-    secret_access_key: $S3_SECRET_ACCESS_KEY
-    bucket: "pixi.js"
-    skip_cleanup: true
-    acl: public_read
-    region: eu-west-1
-    cache_control: "max-age=1209600"
-    local_dir: dist
-    upload-dir: "release"
-    on:
-        all_branches: true
-        condition: $TRAVIS_TAG
+  # - provider: s3
+  #   access_key_id: $S3_ACCESS_KEY_ID
+  #   secret_access_key: $S3_SECRET_ACCESS_KEY
+  #   bucket: "pixi.js"
+  #   skip_cleanup: true
+  #   acl: public_read
+  #   region: eu-west-1
+  #   cache_control: "max-age=1209600"
+  #   local_dir: dist
+  #   upload-dir: "release"
+  #   on:
+  #       all_branches: true
+  #       condition: $TRAVIS_TAG

--- a/packages/graphics/src/GraphicsRenderer.js
+++ b/packages/graphics/src/GraphicsRenderer.js
@@ -216,10 +216,11 @@ export default class GraphicsRenderer extends ObjectRenderer
 
         if (!webGLData || webGLData.nativeLines !== nativeLines || webGLData.points.length > 320000)
         {
-            webGLData = this.graphicsDataPool.pop()
-            || new WebGLGraphicsData(this.renderer.gl,
-                    this.primitiveShader,
-                    this.renderer.state.attribsState);
+            webGLData = this.graphicsDataPool.pop() || new WebGLGraphicsData(
+                this.renderer.gl,
+                this.primitiveShader,
+                this.renderer.state.attribsState
+            );
 
             webGLData.nativeLines = nativeLines;
 


### PR DESCRIPTION
I need to temporarily disable deploying the latest release with Travis on **next**. Need a better solution to deal with pre-releases and S3 deployment. This change will not put v5-alpha.2 as the latest release.