### PR TITLE
Added resolution check

### DIFF
--- a/packages/core/src/textures/Texture.js
+++ b/packages/core/src/textures/Texture.js
@@ -279,13 +279,18 @@ export default class Texture extends EventEmitter
      * @param {object} [options] See {@link PIXI.BaseTexture}'s constructor for options.
      * @return {PIXI.Texture} The newly created texture
      */
-    static from(source, options)
+    static from(source, options = {})
     {
         let cacheId = null;
 
         if (typeof source === 'string')
         {
             cacheId = source;
+
+            if (!options.resolution)
+            {
+                options.resolution = getResolutionOfUrl(source);
+            }
         }
         else
         {


### PR DESCRIPTION
If no resolution is passed to when using ```PIXI.Texture.from```
Pixi will try to figure out the resolution based on the url.
This brings the behaviour in line with how textures are loaded using the loader. Happy days!