### PR TITLE
Clean up of sprite helper functions

### DIFF
--- a/bundles/pixi.js/src/deprecated.js
+++ b/bundles/pixi.js/src/deprecated.js
@@ -824,4 +824,112 @@ export default function deprecated(PIXI)
         BlurXFilter,
         BlurYFilter,
     });
+
+    const { Sprite, Texture } = PIXI;
+
+    // Use these to deprecate all the Sprite from* methods
+    function spriteFrom(name, source, crossorigin, scaleMode)
+    {
+        warn(`PIXI.Sprite.${name} is deprecated, use PIXI.Sprite.from`);
+
+        return Sprite.from(source, {
+            resourceOptions: {
+                scale: scaleMode,
+                crossorigin,
+            },
+        });
+    }
+
+    /**
+     * @deprecated since 5.0.0
+     * @see PIXI.Sprite.from
+     * @method PIXI.Sprite.fromImage
+     * @return {PIXI.Sprite}
+     */
+    Sprite.fromImage = spriteFrom.bind(null, 'fromImage');
+
+    /**
+     * @deprecated since 5.0.0
+     * @method PIXI.Sprite.fromSVG
+     * @see PIXI.Sprite.from
+     * @return {PIXI.Sprite}
+     */
+    Sprite.fromSVG = spriteFrom.bind(null, 'fromSVG');
+
+    /**
+     * @deprecated since 5.0.0
+     * @method PIXI.Sprite.fromCanvas
+     * @see PIXI.Sprite.from
+     * @return {PIXI.Sprite}
+     */
+    Sprite.fromCanvas = spriteFrom.bind(null, 'fromCanvas');
+
+    /**
+     * @deprecated since 5.0.0
+     * @method PIXI.Sprite.fromVideo
+     * @see PIXI.Sprite.from
+     * @return {PIXI.Sprite}
+     */
+    Sprite.fromVideo = spriteFrom.bind(null, 'fromVideo');
+
+    /**
+     * @deprecated since 5.0.0
+     * @method PIXI.Sprite.fromFrame
+     * @see PIXI.Sprite.from
+     * @return {PIXI.Sprite}
+     */
+    Sprite.fromFrame = spriteFrom.bind(null, 'fromFrame');
+
+    // Use these to deprecate all the Texture from* methods
+    function textureFrom(name, source, crossorigin, scaleMode)
+    {
+        warn(`PIXI.Texture.${name} is deprecated, use PIXI.Texture.from`);
+
+        return Texture.from(source, {
+            resourceOptions: {
+                scale: scaleMode,
+                crossorigin,
+            },
+        });
+    }
+
+    /**
+     * @deprecated since 5.0.0
+     * @method PIXI.Texture.fromImage
+     * @see PIXI.Texture.from
+     * @return {PIXI.Texture}
+     */
+    Texture.fromImage = textureFrom.bind(null, 'fromImage');
+
+    /**
+     * @deprecated since 5.0.0
+     * @method PIXI.Texture.fromSVG
+     * @see PIXI.Texture.from
+     * @return {PIXI.Texture}
+     */
+    Texture.fromSVG = textureFrom.bind(null, 'fromSVG');
+
+    /**
+     * @deprecated since 5.0.0
+     * @method PIXI.Texture.fromCanvas
+     * @see PIXI.Texture.from
+     * @return {PIXI.Texture}
+     */
+    Texture.fromCanvas = textureFrom.bind(null, 'fromCanvas');
+
+    /**
+     * @deprecated since 5.0.0
+     * @method PIXI.Texture.fromVideo
+     * @see PIXI.Texture.from
+     * @return {PIXI.Texture}
+     */
+    Texture.fromVideo = textureFrom.bind(null, 'fromVideo');
+
+    /**
+     * @deprecated since 5.0.0
+     * @method PIXI.Texture.fromFrame
+     * @see PIXI.Texture.from
+     * @return {PIXI.Texture}
+     */
+    Texture.fromFrame = textureFrom.bind(null, 'fromFrame');
 }

--- a/packages/core/src/textures/Texture.js
+++ b/packages/core/src/textures/Texture.js
@@ -538,12 +538,6 @@ export default class Texture extends EventEmitter
     }
 }
 
-Texture.fromImage = Texture.from;
-Texture.fromSVG = Texture.from;
-Texture.fromCanvas = Texture.from;
-Texture.fromVideo = Texture.from;
-Texture.fromFrame = Texture.from;
-
 function createWhiteTexture()
 {
     const canvas = document.createElement('canvas');

--- a/packages/sprite/src/Sprite.js
+++ b/packages/sprite/src/Sprite.js
@@ -554,10 +554,3 @@ export default class Sprite extends Container
         }
     }
 }
-
-Sprite.fromImage = Sprite.from;
-Sprite.fromSVG = Sprite.from;
-Sprite.fromCanvas = Sprite.from;
-Sprite.fromVideo = Sprite.from;
-Sprite.fromFrame = Sprite.from;
-

--- a/packages/sprite/src/Sprite.js
+++ b/packages/sprite/src/Sprite.js
@@ -1,5 +1,5 @@
 import { Point, ObservablePoint, Rectangle } from '@pixi/math';
-import { sign, TextureCache } from '@pixi/utils';
+import { sign } from '@pixi/utils';
 import { Texture } from '@pixi/core';
 import { BLEND_MODES } from '@pixi/constants';
 import { Container } from '@pixi/display';
@@ -432,53 +432,17 @@ export default class Sprite extends Container
      * The source can be - frame id, image url, video url, canvas element, video element, base texture
      *
      * @static
-     * @param {number|string|PIXI.BaseTexture|HTMLCanvasElement|HTMLVideoElement} source Source to create texture from
+     * @param {number|string|PIXI.Texture|HTMLCanvasElement|HTMLVideoElement} source Source to create texture from
+     * @param {object} [options] See {@link PIXI.BaseTexture}'s constructor for options.
      * @return {PIXI.Sprite} The newly created sprite
      */
-    static from(source)
+    static from(source, options)
     {
-        return new Sprite(Texture.from(source));
-    }
-
-    /**
-     * Helper function that creates a sprite that will contain a texture from the TextureCache based on the frameId
-     * The frame ids are created when a Texture packer file has been loaded
-     *
-     * @static
-     * @param {string} frameId - The frame Id of the texture in the cache
-     * @return {PIXI.Sprite} A new Sprite using a texture from the texture cache matching the frameId
-     */
-    static fromFrame(frameId)
-    {
-        const texture = TextureCache[frameId];
-
-        if (!texture)
-        {
-            throw new Error(`The frameId "${frameId}" does not exist in the texture cache`);
-        }
+        const texture = (source instanceof Texture)
+            ? source
+            : new Texture.from(source, options);
 
         return new Sprite(texture);
-    }
-
-    /**
-     * Helper function that creates a sprite that will contain a texture based on an image url
-     * If the image is not in the texture cache it will be loaded
-     *
-     * @static
-     * @param {string} imageId - The image url of the texture
-     * @param {boolean} [crossorigin=(auto)] - if you want to specify the cross-origin parameter
-     * @param {number} [scaleMode=PIXI.settings.SCALE_MODE] - if you want to specify the scale mode,
-     *  see {@link PIXI.SCALE_MODES} for possible values
-     * @return {PIXI.Sprite} A new Sprite using a texture from the texture cache matching the image id
-     */
-    static fromImage(imageId, crossorigin, scaleMode)
-    {
-        return new Sprite(Texture.fromImage(imageId, crossorigin, scaleMode));
-    }
-
-    static fromSVG(svgId, crossorigin, scaleMode)
-    {
-        return new Sprite(Texture.fromSVG(svgId, crossorigin, scaleMode));
     }
 
     /**
@@ -590,3 +554,10 @@ export default class Sprite extends Container
         }
     }
 }
+
+Sprite.fromImage = Sprite.from;
+Sprite.fromSVG = Sprite.from;
+Sprite.fromCanvas = Sprite.from;
+Sprite.fromVideo = Sprite.from;
+Sprite.fromFrame = Sprite.from;
+


### PR DESCRIPTION
Cleaned up sprite helper functions.
We only really need one! ```PIXI.Sprite.from```
Added ability to pass texture options
Brings function inline with ```PIXI.Texture.from```
Also you can now pass a texture in to the from function. Handy!