### PR TITLE
Allow any object to be a stencil mask.

### DIFF
--- a/packages/core/src/mask/MaskSystem.js
+++ b/packages/core/src/mask/MaskSystem.js
@@ -38,7 +38,7 @@ export default class MaskSystem extends System
         // be used on render textures more info here:
         // https://github.com/pixijs/pixi.js/pull/3545
 
-        if (maskData.texture)
+        if (maskData.vertexData)
         {
             this.pushSpriteMask(target, maskData);
         }
@@ -78,7 +78,7 @@ export default class MaskSystem extends System
      */
     pop(target, maskData)
     {
-        if (maskData.texture)
+        if (maskData.vertexData)
         {
             this.popSpriteMask(target, maskData);
         }

--- a/packages/core/src/mask/StencilSystem.js
+++ b/packages/core/src/mask/StencilSystem.js
@@ -47,10 +47,6 @@ export default class StencilSystem extends System
      */
     pushStencil(graphics)
     {
-        this.renderer.batch.setObjectRenderer(this.renderer.plugins.graphics);
-
-        //        this.renderer._activeRenderTarget.attachStencilBuffer();
-
         const gl = this.renderer.gl;
         const prevMaskCount = this.stencilMaskStack.length;
 
@@ -65,7 +61,11 @@ export default class StencilSystem extends System
         gl.colorMask(false, false, false, false);
         gl.stencilFunc(gl.EQUAL, prevMaskCount, this._getBitwiseMask());
         gl.stencilOp(gl.KEEP, gl.KEEP, gl.INCR);
-        this.renderer.plugins.graphics.render(graphics);
+
+        graphics.renderable = true;
+        graphics.render(this.renderer);
+        this.renderer.batch.flush();
+        graphics.renderable = false;
 
         this._useCurrent();
     }
@@ -75,8 +75,6 @@ export default class StencilSystem extends System
      */
     popStencil()
     {
-        this.renderer.batch.setObjectRenderer(this.renderer.plugins.graphics);
-
         const gl = this.renderer.gl;
         const graphics = this.stencilMaskStack.pop();
 
@@ -92,7 +90,11 @@ export default class StencilSystem extends System
             // Decrement the refference stencil value where the popped mask overlaps with the other ones
             gl.colorMask(false, false, false, false);
             gl.stencilOp(gl.KEEP, gl.KEEP, gl.DECR);
-            this.renderer.plugins.graphics.render(graphics);
+
+            graphics.renderable = true;
+            graphics.render(this.renderer);
+            this.renderer.batch.flush();
+            graphics.renderable = false;
 
             this._useCurrent();
         }

--- a/packages/interaction/src/InteractionManager.js
+++ b/packages/interaction/src/InteractionManager.js
@@ -1044,7 +1044,7 @@ export default class InteractionManager extends EventEmitter
         {
             if (hitTest)
             {
-                if (!displayObject._mask.containsPoint(point))
+                if (!(displayObject._mask.containsPoint && displayObject._mask.containsPoint(point)))
                 {
                     hitTest = false;
                     hitTestChildren = false;


### PR DESCRIPTION
Now any object can be a stencil mask, including a container.
This gives users loads of power, along with the ability to render more complex masks in a much simpler way.
