### PR TITLE
Fixed a difference between canvas and webgl sprite renderer on scaled textures.

### DIFF
--- a/src/core/sprites/canvas/CanvasSpriteRenderer.js
+++ b/src/core/sprites/canvas/CanvasSpriteRenderer.js
@@ -92,8 +92,8 @@ export default class CanvasSpriteRenderer
                 dy = 0;
             }
 
-            dx -= width / 2;
-            dy -= height / 2;
+            dx -= texture.orig.width / 2;
+            dy -= texture.orig.height / 2;
 
             // Allow for pixel rounding
             if (renderer.roundPixels)
@@ -142,8 +142,8 @@ export default class CanvasSpriteRenderer
                     height * resolution,
                     dx * renderer.resolution,
                     dy * renderer.resolution,
-                    width * renderer.resolution,
-                    height * renderer.resolution
+                    texture.orig.width * renderer.resolution,
+                    texture.orig.height * renderer.resolution
                 );
             }
             else
@@ -156,8 +156,8 @@ export default class CanvasSpriteRenderer
                     height * resolution,
                     dx * renderer.resolution,
                     dy * renderer.resolution,
-                    width * renderer.resolution,
-                    height * renderer.resolution
+                    texture.orig.width * renderer.resolution,
+                    texture.orig.height * renderer.resolution
                 );
             }
         }


### PR DESCRIPTION
You can see it here:
https://jsfiddle.net/1cj8w0mv/24/