### PR TITLE
Edit to RegEx to allow parsing SVG width / height, when using "minified" svg

### DIFF
--- a/src/core/const.js
+++ b/src/core/const.js
@@ -239,7 +239,7 @@ export const DATA_URI = /^\s*data:(?:([\w-]+)\/([\w+.-]+))?(?:;(charset=[\w-]+|b
  * @type {RegExp|string}
  * @example &lt;svg width="100" height="100"&gt;&lt;/svg&gt;
  */
-export const SVG_SIZE = /<svg[^>]*(?:\s(width|height)=('|")(\d*(?:\.\d+)?)(?:px)?('|"))[^>]*(?:\s(width|height)=('|")(\d*(?:\.\d+)?)(?:px)?('|"))[^>]*>/i; // eslint-disable-line max-len
+export const SVG_SIZE = /(?:\s(width|height)=('|")(\d*(?:\.\d+)?)(?:px)?('|"))*(?:\s(width|height)=('|")(\d*(?:\.\d+)?)(?:px)?('|"))/i; // eslint-disable-line max-len
 
 /**
  * Constants that identify shapes, mainly to prevent `instanceof` calls.

--- a/src/core/const.js
+++ b/src/core/const.js
@@ -239,7 +239,7 @@ export const DATA_URI = /^\s*data:(?:([\w-]+)\/([\w+.-]+))?(?:;(charset=[\w-]+|b
  * @type {RegExp|string}
  * @example &lt;svg width="100" height="100"&gt;&lt;/svg&gt;
  */
-export const SVG_SIZE = /(?:\s(width|height)=('|")(\d*(?:\.\d+)?)(?:px)?('|"))*(?:\s(width|height)=('|")(\d*(?:\.\d+)?)(?:px)?('|"))/i; // eslint-disable-line max-len
+export const SVG_SIZE = /(?:\s(width|height)=(['"])(\d*(?:\.\d+)?)(?:px)?(['"]))(?:\s(width|height)=(['"])(\d*(?:\.\d+)?)(?:px)?(['"]))/i; // eslint-disable-line max-len
 
 /**
  * Constants that identify shapes, mainly to prevent `instanceof` calls.

--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -491,14 +491,14 @@ export default class Sprite extends Container
      */
     get width()
     {
-        return Math.abs(this.scale.x) * this._texture.orig.width;
+        return Math.abs(this.scale.x) * this._texture.width;
     }
 
     set width(value) // eslint-disable-line require-jsdoc
     {
         const s = sign(this.scale.x) || 1;
 
-        this.scale.x = s * value / this._texture.orig.width;
+        this.scale.x = s * value / this._texture.width;
         this._width = value;
     }
 
@@ -509,7 +509,7 @@ export default class Sprite extends Container
      */
     get height()
     {
-        return Math.abs(this.scale.y) * this._texture.orig.height;
+        return Math.abs(this.scale.y) * this._texture.height;
     }
 
     set height(value) // eslint-disable-line require-jsdoc

--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -38,6 +38,22 @@ export default class BaseTexture extends EventEmitter
         this.resolution = resolution || settings.RESOLUTION;
 
         /**
+         * Temp width of the BaseTexture, if it can be determined before loading source is complete (like from and svg uri);
+         *
+         * @readonly
+         * @member {number}
+         */
+        this.tempWidth = 0;
+
+        /**
+         * Temp height of the BaseTexture, if it can be determined before loading source is complete (like from and svg uri);
+         *
+         * @readonly
+         * @member {number}
+         */
+        this.tempHeight = 0;
+
+        /**
          * The width of the base texture set when the image has loaded
          *
          * @readonly
@@ -324,7 +340,7 @@ export default class BaseTexture extends EventEmitter
         // Apply source if loaded. Otherwise setup appropriate loading monitors.
         if (((source.src && source.complete) || source.getContext) && source.width && source.height)
         {
-            this._updateImageType();
+            // this._updateImageType();
 
             if (this.imageType === 'svg')
             {
@@ -350,7 +366,7 @@ export default class BaseTexture extends EventEmitter
 
             source.onload = () =>
             {
-                scope._updateImageType();
+                // scope._updateImageType();
                 source.onload = null;
                 source.onerror = null;
 
@@ -434,13 +450,12 @@ export default class BaseTexture extends EventEmitter
             return;
         }
 
-        const dataUri = decomposeDataUri(this.imageUrl);
         let imageType;
 
-        if (dataUri && dataUri.mediaType === 'image')
+        if (this.dataUri && this.dataUri.mediaType === 'image')
         {
             // Check for subType validity
-            const firstSubType = dataUri.subType.split('+')[0];
+            const firstSubType = this.dataUri.subType.split('+')[0];
 
             imageType = getUrlFileExtension(`.${firstSubType}`);
 
@@ -474,11 +489,9 @@ export default class BaseTexture extends EventEmitter
             return;
         }
 
-        const dataUri = decomposeDataUri(this.imageUrl);
-
-        if (dataUri)
+        if (this.dataUri)
         {
-            this._loadSvgSourceUsingDataUri(dataUri);
+            this._loadSvgSourceUsingDataUri(this.dataUri);
         }
         else
         {
@@ -667,9 +680,10 @@ export default class BaseTexture extends EventEmitter
      * @param {boolean} [crossorigin=(auto)] - Should use anonymous CORS? Defaults to true if the URL is not a data-URI.
      * @param {number} [scaleMode=PIXI.settings.SCALE_MODE] - See {@link PIXI.SCALE_MODES} for possible values
      * @param {number} [sourceScale=(auto)] - Scale for the original image, used with Svg images.
+     * @param {number} [resolution=(auto)] - Override resolution if not using @x on the end of image name.
      * @return {PIXI.BaseTexture} The new base texture.
      */
-    static fromImage(imageUrl, crossorigin, scaleMode, sourceScale)
+    static fromImage(imageUrl, crossorigin, scaleMode, sourceScale, resolution)
     {
         let baseTexture = BaseTextureCache[imageUrl];
 
@@ -696,8 +710,40 @@ export default class BaseTexture extends EventEmitter
                 baseTexture.sourceScale = sourceScale;
             }
 
+            // set get image type / check data uri
+            baseTexture.imageUrl = imageUrl;
+            baseTexture.dataUri = decomposeDataUri(imageUrl);
+            baseTexture._updateImageType();
+
             // if there is an @2x at the end of the url we are going to assume its a highres image
-            baseTexture.resolution = getResolutionOfUrl(imageUrl);
+            baseTexture.resolution = resolution || getResolutionOfUrl(imageUrl);
+
+            if (baseTexture.dataUri && baseTexture.imageType === 'svg')
+{
+                let svgString = 0;
+
+                if (baseTexture.dataUri.encoding === 'base64')
+{
+                    if (!atob)
+{
+                        throw new Error('Your browser doesn\'t support base64 conversions.');
+                    }
+                    svgString = atob(baseTexture.dataUri.data);
+                }
+                else
+{
+                    svgString = baseTexture.dataUri.data;
+                }
+
+                const svgSize = getSvgSize(svgString);
+                const svgWidth = svgSize.width;
+                const svgHeight = svgSize.height;
+                const realWidth = Math.round(svgWidth * sourceScale) / baseTexture.resolution;
+                const realHeight = Math.round(svgHeight * sourceScale) / baseTexture.resolution;
+
+                baseTexture.tempWidth = realWidth;
+                baseTexture.tempHeight = realHeight;
+            }
 
             image.src = imageUrl; // Setting this triggers load
 

--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -292,15 +292,16 @@ export default class Texture extends EventEmitter
      * @param {boolean} [crossorigin] - Whether requests should be treated as crossorigin
      * @param {number} [scaleMode=PIXI.settings.SCALE_MODE] - See {@link PIXI.SCALE_MODES} for possible values
      * @param {number} [sourceScale=(auto)] - Scale for the original image, used with SVG images.
+     * @param {number} [resolution=(auto)] - Override resolution if not using @x on the end of image name.
      * @return {PIXI.Texture} The newly created texture
      */
-    static fromImage(imageUrl, crossorigin, scaleMode, sourceScale)
+    static fromImage(imageUrl, crossorigin, scaleMode, sourceScale, resolution)
     {
         let texture = TextureCache[imageUrl];
 
         if (!texture)
         {
-            texture = new Texture(BaseTexture.fromImage(imageUrl, crossorigin, scaleMode, sourceScale));
+            texture = new Texture(BaseTexture.fromImage(imageUrl, crossorigin, scaleMode, sourceScale, resolution));
             Texture.addToCache(texture, imageUrl);
         }
 
@@ -612,7 +613,7 @@ export default class Texture extends EventEmitter
      */
     get width()
     {
-        return this.orig.width;
+        return this.noFrame ? this.baseTexture.tempWidth : this.orig.width;
     }
 
     /**
@@ -622,7 +623,7 @@ export default class Texture extends EventEmitter
      */
     get height()
     {
-        return this.orig.height;
+        return this.noFrame ? this.baseTexture.tempHeight : this.orig.height;
     }
 }
 


### PR DESCRIPTION
Relaxed this regex (should pass unit test now),  so that SVG xml produced by using [this]( https://www.npmjs.com/package/mini-svg-data-uri) works with BaseTexture.fromImage(datauri.., )