### PR TITLE
Next from methods

### DIFF
--- a/packages/app/src/Application.js
+++ b/packages/app/src/Application.js
@@ -16,7 +16,7 @@ import { Ticker, UPDATE_PRIORITY } from '@pixi/ticker';
  * document.body.appendChild(app.view);
  *
  * // ex, add display objects
- * app.stage.addChild(PIXI.Sprite.fromImage('something.png'));
+ * app.stage.addChild(PIXI.Sprite.from('something.png'));
  *
  * @class
  * @memberof PIXI

--- a/packages/core/src/renderTexture/BaseRenderTexture.js
+++ b/packages/core/src/renderTexture/BaseRenderTexture.js
@@ -13,7 +13,7 @@ import FrameBuffer from '../framebuffer/FrameBuffer';
  * ```js
  * let renderer = PIXI.autoDetectRenderer(1024, 1024, { view: canvas, ratio: 1 });
  * let baseRenderTexture = new PIXI.BaseRenderTexture(renderer, 800, 600);
- * let sprite = PIXI.Sprite.fromImage("spinObj_01.png");
+ * let sprite = PIXI.Sprite.from("spinObj_01.png");
  *
  * sprite.position.x = 800/2;
  * sprite.position.y = 600/2;

--- a/packages/core/src/renderTexture/RenderTexture.js
+++ b/packages/core/src/renderTexture/RenderTexture.js
@@ -12,7 +12,7 @@ import Texture from '../textures/Texture';
  * ```js
  * let renderer = PIXI.autoDetectRenderer(1024, 1024, { view: canvas, ratio: 1 });
  * let renderTexture = PIXI.RenderTexture.create(800, 600);
- * let sprite = PIXI.Sprite.fromImage("spinObj_01.png");
+ * let sprite = PIXI.Sprite.from("spinObj_01.png");
  *
  * sprite.position.x = 800/2;
  * sprite.position.y = 600/2;

--- a/packages/core/src/textures/Texture.js
+++ b/packages/core/src/textures/Texture.js
@@ -15,7 +15,7 @@ import { uid, TextureCache, getResolutionOfUrl } from '@pixi/utils';
  * You can directly create a texture from an image and then reuse it multiple times like this :
  *
  * ```js
- * let texture = PIXI.Texture.fromImage('assets/image.png');
+ * let texture = PIXI.Texture.from('assets/image.png');
  * let sprite1 = new PIXI.Sprite(texture);
  * let sprite2 = new PIXI.Sprite(texture);
  * ```
@@ -23,7 +23,7 @@ import { uid, TextureCache, getResolutionOfUrl } from '@pixi/utils';
  * Textures made from SVGs, loaded or not, cannot be used before the file finishes processing.
  * You can check for this by checking the sprite's _textureID property.
  * ```js
- * var texture = PIXI.Texture.fromImage('assets/image.svg');
+ * var texture = PIXI.Texture.from('assets/image.svg');
  * var sprite1 = new PIXI.Sprite(texture);
  * //sprite1._textureID should not be undefined if the texture has finished processing the SVG file
  * ```

--- a/packages/mesh/src/NineSlicePlane.js
+++ b/packages/mesh/src/NineSlicePlane.js
@@ -7,7 +7,7 @@ const DEFAULT_BORDER_SIZE = 10;
  * for buttons with rounded corners for example) and the other areas will be scaled horizontally and or vertically
  *
  *```js
- * let Plane9 = new PIXI.NineSlicePlane(PIXI.Texture.fromImage('BoxWithRoundedCorners.png'), 15, 15, 15, 15);
+ * let Plane9 = new PIXI.NineSlicePlane(PIXI.Texture.from('BoxWithRoundedCorners.png'), 15, 15, 15, 15);
  *  ```
  * <pre>
  *      A                          B

--- a/packages/mesh/src/Plane.js
+++ b/packages/mesh/src/Plane.js
@@ -7,7 +7,7 @@ import Mesh from './Mesh';
  * for (let i = 0; i < 20; i++) {
  *     points.push(new PIXI.Point(i * 50, 0));
  * };
- * let Plane = new PIXI.Plane(PIXI.Texture.fromImage("snake.png"), points);
+ * let Plane = new PIXI.Plane(PIXI.Texture.from("snake.png"), points);
  *  ```
  *
  * @class

--- a/packages/mesh/src/Rope.js
+++ b/packages/mesh/src/Rope.js
@@ -7,7 +7,7 @@ import Mesh from './Mesh';
  * for (let i = 0; i < 20; i++) {
  *     points.push(new PIXI.Point(i * 50, 0));
  * };
- * let rope = new PIXI.Rope(PIXI.Texture.fromImage("snake.png"), points);
+ * let rope = new PIXI.Rope(PIXI.Texture.from("snake.png"), points);
  *  ```
  *
  * @class

--- a/packages/particles/src/ParticleContainer.js
+++ b/packages/particles/src/ParticleContainer.js
@@ -16,7 +16,7 @@ import { Container } from '@pixi/display';
  *
  * for (let i = 0; i < 100; ++i)
  * {
- *     let sprite = new PIXI.Sprite.fromImage("myImage.png");
+ *     let sprite = new PIXI.Sprite.from("myImage.png");
  *     container.addChild(sprite);
  * }
  * ```

--- a/packages/prepare/src/BasePrepare.js
+++ b/packages/prepare/src/BasePrepare.js
@@ -23,7 +23,7 @@ settings.UPLOADS_PER_FRAME = 4;
  *
  * @example
  * // Create a sprite
- * const sprite = new PIXI.Sprite.fromImage('something.png');
+ * const sprite = new PIXI.Sprite.from('something.png');
  *
  * // Load object into GPU
  * app.renderer.plugins.prepare.upload(sprite, () => {

--- a/packages/sprite-animated/src/AnimatedSprite.js
+++ b/packages/sprite-animated/src/AnimatedSprite.js
@@ -18,7 +18,7 @@ import { Ticker, UPDATE_PRIORITY } from '@pixi/ticker';
  *
  * for (let i=0; i < 4; i++)
  * {
- *      let texture = PIXI.Texture.fromImage(alienImages[i]);
+ *      let texture = PIXI.Texture.from(alienImages[i]);
  *      textureArray.push(texture);
  * };
  *
@@ -310,7 +310,7 @@ export default class AnimatedSprite extends Sprite
 
         for (let i = 0; i < frames.length; ++i)
         {
-            textures.push(Texture.fromFrame(frames[i]));
+            textures.push(Texture.from(frames[i]));
         }
 
         return new AnimatedSprite(textures);
@@ -329,7 +329,7 @@ export default class AnimatedSprite extends Sprite
 
         for (let i = 0; i < images.length; ++i)
         {
-            textures.push(Texture.fromImage(images[i]));
+            textures.push(Texture.from(images[i]));
         }
 
         return new AnimatedSprite(textures);

--- a/packages/sprite-tiling/src/TilingSprite.js
+++ b/packages/sprite-tiling/src/TilingSprite.js
@@ -300,14 +300,22 @@ export default class TilingSprite extends Sprite
      * @param {string} imageId - The image url of the texture
      * @param {number} width - the width of the tiling sprite
      * @param {number} height - the height of the tiling sprite
-     * @param {boolean} [crossorigin] - if you want to specify the cross-origin parameter
-     * @param {number} [scaleMode=PIXI.settings.SCALE_MODE] - if you want to specify the scale mode,
-     *  see {@link PIXI.SCALE_MODES} for possible values
+     * @param {Object} [options] - See {@link PIXI.BaseTexture}'s constructor for options.
      * @return {PIXI.TilingSprite} A new TilingSprite using a texture from the texture cache matching the image id
      */
-    static fromImage(imageId, width, height, crossorigin, scaleMode)
+    static fromImage(imageId, width, height, options)
     {
-        return new TilingSprite(Texture.fromImage(imageId, crossorigin, scaleMode), width, height);
+        // Fallback support for crossorigin, scaleMode parameters
+        if (options && typeof options !== 'object') {
+            options = {
+                scaleMode: arguments[4],
+                resourceOptions: {
+                    crossorigin: arguments[3]
+                }
+            };
+        }
+
+        return new TilingSprite(Texture.from(imageId, options), width, height);
     }
 
     /**

--- a/packages/sprite-tiling/src/TilingSprite.js
+++ b/packages/sprite-tiling/src/TilingSprite.js
@@ -306,12 +306,13 @@ export default class TilingSprite extends Sprite
     static fromImage(imageId, width, height, options)
     {
         // Fallback support for crossorigin, scaleMode parameters
-        if (options && typeof options !== 'object') {
+        if (options && typeof options !== 'object')
+        {
             options = {
                 scaleMode: arguments[4],
                 resourceOptions: {
-                    crossorigin: arguments[3]
-                }
+                    crossorigin: arguments[3],
+                },
             };
         }
 

--- a/packages/sprite/src/Sprite.js
+++ b/packages/sprite/src/Sprite.js
@@ -12,7 +12,7 @@ const tempPoint = new Point();
  * A sprite can be created directly from an image like this:
  *
  * ```js
- * let sprite = new PIXI.Sprite.fromImage('assets/image.png');
+ * let sprite = new PIXI.Sprite.from('assets/image.png');
  * ```
  *
  * @class

--- a/packages/spritesheet/test/Spritesheet.js
+++ b/packages/spritesheet/test/Spritesheet.js
@@ -34,7 +34,7 @@ describe('PIXI.Spritesheet', function ()
                 frames: { frame: frameData },
                 meta: { scale: 1 },
             };
-            const baseTexture = BaseTexture.fromCanvas(
+            const baseTexture = BaseTexture.from(
                 document.createElement('canvas')
             );
 

--- a/packages/text-bitmap/test/BitmapFontLoader.js
+++ b/packages/text-bitmap/test/BitmapFontLoader.js
@@ -224,7 +224,7 @@ describe('PIXI.BitmapFontLoader', function ()
 
         spritesheet.parse(() =>
         {
-            const fontTexture  = Texture.fromFrame('resources/font.png');
+            const fontTexture  = Texture.from('resources/font.png');
             const font =  BitmapText.registerFont(this.fontXML, fontTexture);
             const fontX = 158; // bare value from spritesheet frame
             const fontY = 2; // bare value from spritesheet frame
@@ -280,7 +280,7 @@ describe('PIXI.BitmapFontLoader', function ()
 
         spritesheet.parse(() =>
         {
-            const fontTexture  = Texture.fromFrame('resources/font.png');
+            const fontTexture  = Texture.from('resources/font.png');
             const font =  BitmapText.registerFont(this.fontXML, fontTexture);
             const fontX = 158; // bare value from spritesheet frame
             const fontY = 2; // bare value from spritesheet frame


### PR DESCRIPTION
Follow up to #4775 

### Fixed

* Removes `fromFrame`, `fromImage`, etc from the documentation and tests
* Fixes an issue with `TilingSprite.fromImage` not correctly using `Texture.from`