### PR TITLE
Ability to set certain display components to be drawn to rounded pixels

### DIFF
--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -132,6 +132,14 @@ export default class Sprite extends Container
          * @default 'sprite'
          */
         this.pluginName = 'sprite';
+
+        /**
+         * Do we want to force this display component to be drawn at whole pixels only.
+         *
+         * @member {boolean}
+         * @default false
+         */
+        this.roundPixels = false;
     }
 
     /**

--- a/src/core/sprites/canvas/CanvasSpriteRenderer.js
+++ b/src/core/sprites/canvas/CanvasSpriteRenderer.js
@@ -96,7 +96,7 @@ export default class CanvasSpriteRenderer
             dy -= height / 2;
 
             // Allow for pixel rounding
-            if (renderer.roundPixels)
+            if (renderer.roundPixels || sprite.roundPixels)
             {
                 renderer.context.setTransform(
                     wt.a,

--- a/src/core/sprites/webgl/SpriteRenderer.js
+++ b/src/core/sprites/webgl/SpriteRenderer.js
@@ -333,7 +333,7 @@ export default class SpriteRenderer extends ObjectRenderer
             // TODO this sum does not need to be set each frame..
             uvs = sprite._texture._uvs.uvsUint32;
 
-            if (this.renderer.roundPixels)
+            if (this.renderer.roundPixels || sprite.roundPixels)
             {
                 const resolution = this.renderer.resolution;
 

--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -108,6 +108,8 @@ export default class Text extends Sprite
         this.style = style;
 
         this.localStyleID = -1;
+
+        this.roundPixels = true;
     }
 
     /**

--- a/src/extras/BitmapText.js
+++ b/src/extras/BitmapText.js
@@ -125,6 +125,14 @@ export default class BitmapText extends core.Container
          */
         this.dirty = false;
 
+        /**
+         * Do we want to force this display component to be drawn at whole pixels only.
+         *
+         * @member {boolean}
+         * @default false
+         */
+        this.roundPixels = true;
+
         this.updateText();
     }
 
@@ -248,6 +256,7 @@ export default class BitmapText extends core.Container
             else
             {
                 c = new core.Sprite(chars[i].texture);
+                c.roundPixels = this.roundPixels;
                 this._glyphs.push(c);
             }
 

--- a/src/mesh/Mesh.js
+++ b/src/mesh/Mesh.js
@@ -151,6 +151,14 @@ export default class Mesh extends core.Container
          * @default 'mesh'
          */
         this.pluginName = 'mesh';
+
+        /**
+         * Do we want to force this display component to be drawn at whole pixels only.
+         *
+         * @member {boolean}
+         * @default false
+         */
+        this.roundPixels = false;
     }
 
     /**

--- a/src/mesh/NineSlicePlane.js
+++ b/src/mesh/NineSlicePlane.js
@@ -148,7 +148,7 @@ export default class NineSlicePlane extends Plane
         const transform = this.worldTransform;
         const res = renderer.resolution;
 
-        if (renderer.roundPixels)
+        if (renderer.roundPixels || this.roundPixels)
         {
             context.setTransform(
                 transform.a * res,

--- a/src/mesh/canvas/CanvasMeshRenderer.js
+++ b/src/mesh/canvas/CanvasMeshRenderer.js
@@ -31,7 +31,7 @@ export default class MeshSpriteRenderer
         const transform = mesh.worldTransform;
         const res = renderer.resolution;
 
-        if (renderer.roundPixels)
+        if (renderer.roundPixels || mesh.roundPixels)
         {
             context.setTransform(
                 transform.a * res,

--- a/src/particles/ParticleContainer.js
+++ b/src/particles/ParticleContainer.js
@@ -324,7 +324,7 @@ export default class ParticleContainer extends core.Container
 
                 const childTransform = child.worldTransform;
 
-                if (renderer.roundPixels)
+                if (renderer.roundPixels || this.roundPixels)
                 {
                     context.setTransform(
                         childTransform.a,


### PR DESCRIPTION
Ability to set certain display components to be drawn to rounded pixels, independent of the global roundPixels renderer setting.

We get constant reports of Text looking blurry in Pixi
http://www.html5gamedevs.com/topic/33309-can-pixi-create-pixel-perfect-text-in-a-scaled-container/
http://www.html5gamedevs.com/topic/30018-blurry-text-after-scaling/
http://www.html5gamedevs.com/topic/29576-scalable-text-for-pixijs/
http://www.html5gamedevs.com/topic/27810-text-objects-are-blurry/
http://www.html5gamedevs.com/topic/26880-blurry-text-in-pixijs/
http://www.html5gamedevs.com/topic/23136-how-to-disable-font-antialiasing/
https://github.com/pixijs/pixi.js/issues/4242
https://github.com/pixijs/pixi.js/issues/3263

etc. etc.

And the solution is always 'draw to whole pixel positions and it looks a _lot_ sharper'. Which is true.

So this PR adds a 'roundPixels' property to Sprite and some components that inherit from Display Objects. roundPixels is a property that was already found in some Display Objects, so it's not a new usage, just extending it.

And then for the render plugins, it checks if either the roundPixels property is set on the renderer OR on the display object. I've set only set roundPixels to true by default for Text and Bitmap text, so they will always look as sharp as possible.