### PR TITLE
ParticleContainer wrong buffer index

### DIFF
--- a/src/particles/webgl/ParticleRenderer.js
+++ b/src/particles/webgl/ParticleRenderer.js
@@ -189,7 +189,7 @@ export default class ParticleRenderer extends core.ObjectRenderer
             // we always upload the dynamic
             buffer.uploadDynamic(children, i, amount);
 
-            const bid = container._bufferUpdateIDs[i] || 0;
+            const bid = container._bufferUpdateIDs[j] || 0;
 
             updateStatic = updateStatic || (buffer._updateID < bid);
             // we only upload the static content when we have to!


### PR DESCRIPTION
I made a mistake in #4680

Only 5 maggots are rotating, 6-th is added after first render and statics are not updated: https://jsfiddle.net/Hackerham/4m10bjd7/1/

