### PR TITLE
Adds Patreon support link

### DIFF
--- a/bundles/pixi.js/package.json
+++ b/bundles/pixi.js/package.json
@@ -22,11 +22,13 @@
   },
   "scripts": {
     "test": "floss --path test",
+    "postinstall": "node scripts/support-pixi.js",
     "build:min": "uglifyjs dist/pixi.js -c -m -o dist/pixi.min.js --source-map \"content='dist/pixi.js.map',includeSources=true,filename='dist/pixi.min.js.map',url='pixi.min.js.map'\" --comments \"/pixi.js - /\""
   },
   "files": [
     "lib/",
     "dist/",
+    "scripts/",
     "pixi.js.d.ts"
   ],
   "dependencies": {

--- a/bundles/pixi.js/scripts/support-pixi.js
+++ b/bundles/pixi.js/scripts/support-pixi.js
@@ -1,0 +1,9 @@
+/* eslint-disable no-console */
+
+const green = '\u001b[32m';
+const white = '\u001b[22m\u001b[39m';
+const boldCyan = '\u001b[96m\u001b[1m';
+const reset = '\u001b[0m';
+
+console.log(`${green}Have some ❤️  for PixiJS? You can support the project via Patreon:`);
+console.log(`${white}> ${boldCyan}https://www.patreon.com/user?u=2384552\n${reset}`);


### PR DESCRIPTION
## Overview

This PR adds a link to Patreon in the console on postinstall when installing **pixi.js**. Many projects are doing this now, and it's a great idea!

![screen shot 2018-04-29 at 3 50 38 pm](https://user-images.githubusercontent.com/864393/39410335-3a6636ba-4bc5-11e8-9804-1bc0d88185de.png)
