### PR TITLE
fix data_uri regex to allow charset=utf8;base64 for the encoding part…

### DIFF
--- a/src/core/const.js
+++ b/src/core/const.js
@@ -227,7 +227,7 @@ export const URL_FILE_EXTENSION = /\.(\w{3,4})(?:$|\?|#)/i;
  * @type {RegExp|string}
  * @example data:image/png;base64
  */
-export const DATA_URI = /^\s*data:(?:([\w-]+)\/([\w+.-]+))?(?:;(charset=[\w-]+|base64))?,(.*)/i;
+export const DATA_URI = /^\s*data:(?:([\w-]+)\/([\w+.-]+))?(?:;(charset=[\w-]+|base64|charset=[\w-]+;base64))?,(.*)/i;
 
 /**
  * Regexp for SVG size.

--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -496,7 +496,7 @@ export default class BaseTexture extends EventEmitter
     {
         let svgString;
 
-        if (dataUri.encoding === 'base64')
+        if (dataUri.encoding.indexOf('base64') >= 0)
         {
             if (!atob)
             {

--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -306,6 +306,10 @@ export default class BaseTexture extends EventEmitter
      */
     loadSource(source)
     {
+        if (source.src === undefined) return;
+        this.imageUrl = source.src;
+        this.imageType = 'svg';
+
         const wasLoading = this.isLoading;
 
         this.hasLoaded = false;

--- a/test/core/util.js
+++ b/test/core/util.js
@@ -90,6 +90,22 @@ describe('PIXI.utils', function ()
                 .to.equal('94Z9RWUN77ZW');
         });
 
+        it('should decompose a data URI with charset', function ()
+        {
+            const dataUri = PIXI.utils.decomposeDataUri('data:image/svg+xml;charset=utf8;base64,PGRpdiB4bWxucz0Pg==');
+
+            expect(dataUri)
+                .to.be.an('object');
+            expect(dataUri.mediaType)
+                .to.equal('image');
+            expect(dataUri.subType)
+                .to.equal('svg+xml');
+            expect(dataUri.encoding)
+                .to.equal('charset=utf8;base64');
+            expect(dataUri.data)
+                .to.equal('PGRpdiB4bWxucz0Pg==');
+        });
+
         it('should return undefined for anything else', function ()
         {
             const dataUri = PIXI.utils.decomposeDataUri('foo');


### PR DESCRIPTION
This PR initially solves IE11 issue where inline SVG cannot load in a BaseTexture. By digging into the code, I just enabled the DATA_URI regex to catch the whole "charset=utf8;base64" string as the encoding, and then I adapted the check on the encoding in BaseTexture to pass when this new type of encoding is found.

So this PR fixes inline SVG loading on IE11, please let me know if it is not enough generic or could be done in a better way, or if it actually breaks things (I tested it though).

Cheers.

