### PR TITLE
fix data_uri regex to allow charset=utf8;base64 for the encoding part…

### DIFF
--- a/src/core/const.js
+++ b/src/core/const.js
@@ -227,7 +227,7 @@ export const URL_FILE_EXTENSION = /\.(\w{3,4})(?:$|\?|#)/i;
  * @type {RegExp|string}
  * @example data:image/png;base64
  */
-export const DATA_URI = /^\s*data:(?:([\w-]+)\/([\w+.-]+))?(?:;(charset=[\w-]+|base64|charset=[\w-]+;base64))?,(.*)/i;
+export const DATA_URI = /^\s*data:(?:([\w-]+)\/([\w+.-]+))?(?:;charset=([\w-]+))?(?:;(base64))?,(.*)/i;
 
 /**
  * Regexp for SVG size.

--- a/src/core/const.js
+++ b/src/core/const.js
@@ -227,7 +227,7 @@ export const URL_FILE_EXTENSION = /\.(\w{3,4})(?:$|\?|#)/i;
  * @type {RegExp|string}
  * @example data:image/png;base64
  */
-export const DATA_URI = /^\s*data:(?:([\w-]+)\/([\w+.-]+))?(?:;(charset=[\w-]+|base64))?,(.*)/i;
+export const DATA_URI = /^\s*data:(?:([\w-]+)\/([\w+.-]+))?(?:;(charset=[\w-]+|base64|charset=[\w-]+;base64))?,(.*)/i;
 
 /**
  * Regexp for SVG size.

--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -496,7 +496,7 @@ export default class BaseTexture extends EventEmitter
     {
         let svgString;
 
-        if (dataUri.encoding === 'base64')
+        if (dataUri.encoding.indexOf('base64') >= 0)
         {
             if (!atob)
             {

--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -496,7 +496,7 @@ export default class BaseTexture extends EventEmitter
     {
         let svgString;
 
-        if (dataUri.encoding.indexOf('base64') >= 0)
+        if (dataUri.encoding === 'base64')
         {
             if (!atob)
             {

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -186,8 +186,9 @@ export function decomposeDataUri(dataUri)
         return {
             mediaType: dataUriMatch[1] ? dataUriMatch[1].toLowerCase() : undefined,
             subType: dataUriMatch[2] ? dataUriMatch[2].toLowerCase() : undefined,
-            encoding: dataUriMatch[3] ? dataUriMatch[3].toLowerCase() : undefined,
-            data: dataUriMatch[4],
+            charset: dataUriMatch[3] ? dataUriMatch[3].toLowerCase() : undefined,
+            encoding: dataUriMatch[4] ? dataUriMatch[4].toLowerCase() : undefined,
+            data: dataUriMatch[5],
         };
     }
 

--- a/test/core/util.js
+++ b/test/core/util.js
@@ -84,6 +84,8 @@ describe('PIXI.utils', function ()
                 .to.equal('image');
             expect(dataUri.subType)
                 .to.equal('png');
+            expect(dataUri.charset)
+                .to.be.an('undefined');
             expect(dataUri.encoding)
                 .to.equal('base64');
             expect(dataUri.data)
@@ -100,8 +102,28 @@ describe('PIXI.utils', function ()
                 .to.equal('image');
             expect(dataUri.subType)
                 .to.equal('svg+xml');
+            expect(dataUri.charset)
+                .to.equal('utf8');
             expect(dataUri.encoding)
-                .to.equal('charset=utf8;base64');
+                .to.equal('base64');
+            expect(dataUri.data)
+                .to.equal('PGRpdiB4bWxucz0Pg==');
+        });
+
+        it('should decompose a data URI with charset without encoding', function ()
+        {
+            const dataUri = PIXI.utils.decomposeDataUri('data:image/svg+xml;charset=utf8,PGRpdiB4bWxucz0Pg==');
+
+            expect(dataUri)
+                .to.be.an('object');
+            expect(dataUri.mediaType)
+                .to.equal('image');
+            expect(dataUri.subType)
+                .to.equal('svg+xml');
+            expect(dataUri.charset)
+                .to.equal('utf8');
+            expect(dataUri.encoding)
+                .to.be.an('undefined');
             expect(dataUri.data)
                 .to.equal('PGRpdiB4bWxucz0Pg==');
         });

--- a/test/core/util.js
+++ b/test/core/util.js
@@ -90,6 +90,22 @@ describe('PIXI.utils', function ()
                 .to.equal('94Z9RWUN77ZW');
         });
 
+        it('should decompose a data URI with charset', function ()
+        {
+            const dataUri = PIXI.utils.decomposeDataUri('data:image/svg+xml;charset=utf8;base64,PGRpdiB4bWxucz0Pg==');
+
+            expect(dataUri)
+                .to.be.an('object');
+            expect(dataUri.mediaType)
+                .to.equal('image');
+            expect(dataUri.subType)
+                .to.equal('svg+xml');
+            expect(dataUri.encoding)
+                .to.equal('charset=utf8;base64');
+            expect(dataUri.data)
+                .to.equal('PGRpdiB4bWxucz0Pg==');
+        });
+
         it('should return undefined for anything else', function ()
         {
             const dataUri = PIXI.utils.decomposeDataUri('foo');


### PR DESCRIPTION
This PR initially solves IE11 issue where inline SVG cannot load in a BaseTexture. By digging into the code, I just enabled the DATA_URI regex to catch the whole "charset=utf8;base64" string as the encoding, and then I adapted the check on the encoding in BaseTexture to pass when this new type of encoding is found.

So this PR fixes inline SVG loading on IE11, please let me know if it is not enough generic or could be done in a better way, or if it actually breaks things (I tested it though).

Cheers.

