### PR TITLE
Move pointertap after pointerup for clicks.

### DIFF
--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -1346,6 +1346,9 @@ export default class InteractionManager extends EventEmitter
         const isTouch = data.pointerType === 'touch';
 
         const isMouse = (data.pointerType === 'mouse' || data.pointerType === 'pen');
+        // need to track mouse down status in the mouse block so that we can emit
+        // event in a later block
+        let isMouseTap = false;
 
         // Mouse only
         if (isMouse)
@@ -1365,8 +1368,8 @@ export default class InteractionManager extends EventEmitter
                 if (isDown)
                 {
                     this.dispatchEvent(displayObject, isRightButton ? 'rightclick' : 'click', interactionEvent);
-                    // because we can confirm that the mousedown happened on this object, emit pointertap
-                    this.dispatchEvent(displayObject, 'pointertap', interactionEvent);
+                    // because we can confirm that the mousedown happened on this object, flag for later emit of pointertap
+                    isMouseTap = true;
                 }
             }
             else if (isDown)
@@ -1395,8 +1398,8 @@ export default class InteractionManager extends EventEmitter
 
             if (trackingData)
             {
-                // mouse pointer taps are handled in the isMouse block for code simplicity
-                if (!isMouse)
+                // emit pointertap if not a mouse, or if the mouse block decided it was a tap
+                if (!isMouse || isMouseTap)
                 {
                     this.dispatchEvent(displayObject, 'pointertap', interactionEvent);
                 }


### PR DESCRIPTION
Fixes #4908 

I hadn't originally made #4872 this way because it was a little less clean, but in order to retain the same event order this arrangement is required.