### PR TITLE
Add a few code examples in the docs and fix grammatical mistakes

### DIFF
--- a/packages/app/src/Application.js
+++ b/packages/app/src/Application.js
@@ -25,31 +25,31 @@ export default class Application
 {
     // eslint-disable-next-line valid-jsdoc
     /**
-     * @param {object} [options] - The optional renderer parameters
-     * @param {boolean} [options.autoStart=true] - automatically starts the rendering after the construction.
-     *     Note that setting this parameter to false does NOT stop the shared ticker even if you set
+     * @param {object} [options] - The optional renderer parameters.
+     * @param {boolean} [options.autoStart=true] - Automatically starts the rendering after the construction.
+     *     **Note**: Setting this parameter to false does NOT stop the shared ticker even if you set
      *     options.sharedTicker to true in case that it is already started. Stop it by your own.
-     * @param {number} [options.width=800] - the width of the renderers view
-     * @param {number} [options.height=600] - the height of the renderers view
-     * @param {HTMLCanvasElement} [options.view] - the canvas to use as a view, optional
-     * @param {boolean} [options.transparent=false] - If the render view is transparent, default false
+     * @param {number} [options.width=800] - The width of the renderers view.
+     * @param {number} [options.height=600] - The height of the renderers view.
+     * @param {HTMLCanvasElement} [options.view] - The canvas to use as a view, optional.
+     * @param {boolean} [options.transparent=false] - If the render view is transparent.
      * @param {boolean} [options.autoDensity=false] - Resizes renderer view in CSS pixels to allow for
-     *   resolutions other than 1
-     * @param {boolean} [options.antialias=false] - sets antialias (only applicable in chrome at the moment)
-     * @param {boolean} [options.preserveDrawingBuffer=false] - enables drawing buffer preservation, enable this if you
-     *  need to call toDataUrl on the webgl context
-     * @param {number} [options.resolution=1] - The resolution / device pixel ratio of the renderer, retina would be 2
-     * @param {boolean} [options.forceCanvas=false] - prevents selection of WebGL renderer, even if such is present
+     *   resolutions other than 1.
+     * @param {boolean} [options.antialias=false] - Sets antialias (only applicable in Chrome at the moment).
+     * @param {boolean} [options.preserveDrawingBuffer=false] - Enables drawing buffer preservation, enable this if you
+     *  need to call toDataUrl on the WebGL context.
+     * @param {number} [options.resolution=1] - The resolution / device pixel ratio of the renderer, retina would be 2.
+     * @param {boolean} [options.forceCanvas=false] - Prevents selection of WebGL renderer, even if such is present.
      * @param {number} [options.backgroundColor=0x000000] - The background color of the rendered area
      *  (shown if not transparent).
      * @param {boolean} [options.clearBeforeRender=true] - This sets if the renderer will clear the canvas or
      *   not before the new render pass.
      * @param {boolean} [options.roundPixels=false] - If true PixiJS will Math.floor() x/y values when rendering,
      *  stopping pixel interpolation.
-     * @param {boolean} [options.forceFXAA=false] - forces FXAA antialiasing to be used over native.
-     *  FXAA is faster, but may not always look as great **webgl only**
+     * @param {boolean} [options.forceFXAA=false] - Forces FXAA antialiasing to be used over native.
+     *  FXAA is faster, but may not always look as great. **(WebGL only)**.
      * @param {string} [options.powerPreference] - Parameter passed to webgl context, set to "high-performance"
-     *  for devices with dual graphics card **webgl only**
+     *  for devices with dual graphics card. **(WebGL only)**.
      * @param {boolean} [options.sharedTicker=false] - `true` to use PIXI.Ticker.shared, `false` to create new ticker.
      * @param {boolean} [options.sharedLoader=false] - `true` to use PIXI.Loaders.shared, `false` to create new Loader.
      * @param {Window|HTMLElement} [options.resizeTo] - Element to automatically resize stage to.
@@ -81,7 +81,7 @@ export default class Application
         }, options);
 
         /**
-         * WebGL renderer if available, otherwise CanvasRenderer
+         * WebGL renderer if available, otherwise CanvasRenderer.
          * @member {PIXI.Renderer|PIXI.CanvasRenderer}
          */
         this.renderer = this.createRenderer(options);
@@ -226,7 +226,7 @@ export default class Application
     }
 
     /**
-     * Reference to the renderer's screen rectangle. Its safe to use as filterArea or hitArea for whole screen
+     * Reference to the renderer's screen rectangle. Its safe to use as `filterArea` or `hitArea` for the whole screen.
      * @member {PIXI.Rectangle}
      * @readonly
      */

--- a/packages/core/src/AbstractRenderer.js
+++ b/packages/core/src/AbstractRenderer.js
@@ -22,18 +22,18 @@ export default class AbstractRenderer extends EventEmitter
     // eslint-disable-next-line valid-jsdoc
     /**
      * @param {string} system - The name of the system this renderer is for.
-     * @param {object} [options] - The optional renderer parameters
-     * @param {number} [options.width=800] - the width of the screen
-     * @param {number} [options.height=600] - the height of the screen
-     * @param {HTMLCanvasElement} [options.view] - the canvas to use as a view, optional
-     * @param {boolean} [options.transparent=false] - If the render view is transparent, default false
+     * @param {object} [options] - The optional renderer parameters.
+     * @param {number} [options.width=800] - The width of the screen.
+     * @param {number} [options.height=600] - The height of the screen.
+     * @param {HTMLCanvasElement} [options.view] - The canvas to use as a view, optional.
+     * @param {boolean} [options.transparent=false] - If the render view is transparent.
      * @param {boolean} [options.autoDensity=false] - Resizes renderer view in CSS pixels to allow for
-     *   resolutions other than 1
-     * @param {boolean} [options.antialias=false] - sets antialias (only applicable in chrome at the moment)
+     *   resolutions other than 1.
+     * @param {boolean} [options.antialias=false] - Sets antialias (only applicable in Chrome at the moment).
      * @param {number} [options.resolution=1] - The resolution / device pixel ratio of the renderer. The
      *  resolution of the renderer retina would be 2.
-     * @param {boolean} [options.preserveDrawingBuffer=false] - enables drawing buffer preservation,
-     *  enable this if you need to call toDataUrl on the webgl context.
+     * @param {boolean} [options.preserveDrawingBuffer=false] - Enables drawing buffer preservation,
+     *  enable this if you need to call toDataUrl on the WebGL context.
      * @param {boolean} [options.clearBeforeRender=true] - This sets if the renderer will clear the canvas or
      *      not before the new render pass.
      * @param {number} [options.backgroundColor=0x000000] - The background color of the rendered area
@@ -75,23 +75,23 @@ export default class AbstractRenderer extends EventEmitter
         this.type = RENDERER_TYPE.UNKNOWN;
 
         /**
-         * Measurements of the screen. (0, 0, screenWidth, screenHeight)
+         * Measurements of the screen. (0, 0, screenWidth, screenHeight).
          *
-         * Its safe to use as filterArea or hitArea for whole stage
+         * Its safe to use as filterArea or hitArea for the whole stage.
          *
          * @member {PIXI.Rectangle}
          */
         this.screen = new Rectangle(0, 0, options.width, options.height);
 
         /**
-         * The canvas element that everything is drawn to
+         * The canvas element that everything is drawn to.
          *
          * @member {HTMLCanvasElement}
          */
         this.view = options.view || document.createElement('canvas');
 
         /**
-         * The resolution / device pixel ratio of the renderer
+         * The resolution / device pixel ratio of the renderer.
          *
          * @member {number}
          * @default 1
@@ -99,14 +99,14 @@ export default class AbstractRenderer extends EventEmitter
         this.resolution = options.resolution || settings.RESOLUTION;
 
         /**
-         * Whether the render view is transparent
+         * Whether the render view is transparent.
          *
          * @member {boolean}
          */
         this.transparent = options.transparent;
 
         /**
-         * Whether css dimensions of canvas view should be resized to screen dimensions automatically
+         * Whether CSS dimensions of canvas view should be resized to screen dimensions automatically.
          *
          * @member {boolean}
          */
@@ -132,7 +132,7 @@ export default class AbstractRenderer extends EventEmitter
          * This sets if the CanvasRenderer will clear the canvas or not before the new render pass.
          * If the scene is NOT transparent PixiJS will use a canvas sized fillRect operation every
          * frame to set the canvas background color. If the scene is transparent PixiJS will use clearRect
-         * to clear the canvas every frame. Disable this by setting this to false. For example if
+         * to clear the canvas every frame. Disable this by setting this to false. For example, if
          * your game has a canvas filling background image you often don't need this set.
          *
          * @member {boolean}
@@ -175,7 +175,7 @@ export default class AbstractRenderer extends EventEmitter
         this.backgroundColor = options.backgroundColor || this._backgroundColor; // run bg color setter
 
         /**
-         * This temporary display object used as the parent of the currently being rendered item
+         * This temporary display object used as the parent of the currently being rendered item.
          *
          * @member {PIXI.DisplayObject}
          * @private
@@ -213,7 +213,7 @@ export default class AbstractRenderer extends EventEmitter
     }
 
     /**
-     * Same as view.width, actual number of pixels in the canvas by horizontal
+     * Same as view.width, actual number of pixels in the canvas by horizontal.
      *
      * @member {number}
      * @readonly
@@ -225,7 +225,7 @@ export default class AbstractRenderer extends EventEmitter
     }
 
     /**
-     * Same as view.height, actual number of pixels in the canvas by vertical
+     * Same as view.height, actual number of pixels in the canvas by vertical.
      *
      * @member {number}
      * @readonly
@@ -237,11 +237,11 @@ export default class AbstractRenderer extends EventEmitter
     }
 
     /**
-     * Resizes the screen and canvas to the specified width and height
-     * Canvas dimensions are multiplied by resolution
+     * Resizes the screen and canvas to the specified width and height.
+     * Canvas dimensions are multiplied by resolution.
      *
-     * @param {number} screenWidth - the new width of the screen
-     * @param {number} screenHeight - the new height of the screen
+     * @param {number} screenWidth - The new width of the screen.
+     * @param {number} screenHeight - The new height of the screen.
      */
     resize(screenWidth, screenHeight)
     {
@@ -262,12 +262,12 @@ export default class AbstractRenderer extends EventEmitter
      * Useful function that returns a texture of the display object that can then be used to create sprites
      * This can be quite useful if your displayObject is complicated and needs to be reused multiple times.
      *
-     * @param {PIXI.DisplayObject} displayObject - The displayObject the object will be generated from
-     * @param {number} scaleMode - Should be one of the scaleMode consts
-     * @param {number} resolution - The resolution / device pixel ratio of the texture being generated
+     * @param {PIXI.DisplayObject} displayObject - The displayObject the object will be generated from.
+     * @param {number} scaleMode - Should be one of the scaleMode consts.
+     * @param {number} resolution - The resolution / device pixel ratio of the texture being generated.
      * @param {PIXI.Rectangle} [region] - The region of the displayObject, that shall be rendered,
      *        if no region is specified, defaults to the local bounds of the displayObject.
-     * @return {PIXI.Texture} a texture of the graphics object
+     * @return {PIXI.Texture} A texture of the graphics object.
      */
     generateTexture(displayObject, scaleMode, resolution, region)
     {

--- a/packages/core/src/Renderer.js
+++ b/packages/core/src/Renderer.js
@@ -19,10 +19,10 @@ import { Matrix } from '@pixi/math';
 import Runner from 'mini-runner';
 
 /**
- * The Renderer draws the scene and all its content onto a webGL enabled canvas. This renderer
- * should be used for browsers that support webGL. This Render works by automatically managing webGLBatchs.
+ * The Renderer draws the scene and all its content onto a WebGL enabled canvas. This renderer
+ * should be used for browsers that support WebGL. This renderer works by automatically managing WebGLBatches.
  * So no need for Sprite Batches or Sprite Clouds.
- * Don't forget to add the view to your DOM or you will not see anything :)
+ * Don't forget to add the view to your DOM or you will not see anything :).
  *
  * @class
  * @memberof PIXI
@@ -33,30 +33,30 @@ export default class Renderer extends AbstractRenderer
     // eslint-disable-next-line valid-jsdoc
     /**
      *
-     * @param {object} [options] - The optional renderer parameters
-     * @param {number} [options.width=800] - the width of the screen
-     * @param {number} [options.height=600] - the height of the screen
-     * @param {HTMLCanvasElement} [options.view] - the canvas to use as a view, optional
-     * @param {boolean} [options.transparent=false] - If the render view is transparent, default false
+     * @param {object} [options] - The optional renderer parameters.
+     * @param {number} [options.width=800] - The width of the screen.
+     * @param {number} [options.height=600] - The height of the screen.
+     * @param {HTMLCanvasElement} [options.view] - The canvas to use as a view, optional.
+     * @param {boolean} [options.transparent=false] - If the render view is transparent.
      * @param {boolean} [options.autoDensity=false] - Resizes renderer view in CSS pixels to allow for
-     *   resolutions other than 1
-     * @param {boolean} [options.antialias=false] - sets antialias. If not available natively then FXAA
-     *  antialiasing is used
-     * @param {boolean} [options.forceFXAA=false] - forces FXAA antialiasing to be used over native.
-     *  FXAA is faster, but may not always look as great
+     *   resolutions other than 1.
+     * @param {boolean} [options.antialias=false] - Sets antialias. If not available natively then FXAA
+     *  antialiasing is used.
+     * @param {boolean} [options.forceFXAA=false] - Forces FXAA antialiasing to be used over native.
+     *  FXAA is faster, but may not always look as great.
      * @param {number} [options.resolution=1] - The resolution / device pixel ratio of the renderer.
      *  The resolution of the renderer retina would be 2.
      * @param {boolean} [options.clearBeforeRender=true] - This sets if the renderer will clear
      *  the canvas or not before the new render pass. If you wish to set this to false, you *must* set
      *  preserveDrawingBuffer to `true`.
-     * @param {boolean} [options.preserveDrawingBuffer=false] - enables drawing buffer preservation,
-     *  enable this if you need to call toDataUrl on the webgl context.
+     * @param {boolean} [options.preserveDrawingBuffer=false] - Enables drawing buffer preservation,
+     *  enable this if you need to call toDataUrl on the WebGL context.
      * @param {boolean} [options.roundPixels=false] - If true PixiJS will Math.floor() x/y values when
      *  rendering, stopping pixel interpolation.
      * @param {number} [options.backgroundColor=0x000000] - The background color of the rendered area
      *  (shown if not transparent).
-     * @param {string} [options.powerPreference] - Parameter passed to webgl context, set to "high-performance"
-     *  for devices with dual graphics card
+     * @param {string} [options.powerPreference] - Parameter passed to WebGL context, set to "high-performance"
+     *  for devices with dual graphics card.
      */
     constructor(options, arg2, arg3)
     {
@@ -204,7 +204,7 @@ export default class Renderer extends AbstractRenderer
         this.initPlugins(Renderer.__plugins);
 
         /**
-         * The options passed in to create a new webgl context.
+         * The options passed in to create a new WebGL context.
          *
          * @member {object}
          * @private
@@ -291,11 +291,11 @@ export default class Renderer extends AbstractRenderer
     }
 
     /**
-     * Renders the object to its webGL view
+     * Renders the object to its WebGL view
      *
-     * @param {PIXI.DisplayObject} displayObject - the object to be rendered
+     * @param {PIXI.DisplayObject} displayObject - The object to be rendered.
      * @param {PIXI.RenderTexture} renderTexture - The render texture to render to.
-     * @param {boolean} [clear] - Should the canvas be cleared before the new render
+     * @param {boolean} [clear] - Should the canvas be cleared before the new render.
      * @param {PIXI.Transform} [transform] - A transform to apply to the render texture before rendering.
      * @param {boolean} [skipUpdateTransform] - Should we skip the update transform pass?
      */
@@ -353,10 +353,10 @@ export default class Renderer extends AbstractRenderer
     }
 
     /**
-     * Resizes the webGL view to the specified width and height.
+     * Resizes the WebGL view to the specified width and height.
      *
-     * @param {number} screenWidth - the new width of the screen
-     * @param {number} screenHeight - the new height of the screen
+     * @param {number} screenWidth - The new width of the screen.
+     * @param {number} screenHeight - The new height of the screen.
      */
     resize(screenWidth, screenHeight)
     {

--- a/packages/core/src/renderTexture/BaseRenderTexture.js
+++ b/packages/core/src/renderTexture/BaseRenderTexture.js
@@ -8,7 +8,7 @@ import FrameBuffer from '../framebuffer/FrameBuffer';
  * otherwise black rectangles will be drawn instead.
  *
  * A BaseRenderTexture takes a snapshot of any Display Object given to its render method. The position
- * and rotation of the given Display Objects is ignored. For example:
+ * and rotation of the given Display Objects are ignored. For example:
  *
  * ```js
  * let renderer = PIXI.autoDetectRenderer(1024, 1024, { view: canvas, ratio: 1 });
@@ -23,8 +23,8 @@ import FrameBuffer from '../framebuffer/FrameBuffer';
  * baseRenderTexture.render(sprite);
  * ```
  *
- * The Sprite in this case will be rendered using its local transform. To render this sprite at 0,0
- * you can clear the transform
+ * The Sprite, in this case, will be rendered using its local transform. To render this sprite at (0,0)
+ * you can clear the transform.
  *
  * ```js
  *
@@ -44,10 +44,10 @@ export default class BaseRenderTexture extends BaseTexture
 {
     /**
      * @param {object} [options]
-     * @param {number} [options.width=100] - The width of the base render texture
-     * @param {number} [options.height=100] - The height of the base render texture
-     * @param {PIXI.SCALE_MODES} [options.scaleMode] - See {@link PIXI.SCALE_MODES} for possible values
-     * @param {number} [options.resolution=1] - The resolution / device pixel ratio of the texture being generated
+     * @param {number} [options.width=100] - The width of the base render texture.
+     * @param {number} [options.height=100] - The height of the base render texture.
+     * @param {PIXI.SCALE_MODES} [options.scaleMode] - See {@link PIXI.SCALE_MODES} for possible values.
+     * @param {number} [options.resolution=1] - The resolution / device pixel ratio of the texture being generated.
      */
     constructor(options)
     {
@@ -99,14 +99,14 @@ export default class BaseRenderTexture extends BaseTexture
         // TODO - could this be added the systems?
 
         /**
-         * The data structure for the stencil masks
+         * The data structure for the stencil masks.
          *
          * @member {PIXI.Graphics[]}
          */
         this.stencilMaskStack = [];
 
         /**
-         * The data structure for the filters
+         * The data structure for the filters.
          *
          * @member {PIXI.Graphics[]}
          */
@@ -127,7 +127,7 @@ export default class BaseRenderTexture extends BaseTexture
     }
 
     /**
-     * Destroys this texture
+     * Destroys this texture.
      *
      */
     destroy()

--- a/packages/display/src/DisplayObject.js
+++ b/packages/display/src/DisplayObject.js
@@ -25,7 +25,7 @@ export default class DisplayObject extends EventEmitter
         // TODO: need to create Transform from factory
         /**
          * World transform and local transform of this object.
-         * This will become read-only later, please do not assign anything there unless you know what are you doing
+         * This will become read-only later, please do not assign anything there unless you know what are you doing.
          *
          * @member {PIXI.TransformBase}
          */
@@ -42,7 +42,7 @@ export default class DisplayObject extends EventEmitter
          * The visibility of the object. If false the object will not be drawn, and
          * the updateTransform function will not be called.
          *
-         * Only affects recursive calls from parent. You can ask for bounds or call updateTransform manually
+         * Only affects recursive calls from parent. You can ask for bounds or call updateTransform manually.
          *
          * @member {boolean}
          */
@@ -52,7 +52,7 @@ export default class DisplayObject extends EventEmitter
          * Can this object be rendered, if false the object will not be drawn but the updateTransform
          * methods will still be called.
          *
-         * Only affects recursive calls from parent. You can ask for bounds manually
+         * Only affects recursive calls from parent. You can ask for bounds manually.
          *
          * @member {boolean}
          */
@@ -67,7 +67,7 @@ export default class DisplayObject extends EventEmitter
         this.parent = null;
 
         /**
-         * The multiplied alpha of the displayObject
+         * The multiplied alpha of the displayObject.
          *
          * @member {number}
          * @readonly
@@ -76,9 +76,9 @@ export default class DisplayObject extends EventEmitter
 
         /**
          * The area the filter is applied to. This is used as more of an optimization
-         * rather than figuring out the dimensions of the displayObject each frame you can set this rectangle
+         * rather than figuring out the dimensions of the displayObject each frame you can set this rectangle.
          *
-         * Also works as an interaction mask
+         * Also works as an interaction mask.
          *
          * @member {PIXI.Rectangle}
          */
@@ -86,8 +86,8 @@ export default class DisplayObject extends EventEmitter
 
         /**
          * Sets the filters for the displayObject.
-         * * IMPORTANT: This is a webGL only feature and will be ignored by the canvas renderer.
-         * To remove filters simply set this property to 'null'
+         * * IMPORTANT: This is a WebGL only feature and will be ignored by the canvas renderer.
+         * To remove filters simply set this property to `'null'`.
          *
          * @member {PIXI.Filter[]}
          */
@@ -95,7 +95,7 @@ export default class DisplayObject extends EventEmitter
         this._enabledFilters = null;
 
         /**
-         * The bounds object, this is used to calculate and store the bounds of the displayObject
+         * The bounds object, this is used to calculate and store the bounds of the displayObject.
          *
          * @member {PIXI.Rectangle}
          * @private
@@ -107,7 +107,7 @@ export default class DisplayObject extends EventEmitter
         this._localBoundsRect = null;
 
         /**
-         * The original, cached mask of the object
+         * The original, cached mask of the object.
          *
          * @member {PIXI.Graphics|PIXI.Sprite}
          * @private
@@ -153,7 +153,7 @@ export default class DisplayObject extends EventEmitter
     }
 
     /**
-     * Updates the object transform for rendering
+     * Updates the object transform for rendering.
      *
      * TODO - Optimization pass!
      */
@@ -167,7 +167,7 @@ export default class DisplayObject extends EventEmitter
     }
 
     /**
-     * recursively updates transform of all objects from the root to this one
+     * Recursively updates transform of all objects from the root to this one
      * internal function for toLocal()
      */
     _recursivePostUpdateTransform()
@@ -186,11 +186,11 @@ export default class DisplayObject extends EventEmitter
     /**
      * Retrieves the bounds of the displayObject as a rectangle object.
      *
-     * @param {boolean} skipUpdate - setting to true will stop the transforms of the scene graph from
+     * @param {boolean} skipUpdate - Setting to `true` will stop the transforms of the scene graph from
      *  being updated. This means the calculation returned MAY be out of date BUT will give you a
-     *  nice performance boost
-     * @param {PIXI.Rectangle} rect - Optional rectangle to store the result of the bounds calculation
-     * @return {PIXI.Rectangle} the rectangular bounding area
+     *  nice performance boost.
+     * @param {PIXI.Rectangle} rect - Optional rectangle to store the result of the bounds calculation.
+     * @return {PIXI.Rectangle} The rectangular bounding area.
      */
     getBounds(skipUpdate, rect)
     {
@@ -228,10 +228,10 @@ export default class DisplayObject extends EventEmitter
     }
 
     /**
-     * Retrieves the local bounds of the displayObject as a rectangle object
+     * Retrieves the local bounds of the displayObject as a rectangle object.
      *
-     * @param {PIXI.Rectangle} [rect] - Optional rectangle to store the result of the bounds calculation
-     * @return {PIXI.Rectangle} the rectangular bounding area
+     * @param {PIXI.Rectangle} [rect] - Optional rectangle to store the result of the bounds calculation.
+     * @return {PIXI.Rectangle} The rectangular bounding area.
      */
     getLocalBounds(rect)
     {
@@ -260,13 +260,13 @@ export default class DisplayObject extends EventEmitter
     }
 
     /**
-     * Calculates the global position of the display object
+     * Calculates the global position of the display object.
      *
-     * @param {PIXI.Point} position - The world origin to calculate from
+     * @param {PIXI.Point} position - The world origin to calculate from.
      * @param {PIXI.Point} [point] - A Point object in which to store the value, optional
-     *  (otherwise will create a new Point)
+     *  (otherwise will create a new Point).
      * @param {boolean} [skipUpdate=false] - Should we skip the update transform.
-     * @return {PIXI.Point} A point object representing the position of this object
+     * @return {PIXI.Point} A point object representing the position of this object.
      */
     toGlobal(position, point, skipUpdate = false)
     {
@@ -294,12 +294,12 @@ export default class DisplayObject extends EventEmitter
     }
 
     /**
-     * Calculates the local position of the display object relative to another point
+     * Calculates the local position of the display object relative to another point.
      *
-     * @param {PIXI.Point} position - The world origin to calculate from
-     * @param {PIXI.DisplayObject} [from] - The DisplayObject to calculate the global position from
+     * @param {PIXI.Point} position - The world origin to calculate from.
+     * @param {PIXI.DisplayObject} [from] - The DisplayObject to calculate the global position from.
      * @param {PIXI.Point} [point] - A Point object in which to store the value, optional
-     *  (otherwise will create a new Point)
+     *  (otherwise will create a new Point).
      * @param {boolean} [skipUpdate=false] - Should we skip the update transform
      * @return {PIXI.Point} A point object representing the position of this object
      */
@@ -334,9 +334,9 @@ export default class DisplayObject extends EventEmitter
     }
 
     /**
-     * Renders the object using the WebGL renderer
+     * Renders the object using the WebGL renderer.
      *
-     * @param {PIXI.Renderer} renderer - The renderer
+     * @param {PIXI.Renderer} renderer - The renderer.
      */
     render(renderer) // eslint-disable-line no-unused-vars
     {
@@ -344,10 +344,10 @@ export default class DisplayObject extends EventEmitter
     }
 
     /**
-     * Set the parent Container of this DisplayObject
+     * Set the parent Container of this DisplayObject.
      *
-     * @param {PIXI.Container} container - The Container to add this DisplayObject to
-     * @return {PIXI.Container} The Container that this DisplayObject was added to
+     * @param {PIXI.Container} container - The Container to add this DisplayObject to.
+     * @return {PIXI.Container} The Container that this DisplayObject was added to.
      */
     setParent(container)
     {
@@ -394,7 +394,7 @@ export default class DisplayObject extends EventEmitter
      * Base destroy method for generic display objects. This will automatically
      * remove the display object from its parent Container as well as remove
      * all current event listeners and internal references. Do not use a DisplayObject
-     * after calling `destroy`.
+     * after calling `destroy()`.
      *
      */
     destroy()
@@ -453,7 +453,7 @@ export default class DisplayObject extends EventEmitter
     }
 
     /**
-     * Current transform of the object based on world (parent) factors
+     * Current transform of the object based on world (parent) factors.
      *
      * @member {PIXI.Matrix}
      * @readonly
@@ -464,7 +464,7 @@ export default class DisplayObject extends EventEmitter
     }
 
     /**
-     * Current transform of the object based on local factors: position, scale, other stuff
+     * Current transform of the object based on local factors: position, scale, other stuff.
      *
      * @member {PIXI.Matrix}
      * @readonly
@@ -507,7 +507,7 @@ export default class DisplayObject extends EventEmitter
     }
 
     /**
-     * The pivot point of the displayObject that it rotates around
+     * The pivot point of the displayObject that it rotates around.
      * Assignment by value since pixi-v4.
      *
      * @member {PIXI.Point|PIXI.ObservablePoint}
@@ -579,12 +579,19 @@ export default class DisplayObject extends EventEmitter
     /**
      * Sets a mask for the displayObject. A mask is an object that limits the visibility of an
      * object to the shape of the mask applied to it. In PIXI a regular mask must be a
-     * PIXI.Graphics or a PIXI.Sprite object. This allows for much faster masking in canvas as it
-     * utilities shape clipping. To remove a mask, set this property to null.
+     * {@link PIXI.Graphics} or a {@link PIXI.Sprite} object. This allows for much faster masking in canvas as it
+     * utilities shape clipping. To remove a mask, set this property to `null`.
      *
      * For sprite mask both alpha and red channel are used. Black mask is the same as transparent mask.
+     * @example
+     * const graphics = new PIXI.Graphics();
+     * graphics.beginFill(0xFF3300);
+     * graphics.drawRect(50, 250, 100, 100);
+     * graphics.endFill();
      *
-     * @todo For the moment, PIXI.CanvasRenderer doesn't support PIXI.Sprite as mask.
+     * const sprite = new PIXI.Sprite(texture);
+     * sprite.mask = graphics;
+     * @todo At the moment, PIXI.CanvasRenderer doesn't support PIXI.Sprite as mask.
      *
      * @member {PIXI.Graphics|PIXI.Sprite}
      */

--- a/packages/mixin-cache-as-bitmap/src/index.js
+++ b/packages/mixin-cache-as-bitmap/src/index.js
@@ -44,9 +44,9 @@ Object.defineProperties(DisplayObject.prototype, {
      * Set this to true if you want this display object to be cached as a bitmap.
      * This basically takes a snap shot of the display object as it is at that moment. It can
      * provide a performance benefit for complex static displayObjects.
-     * To remove simply set this property to 'false'
+     * To remove simply set this property to `false`
      *
-     * IMPORTANT GOTCHA - make sure that all your textures are preloaded BEFORE setting this property to true
+     * IMPORTANT GOTCHA - Make sure that all your textures are preloaded BEFORE setting this property to true
      * as it will take a snapshot of what is currently there. If the textures have not loaded then they will not appear.
      *
      * @member {boolean}

--- a/packages/mixin-get-child-by-name/src/index.js
+++ b/packages/mixin-get-child-by-name/src/index.js
@@ -9,11 +9,11 @@ import { DisplayObject, Container } from '@pixi/display';
 DisplayObject.prototype.name = null;
 
 /**
- * Returns the display object in the container
+ * Returns the display object in the container.
  *
  * @method getChildByName
  * @memberof PIXI.Container#
- * @param {string} name - instance name
+ * @param {string} name - Instance name.
  * @return {PIXI.DisplayObject} The child with the specified name.
  */
 Container.prototype.getChildByName = function getChildByName(name)

--- a/packages/mixin-get-global-position/src/index.js
+++ b/packages/mixin-get-global-position/src/index.js
@@ -6,11 +6,11 @@ import { Point } from '@pixi/math';
  *
  * @method getGlobalPosition
  * @memberof PIXI.DisplayObject#
- * @param {Point} point - the point to write the global value to. If null a new point will be returned
- * @param {boolean} skipUpdate - setting to true will stop the transforms of the scene graph from
+ * @param {Point} point - The point to write the global value to. If null a new point will be returned
+ * @param {boolean} skipUpdate - Setting to true will stop the transforms of the scene graph from
  *  being updated. This means the calculation returned MAY be out of date BUT will give you a
- *  nice performance boost
- * @return {Point} The updated point
+ *  nice performance boost.
+ * @return {Point} The updated point.
  */
 DisplayObject.prototype.getGlobalPosition = function getGlobalPosition(point = new Point(), skipUpdate = false)
 {

--- a/packages/sprite-animated/src/AnimatedSprite.js
+++ b/packages/sprite-animated/src/AnimatedSprite.js
@@ -32,8 +32,8 @@ import { Ticker, UPDATE_PRIORITY } from '@pixi/ticker';
 export default class AnimatedSprite extends Sprite
 {
     /**
-     * @param {PIXI.Texture[]|PIXI.extras.AnimatedSprite~FrameObject[]} textures - an array of {@link PIXI.Texture} or frame
-     *  objects that make up the animation
+     * @param {PIXI.Texture[]|PIXI.extras.AnimatedSprite~FrameObject[]} textures - An array of {@link PIXI.Texture} or frame
+     *  objects that make up the animation.
      * @param {boolean} [autoUpdate=true] - Whether to use PIXI.Ticker.shared to auto update animation time.
      */
     constructor(textures, autoUpdate)
@@ -61,7 +61,7 @@ export default class AnimatedSprite extends Sprite
         this._autoUpdate = autoUpdate !== false;
 
         /**
-         * The speed that the AnimatedSprite will play at. Higher is faster, lower is slower
+         * The speed that the AnimatedSprite will play at. Higher is faster, lower is slower.
          *
          * @member {number}
          * @default 1
@@ -77,28 +77,28 @@ export default class AnimatedSprite extends Sprite
         this.loop = true;
 
         /**
-         * Function to call when a AnimatedSprite finishes playing
+         * Function to call when a AnimatedSprite finishes playing.
          *
          * @member {Function}
          */
         this.onComplete = null;
 
         /**
-         * Function to call when a AnimatedSprite changes which texture is being rendered
+         * Function to call when a AnimatedSprite changes which texture is being rendered.
          *
          * @member {Function}
          */
         this.onFrameChange = null;
 
         /**
-         * Function to call when 'loop' is true, and an AnimatedSprite is played and loops around to start again
+         * Function to call when `loop` is true, and an AnimatedSprite is played and loops around to start again.
          *
          * @member {Function}
          */
         this.onLoop = null;
 
         /**
-         * Elapsed time since animation has been started, used internally to display current texture
+         * Elapsed time since animation has been started, used internally to display current texture.
          *
          * @member {number}
          * @private
@@ -106,7 +106,7 @@ export default class AnimatedSprite extends Sprite
         this._currentTime = 0;
 
         /**
-         * Indicates if the AnimatedSprite is currently playing
+         * Indicates if the AnimatedSprite is currently playing.
          *
          * @member {boolean}
          * @readonly
@@ -115,7 +115,7 @@ export default class AnimatedSprite extends Sprite
     }
 
     /**
-     * Stops the AnimatedSprite
+     * Stops the AnimatedSprite.
      *
      */
     stop()
@@ -133,7 +133,7 @@ export default class AnimatedSprite extends Sprite
     }
 
     /**
-     * Plays the AnimatedSprite
+     * Plays the AnimatedSprite.
      *
      */
     play()
@@ -151,9 +151,9 @@ export default class AnimatedSprite extends Sprite
     }
 
     /**
-     * Stops the AnimatedSprite and goes to a specific frame
+     * Stops the AnimatedSprite and goes to a specific frame.
      *
-     * @param {number} frameNumber - frame index to stop at
+     * @param {number} frameNumber - Frame index to stop at.
      */
     gotoAndStop(frameNumber)
     {
@@ -170,9 +170,9 @@ export default class AnimatedSprite extends Sprite
     }
 
     /**
-     * Goes to a specific frame and begins playing the AnimatedSprite
+     * Goes to a specific frame and begins playing the AnimatedSprite.
      *
-     * @param {number} frameNumber - frame index to start at
+     * @param {number} frameNumber - Frame index to start at.
      */
     gotoAndPlay(frameNumber)
     {
@@ -265,7 +265,7 @@ export default class AnimatedSprite extends Sprite
     }
 
     /**
-     * Updates the displayed texture to match the current frame index
+     * Updates the displayed texture to match the current frame index.
      *
      * @private
      */
@@ -282,14 +282,14 @@ export default class AnimatedSprite extends Sprite
     }
 
     /**
-     * Stops the AnimatedSprite and destroys it
+     * Stops the AnimatedSprite and destroys it.
      *
      * @param {object|boolean} [options] - Options parameter. A boolean will act as if all options
-     *  have been set to that value
-     * @param {boolean} [options.children=false] - if set to true, all the children will have their destroy
+     *  have been set to that value.
+     * @param {boolean} [options.children=false] - If set to true, all the children will have their destroy
      *      method called as well. 'options' will be passed on to those calls.
-     * @param {boolean} [options.texture=false] - Should it destroy the current texture of the sprite as well
-     * @param {boolean} [options.baseTexture=false] - Should it destroy the base texture of the sprite as well
+     * @param {boolean} [options.texture=false] - Should it destroy the current texture of the sprite as well.
+     * @param {boolean} [options.baseTexture=false] - Should it destroy the base texture of the sprite as well.
      */
     destroy(options)
     {
@@ -298,10 +298,10 @@ export default class AnimatedSprite extends Sprite
     }
 
     /**
-     * A short hand way of creating a movieclip from an array of frame ids
+     * A short hand way of creating a movieclip from an array of frame ids.
      *
      * @static
-     * @param {string[]} frames - The array of frames ids the movieclip will use as its texture frames
+     * @param {string[]} frames - The array of frames ids the movieclip will use as its texture frames.
      * @return {AnimatedSprite} The new animated sprite with the specified frames.
      */
     static fromFrames(frames)
@@ -317,10 +317,10 @@ export default class AnimatedSprite extends Sprite
     }
 
     /**
-     * A short hand way of creating a movieclip from an array of image ids
+     * A short hand way of creating a movieclip from an array of image ids.
      *
      * @static
-     * @param {string[]} images - the array of image urls the movieclip will use as its texture frames
+     * @param {string[]} images - The array of image urls the movieclip will use as its texture frames.
      * @return {AnimatedSprite} The new animate sprite with the specified images as frames.
      */
     static fromImages(images)
@@ -336,7 +336,7 @@ export default class AnimatedSprite extends Sprite
     }
 
     /**
-     * totalFrames is the total number of frames in the AnimatedSprite. This is the same as number of textures
+     * The total number of frames in the AnimatedSprite. This is the same as number of textures
      * assigned to the AnimatedSprite.
      *
      * @readonly
@@ -349,7 +349,7 @@ export default class AnimatedSprite extends Sprite
     }
 
     /**
-     * The array of textures used for this AnimatedSprite
+     * The array of textures used for this AnimatedSprite.
      *
      * @member {PIXI.Texture[]}
      */
@@ -381,7 +381,7 @@ export default class AnimatedSprite extends Sprite
     }
 
     /**
-    * The AnimatedSprites current frame index
+    * The AnimatedSprites current frame index.
     *
     * @member {number}
     * @readonly

--- a/packages/sprite/src/Sprite.js
+++ b/packages/sprite/src/Sprite.js
@@ -22,7 +22,7 @@ const tempPoint = new Point();
 export default class Sprite extends Container
 {
     /**
-     * @param {PIXI.Texture} texture - The texture for this sprite
+     * @param {PIXI.Texture} texture - The texture for this sprite.
      */
     constructor(texture)
     {
@@ -482,10 +482,19 @@ export default class Sprite extends Container
     }
 
     /**
-     * The anchor sets the origin point of the texture.
-     * The default is 0,0 this means the texture's origin is the top left
-     * Setting the anchor to 0.5,0.5 means the texture's origin is centered
-     * Setting the anchor to 1,1 would mean the texture's origin point will be the bottom right corner
+     * The anchor sets the origin point of the text.
+     *
+     * The default is `(0,0)`, this means the text's origin is the top left.
+     *
+     * Setting the anchor to `(0.5,0.5)` means the text's origin is centered.
+     *
+     * Setting the anchor to `(1,1)` would mean the text's origin point will be the bottom right corner.
+     *
+     * If you pass only single parameter, it will set both x and y to the same value as shown in the example below.
+     *
+     * @example
+     * const sprite = new PIXI.Sprite(texture);
+     * sprite.anchor.set(0.5); // This will set the origin to center. (0.5) is same as (0.5, 0.5).
      *
      * @member {PIXI.ObservablePoint}
      */

--- a/packages/text-bitmap/src/BitmapText.js
+++ b/packages/text-bitmap/src/BitmapText.js
@@ -16,8 +16,9 @@ import { removeItems, getResolutionOfUrl } from '@pixi/utils';
  * let bitmapText = new PIXI.BitmapText("text using a fancy font!", {font: "35px Desyrel", align: "right"});
  * ```
  *
- * http://www.angelcode.com/products/bmfont/ for windows or
- * http://www.bmglyph.com/ for mac.
+ * http://www.angelcode.com/products/bmfont/ for Windows or
+ *
+ * http://www.bmglyph.com/ for Mac.
  *
  * @class
  * @extends PIXI.Container
@@ -26,15 +27,15 @@ import { removeItems, getResolutionOfUrl } from '@pixi/utils';
 export default class BitmapText extends Container
 {
     /**
-     * @param {string} text - The copy that you would like the text to display
-     * @param {object} style - The style parameters
+     * @param {string} text - A string that you would like the text to display.
+     * @param {object} style - The style parameters.
      * @param {string|object} style.font - The font descriptor for the object, can be passed as a string of form
      *      "24px FontName" or "FontName" or as an object with explicit name/size properties.
-     * @param {string} [style.font.name] - The bitmap font id
+     * @param {string} [style.font.name] - The bitmap font id.
      * @param {number} [style.font.size] - The size of the font in pixels, e.g. 24
      * @param {string} [style.align='left'] - Alignment for multiline text ('left', 'center' or 'right'), does not affect
-     *      single line text
-     * @param {number} [style.tint=0xFFFFFF] - The tint color
+     *      single line text.
+     * @param {number} [style.tint=0xFFFFFF] - The tint color.
      */
     constructor(text, style = {})
     {
@@ -323,7 +324,7 @@ export default class BitmapText extends Container
     }
 
     /**
-     * The tint of the BitmapText object
+     * The tint of the BitmapText object.
      *
      * @member {number}
      */
@@ -340,7 +341,7 @@ export default class BitmapText extends Container
     }
 
     /**
-     * The alignment of the BitmapText object
+     * The alignment of the BitmapText object.
      *
      * @member {string}
      * @default 'left'
@@ -359,9 +360,12 @@ export default class BitmapText extends Container
 
     /**
      * The anchor sets the origin point of the text.
-     * The default is 0,0 this means the text's origin is the top left
-     * Setting the anchor to 0.5,0.5 means the text's origin is centered
-     * Setting the anchor to 1,1 would mean the text's origin point will be the bottom right corner
+     *
+     * The default is `(0,0)`, this means the text's origin is the top left.
+     *
+     * Setting the anchor to `(0.5,0.5)` means the text's origin is centered.
+     *
+     * Setting the anchor to `(1,1)` would mean the text's origin point will be the bottom right corner.
      *
      * @member {PIXI.Point | number}
      */
@@ -383,7 +387,7 @@ export default class BitmapText extends Container
     }
 
     /**
-     * The font descriptor of the BitmapText object
+     * The font descriptor of the BitmapText object.
      *
      * @member {string|object}
      */
@@ -416,7 +420,7 @@ export default class BitmapText extends Container
     }
 
     /**
-     * The text of the BitmapText object
+     * The text of the BitmapText object.
      *
      * @member {string}
      */
@@ -439,7 +443,7 @@ export default class BitmapText extends Container
     /**
      * The max width of this bitmap text in pixels. If the text provided is longer than the
      * value provided, line breaks will be automatically inserted in the last whitespace.
-     * Disable by setting value to 0
+     * Disable by setting the value to 0.
      *
      * @member {number}
      */
@@ -460,7 +464,7 @@ export default class BitmapText extends Container
 
     /**
      * The max line height. This is useful when trying to use the total height of the Text,
-     * ie: when trying to vertically align.
+     * i.e. when trying to vertically align.
      *
      * @member {number}
      * @readonly
@@ -474,7 +478,7 @@ export default class BitmapText extends Container
 
     /**
      * The width of the overall text, different from fontSize,
-     * which is defined in the style object
+     * which is defined in the style object.
      *
      * @member {number}
      * @readonly
@@ -488,7 +492,7 @@ export default class BitmapText extends Container
 
     /**
      * The height of the overall text, different from fontSize,
-     * which is defined in the style object
+     * which is defined in the style object.
      *
      * @member {number}
      * @readonly

--- a/packages/utils/src/browser/isWebGLSupported.js
+++ b/packages/utils/src/browser/isWebGLSupported.js
@@ -1,9 +1,9 @@
 /**
- * Helper for checking for webgl support
+ * Helper for checking for WebGL support.
  *
  * @memberof PIXI.utils
  * @function isWebGLSupported
- * @return {boolean} is webgl supported
+ * @return {boolean} Is WebGL supported.
  */
 export function isWebGLSupported()
 {

--- a/tools/renders/src/Renderer.js
+++ b/tools/renders/src/Renderer.js
@@ -11,8 +11,8 @@ class Renderer
 {
     /**
      * @constructor
-     * @param {HTMLCanvasElement} [viewWebGL] Optional canvas element for webgl
-     * @param {HTMLCanvasElement} [viewContext2d] Optional canvas element for context2d
+     * @param {HTMLCanvasElement} [viewWebGL] Optional canvas element for WebGL.
+     * @param {HTMLCanvasElement} [viewContext2d] Optional canvas element for Context2D.
      * @param {HTMLElement} [parentNode] container, defaults to `document.body`
      */
     constructor(viewWebGL, viewContext2d, parentNode)


### PR DESCRIPTION
Code examples make it easy for anyone quickly see how a function or property is used. Add a few code examples for (Sprite.anchor) and (DisplayObject.mask). Fix many grammatical, spellings and punctuation mistakes. Also, highlight actual code values in the description.

First PR to PixiJS, hoping to get more in. Next, I'll try to write some useful unit-tests.