### PR TITLE
Allow passing DisplayObject destroy options from PIXI.Application

### DIFF
--- a/src/core/Application.js
+++ b/src/core/Application.js
@@ -176,8 +176,16 @@ export default class Application
     /**
      * Destroy and don't use after this.
      * @param {Boolean} [removeView=false] Automatically remove canvas from DOM.
+     * @param {object|boolean} [stageOptions] - Options parameter. A boolean will act as if all options
+     *  have been set to that value
+     * @param {boolean} [stageOptions.children=false] - if set to true, all the children will have their destroy
+     *  method called as well. 'stageOptions' will be passed on to those calls.
+     * @param {boolean} [stageOptions.texture=false] - Only used for child Sprites if stageOptions.children is set
+     *  to true. Should it destroy the texture of the child sprite
+     * @param {boolean} [stageOptions.baseTexture=false] - Only used for child Sprites if stageOptions.children is set
+     *  to true. Should it destroy the base texture of the child sprite
      */
-    destroy(removeView)
+    destroy(removeView, stageOptions)
     {
         if (this._ticker)
         {
@@ -187,7 +195,7 @@ export default class Application
             oldTicker.destroy();
         }
 
-        this.stage.destroy();
+        this.stage.destroy(stageOptions);
         this.stage = null;
 
         this.renderer.destroy(removeView);

--- a/src/loaders/index.js
+++ b/src/loaders/index.js
@@ -69,12 +69,12 @@ Object.defineProperty(AppPrototype, 'loader', {
 // Override the destroy function
 // making sure to destroy the current Loader
 AppPrototype._parentDestroy = AppPrototype.destroy;
-AppPrototype.destroy = function destroy(removeView)
+AppPrototype.destroy = function destroy(removeView, stageOptions)
 {
     if (this._loader)
     {
         this._loader.destroy();
         this._loader = null;
     }
-    this._parentDestroy(removeView);
+    this._parentDestroy(removeView, stageOptions);
 };

--- a/test/core/Application.js
+++ b/test/core/Application.js
@@ -128,4 +128,44 @@ describe('PIXI.Application', function ()
             expect(this.app._ticker).to.be.null;
         });
     });
+
+    describe('destroy', function ()
+    {
+        it('should not destroy children by default', function (done)
+        {
+            const app = new PIXI.Application();
+            const stage = app.stage;
+            const child = new PIXI.DisplayObject();
+
+            stage.addChild(child);
+
+            app.ticker.addOnce(() =>
+            {
+                app.destroy();
+                expect(stage.children.length).to.be.equals(0);
+                expect(child.transform).to.not.be.null;
+
+                done();
+            });
+        });
+
+        it('should allow children destroy', function (done)
+        {
+            const app = new PIXI.Application();
+            const stage = app.stage;
+            const child = new PIXI.DisplayObject();
+
+            stage.addChild(child);
+
+            app.ticker.addOnce(() =>
+            {
+                app.destroy(false, true);
+                expect(stage.children.length).to.be.equals(0);
+                expect(stage.transform).to.be.null;
+                expect(child.transform).to.be.null;
+
+                done();
+            });
+        });
+    });
 });


### PR DESCRIPTION
## Overview
This PR adds the ability to completely destroy an application including it's textures from a single call to `PIXI.Application.destroy` at the top level.

## Usage
```javascript
const app = new PIXI.Application();
app.destroy(false, true);
```

[More details](https://github.com/pixijs/pixi.js/issues/4135)