### PR TITLE
[next] Fixes Multi-Texture BitmapText Fonts

### DIFF
--- a/packages/text-bitmap/test/BitmapFontLoader.js
+++ b/packages/text-bitmap/test/BitmapFontLoader.js
@@ -330,11 +330,9 @@ describe('PIXI.BitmapFontLoader', function ()
 
     it('should properly register bitmap font having more than one texture', function (done)
     {
-        Loader.registerPlugin(BitmapFontLoader);
-
         const loader = new Loader();
 
-        loader.add(`${__dirname}/resources/split_font.fnt`);
+        loader.add(path.join(this.resources, 'split_font.fnt'));
         loader.load(() =>
         {
             const font = BitmapText.fonts.split_font;

--- a/packages/text-bitmap/test/resources/font1.fnt
+++ b/packages/text-bitmap/test/resources/font1.fnt
@@ -1,8 +1,8 @@
 <font>
-  <info face="font" size="24" bold="0" italic="0" charset="" unicode="" stretchH="100" smooth="1" aa="1" padding="2,2,2,2" spacing="0,0" outline="0"/>
+  <info face="font1" size="24" bold="0" italic="0" charset="" unicode="" stretchH="100" smooth="1" aa="1" padding="2,2,2,2" spacing="0,0" outline="0"/>
   <common lineHeight="27" base="18" scaleW="46" scaleH="201" pages="1" packed="0"/>
   <pages>
-    <page id="0" file="font.png"/>
+    <page id="0" file="font1.png"/>
   </pages>
   <chars count="15">
     <char id="65" x="2" y="2" width="19" height="20" xoffset="0" yoffset="0" xadvance="16" page="0" chnl="15"/>


### PR DESCRIPTION
This is a cleanup of #4641 which was breaking **next**. The root of the problem is the management of TextureCache by BitmapFontLoader. Resource-Loader middleware should not rely on TextureCache for cached textures and instead should rely on the loader's `resources` object. 

A similar change should probably be backported to v4.