### PR TITLE
Upgrade to Node 8 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-    - "4"
+    - "8"
 
 env:
   - CXX=g++-4.8


### PR DESCRIPTION
The [changes made recently](https://github.com/pixijs/pixi-jsdoc-template/tree/v2.4.1) to `@pixi/jsdoc-template` that fixes a bug are not exactly compatible with Node.js v4. In the latest release of PixiJS v4.8.0, the documentation didn't build correctly, this has since been fixed manually. This change will keep future versions from breaking and also make sure Travis uses package-lock.json.