### PR TITLE
Creates unit-test and improves single and multiple image font loading

### DIFF
--- a/src/extras/BitmapText.js
+++ b/src/extras/BitmapText.js
@@ -574,7 +574,7 @@ export default class BitmapText extends core.Container
             const id = pages[i].getAttribute('id');
             const file = pages[i].getAttribute('file');
 
-            pagesTextures[id] = textures[file] || textures[i];
+            pagesTextures[id] = textures instanceof Array ? textures[i] : textures[file];
         }
 
         // parse letters

--- a/src/extras/BitmapText.js
+++ b/src/extras/BitmapText.js
@@ -565,29 +565,18 @@ export default class BitmapText extends core.Container
 
         // parse letters
         const letters = xml.getElementsByTagName('char');
-        let page;
 
         for (let i = 0; i < letters.length; i++)
         {
             const letter = letters[i];
             const charCode = parseInt(letter.getAttribute('id'), 10);
-            let textureRect;
-
-            page = parseInt(letter.getAttribute('page'), 10);
-            if (isNaN(page))
-            {
-                textureRect = new core.Rectangle(0, 0, 0, 0);
-                page = 0;
-            }
-            else
-            {
-                textureRect = new core.Rectangle(
-                    (parseInt(letter.getAttribute('x'), 10) / res) + (textures[page].frame.x / res),
-                    (parseInt(letter.getAttribute('y'), 10) / res) + (textures[page].frame.y / res),
-                    parseInt(letter.getAttribute('width'), 10) / res,
-                    parseInt(letter.getAttribute('height'), 10) / res
-                );
-            }
+            const page = letter.getAttribute('page') ? parseInt(letter.getAttribute('page'), 10) : 0;
+            const textureRect = new core.Rectangle(
+                (parseInt(letter.getAttribute('x'), 10) / res) + (textures[page].frame.x / res),
+                (parseInt(letter.getAttribute('y'), 10) / res) + (textures[page].frame.y / res),
+                parseInt(letter.getAttribute('width'), 10) / res,
+                parseInt(letter.getAttribute('height'), 10) / res
+            );
 
             data.chars[charCode] = {
                 xOffset: parseInt(letter.getAttribute('xoffset'), 10) / res,

--- a/src/loaders/bitmapFontParser.js
+++ b/src/loaders/bitmapFontParser.js
@@ -67,47 +67,54 @@ export default function ()
         }
 
         const pages = resource.data.getElementsByTagName('page');
-        const textures = [];
+        const textures = {};
 
         // Handle completed, when the number of textures
         // load is the same number as references in the fnt file
-        const completed = () =>
+        const completed = (page) =>
         {
-            if (textures.length === pages.length)
+            textures[page.metadata.pageId || 0] = page.texture;
+
+            if (Object.keys(textures).length === pages.length)
             {
                 parse(resource, textures);
                 next();
             }
         };
 
-        // Standard loading options for images
-        const loadOptions = {
-            crossOrigin: resource.crossOrigin,
-            loadType: Resource.LOAD_TYPE.IMAGE,
-            metadata: resource.metadata.imageMetadata,
-            parentResource: resource,
-        };
-
         for (let i = 0; i < pages.length; ++i)
         {
             const url = xmlUrl + pages[i].getAttribute('file');
+            let exists = false;
+
+            // incase the image is loaded outside
+            // using the same loader, resource will be available
+            for (const name in this.resources)
+            {
+                if (this.resources[name].url === url)
+                {
+                    completed(this.resources[name]);
+                    exists = true;
+                    break;
+                }
+            }
 
             // texture is not loaded, we'll attempt to add
             // it to the load and add the texture to the list
-            if (!this.resources[url])
+            if (!exists)
             {
-                this.add(url, loadOptions, (resource) =>
-                {
-                    textures.push(resource.texture);
-                    completed();
-                });
-            }
-            else
-            {
-                // incase the image is loaded outside
-                // using the same loader, texture will be available
-                textures.push(this.resources[url].texture);
-                completed();
+                // Standard loading options for images
+                const options = {
+                    crossOrigin: resource.crossOrigin,
+                    loadType: Resource.LOAD_TYPE.IMAGE,
+                    metadata: Object.assign(
+                        { pageId: pages[i].getAttribute('id') },
+                        resource.metadata.imageMetadata
+                    ),
+                    parentResource: resource,
+                };
+
+                this.add(url, options, completed);
             }
         }
     };

--- a/src/loaders/bitmapFontParser.js
+++ b/src/loaders/bitmapFontParser.js
@@ -73,7 +73,7 @@ export default function ()
         // load is the same number as references in the fnt file
         const completed = (page) =>
         {
-            textures[page.metadata.pageId || 0] = page.texture;
+            textures[page.metadata.pageFile] = page.texture;
 
             if (Object.keys(textures).length === pages.length)
             {
@@ -84,7 +84,8 @@ export default function ()
 
         for (let i = 0; i < pages.length; ++i)
         {
-            const url = xmlUrl + pages[i].getAttribute('file');
+            const pageFile = pages[i].getAttribute('file');
+            const url = xmlUrl + pageFile;
             let exists = false;
 
             // incase the image is loaded outside
@@ -93,6 +94,7 @@ export default function ()
             {
                 if (this.resources[name].url === url)
                 {
+                    this.resources[name].metadata.pageFile = pageFile;
                     completed(this.resources[name]);
                     exists = true;
                     break;
@@ -108,7 +110,7 @@ export default function ()
                     crossOrigin: resource.crossOrigin,
                     loadType: Resource.LOAD_TYPE.IMAGE,
                     metadata: Object.assign(
-                        { pageId: pages[i].getAttribute('id') },
+                        { pageFile },
                         resource.metadata.imageMetadata
                     ),
                     parentResource: resource,

--- a/test/extras/BitmapText.js
+++ b/test/extras/BitmapText.js
@@ -30,17 +30,21 @@ describe('PIXI.extras.BitmapText', function ()
         this.resources = path.join(__dirname, 'resources');
         Promise.all([
             loadXML('font.fnt'),
+            loadXML('font-no-page.fnt'),
             loadImage('font.png'),
         ]).then(([
             fontXML,
+            font2XML,
             fontImage,
         ]) =>
         {
             this.fontXML = fontXML;
+            this.font2XML = font2XML;
             this.fontImage = fontImage;
             const texture = new PIXI.Texture(new PIXI.BaseTexture(this.fontImage, null, 1));
 
             this.font = PIXI.extras.BitmapText.registerFont(this.fontXML, texture);
+            this.font2 = PIXI.extras.BitmapText.registerFont(this.font2XML, texture);
             done();
         });
     });
@@ -54,6 +58,15 @@ describe('PIXI.extras.BitmapText', function ()
             });
 
             expect(text.children.length).to.equal(4);
+        });
+        it('should support font without page reference', function ()
+        {
+            const text = new PIXI.extras.BitmapText('A', {
+                font: this.font2.font,
+            });
+
+            expect(text.children[0].width).to.equal(19);
+            expect(text.children[0].height).to.equal(20);
         });
         it('should break line on space', function ()
         {

--- a/test/extras/BitmapText.js
+++ b/test/extras/BitmapText.js
@@ -41,77 +41,84 @@ describe('PIXI.extras.BitmapText', function ()
             this.fontXML = fontXML;
             this.font2XML = font2XML;
             this.fontImage = fontImage;
-            const texture = new PIXI.Texture(new PIXI.BaseTexture(this.fontImage, null, 1));
-
-            this.font = PIXI.extras.BitmapText.registerFont(this.fontXML, texture);
-            this.font2 = PIXI.extras.BitmapText.registerFont(this.font2XML, texture);
             done();
         });
     });
 
-    describe('text', function ()
+    after(function ()
     {
-        it('should render text even if there are unsupported characters', function ()
-        {
-            const text = new PIXI.extras.BitmapText('ABCDEFG', {
-                font: this.font.font,
-            });
+        this.texture.destroy(true);
+        this.texture = null;
+        this.font = null;
+        this.font2 = null;
+    });
 
-            expect(text.children.length).to.equal(4);
+    it('should regster fonts from preloaded images', function ()
+    {
+        this.texture = new PIXI.Texture(new PIXI.BaseTexture(this.fontImage, null, 1));
+        this.font = PIXI.extras.BitmapText.registerFont(this.fontXML, this.texture);
+        this.font2 = PIXI.extras.BitmapText.registerFont(this.font2XML, this.texture);
+    });
+    it('should render text even if there are unsupported characters', function ()
+    {
+        const text = new PIXI.extras.BitmapText('ABCDEFG', {
+            font: this.font.font,
         });
-        it('should support font without page reference', function ()
-        {
-            const text = new PIXI.extras.BitmapText('A', {
-                font: this.font2.font,
-            });
 
-            expect(text.children[0].width).to.equal(19);
-            expect(text.children[0].height).to.equal(20);
+        expect(text.children.length).to.equal(4);
+    });
+    it('should support font without page reference', function ()
+    {
+        const text = new PIXI.extras.BitmapText('A', {
+            font: this.font2.font,
         });
-        it('should break line on space', function ()
-        {
-            const bmpText = new PIXI.extras.BitmapText('', {
-                font: this.font.font,
-                size: 24,
-            });
 
-            bmpText.maxWidth = 40;
-            bmpText.text = 'A A A A A A A ';
+        expect(text.children[0].width).to.equal(19);
+        expect(text.children[0].height).to.equal(20);
+    });
+    it('should break line on space', function ()
+    {
+        const bmpText = new PIXI.extras.BitmapText('', {
+            font: this.font.font,
+            size: 24,
+        });
+
+        bmpText.maxWidth = 40;
+        bmpText.text = 'A A A A A A A ';
+        bmpText.updateText();
+
+        expect(bmpText.textWidth).to.lessThan(bmpText.maxWidth);
+
+        bmpText.maxWidth = 40;
+        bmpText.text = 'A A A A A A A';
+        bmpText.updateText();
+
+        expect(bmpText.textWidth).to.lessThan(bmpText.maxWidth);
+    });
+    it('letterSpacing should add extra space between characters', function ()
+    {
+        const text = 'ABCD zz DCBA';
+        const bmpText = new PIXI.extras.BitmapText(text, {
+            font: this.font.font,
+        });
+        const positions = [];
+        const renderedChars = bmpText.children.length;
+
+        for (let x = 0; x < renderedChars; ++x)
+        {
+            positions.push(bmpText.children[x].x);
+        }
+        for (let space = 1; space < 20; ++space)
+        {
+            bmpText.letterSpacing = space;
             bmpText.updateText();
+            let prevPos = bmpText.children[0].x;
 
-            expect(bmpText.textWidth).to.lessThan(bmpText.maxWidth);
-
-            bmpText.maxWidth = 40;
-            bmpText.text = 'A A A A A A A';
-            bmpText.updateText();
-
-            expect(bmpText.textWidth).to.lessThan(bmpText.maxWidth);
-        });
-        it('letterSpacing should add extra space between characters', function ()
-        {
-            const text = 'ABCD zz DCBA';
-            const bmpText = new PIXI.extras.BitmapText(text, {
-                font: this.font.font,
-            });
-            const positions = [];
-            const renderedChars = bmpText.children.length;
-
-            for (let x = 0; x < renderedChars; ++x)
+            for (let char = 1; char < renderedChars; ++char)
             {
-                positions.push(bmpText.children[x].x);
+                expect(bmpText.children[char].x).to.equal(prevPos + space + positions[char] - positions[char - 1]);
+                prevPos = bmpText.children[char].x;
             }
-            for (let space = 1; space < 20; ++space)
-            {
-                bmpText.letterSpacing = space;
-                bmpText.updateText();
-                let prevPos = bmpText.children[0].x;
-
-                for (let char = 1; char < renderedChars; ++char)
-                {
-                    expect(bmpText.children[char].x).to.equal(prevPos + space + positions[char] - positions[char - 1]);
-                    prevPos = bmpText.children[char].x;
-                }
-            }
-        });
+        }
     });
 });

--- a/test/extras/resources/font-no-page.fnt
+++ b/test/extras/resources/font-no-page.fnt
@@ -1,0 +1,29 @@
+<font>
+  <info face="font-no-page" size="24" bold="0" italic="0" charset="" unicode="" stretchH="100" smooth="1" aa="1" padding="2,2,2,2" spacing="0,0" outline="0"/>
+  <common lineHeight="27" base="18" scaleW="46" scaleH="201" pages="1" packed="0"/>
+  <pages>
+    <page id="0" file="font.png"/>
+  </pages>
+  <chars count="15">
+    <char id="65" x="2" y="2" width="19" height="20" xoffset="0" yoffset="0" xadvance="16" chnl="15"/>
+    <char id="66" x="2" y="24" width="15" height="20" xoffset="2" yoffset="0" xadvance="16" chnl="15"/>
+    <char id="67" x="2" y="46" width="18" height="20" xoffset="1" yoffset="0" xadvance="17" chnl="15"/>
+    <char id="68" x="19" y="24" width="17" height="20" xoffset="2" yoffset="0" xadvance="17" chnl="15"/>
+    <char id="91" x="2" y="68" width="7" height="24" xoffset="2" yoffset="0" xadvance="7" chnl="15"/>
+    <char id="45" x="23" y="2" width="9" height="4" xoffset="1" yoffset="10" xadvance="8" chnl="15"/>
+    <char id="92" x="34" y="2" width="10" height="20" xoffset="-1" yoffset="0" xadvance="7" chnl="15"/>
+    <char id="47" x="2" y="94" width="10" height="20" xoffset="-1" yoffset="0" xadvance="7" chnl="15"/>
+    <char id="46" x="23" y="8" width="5" height="5" xoffset="2" yoffset="15" xadvance="7" chnl="15"/>
+    <char id="44" x="11" y="68" width="5" height="8" xoffset="2" yoffset="15" xadvance="7" chnl="15"/>
+    <char id="63" x="2" y="116" width="13" height="20" xoffset="1" yoffset="0" xadvance="13" chnl="15"/>
+    <char id="33" x="14" y="78" width="5" height="20" xoffset="2" yoffset="0" xadvance="7" chnl="15"/>
+    <char id="59" x="2" y="138" width="5" height="18" xoffset="2" yoffset="5" xadvance="7" chnl="15"/>
+    <char id="58" x="2" y="158" width="5" height="15" xoffset="2" yoffset="5" xadvance="7" chnl="15"/>
+    <char id="93" x="2" y="175" width="7" height="24" xoffset="0" yoffset="0" xadvance="7" chnl="15"/>
+    <char id="32" x="0" y="0" width="0" height="0" xoffset="0" yoffset="0" xadvance="7" chnl="15"/>
+  </chars>
+  <kernings count="2">
+    <kerning first="32" second="65" amount="-1"/>
+    <kerning first="65" second="32" amount="-1"/>
+  </kernings>
+</font>

--- a/test/loaders/bitmapFontParser.js
+++ b/test/loaders/bitmapFontParser.js
@@ -381,8 +381,8 @@ describe('PIXI.loaders.bitmapFontParser', function ()
             const page0 = path.join(this.resources, 'split_font_ab.png');
             const page1 = path.join(this.resources, 'split_font_cd.png');
 
-            expect(loader.resources[page0].metadata.pageId).to.equal('0');
-            expect(loader.resources[page1].metadata.pageId).to.equal('1');
+            expect(loader.resources[page0].metadata.pageFile).to.equal('split_font_ab.png');
+            expect(loader.resources[page1].metadata.pageFile).to.equal('split_font_cd.png');
 
             const font = PIXI.extras.BitmapText.fonts.split_font2;
             const charA = font.chars['A'.charCodeAt(0) || 65];

--- a/test/loaders/bitmapFontParser.js
+++ b/test/loaders/bitmapFontParser.js
@@ -116,7 +116,7 @@ describe('PIXI.loaders.bitmapFontParser', function ()
         expect(font).to.be.an.object;
         expect(PIXI.extras.BitmapText.fonts.font).to.equal(font);
         expect(font).to.have.property('chars');
-        const charA = font.chars['A'.charCodeAt(0) || 65];
+        const charA = font.chars['A'.charCodeAt(0)];
 
         expect(charA).to.exist;
         expect(charA.texture.baseTexture.source).to.equal(this.fontImage);
@@ -124,7 +124,7 @@ describe('PIXI.loaders.bitmapFontParser', function ()
         expect(charA.texture.frame.y).to.equal(2);
         expect(charA.texture.frame.width).to.equal(19);
         expect(charA.texture.frame.height).to.equal(20);
-        const charB = font.chars['B'.charCodeAt(0) || 66];
+        const charB = font.chars['B'.charCodeAt(0)];
 
         expect(charB).to.exist;
         expect(charB.texture.baseTexture.source).to.equal(this.fontImage);
@@ -132,7 +132,7 @@ describe('PIXI.loaders.bitmapFontParser', function ()
         expect(charB.texture.frame.y).to.equal(24);
         expect(charB.texture.frame.width).to.equal(15);
         expect(charB.texture.frame.height).to.equal(20);
-        const charC = font.chars['C'.charCodeAt(0) || 67];
+        const charC = font.chars['C'.charCodeAt(0)];
 
         expect(charC).to.exist;
         expect(charC.texture.baseTexture.source).to.equal(this.fontImage);
@@ -140,7 +140,7 @@ describe('PIXI.loaders.bitmapFontParser', function ()
         expect(charC.texture.frame.y).to.equal(2);
         expect(charC.texture.frame.width).to.equal(18);
         expect(charC.texture.frame.height).to.equal(20);
-        const charD = font.chars['D'.charCodeAt(0) || 68];
+        const charD = font.chars['D'.charCodeAt(0)];
 
         expect(charD).to.exist;
         expect(charD.texture.baseTexture.source).to.equal(this.fontImage);
@@ -148,7 +148,7 @@ describe('PIXI.loaders.bitmapFontParser', function ()
         expect(charD.texture.frame.y).to.equal(24);
         expect(charD.texture.frame.width).to.equal(17);
         expect(charD.texture.frame.height).to.equal(20);
-        const charE = font.chars['E'.charCodeAt(0) || 69];
+        const charE = font.chars['E'.charCodeAt(0)];
 
         expect(charE).to.be.undefined;
         done();
@@ -162,7 +162,7 @@ describe('PIXI.loaders.bitmapFontParser', function ()
         expect(font).to.be.an.object;
         expect(PIXI.extras.BitmapText.fonts.font).to.equal(font);
         expect(font).to.have.property('chars');
-        const charA = font.chars['A'.charCodeAt(0) || 65];
+        const charA = font.chars['A'.charCodeAt(0)];
 
         expect(charA).to.exist;
         expect(charA.texture.baseTexture.source).to.equal(this.fontScaledImage);
@@ -170,7 +170,7 @@ describe('PIXI.loaders.bitmapFontParser', function ()
         expect(charA.texture.frame.y).to.equal(4); // 2 / 0.5
         expect(charA.texture.frame.width).to.equal(38); // 19 / 0.5
         expect(charA.texture.frame.height).to.equal(40); // 20 / 0.5
-        const charB = font.chars['B'.charCodeAt(0) || 66];
+        const charB = font.chars['B'.charCodeAt(0)];
 
         expect(charB).to.exist;
         expect(charB.texture.baseTexture.source).to.equal(this.fontScaledImage);
@@ -178,7 +178,7 @@ describe('PIXI.loaders.bitmapFontParser', function ()
         expect(charB.texture.frame.y).to.equal(48); // 24 / 0.5
         expect(charB.texture.frame.width).to.equal(30); // 15 / 0.5
         expect(charB.texture.frame.height).to.equal(40); // 20 / 0.5
-        const charC = font.chars['C'.charCodeAt(0) || 67];
+        const charC = font.chars['C'.charCodeAt(0)];
 
         expect(charC).to.exist;
         expect(charC.texture.baseTexture.source).to.equal(this.fontScaledImage);
@@ -186,7 +186,7 @@ describe('PIXI.loaders.bitmapFontParser', function ()
         expect(charC.texture.frame.y).to.equal(4); // 2 / 0.5
         expect(charC.texture.frame.width).to.equal(36); // 18 / 0.5
         expect(charC.texture.frame.height).to.equal(40); // 20 / 0.5
-        const charD = font.chars['D'.charCodeAt(0) || 68];
+        const charD = font.chars['D'.charCodeAt(0)];
 
         expect(charD).to.exist;
         expect(charD.texture.baseTexture.source).to.equal(this.fontScaledImage);
@@ -194,7 +194,7 @@ describe('PIXI.loaders.bitmapFontParser', function ()
         expect(charD.texture.frame.y).to.equal(48); // 24 / 0.5
         expect(charD.texture.frame.width).to.equal(34); // 17 / 0.5
         expect(charD.texture.frame.height).to.equal(40); // 20 / 0.5
-        const charE = font.chars['E'.charCodeAt(0) || 69];
+        const charE = font.chars['E'.charCodeAt(0)];
 
         expect(charE).to.be.undefined;
         done();
@@ -215,7 +215,7 @@ describe('PIXI.loaders.bitmapFontParser', function ()
             expect(font).to.be.an.object;
             expect(PIXI.extras.BitmapText.fonts.font).to.equal(font);
             expect(font).to.have.property('chars');
-            const charA = font.chars['A'.charCodeAt(0) || 65];
+            const charA = font.chars['A'.charCodeAt(0)];
 
             expect(charA).to.exist;
             expect(charA.texture.baseTexture.source).to.equal(this.atlasImage);
@@ -223,7 +223,7 @@ describe('PIXI.loaders.bitmapFontParser', function ()
             expect(charA.texture.frame.y).to.equal(fontY + 2);
             expect(charA.texture.frame.width).to.equal(19);
             expect(charA.texture.frame.height).to.equal(20);
-            const charB = font.chars['B'.charCodeAt(0) || 66];
+            const charB = font.chars['B'.charCodeAt(0)];
 
             expect(charB).to.exist;
             expect(charB.texture.baseTexture.source).to.equal(this.atlasImage);
@@ -231,7 +231,7 @@ describe('PIXI.loaders.bitmapFontParser', function ()
             expect(charB.texture.frame.y).to.equal(fontY + 24);
             expect(charB.texture.frame.width).to.equal(15);
             expect(charB.texture.frame.height).to.equal(20);
-            const charC = font.chars['C'.charCodeAt(0) || 67];
+            const charC = font.chars['C'.charCodeAt(0)];
 
             expect(charC).to.exist;
             expect(charC.texture.baseTexture.source).to.equal(this.atlasImage);
@@ -239,7 +239,7 @@ describe('PIXI.loaders.bitmapFontParser', function ()
             expect(charC.texture.frame.y).to.equal(fontY + 2);
             expect(charC.texture.frame.width).to.equal(18);
             expect(charC.texture.frame.height).to.equal(20);
-            const charD = font.chars['D'.charCodeAt(0) || 68];
+            const charD = font.chars['D'.charCodeAt(0)];
 
             expect(charD).to.exist;
             expect(charD.texture.baseTexture.source).to.equal(this.atlasImage);
@@ -247,7 +247,7 @@ describe('PIXI.loaders.bitmapFontParser', function ()
             expect(charD.texture.frame.y).to.equal(fontY + 24);
             expect(charD.texture.frame.width).to.equal(17);
             expect(charD.texture.frame.height).to.equal(20);
-            const charE = font.chars['E'.charCodeAt(0) || 69];
+            const charE = font.chars['E'.charCodeAt(0)];
 
             expect(charE).to.be.undefined;
             done();
@@ -269,7 +269,7 @@ describe('PIXI.loaders.bitmapFontParser', function ()
             expect(font).to.be.an.object;
             expect(PIXI.extras.BitmapText.fonts.font).to.equal(font);
             expect(font).to.have.property('chars');
-            const charA = font.chars['A'.charCodeAt(0) || 65];
+            const charA = font.chars['A'.charCodeAt(0)];
 
             expect(charA).to.exist;
             expect(charA.texture.baseTexture.source).to.equal(this.atlasScaledImage);
@@ -277,7 +277,7 @@ describe('PIXI.loaders.bitmapFontParser', function ()
             expect(charA.texture.frame.y).to.equal(fontY + 2);
             expect(charA.texture.frame.width).to.equal(19);
             expect(charA.texture.frame.height).to.equal(20);
-            const charB = font.chars['B'.charCodeAt(0) || 66];
+            const charB = font.chars['B'.charCodeAt(0)];
 
             expect(charB).to.exist;
             expect(charB.texture.baseTexture.source).to.equal(this.atlasScaledImage);
@@ -285,7 +285,7 @@ describe('PIXI.loaders.bitmapFontParser', function ()
             expect(charB.texture.frame.y).to.equal(fontY + 24);
             expect(charB.texture.frame.width).to.equal(15);
             expect(charB.texture.frame.height).to.equal(20);
-            const charC = font.chars['C'.charCodeAt(0) || 67];
+            const charC = font.chars['C'.charCodeAt(0)];
 
             expect(charC).to.exist;
             expect(charC.texture.baseTexture.source).to.equal(this.atlasScaledImage);
@@ -293,7 +293,7 @@ describe('PIXI.loaders.bitmapFontParser', function ()
             expect(charC.texture.frame.y).to.equal(fontY + 2);
             expect(charC.texture.frame.width).to.equal(18);
             expect(charC.texture.frame.height).to.equal(20);
-            const charD = font.chars['D'.charCodeAt(0) || 68];
+            const charD = font.chars['D'.charCodeAt(0)];
 
             expect(charD).to.exist;
             expect(charD.texture.baseTexture.source).to.equal(this.atlasScaledImage);
@@ -301,7 +301,7 @@ describe('PIXI.loaders.bitmapFontParser', function ()
             expect(charD.texture.frame.y).to.equal(fontY + 24);
             expect(charD.texture.frame.width).to.equal(17);
             expect(charD.texture.frame.height).to.equal(20);
-            const charE = font.chars['E'.charCodeAt(0) || 69];
+            const charE = font.chars['E'.charCodeAt(0)];
 
             expect(charE).to.be.undefined;
             done();
@@ -320,7 +320,7 @@ describe('PIXI.loaders.bitmapFontParser', function ()
             expect(font).to.be.an.object;
             expect(PIXI.extras.BitmapText.fonts.split_font).to.equal(font);
             expect(font).to.have.property('chars');
-            const charA = font.chars['A'.charCodeAt(0) || 65];
+            const charA = font.chars['A'.charCodeAt(0)];
 
             expect(charA).to.exist;
             let src = charA.texture.baseTexture.source.src;
@@ -331,7 +331,7 @@ describe('PIXI.loaders.bitmapFontParser', function ()
             expect(charA.texture.frame.y).to.equal(2);
             expect(charA.texture.frame.width).to.equal(19);
             expect(charA.texture.frame.height).to.equal(20);
-            const charB = font.chars['B'.charCodeAt(0) || 66];
+            const charB = font.chars['B'.charCodeAt(0)];
 
             expect(charB).to.exist;
             src = charB.texture.baseTexture.source.src;
@@ -342,7 +342,7 @@ describe('PIXI.loaders.bitmapFontParser', function ()
             expect(charB.texture.frame.y).to.equal(24);
             expect(charB.texture.frame.width).to.equal(15);
             expect(charB.texture.frame.height).to.equal(20);
-            const charC = font.chars['C'.charCodeAt(0) || 67];
+            const charC = font.chars['C'.charCodeAt(0)];
 
             expect(charC).to.exist;
             src = charC.texture.baseTexture.source.src;
@@ -353,7 +353,7 @@ describe('PIXI.loaders.bitmapFontParser', function ()
             expect(charC.texture.frame.y).to.equal(2);
             expect(charC.texture.frame.width).to.equal(18);
             expect(charC.texture.frame.height).to.equal(20);
-            const charD = font.chars['D'.charCodeAt(0) || 68];
+            const charD = font.chars['D'.charCodeAt(0)];
 
             expect(charD).to.exist;
             src = charD.texture.baseTexture.source.src;
@@ -364,7 +364,7 @@ describe('PIXI.loaders.bitmapFontParser', function ()
             expect(charD.texture.frame.y).to.equal(24);
             expect(charD.texture.frame.width).to.equal(17);
             expect(charD.texture.frame.height).to.equal(20);
-            const charE = font.chars['E'.charCodeAt(0) || 69];
+            const charE = font.chars['E'.charCodeAt(0)];
 
             expect(charE).to.be.undefined;
             done();
@@ -385,8 +385,8 @@ describe('PIXI.loaders.bitmapFontParser', function ()
             expect(loader.resources[page1].metadata.pageFile).to.equal('split_font_cd.png');
 
             const font = PIXI.extras.BitmapText.fonts.split_font2;
-            const charA = font.chars['A'.charCodeAt(0) || 65];
-            const charC = font.chars['C'.charCodeAt(0) || 67];
+            const charA = font.chars['A'.charCodeAt(0)];
+            const charC = font.chars['C'.charCodeAt(0)];
 
             expect(charA.page).to.equal('0');
             expect(charC.page).to.equal('1');

--- a/test/loaders/bitmapFontParser.js
+++ b/test/loaders/bitmapFontParser.js
@@ -370,6 +370,50 @@ describe('PIXI.loaders.bitmapFontParser', function ()
             done();
         });
     });
+
+    it('should split fonts if page IDs are in chronological order', function (done)
+    {
+        const loader = new PIXI.loaders.Loader();
+
+        loader.add(path.join(this.resources, 'split_font2.fnt'));
+        loader.load(() =>
+        {
+            const page0 = path.join(this.resources, 'split_font_ab.png');
+            const page1 = path.join(this.resources, 'split_font_cd.png');
+
+            expect(loader.resources[page0].metadata.pageId).to.equal('0');
+            expect(loader.resources[page1].metadata.pageId).to.equal('1');
+
+            const font = PIXI.extras.BitmapText.fonts.split_font2;
+            const charA = font.chars['A'.charCodeAt(0) || 65];
+            const charC = font.chars['C'.charCodeAt(0) || 67];
+
+            expect(charA.page).to.equal('0');
+            expect(charC.page).to.equal('1');
+            expect(charA.texture.baseTexture.imageUrl).to.equal(page0);
+            expect(charC.texture.baseTexture.imageUrl).to.equal(page1);
+
+            done();
+        });
+    });
+
+    it('should register bitmap font with side-loaded image', function (done)
+    {
+        const loader = new PIXI.loaders.Loader();
+        const imagePath = path.join(this.resources, 'font.png');
+        const fontPath = path.join(this.resources, 'font.fnt');
+
+        loader.add('image', imagePath);
+        loader.add('font', fontPath);
+        loader.load(() =>
+        {
+            expect(Object.values(loader.resources).length).to.equal(2);
+            expect(loader.resources.image.url).to.equal(imagePath);
+            expect(loader.resources.font.url).to.equal(fontPath);
+
+            done();
+        });
+    });
 });
 
 describe('PIXI.loaders.parseBitmapFontData', function ()

--- a/test/loaders/resources/split_font2.fnt
+++ b/test/loaders/resources/split_font2.fnt
@@ -1,0 +1,16 @@
+<font>
+  <info face="split_font2" size="24" bold="0" italic="0" charset="" unicode="" stretchH="100" smooth="1" aa="1" padding="2,2,2,2" spacing="0,0" outline="0"/>
+  <common lineHeight="27" base="18" scaleW="22" scaleH="46" pages="2" packed="0"/>
+  <pages>
+    <page id="1" file="split_font_cd.png"/>
+    <page id="0" file="split_font_ab.png"/>
+  </pages>
+  <chars count="5">
+    <char id="65" x="2" y="2" width="19" height="20" xoffset="0" yoffset="0" xadvance="16" page="0" chnl="15"/>
+    <char id="66" x="2" y="24" width="15" height="20" xoffset="2" yoffset="0" xadvance="16" page="0" chnl="15"/>
+
+    <char id="67" x="2" y="2" width="18" height="20" xoffset="1" yoffset="0" xadvance="17" page="1" chnl="15"/>
+    <char id="68" x="2" y="24" width="17" height="20" xoffset="2" yoffset="0" xadvance="17" page="1" chnl="15"/>
+  </chars>
+  <kernings count="0"/>
+</font>


### PR DESCRIPTION
Fixes #4950

This is a clean up of #4641 which had some issues. Namely:
* Did not gracefully support manually side-loading images with the loader
* Introduced potential race-conditions when loading split image fonts
* Fails to work with single page fonts which do not contain a `page` attribute on `<char>` elements

### Fixed

* Without `page` attributes for the `<char>` element, falls back to a default of `0` instead of creating a 0 width and 0 height Texture frame.
* Fixes and adds tests for side-loading images inside fnt file and prefer an explicit object map of page file names to textures as the first parameter for `BitmapText.registerFont`. This will make sure that textures line up, even if the pages are out of order or have non-numerical IDs.

```js
// If registering fonts with split images, use a map of the "file" attributes
// referenced in the <page> object within the fnt file
PIXI.extras.BitmapFont.registerFont(data, {
   'font-0.png': texture0,
   'font-1.png': texture1,
   'font-2.png': texture2
});

// Using an array will just map the textures to the page in the order
// which they appear in the fnt file <pages> section
PIXI.extras.BitmapFont.registerFont(data, [
   texture0,
   texture1,
   texture2
]);
```
cc @ceco-fmedia 