### PR TITLE
Added support for drawing complex rounded rectangles

### DIFF
--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -751,7 +751,24 @@ export default class Graphics extends Container
      */
     drawRoundedRect(x, y, width, height, radius)
     {
-        this.drawShape(new RoundedRectangle(x, y, width, height, radius));
+        return this.drawRoundedRectComplex(x, y, width, height, radius, radius, radius, radius);
+    }
+
+    /**
+     *
+     * @param {number} x - The X coord of the top-left of the rectangle
+     * @param {number} y - The Y coord of the top-left of the rectangle
+     * @param {number} width - The width of the rectangle
+     * @param {number} height - The height of the rectangle
+     * @param {number} radiusTL - Radius of the top left rectangle corner
+     * @param {number} radiusTR - Radius of the top right rectangle corner
+     * @param {number} radiusBR - Radius of the bottom right rectangle corner
+     * @param {number} radiusBL - Radius of the bottom left rectangle corner
+     * @return {PIXI.Graphics} This Graphics object. Good for chaining method calls
+     */
+    drawRoundedRectComplex(x, y, width, height, radiusTL, radiusTR, radiusBR, radiusBL)
+    {
+        this.drawShape(new RoundedRectangle(x, y, width, height, radiusTL, radiusTR, radiusBR, radiusBL));
 
         return this;
     }

--- a/src/core/graphics/canvas/CanvasGraphicsRenderer.js
+++ b/src/core/graphics/canvas/CanvasGraphicsRenderer.js
@@ -182,22 +182,28 @@ export default class CanvasGraphicsRenderer
                 const ry = shape.y;
                 const width = shape.width;
                 const height = shape.height;
-                let radius = shape.radius;
+                let radiusTL = shape.radiusTL;
+                let radiusTR = shape.radiusTR;
+                let radiusBR = shape.radiusBR;
+                let radiusBL = shape.radiusBL;
 
                 const maxRadius = Math.min(width, height) / 2 | 0;
 
-                radius = radius > maxRadius ? maxRadius : radius;
+                radiusTL = Math.min(radiusTL, maxRadius);
+                radiusTR = Math.min(radiusTR, maxRadius);
+                radiusBR = Math.min(radiusBR, maxRadius);
+                radiusBL = Math.min(radiusBL, maxRadius);
 
                 context.beginPath();
-                context.moveTo(rx, ry + radius);
-                context.lineTo(rx, ry + height - radius);
-                context.quadraticCurveTo(rx, ry + height, rx + radius, ry + height);
-                context.lineTo(rx + width - radius, ry + height);
-                context.quadraticCurveTo(rx + width, ry + height, rx + width, ry + height - radius);
-                context.lineTo(rx + width, ry + radius);
-                context.quadraticCurveTo(rx + width, ry, rx + width - radius, ry);
-                context.lineTo(rx + radius, ry);
-                context.quadraticCurveTo(rx, ry, rx, ry + radius);
+                context.moveTo(rx, ry + radiusTL);
+                context.lineTo(rx, ry + height - radiusBL);
+                context.quadraticCurveTo(rx, ry + height, rx + radiusBL, ry + height);
+                context.lineTo(rx + width - radiusBR, ry + height);
+                context.quadraticCurveTo(rx + width, ry + height, rx + width, ry + height - radiusBR);
+                context.lineTo(rx + width, ry + radiusTR);
+                context.quadraticCurveTo(rx + width, ry, rx + width - radiusTR, ry);
+                context.lineTo(rx + radiusTL, ry);
+                context.quadraticCurveTo(rx, ry, rx, ry + radiusTL);
                 context.closePath();
 
                 if (data.fillColor || data.fillColor === 0)

--- a/src/core/graphics/webgl/utils/buildRoundedRectangle.js
+++ b/src/core/graphics/webgl/utils/buildRoundedRectangle.js
@@ -21,15 +21,19 @@ export default function buildRoundedRectangle(graphicsData, webGLData, webGLData
     const width = rrectData.width;
     const height = rrectData.height;
 
-    const radius = rrectData.radius;
+    const radiusTL = rrectData.radiusTL;
+    const radiusTR = rrectData.radiusTR;
+    const radiusBR = rrectData.radiusBR;
+    const radiusBL = rrectData.radiusBL;
 
     const recPoints = [];
 
-    recPoints.push(x, y + radius);
-    quadraticBezierCurve(x, y + height - radius, x, y + height, x + radius, y + height, recPoints);
-    quadraticBezierCurve(x + width - radius, y + height, x + width, y + height, x + width, y + height - radius, recPoints);
-    quadraticBezierCurve(x + width, y + radius, x + width, y, x + width - radius, y, recPoints);
-    quadraticBezierCurve(x + radius, y, x, y, x, y + radius + 0.0000000001, recPoints);
+    recPoints.push(x, y + radiusTL);
+    quadraticBezierCurve(x, y + height - radiusBL, x, y + height, x + radiusBL, y + height, recPoints);
+    quadraticBezierCurve(x + width - radiusBR, y + height, x + width, y + height, x + width, y + height - radiusBR,
+        recPoints);
+    quadraticBezierCurve(x + width, y + radiusTR, x + width, y, x + width - radiusTR, y, recPoints);
+    quadraticBezierCurve(x + radiusTL, y, x, y, x, y + radiusTL + 0.0000000001, recPoints);
 
     // this tiny number deals with the issue that occurs when points overlap and earcut fails to triangulate the item.
     // TODO - fix this properly, this is not very elegant.. but it works for now.

--- a/src/core/math/shapes/RoundedRectangle.js
+++ b/src/core/math/shapes/RoundedRectangle.js
@@ -14,9 +14,12 @@ export default class RoundedRectangle
      * @param {number} [y=0] - The Y coordinate of the upper-left corner of the rounded rectangle
      * @param {number} [width=0] - The overall width of this rounded rectangle
      * @param {number} [height=0] - The overall height of this rounded rectangle
-     * @param {number} [radius=20] - Controls the radius of the rounded corners
+     * @param {number} [radiusTL=20] - Controls the radius of the top left rounded corner
+     * @param {number} [radiusTR=20] - Controls the radius of the top right rounded corner
+     * @param {number} [radiusBR=20] - Controls the radius of the bottom right rounded corner
+     * @param {number} [radiusBL=20] - Controls the radius of the bottom left rounded corner
      */
-    constructor(x = 0, y = 0, width = 0, height = 0, radius = 20)
+    constructor(x = 0, y = 0, width = 0, height = 0, radiusTL = 20, radiusTR = 20, radiusBR = 20, radiusBL = 20)
     {
         /**
          * @member {number}
@@ -46,7 +49,25 @@ export default class RoundedRectangle
          * @member {number}
          * @default 20
          */
-        this.radius = radius;
+        this.radiusTL = radiusTL;
+
+        /**
+         * @member {number}
+         * @default 20
+         */
+        this.radiusTR = radiusTR;
+
+        /**
+         * @member {number}
+         * @default 20
+         */
+        this.radiusBR = radiusBR;
+
+        /**
+         * @member {number}
+         * @default 20
+         */
+        this.radiusBL = radiusBL;
 
         /**
          * The type of the object, mainly used to avoid `instanceof` checks
@@ -66,7 +87,8 @@ export default class RoundedRectangle
      */
     clone()
     {
-        return new RoundedRectangle(this.x, this.y, this.width, this.height, this.radius);
+        return new RoundedRectangle(this.x, this.y, this.width, this.height, this.radiusTL, this.radiusTR, this.radiusBR,
+                                    this.radiusBL);
     }
 
     /**
@@ -86,31 +108,61 @@ export default class RoundedRectangle
         {
             if (y >= this.y && y <= this.y + this.height)
             {
-                if ((y >= this.y + this.radius && y <= this.y + this.height - this.radius)
-                || (x >= this.x + this.radius && x <= this.x + this.width - this.radius))
-                {
-                    return true;
-                }
-                let dx = x - (this.x + this.radius);
-                let dy = y - (this.y + this.radius);
-                const radius2 = this.radius * this.radius;
+                let rx1;
+                let rx2;
+                let ry1;
+                let ry2;
 
-                if ((dx * dx) + (dy * dy) <= radius2)
+                if (y < this.y + (this.height / 2))
+                {
+                    rx1 = this.radiusTL;
+                    rx2 = this.radiusTR;
+                }
+                else
+                {
+                    rx1 = this.radiusBL;
+                    rx2 = this.radiusBR;
+                }
+
+                if (x < this.x + (this.width / 2))
+                {
+                    ry1 = this.radiusTL;
+                    ry2 = this.radiusBL;
+                }
+                else
+                {
+                    ry1 = this.radiusTR;
+                    ry2 = this.radiusBR;
+                }
+
+                if ((y >= this.y + ry1 && y <= this.y + this.height - ry2)
+                || (x >= this.x + rx1 && x <= this.x + this.width - rx2))
                 {
                     return true;
                 }
-                dx = x - (this.x + this.width - this.radius);
-                if ((dx * dx) + (dy * dy) <= radius2)
+
+                let dx = x - (this.x + this.radiusTL);
+                let dy = y - (this.y + this.radiusTL);
+
+                if ((dx * dx) + (dy * dy) <= this.radiusTL * this.radiusTL)
                 {
                     return true;
                 }
-                dy = y - (this.y + this.height - this.radius);
-                if ((dx * dx) + (dy * dy) <= radius2)
+                dx = x - (this.x + this.width - this.radiusTR);
+                dy = y - (this.y + this.radiusTR);
+                if ((dx * dx) + (dy * dy) <= this.radiusTR * this.radiusTR)
                 {
                     return true;
                 }
-                dx = x - (this.x + this.radius);
-                if ((dx * dx) + (dy * dy) <= radius2)
+                dx = x - (this.x + this.width - this.radiusBR);
+                dy = y - (this.y + this.height - this.radiusBR);
+                if ((dx * dx) + (dy * dy) <= this.radiusBR * this.radiusBR)
+                {
+                    return true;
+                }
+                dx = x - (this.x + this.radiusBL);
+                dy = y - (this.y + this.height - this.radiusBL);
+                if ((dx * dx) + (dy * dy) <= this.radiusBL * this.radiusBL)
                 {
                     return true;
                 }


### PR DESCRIPTION
Next to Graphics.drawRoundedRect() there now is Graphics.drawRoundedRectComplex() which expects 4 radii instead of 1. Going clockwise starting from top left.
core.math.shapes.RoundedRectangle has been changed in order to hold the 4 different radii. The contains(x,y) function has been adjusted, as well as the associated drawing methods for Canvas & WebGL.

