### PR TITLE
TextMetrics.wordWrap - Don't add a newline if it's the last token/word

### DIFF
--- a/src/core/text/TextMetrics.js
+++ b/src/core/text/TextMetrics.js
@@ -248,7 +248,7 @@ export default class TextMetrics
 
                     const isLastToken = i === tokens.length - 1;
 
-					// give it its own line if it's not the end
+                    // give it its own line if it's not the end
                     lines += TextMetrics.addLine(token, !isLastToken);
                     canPrependSpaces = false;
                     line = '';

--- a/src/core/text/TextMetrics.js
+++ b/src/core/text/TextMetrics.js
@@ -246,8 +246,10 @@ export default class TextMetrics
                         width = 0;
                     }
 
-                    // give it its own line
-                    lines += TextMetrics.addLine(token);
+                    const isLastToken = i === tokens.length - 1;
+
+					// give it its own line if it's not the end
+                    lines += TextMetrics.addLine(token, !isLastToken);
                     canPrependSpaces = false;
                     line = '';
                     width = 0;


### PR DESCRIPTION
Fix for the issue I mentioned in https://github.com/pixijs/pixi.js/issues/4791.