### PR TITLE
Do not quote escape generic font families

### DIFF
--- a/src/core/text/TextStyle.js
+++ b/src/core/text/TextStyle.js
@@ -36,6 +36,15 @@ const defaultStyle = {
     leading: 0,
 };
 
+const genericFontFamilies = [
+    'serif',
+    'sans-serif',
+    'monospace',
+    'cursive',
+    'fantasy',
+    'system-ui',
+]
+
 /**
  * A TextStyle Object decorates a Text Object. It can be shared between
  * multiple Text objects. Changing the style will update all text objects using it.
@@ -694,8 +703,8 @@ export default class TextStyle
             // Trim any extra white-space
             let fontFamily = fontFamilies[i].trim();
 
-            // Check if font already contains strings
-            if (!(/([\"\'])[^\'\"]+\1/).test(fontFamily))
+            // Check if font is already escaped in quotes except for CSS generic fonts
+            if (!(/([\"\'])[^\'\"]+\1/).test(fontFamily) && genericFontFamilies.indexOf(fontFamily) < 0)
             {
                 fontFamily = `"${fontFamily}"`;
             }

--- a/test/core/TextStyle.js
+++ b/test/core/TextStyle.js
@@ -39,7 +39,7 @@ describe('PIXI.TextStyle', function ()
             fontFamily: ['Georgia', 'Arial', 'sans-serif'],
         });
 
-        expect(style.toFontString()).to.have.string('"Georgia","Arial","sans-serif"');
+        expect(style.toFontString()).to.have.string('"Georgia","Arial",sans-serif');
     });
 
     it('should handle multiple fonts as string', function ()
@@ -48,7 +48,7 @@ describe('PIXI.TextStyle', function ()
             fontFamily: 'Georgia, "Arial", sans-serif',
         });
 
-        expect(style.toFontString()).to.have.string('"Georgia","Arial","sans-serif"');
+        expect(style.toFontString()).to.have.string('"Georgia","Arial",sans-serif');
     });
 
     it('should not shared array / object references between different instances', function ()


### PR DESCRIPTION
The CanvasRenderingContext2D.font property when taking in CSS generic font families doesn't work correctly when those families are quoted. This makes a whitelist to not quote those families.

