### PR TITLE
Fix for odd sized text and svg textures. #4970

### DIFF
--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -2,7 +2,7 @@
 import Sprite from '../sprites/Sprite';
 import Texture from '../textures/Texture';
 import { Rectangle } from '../math';
-import { sign } from '../utils';
+import { sign, expandToEven } from '../utils';
 import { TEXT_GRADIENT } from '../const';
 import settings from '../settings';
 import TextStyle from './TextStyle';
@@ -145,8 +145,8 @@ export default class Text extends Sprite
         const maxLineWidth = measured.maxLineWidth;
         const fontProperties = measured.fontProperties;
 
-        this.canvas.width = Math.ceil((Math.max(1, width) + (style.padding * 2)) * this.resolution);
-        this.canvas.height = Math.ceil((Math.max(1, height) + (style.padding * 2)) * this.resolution);
+        this.canvas.width = expandToEven(Math.ceil((Math.max(1, width) + (style.padding * 2)) * this.resolution));
+        this.canvas.height = expandToEven(Math.ceil((Math.max(1, height) + (style.padding * 2)) * this.resolution));
 
         context.scale(this.resolution, this.resolution);
 
@@ -319,8 +319,8 @@ export default class Text extends Sprite
         {
             const trimmed = trimCanvas(canvas);
 
-            canvas.width = trimmed.width;
-            canvas.height = trimmed.height;
+            canvas.width = trimmed.width(trimmed.width);
+            canvas.height = trimmed.width(trimmed.height);
             this.context.putImageData(trimmed.data, 0, 0);
         }
 

--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -1,6 +1,6 @@
 import {
     uid, getUrlFileExtension, decomposeDataUri, getSvgSize,
-    getResolutionOfUrl, BaseTextureCache, TextureCache,
+    getResolutionOfUrl, BaseTextureCache, TextureCache, expandToEven
 } from '../utils';
 import settings from '../settings';
 import EventEmitter from 'eventemitter3';
@@ -564,8 +564,8 @@ export default class BaseTexture extends EventEmitter
         }
 
         // Scale realWidth and realHeight
-        this.realWidth = Math.round(svgWidth * this.sourceScale);
-        this.realHeight = Math.round(svgHeight * this.sourceScale);
+        this.realWidth = expandToEven(Math.round(svgWidth * this.sourceScale));
+        this.realHeight = expandToEven(Math.round(svgHeight * this.sourceScale));
 
         this._updateDimensions();
 

--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -1,6 +1,6 @@
 import {
     uid, getUrlFileExtension, decomposeDataUri, getSvgSize,
-    getResolutionOfUrl, BaseTextureCache, TextureCache, expandToEven
+    getResolutionOfUrl, BaseTextureCache, TextureCache, expandToEven,
 } from '../utils';
 import settings from '../settings';
 import EventEmitter from 'eventemitter3';

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -133,6 +133,7 @@ export function hex2string(hex)
  */
 export function expandToEven(input)
 {
+    input = Math.ceil(input);
     if (input & 1)
     {
         input++;

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -128,13 +128,16 @@ export function hex2string(hex)
  *
  * @memberof PIXI.utils
  * @function expandToEven
- * @param {number} 
+ * @param {number} input - the integer to convert
  * @return {number} even integer.
  */
-export function expandToEven(input) {
-    if(input & 1) {
+export function expandToEven(input)
+{
+    if (input & 1)
+    {
         input++;
     }
+
     return input;
 }
 

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -124,6 +124,21 @@ export function hex2string(hex)
 }
 
 /**
+ * Converts an integer to closest even integer.
+ *
+ * @memberof PIXI.utils
+ * @function expandToEven
+ * @param {number} 
+ * @return {number} even integer.
+ */
+export function expandToEven(input) {
+    if(input & 1) {
+        input++;
+    }
+    return input;
+}
+
+/**
  * Converts a color as an [R, G, B] array to a hex number
  *
  * @memberof PIXI.utils


### PR DESCRIPTION
When Text generates odd sized texture, its become blurred if set anchor to (0.5, 0.5).
PR expands canvas to even sizes. Trimmed canvas and SVG generated canvas included also by the way.