### PR TITLE
Fixes JSdoc Events in 3.5.5

### DIFF
--- a/packages/canvas/canvas-renderer/src/CanvasRenderer.js
+++ b/packages/canvas/canvas-renderer/src/CanvasRenderer.js
@@ -107,8 +107,6 @@ export default class CanvasRenderer extends AbstractRenderer
 
         sayHello('Canvas');
 
-        this.resize(this.options.width, this.options.height);
-
         /**
          * Fired after rendering finishes.
          *
@@ -120,6 +118,8 @@ export default class CanvasRenderer extends AbstractRenderer
          *
          * @event PIXI.CanvasRenderer#prerender
          */
+
+        this.resize(this.options.width, this.options.height);
     }
 
     /**

--- a/packages/core/src/Renderer.js
+++ b/packages/core/src/Renderer.js
@@ -268,8 +268,6 @@ export default class Renderer extends AbstractRenderer
             this.runners[i].add(system);
         }
 
-        return this;
-
         /**
          * Fired after rendering finishes.
          *
@@ -288,6 +286,8 @@ export default class Renderer extends AbstractRenderer
          * @event PIXI.Renderer#context
          * @param {WebGLRenderingContext} gl - WebGL context.
          */
+
+        return this;
     }
 
     /**

--- a/packages/core/src/textures/BaseTexture.js
+++ b/packages/core/src/textures/BaseTexture.js
@@ -225,9 +225,6 @@ export default class BaseTexture extends EventEmitter
          */
         this.resource = null;
 
-        // Set the resource
-        this.setResource(resource);
-
         /**
          * Fired when a not-immediately-available source finishes loading.
          *
@@ -275,6 +272,9 @@ export default class BaseTexture extends EventEmitter
          * @event PIXI.BaseTexture#dispose
          * @param {PIXI.BaseTexture} baseTexture - Instance of texture being destroyed.
          */
+
+        // Set the resource
+        this.setResource(resource);
     }
 
     /**

--- a/packages/display/src/DisplayObject.js
+++ b/packages/display/src/DisplayObject.js
@@ -115,15 +115,6 @@ export default class DisplayObject extends EventEmitter
         this._mask = null;
 
         /**
-         * If the object has been destroyed via destroy(). If true, it should not be used.
-         *
-         * @member {boolean}
-         * @private
-         * @readonly
-         */
-        this._destroyed = false;
-
-        /**
          * Fired when this DisplayObject is added to a Container.
          *
          * @event PIXI.DisplayObject#added
@@ -136,6 +127,15 @@ export default class DisplayObject extends EventEmitter
          * @event PIXI.DisplayObject#removed
          * @param {PIXI.Container} container - The container removed from.
          */
+
+        /**
+         * If the object has been destroyed via destroy(). If true, it should not be used.
+         *
+         * @member {boolean}
+         * @private
+         * @readonly
+         */
+        this._destroyed = false;
     }
 
     /**

--- a/packages/interaction/src/InteractionManager.js
+++ b/packages/interaction/src/InteractionManager.js
@@ -645,6 +645,7 @@ export default class InteractionManager extends EventEmitter
          * @event PIXI.DisplayObject#touchmove
          * @param {PIXI.interaction.InteractionEvent} event - Interaction event
          */
+
         this.setTargetElement(this.renderer.view, this.renderer.resolution);
     }
 

--- a/packages/interaction/src/InteractionManager.js
+++ b/packages/interaction/src/InteractionManager.js
@@ -253,8 +253,6 @@ export default class InteractionManager extends EventEmitter
          */
         this.resolution = 1;
 
-        this.setTargetElement(this.renderer.view, this.renderer.resolution);
-
         /**
          * Fired when a pointer device button (usually a mouse left-button) is pressed on the display
          * object.
@@ -647,6 +645,8 @@ export default class InteractionManager extends EventEmitter
          * @event PIXI.DisplayObject#touchmove
          * @param {PIXI.interaction.InteractionEvent} event - Interaction event
          */
+        this.setTargetElement(this.renderer.view, this.renderer.resolution);
+
     }
 
     /**

--- a/packages/interaction/src/InteractionManager.js
+++ b/packages/interaction/src/InteractionManager.js
@@ -646,7 +646,6 @@ export default class InteractionManager extends EventEmitter
          * @param {PIXI.interaction.InteractionEvent} event - Interaction event
          */
         this.setTargetElement(this.renderer.view, this.renderer.resolution);
-
     }
 
     /**


### PR DESCRIPTION
Follow-up to #4232

This is a workaround for https://github.com/jsdoc3/jsdoc/issues/1425 which doesn't document `@event` correctly if the events are at the bottom of the constructor. Since this is a convention that PixiJS uses in a few places, I moved the events just above the last line. Event now show up correctly and works with JSdoc 3.5.5+.