### PR TITLE
Bugfix: Don't autoclose paths when using canvas (#4154)

### DIFF
--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -1223,7 +1223,7 @@ export default class Graphics extends Container
 
         if (data.type === SHAPES.POLY)
         {
-            data.shape.closed = data.shape.closed || this.filling;
+            data.shape.closed = data.shape.closed;
             this.currentPath = data;
         }
 


### PR DESCRIPTION
When defining a path, any call to beginFill results in the path being closed,
but only for the Canvas renderer, not for the WebGL renderer.
This commit removes the check that sets the shape to be closed when a fill is
active. This unifies the rendering behavior between Canvas and WebGL.

