### PR TITLE
Added removeFromParent method to DisplayObject

### DIFF
--- a/src/core/display/DisplayObject.js
+++ b/src/core/display/DisplayObject.js
@@ -400,6 +400,18 @@ export default class DisplayObject extends EventEmitter
     }
 
     /**
+     * Removes the display object from its parent Container if it's attached to a parent.
+     *
+     */
+    removeFromParent()
+    {
+        if (this.parent)
+        {
+            this.parent.removeChild(this);
+        }
+    }
+
+    /**
      * Base destroy method for generic display objects. This will automatically
      * remove the display object from its parent Container as well as remove
      * all current event listeners and internal references. Do not use a DisplayObject


### PR DESCRIPTION
Simplifies removing a child from a parent.
No need anymore for checking if the child is actually attached to a parent in the first place.