### PR TITLE
[docs] Sprite.anchor: add periods

### DIFF
--- a/src/core/sprites/Sprite.js
+++ b/src/core/sprites/Sprite.js
@@ -30,9 +30,9 @@ export default class Sprite extends Container
 
         /**
          * The anchor sets the origin point of the texture.
-         * The default is 0,0 this means the texture's origin is the top left
-         * Setting the anchor to 0.5,0.5 means the texture's origin is centered
-         * Setting the anchor to 1,1 would mean the texture's origin point will be the bottom right corner
+         * The default is 0,0 this means the texture's origin is the top left.
+         * Setting the anchor to 0.5,0.5 means the texture's origin is centered.
+         * Setting the anchor to 1,1 would mean the texture's origin point will be the bottom right corner.
          *
          * @member {PIXI.ObservablePoint}
          * @private


### PR DESCRIPTION
This makes the documentation read correctly when the line breaks are lost when reading on https://pixijs.download/dev/docs/PIXI.Sprite.html

