### PR TITLE
Setting text to be "" means it is actually "", and not transformed to " "

### DIFF
--- a/packages/text-bitmap/src/BitmapText.js
+++ b/packages/text-bitmap/src/BitmapText.js
@@ -150,7 +150,7 @@ export default class BitmapText extends Container
         const pos = new Point();
         const chars = [];
         const lineWidths = [];
-        const text = this.text.replace(/(?:\r\n|\r)/g, '\n');
+        const text = this._text.replace(/(?:\r\n|\r)/g, '\n') || ' ';
         const textLength = text.length;
         const maxWidth = this._maxWidth * data.size / this._font.size;
 
@@ -450,14 +450,15 @@ export default class BitmapText extends Container
         return this._text;
     }
 
-    set text(value) // eslint-disable-line require-jsdoc
+    set text(text) // eslint-disable-line require-jsdoc
     {
-        value = value.toString() || ' ';
-        if (this._text === value)
+        text = String(text === null || text === undefined ? '' : text);
+
+        if (this._text === text)
         {
             return;
         }
-        this._text = value;
+        this._text = text;
         this.dirty = true;
     }
 

--- a/packages/text/src/Text.js
+++ b/packages/text/src/Text.js
@@ -135,7 +135,7 @@ export default class Text extends Sprite
         this._font = this._style.toFontString();
 
         const context = this.context;
-        const measured = TextMetrics.measureText(this._text, this._style, this._style.wordWrap, this.canvas);
+        const measured = TextMetrics.measureText(this._text || ' ', this._style, this._style.wordWrap, this.canvas);
         const width = measured.width;
         const height = measured.height;
         const lines = measured.lines;
@@ -637,7 +637,7 @@ export default class Text extends Sprite
 
     set text(text) // eslint-disable-line require-jsdoc
     {
-        text = String(text === '' || text === null || text === undefined ? ' ' : text);
+        text = String(text === null || text === undefined ? '' : text);
 
         if (this._text === text)
         {

--- a/packages/text/src/Text.js
+++ b/packages/text/src/Text.js
@@ -50,9 +50,6 @@ export default class Text extends Sprite
 
         super(texture);
 
-        // base texture is already automatically added to the cache, now adding the actual texture
-        Texture.addToCache(this._texture, this._texture.baseTexture.textureCacheIds[0]);
-
         /**
          * The canvas element that everything is drawn to
          *

--- a/packages/text/test/Text.js
+++ b/packages/text/test/Text.js
@@ -100,21 +100,21 @@ describe('PIXI.Text', function ()
         {
             const text = new Text(null);
 
-            expect(text.text).to.equal(' ');
+            expect(text.text).to.equal('');
         });
 
         it('should prevent setting undefined', function ()
         {
             const text = new Text();
 
-            expect(text.text).to.equal(' ');
+            expect(text.text).to.equal('');
         });
 
-        it('should prevent setting \'\'', function ()
+        it('should allow setting \'\' for v5', function ()
         {
             const text = new Text('');
 
-            expect(text.text).to.equal(' ');
+            expect(text.text).to.equal('');
         });
 
         it('should keep at least 1 pixel for canvas width and height', function ()


### PR DESCRIPTION
As requested by https://github.com/pixijs/pixi.js/issues/4942
It is annoying to have to check against " " for an empty string when you've set that piece of text to "".
Internally, it'll use " " as it's just easier to deal with for measuring the size of text
