### PR TITLE
Try fix cursor pointerout

### DIFF
--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -1522,19 +1522,27 @@ export default class InteractionManager extends EventEmitter
         // Only mouse and pointer can call onPointerOut, so events will always be length 1
         const event = events[0];
 
-        if (event.pointerType === 'mouse')
-        {
-            this.mouseOverRenderer = false;
-            this.setCursorMode(null);
-        }
-
         const interactionData = this.getInteractionDataForPointerId(event);
 
         const interactionEvent = this.configureInteractionEventForDOMEvent(this.eventData, event, interactionData);
 
         interactionEvent.data.originalEvent = event;
 
-        this.processInteractive(interactionEvent, this.renderer._lastObjectRendered, this.processPointerOverOut, false);
+        // eslint-disable-next-line max-len
+        const hit = this.processInteractive(interactionEvent, this.renderer._lastObjectRendered, this.processPointerOverOut, false);
+
+        if (hit > 0)
+        {
+            this.setCursorMode(this.cursor);
+
+            return;
+        }
+
+        if (event.pointerType === 'mouse')
+        {
+            this.mouseOverRenderer = false;
+            this.setCursorMode(null);
+        }
 
         this.emit('pointerout', interactionEvent);
         if (event.pointerType === 'mouse' || event.pointerType === 'pen')

--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -1529,7 +1529,7 @@ export default class InteractionManager extends EventEmitter
         interactionEvent.data.originalEvent = event;
 
         // eslint-disable-next-line max-len
-        const hit = this.processInteractive(interactionEvent, this.renderer._lastObjectRendered, this.processPointerOverOut, false);
+        const hit = this.processInteractive(interactionEvent, this.renderer._lastObjectRendered, this.processPointerOverOut, true);
 
         if (hit > 0)
         {


### PR DESCRIPTION
@Dairnon did a magic trick and solved a problem with sudden pointerout. It was described before somewhere in issues but i cant find it right now.

How to reproduce: try clicking fast on the image.

4.8.1 release: https://jsfiddle.net/f2js5pu9/1/
this version: https://jsfiddle.net/f2js5pu9/3/

I really dont understand this magic, I'm just helping @Dairnon .