### PR TITLE
[docs] Add missing period to pivot docs.

### DIFF
--- a/src/core/display/DisplayObject.js
+++ b/src/core/display/DisplayObject.js
@@ -516,7 +516,7 @@ export default class DisplayObject extends EventEmitter
     }
 
     /**
-     * The pivot point of the displayObject that it rotates around
+     * The pivot point of the displayObject that it rotates around.
      * Assignment by value since pixi-v4.
      *
      * @member {PIXI.Point|PIXI.ObservablePoint}

--- a/src/core/display/Transform.js
+++ b/src/core/display/Transform.js
@@ -40,7 +40,7 @@ export default class Transform extends TransformBase
         this.skew = new ObservablePoint(this.updateSkew, this, 0, 0);
 
         /**
-         * The pivot point of the displayObject that it rotates around
+         * The pivot point of the displayObject that it rotates around.
          *
          * @member {PIXI.Point}
          */

--- a/src/core/display/TransformStatic.js
+++ b/src/core/display/TransformStatic.js
@@ -32,7 +32,7 @@ export default class TransformStatic extends TransformBase
         this.scale = new ObservablePoint(this.onChange, this, 1, 1);
 
         /**
-         * The pivot point of the displayObject that it rotates around
+         * The pivot point of the displayObject that it rotates around.
          *
          * @member {PIXI.ObservablePoint}
          */


### PR DESCRIPTION
This fixes a documentation problem where two sentences run into
each other when displayed in HTML.

See: http://pixijs.download/release/docs/PIXI.Graphics.html#pivot

