### PR TITLE
Update pointerup docs

### DIFF
--- a/src/interaction/InteractionManager.js
+++ b/src/interaction/InteractionManager.js
@@ -348,6 +348,9 @@ export default class InteractionManager extends EventEmitter
 
         /**
          * Fired when a pointer device button is released over the display object.
+         * Not always fired when some buttons are held down while others are released. In those cases,
+         * use [mousedown]{@link PIXI.interaction.InteractionManager#event:mousedown} and
+         * [mouseup]{@link PIXI.interaction.InteractionManager#event:mouseup} instead.
          *
          * @event PIXI.interaction.InteractionManager#pointerup
          * @param {PIXI.interaction.InteractionEvent} event - Interaction event


### PR DESCRIPTION
Leave note in pointerup docs suggesting mousedown / mouseup instead when multiple button events are desired. Clarification added for #4863