### PR TITLE
Small TextMetrics fix - Couldn't override wordWrap to false if TextStyle.wordWrap was true

### DIFF
--- a/src/core/text/TextMetrics.js
+++ b/src/core/text/TextMetrics.js
@@ -46,7 +46,7 @@ export default class TextMetrics
      */
     static measureText(text, style, wordWrap, canvas = TextMetrics._canvas)
     {
-        wordWrap = wordWrap || style.wordWrap;
+        wordWrap = (wordWrap === undefined || wordWrap === null) ? style.wordWrap : wordWrap;
         const font = style.toFontString();
         const fontProperties = TextMetrics.measureFont(font);
         const context = canvas.getContext('2d');

--- a/test/core/TextMetrics.js
+++ b/test/core/TextMetrics.js
@@ -125,6 +125,13 @@ describe('PIXI.TextMetrics', function ()
                 expect(line[line - 1]).to.not.equal(' ', 'no lines should have a space at the end');
             });
         });
+
+        it('should be able to override wordWrap to false in measureText', function ()
+        {
+            const metrics = PIXI.TextMetrics.measureText(longText, new PIXI.TextStyle(defaultStyle), false);
+
+            expect(metrics.lines.length).to.equal(1);
+        });
     });
 
     describe('wordWrap with breakWords', function ()


### PR DESCRIPTION
`TextMetrics.measureText`'s wordWrap override just used an or statement to detect undefined/null, but in cases of passing an override of false when the style's wordWrap was true, this would just do `= false || true` and not override.