### PR TITLE
prevent gaps in duplicate lineTo calls

### DIFF
--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -423,8 +423,16 @@ export default class Graphics extends Container
      */
     lineTo(x, y)
     {
-        this.currentPath.shape.points.push(x, y);
-        this.dirty++;
+        const points = this.currentPath.shape.points;
+
+        const fromX = points[points.length - 2];
+        const fromY = points[points.length - 1];
+
+        if (fromX !== x || fromY !== y)
+        {
+            points.push(x, y);
+            this.dirty++;
+        }
 
         return this;
     }

--- a/test/core/Graphics.js
+++ b/test/core/Graphics.js
@@ -104,6 +104,18 @@ describe('PIXI.Graphics', function ()
             expect(graphics.width).to.be.equals(70);
             expect(graphics.height).to.be.equals(70);
         });
+
+        it('should ignore duplicate calls', function ()
+        {
+            const graphics = new PIXI.Graphics();
+
+            graphics.moveTo(0, 0);
+            graphics.lineTo(0, 0);
+            graphics.lineTo(10, 0);
+            graphics.lineTo(10, 0);
+
+            expect(graphics.currentPath.shape.points.length).to.be.equals(4);
+        });
     });
 
     describe('containsPoint', function ()

--- a/test/core/Graphics.js
+++ b/test/core/Graphics.js
@@ -114,7 +114,7 @@ describe('PIXI.Graphics', function ()
             graphics.lineTo(10, 0);
             graphics.lineTo(10, 0);
 
-            expect(graphics.currentPath.shape.points.length).to.be.equals(4);
+            expect(graphics.currentPath.shape.points).to.deep.equal([0, 0, 10, 0]);
         });
     });
 


### PR DESCRIPTION
Ignore duplicate calls to lineTo (same x, y inputs) to prevent gaps in WebGL render. Addresses #4046 and #3592. edit: also #4890

Notes: it is not yet understood why duplicate lineTo calls caused gaps to begin with. Also, I'm not sure of a good way to unit test this without comparing render output. If anyone has anything to say about either point, I'm all ears. Thanks!