### PR TITLE
Fix gaps in circle borders during WebGL render

### DIFF
--- a/src/core/graphics/webgl/utils/buildCircle.js
+++ b/src/core/graphics/webgl/utils/buildCircle.js
@@ -82,13 +82,18 @@ export default function buildCircle(graphicsData, webGLData, webGLDataNativeLine
 
         graphicsData.points = [];
 
-        for (let i = 0; i < totalSegs + 1; i++)
+        for (let i = 0; i < totalSegs; i++)
         {
             graphicsData.points.push(
                 x + (Math.sin(seg * -i) * width),
                 y + (Math.cos(seg * -i) * height)
             );
         }
+
+        graphicsData.points.push(
+            graphicsData.points[0],
+            graphicsData.points[1]
+        );
 
         buildLine(graphicsData, webGLData, webGLDataNativeLines);
 

--- a/test/core/Graphics.js
+++ b/test/core/Graphics.js
@@ -284,4 +284,31 @@ describe('PIXI.Graphics', function ()
             }
         }));
     });
+
+    describe('drawCircle', function ()
+    {
+        it('should have no gaps in line border', withGL(function ()
+        {
+            const renderer = new PIXI.WebGLRenderer(200, 200, {});
+
+            try
+            {
+                const graphics = new PIXI.Graphics();
+
+                graphics.lineStyle(15, 0x8FC7E6);
+                graphics.drawCircle(100, 100, 30);
+
+                renderer.render(graphics);
+
+                const points = graphics.graphicsData[0].points;
+
+                expect(points[0]).to.equals(points[points.length - 1]);
+                expect(points[1]).to.equals(points[points.length]);
+            }
+            finally
+            {
+                renderer.destroy();
+            }
+        }));
+    });
 });


### PR DESCRIPTION
Fixes #4701 

Issue caused by precision errors while calculating the line border's last point coordinates. Instead of calculating the final point, just set to the same coordinates as the first point (since circles generally end where they start).

Note: I wrote a test but when I run `npm test` it shows up as `pending`. How do I run my test? I will fix any errors in it once I get it to run. Thanks!