### PR TITLE
Fixes ObservablePoint compatibility with Point

### DIFF
--- a/src/core/math/ObservablePoint.js
+++ b/src/core/math/ObservablePoint.js
@@ -84,7 +84,7 @@ export default class ObservablePoint
      */
     equals(p)
     {
-        return (p.x === this.x) && (p.y === this.y);
+        return (p.x === this._x) && (p.y === this._y);
     }
 
     /**

--- a/src/core/math/ObservablePoint.js
+++ b/src/core/math/ObservablePoint.js
@@ -48,6 +48,7 @@ export default class ObservablePoint extends Point
     {
         const _cb = cb || this.cb;
         const _scope = scope || this.scope;
+        
         return new ObservablePoint(_cb, _scope, this._x, this._y);
     }
 

--- a/src/core/math/ObservablePoint.js
+++ b/src/core/math/ObservablePoint.js
@@ -1,3 +1,5 @@
+import Point from './Point';
+
 /**
  * The Point object represents a location in a two-dimensional coordinate system, where x represents
  * the horizontal axis and y represents the vertical axis.
@@ -5,8 +7,9 @@
  *
  * @class
  * @memberof PIXI
+ * @extends PIXI.Point
  */
-export default class ObservablePoint
+export default class ObservablePoint extends Point
 {
     /**
      * @param {Function} cb - callback when changed
@@ -16,17 +19,43 @@ export default class ObservablePoint
      */
     constructor(cb, scope, x = 0, y = 0)
     {
-        this._x = x;
-        this._y = y;
+        super(x, y);
 
+        /**
+         * @protected
+         * @member {Function}
+         */
         this.cb = cb;
+
+        /**
+         * @protected
+         * @member {object}
+         */
         this.scope = scope;
+    }
+
+    /**
+     * Creates a clone of this point.
+     * The callback and scope params can be overidden otherwise they will default
+     * to the clone object's values.
+     *
+     * @override
+     * @param {Function} [cb=null] - callback when changed
+     * @param {object} [scope=null] - owner of callback
+     * @return {PIXI.ObservablePoint} a copy of the point
+     */
+    clone(cb = null, scope = null)
+    {
+        const _cb = cb || this.cb;
+        const _scope = scope || this.scope;
+        return new ObservablePoint(_cb, _scope, this._x, this._y);
     }
 
     /**
      * Sets the point to a new x and y position.
      * If y is omitted, both x and y will be set to x.
      *
+     * @override
      * @param {number} [x=0] - position of the point on the x axis
      * @param {number} [y=0] - position of the point on the y axis
      */
@@ -37,23 +66,7 @@ export default class ObservablePoint
 
         if (this._x !== _x || this._y !== _y)
         {
-            this._x = _x;
-            this._y = _y;
-            this.cb.call(this.scope);
-        }
-    }
-
-    /**
-     * Copies the data from another point
-     *
-     * @param {PIXI.Point|PIXI.ObservablePoint} point - point to copy from
-     */
-    copy(point)
-    {
-        if (this._x !== point.x || this._y !== point.y)
-        {
-            this._x = point.x;
-            this._y = point.y;
+            super.set(_x, _y);
             this.cb.call(this.scope);
         }
     }
@@ -61,18 +74,19 @@ export default class ObservablePoint
     /**
      * The position of the displayObject on the x axis relative to the local coordinates of the parent.
      *
+     * @override
      * @member {number}
      */
     get x()
     {
-        return this._x;
+        return super.x;
     }
 
     set x(value) // eslint-disable-line require-jsdoc
     {
         if (this._x !== value)
         {
-            this._x = value;
+            super.x = value;
             this.cb.call(this.scope);
         }
     }
@@ -80,18 +94,19 @@ export default class ObservablePoint
     /**
      * The position of the displayObject on the x axis relative to the local coordinates of the parent.
      *
+     * @override
      * @member {number}
      */
     get y()
     {
-        return this._y;
+        return super.y;
     }
 
     set y(value) // eslint-disable-line require-jsdoc
     {
         if (this._y !== value)
         {
-            this._y = value;
+            super.y = value;
             this.cb.call(this.scope);
         }
     }

--- a/src/core/math/ObservablePoint.js
+++ b/src/core/math/ObservablePoint.js
@@ -48,7 +48,7 @@ export default class ObservablePoint extends Point
     {
         const _cb = cb || this.cb;
         const _scope = scope || this.scope;
-        
+
         return new ObservablePoint(_cb, _scope, this._x, this._y);
     }
 

--- a/src/core/math/ObservablePoint.js
+++ b/src/core/math/ObservablePoint.js
@@ -80,14 +80,14 @@ export default class ObservablePoint extends Point
      */
     get x()
     {
-        return super.x;
+        return this._x;
     }
 
     set x(value) // eslint-disable-line require-jsdoc
     {
         if (this._x !== value)
         {
-            super.x = value;
+            this._x = value;
             this.cb.call(this.scope);
         }
     }
@@ -100,14 +100,14 @@ export default class ObservablePoint extends Point
      */
     get y()
     {
-        return super.y;
+        return this._y;
     }
 
     set y(value) // eslint-disable-line require-jsdoc
     {
         if (this._y !== value)
         {
-            super.y = value;
+            this._y = value;
             this.cb.call(this.scope);
         }
     }

--- a/src/core/math/ObservablePoint.js
+++ b/src/core/math/ObservablePoint.js
@@ -1,5 +1,3 @@
-import Point from './Point';
-
 /**
  * The Point object represents a location in a two-dimensional coordinate system, where x represents
  * the horizontal axis and y represents the vertical axis.
@@ -7,9 +5,8 @@ import Point from './Point';
  *
  * @class
  * @memberof PIXI
- * @extends PIXI.Point
  */
-export default class ObservablePoint extends Point
+export default class ObservablePoint
 {
     /**
      * @param {Function} cb - callback when changed
@@ -19,18 +16,10 @@ export default class ObservablePoint extends Point
      */
     constructor(cb, scope, x = 0, y = 0)
     {
-        super(x, y);
+        this._x = x;
+        this._y = y;
 
-        /**
-         * @protected
-         * @member {Function}
-         */
         this.cb = cb;
-
-        /**
-         * @protected
-         * @member {object}
-         */
         this.scope = scope;
     }
 
@@ -56,7 +45,6 @@ export default class ObservablePoint extends Point
      * Sets the point to a new x and y position.
      * If y is omitted, both x and y will be set to x.
      *
-     * @override
      * @param {number} [x=0] - position of the point on the x axis
      * @param {number} [y=0] - position of the point on the y axis
      */
@@ -67,15 +55,41 @@ export default class ObservablePoint extends Point
 
         if (this._x !== _x || this._y !== _y)
         {
-            super.set(_x, _y);
+            this._x = _x;
+            this._y = _y;
             this.cb.call(this.scope);
         }
     }
 
     /**
+     * Copies the data from another point
+     *
+     * @param {PIXI.Point|PIXI.ObservablePoint} point - point to copy from
+     */
+    copy(point)
+    {
+        if (this._x !== point.x || this._y !== point.y)
+        {
+            this._x = point.x;
+            this._y = point.y;
+            this.cb.call(this.scope);
+        }
+    }
+
+    /**
+     * Returns true if the given point is equal to this point
+     *
+     * @param {PIXI.Point|PIXI.ObservablePoint} p - The point to check
+     * @returns {boolean} Whether the given point equal to this point
+     */
+    equals(p)
+    {
+        return (p.x === this.x) && (p.y === this.y);
+    }
+
+    /**
      * The position of the displayObject on the x axis relative to the local coordinates of the parent.
      *
-     * @override
      * @member {number}
      */
     get x()
@@ -95,7 +109,6 @@ export default class ObservablePoint extends Point
     /**
      * The position of the displayObject on the x axis relative to the local coordinates of the parent.
      *
-     * @override
      * @member {number}
      */
     get y()

--- a/src/core/math/Point.js
+++ b/src/core/math/Point.js
@@ -14,18 +14,16 @@ export default class Point
     constructor(x = 0, y = 0)
     {
         /**
-         * @protected
          * @member {number}
          * @default 0
          */
-        this._x = x;
+        this.x = x;
 
         /**
-         * @protected
          * @member {number}
          * @default 0
          */
-        this._y = y;
+        this.y = y;
     }
 
     /**
@@ -35,7 +33,7 @@ export default class Point
      */
     clone()
     {
-        return new Point(this._x, this._y);
+        return new Point(this.x, this.y);
     }
 
     /**
@@ -45,10 +43,7 @@ export default class Point
      */
     copy(p)
     {
-        if (!this.equals(p))
-        {
-            this.set(p.x, p.y);
-        }
+        this.set(p.x, p.y);
     }
 
     /**
@@ -59,7 +54,7 @@ export default class Point
      */
     equals(p)
     {
-        return (p.x === this._x) && (p.y === this._y);
+        return (p.x === this.x) && (p.y === this.y);
     }
 
     /**
@@ -71,38 +66,8 @@ export default class Point
      */
     set(x, y)
     {
-        this._x = x || 0;
-        this._y = y || ((y !== 0) ? this._x : 0);
-    }
-
-    /**
-     * The position of the point on the x axis
-     *
-     * @member {number}
-     */
-    get x()
-    {
-        return this._x;
-    }
-
-    set x(value) // eslint-disable-line require-jsdoc
-    {
-        this._x = value;
-    }
-
-    /**
-     * The position of the point on the y axis
-     *
-     * @member {number}
-     */
-    get y()
-    {
-        return this._y;
-    }
-
-    set y(value) // eslint-disable-line require-jsdoc
-    {
-        this._y = value;
+        this.x = x || 0;
+        this.y = y || ((y !== 0) ? this.x : 0);
     }
 
 }

--- a/src/core/math/Point.js
+++ b/src/core/math/Point.js
@@ -14,16 +14,18 @@ export default class Point
     constructor(x = 0, y = 0)
     {
         /**
+         * @protected
          * @member {number}
          * @default 0
          */
-        this.x = x;
+        this._x = x;
 
         /**
+         * @protected
          * @member {number}
          * @default 0
          */
-        this.y = y;
+        this._y = y;
     }
 
     /**
@@ -33,7 +35,7 @@ export default class Point
      */
     clone()
     {
-        return new Point(this.x, this.y);
+        return new Point(this._x, this._y);
     }
 
     /**
@@ -43,7 +45,10 @@ export default class Point
      */
     copy(p)
     {
-        this.set(p.x, p.y);
+        if (!this.equals(p))
+        {
+            this.set(p.x, p.y);
+        }
     }
 
     /**
@@ -54,7 +59,7 @@ export default class Point
      */
     equals(p)
     {
-        return (p.x === this.x) && (p.y === this.y);
+        return (p.x === this._x) && (p.y === this._y);
     }
 
     /**
@@ -66,8 +71,38 @@ export default class Point
      */
     set(x, y)
     {
-        this.x = x || 0;
-        this.y = y || ((y !== 0) ? this.x : 0);
+        this._x = x || 0;
+        this._y = y || ((y !== 0) ? this._x : 0);
+    }
+
+    /**
+     * The position of the point on the x axis
+     *
+     * @member {number}
+     */
+    get x()
+    {
+        return this._x;
+    }
+
+    set x(value) // eslint-disable-line require-jsdoc
+    {
+        this._x = value;
+    }
+
+    /**
+     * The position of the point on the y axis
+     *
+     * @member {number}
+     */
+    get y()
+    {
+        return this._y;
+    }
+
+    set y(value) // eslint-disable-line require-jsdoc
+    {
+        this._y = value;
     }
 
 }


### PR DESCRIPTION
Observable point was missing clone and equals methods. Since the ObservablePoint is highly coupled to Point, and Point already had those methods, I've updated it to extend.

