### PR TITLE
Fix the exception if an unused uniform is defined.

### DIFF
--- a/src/core/renderers/webgl/managers/FilterManager.js
+++ b/src/core/renderers/webgl/managers/FilterManager.js
@@ -6,6 +6,8 @@ import Shader from '../../../Shader';
 import * as filterTransforms from '../filters/filterTransforms';
 import bitTwiddle from 'bit-twiddle';
 
+const { hasOwnProperty } = Object.prototype;
+
 /**
  * @ignore
  * @class
@@ -362,6 +364,11 @@ export default class FilterManager extends WebGLManager
         // TODO Cacheing layer..
         for (const i in uniformData)
         {
+            if (hasOwnProperty.call(shader.uniforms, i))
+            {
+                continue;
+            }
+
             const type = uniformData[i].type;
 
             if (type === 'sampler2d' && uniforms[i] !== 0)

--- a/src/core/renderers/webgl/managers/FilterManager.js
+++ b/src/core/renderers/webgl/managers/FilterManager.js
@@ -6,8 +6,6 @@ import Shader from '../../../Shader';
 import * as filterTransforms from '../filters/filterTransforms';
 import bitTwiddle from 'bit-twiddle';
 
-const { hasOwnProperty } = Object.prototype;
-
 /**
  * @ignore
  * @class
@@ -364,7 +362,7 @@ export default class FilterManager extends WebGLManager
         // TODO Caching layer..
         for (const i in uniformData)
         {
-            if (hasOwnProperty.call(shader.uniforms, i))
+            if (!shader.uniforms.data[i])
             {
                 continue;
             }


### PR DESCRIPTION
The code below ([jsfiddle](http://jsfiddle.net/ypex3ktg/4/)) will fail with `Uncaught TypeError: Cannot read property 'value' of undefined`

```javascript

const app = new PIXI.Application({
  width: 400,
  height: 400,
})

const sprite = new PIXI.Sprite()
sprite.width = 400
sprite.height = 400
const filter = new PIXI.Filter(undefined, `
  uniform float xxx;

  void main(){
    gl_FragColor=vec4(1,0,0,1);
  }
`, {
  xxx: {
    type: 'float',
    value: 1.2,
  },
})

sprite.filters = [filter]

app.stage.addChild(sprite)
document.body.appendChild(app.view)
```

https://github.com/pixijs/pixi.js/blob/32219397a2a4dbc2d0ad0ead601ffb8636c6d224/src/core/renderers/webgl/managers/FilterManager.js#L422

Because `filter.uniformData` contains `xxx` but `filter.uniforms` does not.

So I am adding a checker here.
