### PR TITLE
fix: call `_onCanPlay()` on nextTick to make `autoPlay=false` working

### DIFF
--- a/src/core/textures/VideoBaseTexture.js
+++ b/src/core/textures/VideoBaseTexture.js
@@ -84,7 +84,7 @@ export default class VideoBaseTexture extends BaseTexture
         }
         else
         {
-            this._onCanPlay();
+            setTimeout(this._onCanPlay, 0);
         }
     }
 


### PR DESCRIPTION
`autoPlay=false` not working in my code:

```javascript
// video has been ready
const videoBaseTexture = new PIXI.VideoBaseTexture(video)
videoBaseTexture.autoPlay = false
```

Because `_onCanPlay()` was called before `autoPlay` set to `false`.