### PR TITLE
video autoplay from source

### DIFF
--- a/src/core/textures/VideoBaseTexture.js
+++ b/src/core/textures/VideoBaseTexture.js
@@ -67,7 +67,7 @@ export default class VideoBaseTexture extends BaseTexture
          * @member {boolean}
          * @default true
          */
-        this.autoPlay = true;
+        this.autoPlay = source.autoplay;
 
         this.update = this.update.bind(this);
         this._onCanPlay = this._onCanPlay.bind(this);


### PR DESCRIPTION
user should allowed to setup autoplay manually

I don't know what other dev think about this.
It's very problematic on my side.

this allow user to manually setup the source if need **autoplay**
Default it **false**;
```javascript
    const texture = PIXI.Texture.fromVideo('data2/Video/intro/vidA1.webm');
    texture.baseTexture.source.autoplay = true; // working if need autoplay
    const videoSprite = new PIXI.Sprite(texture);
    const videoControler = texture.baseTexture.source;
```