### PR TITLE
Fix cache as bitmap filters check

### DIFF
--- a/src/extras/cacheAsBitmap.js
+++ b/src/extras/cacheAsBitmap.js
@@ -173,7 +173,7 @@ DisplayObject.prototype._initCachedDisplayObject = function _initCachedDisplayOb
     const bounds = this.getLocalBounds().clone();
 
     // add some padding!
-    if (this._filters)
+    if (this._filters && this._filters.length)
     {
         const padding = this._filters[0].padding;
 


### PR DESCRIPTION
In our internal PIXI-wrapped engine we ended up setting an empty array on the filters property of some cached elements and I found this.

Not that I consider this is a "bug", but adding this won't harm.

Edit: I couldn't find any associated unit tests. Am I missing something?