### PR TITLE
Extra constructor property to control video autoPlay

### DIFF
--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -356,16 +356,18 @@ export default class Texture extends EventEmitter
      * @static
      * @param {HTMLVideoElement|string} video - The URL or actual element of the video
      * @param {number} [scaleMode=PIXI.settings.SCALE_MODE] - See {@link PIXI.SCALE_MODES} for possible values
+     * @param {boolean} [crossorigin=(auto)] - Should use anonymous CORS? Defaults to true if the URL is not a data-URI.
+     * @param {boolean} [autoPlay=true] - Start playing video as soon as it is loaded
      * @return {PIXI.Texture} The newly created texture
      */
-    static fromVideo(video, scaleMode)
+    static fromVideo(video, scaleMode, crossorigin, autoPlay)
     {
         if (typeof video === 'string')
         {
-            return Texture.fromVideoUrl(video, scaleMode);
+            return Texture.fromVideoUrl(video, scaleMode, crossorigin, autoPlay);
         }
 
-        return new Texture(VideoBaseTexture.fromVideo(video, scaleMode));
+        return new Texture(VideoBaseTexture.fromVideo(video, scaleMode, autoPlay));
     }
 
     /**
@@ -374,11 +376,13 @@ export default class Texture extends EventEmitter
      * @static
      * @param {string} videoUrl - URL of the video
      * @param {number} [scaleMode=PIXI.settings.SCALE_MODE] - See {@link PIXI.SCALE_MODES} for possible values
+     * @param {boolean} [crossorigin=(auto)] - Should use anonymous CORS? Defaults to true if the URL is not a data-URI.
+     * @param {boolean} [autoPlay=true] - Start playing video as soon as it is loaded
      * @return {PIXI.Texture} The newly created texture
      */
-    static fromVideoUrl(videoUrl, scaleMode)
+    static fromVideoUrl(videoUrl, scaleMode, crossorigin, autoPlay)
     {
-        return new Texture(VideoBaseTexture.fromUrl(videoUrl, scaleMode));
+        return new Texture(VideoBaseTexture.fromUrl(videoUrl, scaleMode, crossorigin, autoPlay));
     }
 
     /**

--- a/src/core/textures/VideoBaseTexture.js
+++ b/src/core/textures/VideoBaseTexture.js
@@ -35,8 +35,9 @@ export default class VideoBaseTexture extends BaseTexture
     /**
      * @param {HTMLVideoElement} source - Video source
      * @param {number} [scaleMode=PIXI.settings.SCALE_MODE] - See {@link PIXI.SCALE_MODES} for possible values
+     * @param {boolean} [autoPlay=true] - Start playing video as soon as it is loaded
      */
-    constructor(source, scaleMode)
+    constructor(source, scaleMode, autoPlay = true)
     {
         if (!source)
         {
@@ -67,7 +68,7 @@ export default class VideoBaseTexture extends BaseTexture
          * @member {boolean}
          * @default true
          */
-        this.autoPlay = true;
+        this.autoPlay = autoPlay;
 
         this.update = this.update.bind(this);
         this._onCanPlay = this._onCanPlay.bind(this);
@@ -211,9 +212,10 @@ export default class VideoBaseTexture extends BaseTexture
      * @static
      * @param {HTMLVideoElement} video - Video to create texture from
      * @param {number} [scaleMode=PIXI.settings.SCALE_MODE] - See {@link PIXI.SCALE_MODES} for possible values
+     * @param {boolean} [autoPlay=true] - Start playing video as soon as it is loaded
      * @return {PIXI.VideoBaseTexture} Newly created VideoBaseTexture
      */
-    static fromVideo(video, scaleMode)
+    static fromVideo(video, scaleMode, autoPlay)
     {
         if (!video._pixiId)
         {
@@ -224,7 +226,7 @@ export default class VideoBaseTexture extends BaseTexture
 
         if (!baseTexture)
         {
-            baseTexture = new VideoBaseTexture(video, scaleMode);
+            baseTexture = new VideoBaseTexture(video, scaleMode, autoPlay);
             BaseTexture.addToCache(baseTexture, video._pixiId);
         }
 
@@ -242,9 +244,10 @@ export default class VideoBaseTexture extends BaseTexture
      *  the url's extension will be used as the second part of the mime type.
      * @param {number} scaleMode - See {@link PIXI.SCALE_MODES} for possible values
      * @param {boolean} [crossorigin=(auto)] - Should use anonymous CORS? Defaults to true if the URL is not a data-URI.
+     * @param {boolean} [autoPlay=true] - Start playing video as soon as it is loaded
      * @return {PIXI.VideoBaseTexture} Newly created VideoBaseTexture
      */
-    static fromUrl(videoSrc, scaleMode, crossorigin)
+    static fromUrl(videoSrc, scaleMode, crossorigin, autoPlay)
     {
         const video = document.createElement('video');
 
@@ -278,7 +281,7 @@ export default class VideoBaseTexture extends BaseTexture
 
         video.load();
 
-        return VideoBaseTexture.fromVideo(video, scaleMode);
+        return VideoBaseTexture.fromVideo(video, scaleMode, autoPlay);
     }
 
     /**


### PR DESCRIPTION
There are already 2 PRs to try and solve a problem devs are having; not wanting video to autoplay when created.

https://github.com/pixijs/pixi.js/pull/5109
https://github.com/pixijs/pixi.js/pull/5112

We've put a lockdown on new APIs for v4, which means these 2 PRs are both compromised on how they work, imo.

Since this is a very real issue that multiple developers are having, I think we should allow this extra parameter in the constructor to solve this properly.