### PR TITLE
Added 'angle' property for DisplayObject

### DIFF
--- a/packages/display/src/DisplayObject.js
+++ b/packages/display/src/DisplayObject.js
@@ -540,7 +540,7 @@ export default class DisplayObject extends EventEmitter
 
     /**
      * The rotation of the object in radians.
-     * 'rotation' and 'angle' have the same effect on display object; rotation is in radians, angle is in degrees.
+     * 'rotation' and 'angle' have the same effect on a display object; rotation is in radians, angle is in degrees.
      *
      * @member {number}
      */

--- a/packages/display/src/DisplayObject.js
+++ b/packages/display/src/DisplayObject.js
@@ -1,5 +1,5 @@
 import EventEmitter from 'eventemitter3';
-import { Rectangle, Transform } from '@pixi/math';
+import { Rectangle, Transform, RAD_TO_DEG, DEG_TO_RAD } from '@pixi/math';
 import Bounds from './Bounds';
 // _tempDisplayObjectParent = new DisplayObject();
 
@@ -540,6 +540,7 @@ export default class DisplayObject extends EventEmitter
 
     /**
      * The rotation of the object in radians.
+     * 'rotation' and 'angle' have the same effect on display object; rotation is in radians, angle is in degrees.
      *
      * @member {number}
      */
@@ -551,6 +552,22 @@ export default class DisplayObject extends EventEmitter
     set rotation(value) // eslint-disable-line require-jsdoc
     {
         this.transform.rotation = value;
+    }
+
+    /**
+     * The angle of the object in degrees.
+     * 'rotation' and 'angle' have the same effect on a display object; rotation is in radians, angle is in degrees.
+     *
+     * @member {number}
+     */
+    get angle()
+    {
+        return this.transform.rotation * RAD_TO_DEG;
+    }
+
+    set angle(value) // eslint-disable-line require-jsdoc
+    {
+        this.transform.rotation = value * DEG_TO_RAD;
     }
 
     /**

--- a/packages/display/test/DisplayObject.js
+++ b/packages/display/test/DisplayObject.js
@@ -1,4 +1,5 @@
 const { DisplayObject, Container } = require('../');
+const { RAD_TO_DEG, DEG_TO_RAD } = require('@pixi/math');
 
 describe('PIXI.DisplayObject', function ()
 {
@@ -84,6 +85,27 @@ describe('PIXI.DisplayObject', function ()
             grandParent.visible = false;
 
             expect(child.worldVisible).to.be.false;
+        });
+    });
+
+    describe('rotation', function ()
+    {
+        it('rotation and angle are different units of the same transformation', function ()
+        {
+            const object = new DisplayObject();
+
+            expect(object.rotation).to.be.equal(0);
+            expect(object.angle).to.be.equal(0);
+
+            object.rotation = 2;
+
+            expect(object.rotation).to.be.equal(2);
+            expect(object.angle).to.be.equal(2 * RAD_TO_DEG);
+
+            object.angle = 180;
+
+            expect(object.rotation).to.be.equal(180 * DEG_TO_RAD);
+            expect(object.angle).to.be.equal(180);
         });
     });
 });


### PR DESCRIPTION
The proposed solution from https://github.com/pixijs/pixi.js/pull/4579 which got recently closed.

I've had `angle` as a property like this on my version of PIXI for a while, and it makes it so much easier to configure a display object's rotation via JSON :)