### PR TITLE
render children first

### DIFF
--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -387,6 +387,31 @@ export default class Container extends DisplayObject
     }
 
     /**
+     * Renders all the object based on renderChildrenFirst
+     *
+     * @private
+     * @param {PIXI.WebGLRenderer} renderer - The renderer
+     */
+    _renderObjects(renderer)
+    {
+        if (!this.renderChildrenFirst)
+        {
+            this._renderWebGL(renderer);
+        }
+
+        // now loop through the children and make sure they get rendered
+        for (let i = 0, j = this.children.length; i < j; i++)
+        {
+            this.children[i].renderWebGL(renderer);
+        }
+
+        if (this.renderChildrenFirst)
+        {
+            this._renderWebGL(renderer);
+        }
+    }
+
+    /**
      * Renders the object using the WebGL renderer
      *
      * @param {PIXI.WebGLRenderer} renderer - The renderer
@@ -406,21 +431,7 @@ export default class Container extends DisplayObject
         }
         else
         {
-            if (!this.renderChildrenFirst)
-            {
-                this._renderWebGL(renderer);
-            }
-
-            // simple render children!
-            for (let i = 0, j = this.children.length; i < j; ++i)
-            {
-                this.children[i].renderWebGL(renderer);
-            }
-
-            if (this.renderChildrenFirst)
-            {
-                this._renderWebGL(renderer);
-            }
+            this._renderObjects(renderer);
         }
     }
 
@@ -466,22 +477,8 @@ export default class Container extends DisplayObject
             renderer.maskManager.pushMask(this, this._mask);
         }
 
-        // add this object to the batch, only rendered if it has a texture.
-        if (!this.renderChildrenFirst)
-        {
-            this._renderWebGL(renderer);
-        }
-
-        // now loop through the children and make sure they get rendered
-        for (let i = 0, j = this.children.length; i < j; i++)
-        {
-            this.children[i].renderWebGL(renderer);
-        }
-
-        if (this.renderChildrenFirst)
-        {
-            this._renderWebGL(renderer);
-        }
+        //render all objects
+        this._renderObjects(renderer);
 
         renderer.flush();
 

--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -477,7 +477,7 @@ export default class Container extends DisplayObject
             renderer.maskManager.pushMask(this, this._mask);
         }
 
-        //render all objects
+        // render all objects
         this._renderWebGLObjects(renderer);
 
         renderer.flush();

--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -392,7 +392,7 @@ export default class Container extends DisplayObject
      * @private
      * @param {PIXI.WebGLRenderer} renderer - The renderer
      */
-    _renderObjects(renderer)
+    _renderWebGLObjects(renderer)
     {
         if (!this.renderChildrenFirst)
         {
@@ -431,7 +431,7 @@ export default class Container extends DisplayObject
         }
         else
         {
-            this._renderObjects(renderer);
+            this._renderWebGLObjects(renderer);
         }
     }
 
@@ -478,7 +478,7 @@ export default class Container extends DisplayObject
         }
 
         //render all objects
-        this._renderObjects(renderer);
+        this._renderWebGLObjects(renderer);
 
         renderer.flush();
 

--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -406,12 +406,20 @@ export default class Container extends DisplayObject
         }
         else
         {
-            this._renderWebGL(renderer);
+            if (!this.renderChildrenFirst)
+            {
+                this._renderWebGL(renderer);
+            }
 
             // simple render children!
             for (let i = 0, j = this.children.length; i < j; ++i)
             {
                 this.children[i].renderWebGL(renderer);
+            }
+
+            if (this.renderChildrenFirst)
+            {
+                this._renderWebGL(renderer);
             }
         }
     }
@@ -459,12 +467,20 @@ export default class Container extends DisplayObject
         }
 
         // add this object to the batch, only rendered if it has a texture.
-        this._renderWebGL(renderer);
+        if (!this.renderChildrenFirst)
+        {
+            this._renderWebGL(renderer);
+        }
 
         // now loop through the children and make sure they get rendered
         for (let i = 0, j = this.children.length; i < j; i++)
         {
             this.children[i].renderWebGL(renderer);
+        }
+
+        if (this.renderChildrenFirst)
+        {
+            this._renderWebGL(renderer);
         }
 
         renderer.flush();
@@ -520,10 +536,19 @@ export default class Container extends DisplayObject
             renderer.maskManager.pushMask(this._mask);
         }
 
-        this._renderCanvas(renderer);
+        if (!this.renderChildrenFirst)
+        {
+            this._renderCanvas(renderer);
+        }
+
         for (let i = 0, j = this.children.length; i < j; ++i)
         {
             this.children[i].renderCanvas(renderer);
+        }
+
+        if (this.renderChildrenFirst)
+        {
+            this._renderCanvas(renderer);
         }
 
         if (this._mask)

--- a/src/core/display/DisplayObject.js
+++ b/src/core/display/DisplayObject.js
@@ -65,7 +65,7 @@ export default class DisplayObject extends EventEmitter
         this.renderable = true;
 
         /**
-         * All children will be rendered underneath the parent element
+         * If renderChildrenFirst is set to true: all children will be rendered underneath their parent element
          *
          * @member {boolean}
          */

--- a/src/core/display/DisplayObject.js
+++ b/src/core/display/DisplayObject.js
@@ -65,6 +65,13 @@ export default class DisplayObject extends EventEmitter
         this.renderable = true;
 
         /**
+         * All children will be rendered underneath the parent element
+         *
+         * @member {boolean}
+         */
+        this.renderChildrenFirst = false;
+
+        /**
          * The display object container that contains this display object.
          *
          * @member {PIXI.Container}


### PR DESCRIPTION
added possibility to render all children underneath the parent element

**Example:**
```
let pixiItem = new Sprite(tex);
let pixiItem2 = new Sprite(tex);
let pixiItem3 = new Sprite(tex);
let pixiItem4 = new Sprite(tex);

pixiItem.renderChildrenFirst = true;
pixiItem2.renderChildrenFirst = true;
pixiItem3.renderChildrenFirst = true;
pixiItem4.renderChildrenFirst = true;

stage.addChild(pixiItem);
pixiItem.addChild(pixiItem2);
pixiItem2.addChild(pixiItem3);
pixiItem3.addChild(pixiItem4);
```

**Result:**

`renderChildrenFirst = false`:
![from](https://user-images.githubusercontent.com/4087801/46734176-c2c85300-cc92-11e8-9aea-f52fcd3671c4.jpg)

`renderChildrenFirst = true`:
![to](https://user-images.githubusercontent.com/4087801/46734180-c65bda00-cc92-11e8-8a16-a2afd1ade21a.jpg)
