### PR TITLE
[Next] Allows more texture units to be used by modern Android and Apple devices

### DIFF
--- a/packages/settings/src/settings.js
+++ b/packages/settings/src/settings.js
@@ -1,3 +1,4 @@
+import Device from 'ismobilejs';
 import maxRecommendedTextures from './utils/maxRecommendedTextures';
 import canUploadSameBuffer from './utils/canUploadSameBuffer';
 
@@ -149,7 +150,7 @@ export default {
     WRAP_MODE: 33071,
 
     /**
-     * The scale modes that are supported by pixi.
+     * Default scale mode for textures.
      *
      * @static
      * @memberof PIXI.settings
@@ -176,7 +177,7 @@ export default {
      * @type {PIXI.PRECISION}
      * @default PIXI.PRECISION.MEDIUM
      */
-    PRECISION_FRAGMENT: 'mediump',
+    PRECISION_FRAGMENT: Device.apple.device ? 'highp' : 'mediump',
 
     /**
      * Can we upload the same buffer in a single frame?

--- a/packages/settings/src/utils/canUploadSameBuffer.js
+++ b/packages/settings/src/utils/canUploadSameBuffer.js
@@ -1,9 +1,13 @@
+import Device from 'ismobilejs';
+
+/**
+ * Uploading the same buffer multiple times in a single frame can cause performance issues.
+ * Apparent on iOS so only check for that at the moment
+ * This check may become more complex if this issue pops up elsewhere.
+ *
+ * @returns {boolean}
+ */
 export default function canUploadSameBuffer()
 {
-    // Uploading the same buffer multiple times in a single frame can cause perf issues.
-    // Apparent on IOS so only check for that at the moment
-    // this check may become more complex if this issue pops up elsewhere.
-    const ios = !!navigator.platform && (/iPad|iPhone|iPod/).test(navigator.platform);
-
-    return !ios;
+    return !Device.apple.device;
 }

--- a/packages/settings/src/utils/maxRecommendedTextures.js
+++ b/packages/settings/src/utils/maxRecommendedTextures.js
@@ -1,13 +1,56 @@
 import Device from 'ismobilejs';
 
+/**
+ * The maximum recommended texture units to use.
+ * In theory the bigger the better, and for desktop we'll use as many as we can.
+ * But some mobile devices slow down if there is to many branches in the shader.
+ * So in practice there seems to be a sweet spot size that varies depending on the device.
+ *
+ * In v4, all mobile devices were limited to 4 texture units because for this.
+ * In v5, we allow all texture units to be used on modern Apple or Android devices.
+ *
+ * @param {number} max
+ * @returns {number}
+ */
 export default function maxRecommendedTextures(max)
 {
+    let allowMax = true;
+
     if (Device.tablet || Device.phone)
     {
-        // check if the res is iphone 6 or higher..
-        return 4;
+        allowMax = false;
+
+        if (Device.apple.device)
+        {
+            const match = (navigator.userAgent).match(/OS (\d+)_(\d+)?/);
+
+            if (match)
+            {
+                const majorVersion = parseInt(match[1], 10);
+
+                // All texture units can be used on devices that support ios 11 or above
+                if (majorVersion >= 11)
+                {
+                    allowMax = true;
+                }
+            }
+        }
+        if (Device.android.device)
+        {
+            const match = (navigator.userAgent).match(/Android\s([0-9.]*)/);
+
+            if (match)
+            {
+                const majorVersion = parseInt(match[1], 10);
+
+                // All texture units can be used on devices that support Android 7 (Nougat) or above
+                if (majorVersion >= 7)
+                {
+                    allowMax = true;
+                }
+            }
+        }
     }
 
-    // desktop should be ok
-    return max;
+    return allowMax ? max : 4;
 }


### PR DESCRIPTION
Also defaults precision fragment on ios to 'highp' - to stop issues of wobbling sprites by default like with https://github.com/pixijs/pixi.js/issues/3742
canUploadSameBuffer to not use it's own ios detection code, and use 'ismobilejs'

