### PR TITLE
Fix fontSize larger because of fontWeight

### DIFF
--- a/src/core/const.js
+++ b/src/core/const.js
@@ -336,3 +336,15 @@ export const UPDATE_PRIORITY = {
     LOW: -25,
     UTILITY: -50,
 };
+
+/**
+ * Regexp for fontWeight.
+ *
+ * @static
+ * @constant
+ * @name FONT_WEIGHT
+ * @memberof PIXI
+ * @type {RegExp|string}
+ * @example bold;
+ */
+export const FONT_WEIGHT = /\b(bold|bolder|lighter|100|200|300|400|500|600|700|800|900)\b/;

--- a/src/core/text/TextMetrics.js
+++ b/src/core/text/TextMetrics.js
@@ -1,3 +1,5 @@
+import { FONT_WEIGHT } from '../const';
+
 /**
  * The TextMetrics object represents the measurement of a block of text with a specified style.
  *
@@ -537,7 +539,7 @@ export default class TextMetrics
         context.fillStyle = '#f00';
         context.fillRect(0, 0, width, height);
 
-        context.font = font;
+        context.font = font.replace(FONT_WEIGHT, 'normal');
 
         context.textBaseline = 'alphabetic';
         context.fillStyle = '#000';
@@ -598,6 +600,8 @@ export default class TextMetrics
                 break;
             }
         }
+
+        context.font = font;
 
         properties.descent = i - baseline;
         properties.fontSize = properties.ascent + properties.descent;


### PR DESCRIPTION
#5191 
If calculate text ascent & descent with fontWeight, the ascent & descent unequal with normal one.
So the properties.fontSize will be larger.