### PR TITLE
Allow to re-use existing SVG images

### DIFF
--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -324,6 +324,11 @@ export default class BaseTexture extends EventEmitter
         // Apply source if loaded. Otherwise setup appropriate loading monitors.
         if (((source.src && source.complete) || source.getContext) && source.width && source.height)
         {
+            if (!this.imageUrl)
+            {
+                this.imageUrl = source.src;
+            }
+
             this._updateImageType();
 
             if (this.imageType === 'svg')


### PR DESCRIPTION
The problem: `BaseTexture#_updateImageType` will refuse to do anything if `BaseTexture#imageUrl` is null. This will lead to SVG be loaded as a non-SVG source:
```
            if (this.imageType === 'svg') { // imageType has not been set, so it's not svg
                this._loadSvgSource();
            } else {
                this._sourceLoaded(); // called for svg file - bummer!
            }
```

This won't happen in normal use cases when `BaseTexture` is created with `BaseTexture.from`. However, this will happen if `BaseTexture` is created with `new`, e.g.

```
// `image` is an already loaded `Image` instance
const baseTexture = new PIXI.BaseTexture(image);
```

Solution: make sure to at least try to set `source` before guessing type.