### PR TITLE
[next] Graphics memory leak

### DIFF
--- a/packages/core/src/batch/BatchRenderer.js
+++ b/packages/core/src/batch/BatchRenderer.js
@@ -247,6 +247,8 @@ export default class BatchRenderer extends ObjectRenderer
 
             const sprite = elements[i];
 
+            elements[i] = null;
+
             nextTexture = sprite._texture.baseTexture;
 
             const spriteBlendMode = premultiplyBlendMode[nextTexture.premultiplyAlpha ? 1 : 0][sprite.blendMode];
@@ -352,6 +354,7 @@ export default class BatchRenderer extends ObjectRenderer
             for (let j = 0; j < groupTextureCount; j++)
             {
                 textureSystem.bind(group.textures[j], j);
+                group.textures[j] = null;
             }
 
             // this.state.blendMode = group.blend;

--- a/packages/graphics/src/GraphicsData.js
+++ b/packages/graphics/src/GraphicsData.js
@@ -67,8 +67,8 @@ export default class GraphicsData
     {
         return new GraphicsData(
             this.shape,
-            this.lineStyle,
             this.fillStyle,
+            this.lineStyle,
             this.matrix
         );
     }

--- a/packages/graphics/src/GraphicsGeometry.js
+++ b/packages/graphics/src/GraphicsGeometry.js
@@ -685,7 +685,7 @@ export default class GraphicsGeometry extends BatchGeometry
 
         if (this.graphicsData.length)
         {
-            let shape = 0;
+            let shape = null;
             let x = 0;
             let y = 0;
             let w = 0;

--- a/packages/graphics/src/GraphicsGeometry.js
+++ b/packages/graphics/src/GraphicsGeometry.js
@@ -1,5 +1,5 @@
 import { BatchGeometry } from '@pixi/core';
-import { Rectangle, SHAPES } from '@pixi/math';
+import { Bounds, SHAPES } from '@pixi/math';
 
 import GraphicsData from './GraphicsData';
 import buildCircle from './utils/buildCircle';
@@ -157,10 +157,10 @@ export default class GraphicsGeometry extends BatchGeometry
         /**
          * Cached bounds.
          *
-         * @member {PIXI.Rectangle}
+         * @member {PIXI.Bounds}
          * @private
          */
-        this._bounds = new Rectangle();
+        this._bounds = new Bounds();
 
         /**
          * The bounds dirty flag.
@@ -182,7 +182,7 @@ export default class GraphicsGeometry extends BatchGeometry
     /**
      * Get the current bounds of the graphic geometry.
      *
-     * @member {PIXI.Rectangle}
+     * @member {PIXI.Bounds}
      * @readonly
      */
     get bounds()

--- a/packages/graphics/src/GraphicsGeometry.js
+++ b/packages/graphics/src/GraphicsGeometry.js
@@ -215,9 +215,11 @@ export default class GraphicsGeometry extends BatchGeometry
             this.colors.length = 0;
             this.uvs.length = 0;
             this.indices.length = 0;
+            this.textureIds.length = 0;
 
-            for (let i = 0; i < DRAW_CALL_POOL.length; i++)
+            for (let i = 0; i < this.drawCalls.length; i++)
             {
+                this.drawCalls[i].textures.length = 0;
                 DRAW_CALL_POOL.push(this.drawCalls[i]);
             }
 
@@ -533,6 +535,7 @@ export default class GraphicsGeometry extends BatchGeometry
 
         for (let i = 0; i < this.drawCalls.length; i++)
         {
+            this.drawCalls[i].textures.length = 0;
             DRAW_CALL_POOL.push(this.drawCalls[i]);
         }
 

--- a/packages/graphics/src/GraphicsGeometry.js
+++ b/packages/graphics/src/GraphicsGeometry.js
@@ -1,5 +1,6 @@
 import { BatchGeometry } from '@pixi/core';
-import { Bounds, SHAPES } from '@pixi/math';
+import { SHAPES } from '@pixi/math';
+import { Bounds } from '@pixi/display';
 
 import GraphicsData from './GraphicsData';
 import buildCircle from './utils/buildCircle';
@@ -177,6 +178,12 @@ export default class GraphicsGeometry extends BatchGeometry
          * @default 0
          */
         this.boundsPadding = 0;
+
+        this.batchable = false;
+
+        this.indicesUint16 = null;
+
+        this.uvsFloat32 = null;
     }
 
     /**

--- a/packages/mesh-extras/src/SimplePlane.js
+++ b/packages/mesh-extras/src/SimplePlane.js
@@ -31,7 +31,7 @@ export default class SimplePlane extends Mesh
         super(planeGeometry, meshMaterial);
 
         // wait for the texture to load
-        if (!texture.baseTexture.hasLoaded)
+        if (!texture.baseTexture.valid)
         {
             texture.once('update', this.textureUpdated, this);
         }

--- a/packages/mesh-extras/src/SimpleRope.js
+++ b/packages/mesh-extras/src/SimpleRope.js
@@ -34,8 +34,8 @@ export default class SimpleRope extends Mesh
 
     _render(renderer)
     {
-        if (this.autoUpdate ||
-            this.geometry.width !== this.shader.texture.height)
+        if (this.autoUpdate
+            || this.geometry.width !== this.shader.texture.height)
         {
             this.geometry.width = this.shader.texture.height;
             this.geometry.update();

--- a/packages/mesh-extras/src/SimpleRope.js
+++ b/packages/mesh-extras/src/SimpleRope.js
@@ -28,11 +28,18 @@ export default class SimpleRope extends Mesh
         const meshMaterial = new MeshMaterial(texture);
 
         super(ropeGeometry, meshMaterial);
+
+        this.autoUpdate = true;
     }
 
     _render(renderer)
     {
-        this.geometry.width = this.shader.texture.height;
+        if (this.autoUpdate ||
+            this.geometry.width !== this.shader.texture.height)
+        {
+            this.geometry.width = this.shader.texture.height;
+            this.geometry.update();
+        }
 
         super._render(renderer);
     }

--- a/packages/mesh/src/Mesh.js
+++ b/packages/mesh/src/Mesh.js
@@ -107,6 +107,8 @@ export default class Mesh extends Container
          */
         this.vertexDirty = 0;
 
+        this._transformID = -1;
+
         // Inherited from DisplayMode, set defaults
         this.tint = 0xFFFFFF;
         this.blendMode = BLEND_MODES.NORMAL;

--- a/packages/sprite-animated/src/AnimatedSprite.js
+++ b/packages/sprite-animated/src/AnimatedSprite.js
@@ -286,7 +286,9 @@ export default class AnimatedSprite extends Sprite
     {
         this._texture = this._textures[this.currentFrame];
         this._textureID = -1;
+        this._textureTrimmedID = -1;
         this.cachedTint = 0xFFFFFF;
+        this.uvs = this._texture._uvs.uvsFloat32;
 
         if (this.onFrameChange)
         {


### PR DESCRIPTION
PR contains only simple fixes

Mesh refactoring will be separate

> `this.textureIds.length = 0;`

That thing crashed https://pixijs.io/examples/?v=next#/basics/textured-mesh.js

> `elements[i] = null;`

Backport from v4 fix