### PR TITLE
[Next] default sprite anchor

### DIFF
--- a/packages/core/src/textures/Texture.js
+++ b/packages/core/src/textures/Texture.js
@@ -159,10 +159,10 @@ export default class Texture extends EventEmitter
         /**
          * Anchor point that is used as default if sprite is created with this texture.
          * Changing the `defaultAnchor` at a later point of time will not update Sprite's anchor point.
-         * @member {PIXI.Point}
-         * @default {0,0}
+         * @member {?PIXI.Point}
+         * @default null
          */
-        this.defaultAnchor = anchor ? new Point(anchor.x, anchor.y) : new Point(0, 0);
+        this.defaultAnchor = anchor ? new Point(anchor.x, anchor.y) : null;
 
         /**
          * Update ID is observed by sprites and TextureMatrix instances.

--- a/packages/sprite/src/Sprite.js
+++ b/packages/sprite/src/Sprite.js
@@ -45,7 +45,7 @@ export default class Sprite extends Container
         /**
          * The anchor sets the origin point of the texture.
          * The default is either taken from the {@link PIXI.Texture#defaultAnchor|Texture}
-         * passed to the constructor, or from {@link PIXI.settings.DEFAULT_SPRITE_ANCHOR},
+         * passed to the constructor, or from {@link PIXI.settings.SPRITE_DEFAULT_ANCHOR},
          * which has a default of 0,0.
          *
          * Setting the anchor to `(0,0)`, means the texture's origin is the top left corner.
@@ -57,7 +57,7 @@ export default class Sprite extends Container
          * Note: Updating the {@link PIXI.Texture#defaultAnchor} after a Texture is
          * created does _not_ update the Sprite's anchor values.
          *
-         * Note: Updating {@link PIXI.settings.DEFAULT_SPRITE_ANCHOR} after a Sprite is already
+         * Note: Updating {@link PIXI.settings.SPRITE_DEFAULT_ANCHOR} after a Sprite is already
          * created also does _not_ update the Sprite's anchor values.
          *
          * @member {PIXI.ObservablePoint}
@@ -66,8 +66,8 @@ export default class Sprite extends Container
         this._anchor = new ObservablePoint(
             this._onAnchorUpdate,
             this,
-            (texture && texture.defaultAnchor ? texture.defaultAnchor.x : settings.DEFAULT_SPRITE_ANCHOR.x || 0),
-            (texture && texture.defaultAnchor ? texture.defaultAnchor.y : settings.DEFAULT_SPRITE_ANCHOR.y || 0)
+            (texture && texture.defaultAnchor ? texture.defaultAnchor.x : settings.SPRITE_DEFAULT_ANCHOR.x || 0),
+            (texture && texture.defaultAnchor ? texture.defaultAnchor.y : settings.SPRITE_DEFAULT_ANCHOR.y || 0)
         );
 
         /**
@@ -531,7 +531,7 @@ export default class Sprite extends Container
     /**
      * The anchor sets the origin point of the texture.
      * The default is either taken from the {@link PIXI.Texture#defaultAnchor|Texture}
-     * passed to the constructor, or from {@link PIXI.settings.DEFAULT_SPRITE_ANCHOR},
+     * passed to the constructor, or from {@link PIXI.settings.SPRITE_DEFAULT_ANCHOR},
      * which has a default of 0,0.
      *
      * Setting the anchor to `(0,0)`, means the texture's origin is the top left corner.
@@ -543,7 +543,7 @@ export default class Sprite extends Container
      * Note: Updating the {@link PIXI.Texture#defaultAnchor} after a Texture is
      * created does _not_ update the Sprite's anchor values.
      *
-     * Note: Updating {@link PIXI.settings.DEFAULT_SPRITE_ANCHOR} after a Sprite is already
+     * Note: Updating {@link PIXI.settings.SPRITE_DEFAULT_ANCHOR} after a Sprite is already
      * created also does _not_ update the Sprite's anchor values.
      *
      * If you pass only single parameter, it will set both x and y to the same value as shown in the example below.

--- a/packages/sprite/src/Sprite.js
+++ b/packages/sprite/src/Sprite.js
@@ -3,6 +3,7 @@ import { sign } from '@pixi/utils';
 import { Texture } from '@pixi/core';
 import { BLEND_MODES } from '@pixi/constants';
 import { Container } from '@pixi/display';
+import { settings } from '@pixi/settings';
 
 const tempPoint = new Point();
 const indices = new Uint16Array([0, 1, 2, 0, 2, 3]);
@@ -43,12 +44,21 @@ export default class Sprite extends Container
 
         /**
          * The anchor sets the origin point of the texture.
-         * The default is 0,0 or taken from the {@link PIXI.Texture#defaultAnchor|Texture}
-         * passed to the constructor. A value of 0,0 means the texture's origin is the top left.
-         * Setting the anchor to 0.5,0.5 means the texture's origin is centered.
-         * Setting the anchor to 1,1 would mean the texture's origin point will be the bottom right corner.
+         * The default is either taken from the {@link PIXI.Texture#defaultAnchor|Texture}
+         * passed to the constructor, or from {@link PIXI.settings.DEFAULT_SPRITE_ANCHOR|DEFAULT_SPRITE_ANCHOR},
+         * which has a default of 0,0.
+         *
+         * Setting the anchor to `(0,0)`, means the texture's origin is the top left corner.
+         *
+         * Setting the anchor to `(0.5,0.5)` means the texture's origin is centered.
+         *
+         * Setting the anchor to `(1,1)` means the texture's origin is the bottom right corner.
+         *
          * Note: Updating the {@link PIXI.Texture#defaultAnchor} after a Texture is
          * created does _not_ update the Sprite's anchor values.
+         *
+         * Note: Updating {@link PIXI.settings.DEFAULT_SPRITE_ANCHOR} after a Sprite is already
+         * created also does _not_ update the Sprite's anchor values.
          *
          * @member {PIXI.ObservablePoint}
          * @private
@@ -56,8 +66,8 @@ export default class Sprite extends Container
         this._anchor = new ObservablePoint(
             this._onAnchorUpdate,
             this,
-            (texture ? texture.defaultAnchor.x : 0),
-            (texture ? texture.defaultAnchor.y : 0)
+            (texture && texture.defaultAnchor ? texture.defaultAnchor.x : settings.DEFAULT_SPRITE_ANCHOR.x || 0),
+            (texture && texture.defaultAnchor ? texture.defaultAnchor.y : settings.DEFAULT_SPRITE_ANCHOR.y || 0)
         );
 
         /**
@@ -519,14 +529,22 @@ export default class Sprite extends Container
     }
 
     /**
-     * The anchor sets the origin point of the text. The default value is taken from the {@link PIXI.Texture|Texture}
-     * and passed to the constructor.
+     * The anchor sets the origin point of the texture.
+     * The default is either taken from the {@link PIXI.Texture#defaultAnchor|Texture}
+     * passed to the constructor, or from {@link PIXI.settings.DEFAULT_SPRITE_ANCHOR},
+     * which has a default of 0,0.
      *
-     * The default is `(0,0)`, this means the text's origin is the top left.
+     * Setting the anchor to `(0,0)`, means the texture's origin is the top left corner.
      *
-     * Setting the anchor to `(0.5,0.5)` means the text's origin is centered.
+     * Setting the anchor to `(0.5,0.5)` means the texture's origin is centered.
      *
-     * Setting the anchor to `(1,1)` would mean the text's origin point will be the bottom right corner.
+     * Setting the anchor to `(1,1)` means the texture's origin is the bottom right corner.
+     *
+     * Note: Updating the {@link PIXI.Texture#defaultAnchor} after a Texture is
+     * created does _not_ update the Sprite's anchor values.
+     *
+     * Note: Updating {@link PIXI.settings.DEFAULT_SPRITE_ANCHOR} after a Sprite is already
+     * created also does _not_ update the Sprite's anchor values.
      *
      * If you pass only single parameter, it will set both x and y to the same value as shown in the example below.
      *

--- a/packages/sprite/src/Sprite.js
+++ b/packages/sprite/src/Sprite.js
@@ -45,7 +45,7 @@ export default class Sprite extends Container
         /**
          * The anchor sets the origin point of the texture.
          * The default is either taken from the {@link PIXI.Texture#defaultAnchor|Texture}
-         * passed to the constructor, or from {@link PIXI.settings.DEFAULT_SPRITE_ANCHOR|DEFAULT_SPRITE_ANCHOR},
+         * passed to the constructor, or from {@link PIXI.settings.DEFAULT_SPRITE_ANCHOR},
          * which has a default of 0,0.
          *
          * Setting the anchor to `(0,0)`, means the texture's origin is the top left corner.

--- a/packages/sprite/src/index.js
+++ b/packages/sprite/src/index.js
@@ -1,1 +1,3 @@
 export { default as Sprite } from './Sprite';
+
+import './settings';

--- a/packages/sprite/src/settings.js
+++ b/packages/sprite/src/settings.js
@@ -1,15 +1,24 @@
 import { settings } from '@pixi/settings';
 
 /**
- * Target frames per millisecond.
+ * Sets the default anchor for all subsequently created sprites,
+ * if a default anchor hasn't already been supplied by the texture.
+ *
+ * The anchor sets the origin point of the texture.
+ *
+ * Setting the anchor to `x:0,y:0`, means the texture's origin is the top left corner.
+ *
+ * Setting the anchor to `x:0.5,y:0.5` means the texture's origin is centered.
+ *
+ * Setting the anchor to `x:1,y:1` means the texture's origin is the bottom right corner.
  *
  * @static
  * @memberof PIXI.settings
- * @name DEFAULT_SPRITE_ANCHOR
+ * @name SPRITE_DEFAULT_ANCHOR
  * @type {PIXI.Point}
  * @default {x:0, y:0}
  */
-settings.DEFAULT_SPRITE_ANCHOR = {
+settings.SPRITE_DEFAULT_ANCHOR = {
     x: 0,
     y: 0,
 };

--- a/packages/sprite/src/settings.js
+++ b/packages/sprite/src/settings.js
@@ -5,12 +5,13 @@ import { settings } from '@pixi/settings';
  *
  * @static
  * @memberof PIXI.settings
+ * @name DEFAULT_SPRITE_ANCHOR
  * @type {PIXI.Point}
  * @default {x:0, y:0}
  */
 settings.DEFAULT_SPRITE_ANCHOR = {
     x: 0,
-    y: 0
+    y: 0,
 };
 
 export { settings };

--- a/packages/sprite/src/settings.js
+++ b/packages/sprite/src/settings.js
@@ -1,0 +1,16 @@
+import { settings } from '@pixi/settings';
+
+/**
+ * Target frames per millisecond.
+ *
+ * @static
+ * @memberof PIXI.settings
+ * @type {PIXI.Point}
+ * @default {x:0, y:0}
+ */
+settings.DEFAULT_SPRITE_ANCHOR = {
+    x: 0,
+    y: 0
+};
+
+export { settings };

--- a/packages/spritesheet/test/Spritesheet.js
+++ b/packages/spritesheet/test/Spritesheet.js
@@ -20,8 +20,7 @@ describe('PIXI.Spritesheet', function ()
                 expect(textures[id]).to.be.an.instanceof(Texture);
                 expect(textures[id].width).to.equal(width / spritesheet.resolution);
                 expect(textures[id].height).to.equal(height / spritesheet.resolution);
-                expect(textures[id].defaultAnchor.x).to.equal(0);
-                expect(textures[id].defaultAnchor.y).to.equal(0);
+                expect(textures[id].defaultAnchor).to.equal(null);
                 expect(textures[id].textureCacheIds.indexOf(id)).to.equal(0);
 
                 expect(this.animations).to.have.property('star').that.is.an('array');

--- a/packages/spritesheet/test/SpritesheetLoader.js
+++ b/packages/spritesheet/test/SpritesheetLoader.js
@@ -80,8 +80,7 @@ describe('PIXI.SpritesheetLoader', function ()
         expect(res.textures['0.png'].frame.y).to.equal(28);
         expect(res.textures['0.png'].defaultAnchor.x).to.equal(0.3);
         expect(res.textures['0.png'].defaultAnchor.y).to.equal(0.4);
-        expect(res.textures['1.png'].defaultAnchor.x).to.equal(0.0); // default of defaultAnchor is 0,0
-        expect(res.textures['1.png'].defaultAnchor.y).to.equal(0.0);
+        expect(res.textures['1.png'].defaultAnchor).to.equal(null);
 
         expect(res).to.have.property('spritesheet')
             .to.have.property('animations')

--- a/packages/text-bitmap/src/BitmapText.js
+++ b/packages/text-bitmap/src/BitmapText.js
@@ -381,14 +381,17 @@ export default class BitmapText extends Container
 
     /**
      * The anchor sets the origin point of the text.
+     * The default is 0,0.
      *
-     * The default is `(0,0)`, this means the text's origin is the top left.
+     * Setting the anchor to `(0,0)`, means the text's origin is the top left corner.
      *
      * Setting the anchor to `(0.5,0.5)` means the text's origin is centered.
      *
-     * Setting the anchor to `(1,1)` would mean the text's origin point will be the bottom right corner.
+     * Setting the anchor to `(1,1)` means the text's origin is the bottom right corner.
      *
-     * @member {PIXI.Point | number}
+     * If you pass only single parameter, it will set both x and y to the same value.
+     *
+     * @member {PIXI.Point|number}
      */
     get anchor()
     {


### PR DESCRIPTION
It's such a common requirement to easily have all Sprites be anchored from the center point... here's a setting to make that possible