### PR TITLE
[Next] jsdoc fixes for settings

### DIFF
--- a/packages/canvas/canvas-mesh/src/settings.js
+++ b/packages/canvas/canvas-mesh/src/settings.js
@@ -5,9 +5,9 @@ import { settings } from '@pixi/settings';
  *
  * @see PIXI.Mesh2d#canvasPadding
  * @static
- * @constant
+ * @name MESH_CANVAS_PADDING
  * @memberof PIXI.settings
- * @member {number} MESH_CANVAS_PADDING
+ * @type {number}
  * @default 0
  */
 settings.MESH_CANVAS_PADDING = 0;

--- a/packages/core/src/settings.js
+++ b/packages/core/src/settings.js
@@ -9,7 +9,6 @@ import { ENV } from '@pixi/constants';
  * baseline, prefer a lower environment.
  *
  * @static
- * @constant
  * @name PREFER_ENV
  * @memberof PIXI.settings
  * @type {number}

--- a/packages/settings/src/settings.js
+++ b/packages/settings/src/settings.js
@@ -21,6 +21,7 @@ export default {
      * Mipmapping will only succeed if the base texture uploaded has power of two dimensions.
      *
      * @static
+     * @name MIPMAP_TEXTURES
      * @memberof PIXI.settings
      * @type {boolean}
      * @default true
@@ -31,6 +32,7 @@ export default {
      * Default resolution / device pixel ratio of the renderer.
      *
      * @static
+     * @name RESOLTION
      * @memberof PIXI.settings
      * @type {number}
      * @default 1
@@ -41,6 +43,7 @@ export default {
      * Default filter resolution.
      *
      * @static
+     * @name FILTER_RESOLUTION
      * @memberof PIXI.settings
      * @type {number}
      * @default 1
@@ -51,6 +54,7 @@ export default {
      * The maximum textures that this device supports.
      *
      * @static
+     * @name SPRITE_MAX_TEXTURES
      * @memberof PIXI.settings
      * @type {number}
      * @default 32
@@ -66,6 +70,7 @@ export default {
      * The default aims to balance desktop and mobile devices.
      *
      * @static
+     * @name SPRITE_BATCH_SIZE
      * @memberof PIXI.settings
      * @type {number}
      * @default 4096
@@ -77,7 +82,7 @@ export default {
      * or {@link PIXI.CanvasRenderer}.
      *
      * @static
-     * @constant
+     * @name RENDER_OPTIONS
      * @memberof PIXI.settings
      * @type {object}
      * @property {HTMLCanvasElement} view=null
@@ -113,6 +118,7 @@ export default {
      * Default Garbage Collection mode.
      *
      * @static
+     * @name GC_MODE
      * @memberof PIXI.settings
      * @type {PIXI.GC_MODES}
      * @default PIXI.GC_MODES.AUTO
@@ -123,6 +129,7 @@ export default {
      * Default Garbage Collection max idle.
      *
      * @static
+     * @name GC_MAX_IDLE
      * @memberof PIXI.settings
      * @type {number}
      * @default 3600
@@ -133,6 +140,7 @@ export default {
      * Default Garbage Collection maximum check count.
      *
      * @static
+     * @name GC_MAX_CHECK_COUNT
      * @memberof PIXI.settings
      * @type {number}
      * @default 600
@@ -143,6 +151,7 @@ export default {
      * Default wrap modes that are supported by pixi.
      *
      * @static
+     * @name WRAP_MODE
      * @memberof PIXI.settings
      * @type {PIXI.WRAP_MODES}
      * @default PIXI.WRAP_MODES.CLAMP
@@ -153,6 +162,7 @@ export default {
      * Default scale mode for textures.
      *
      * @static
+     * @name SCALE_MODE
      * @memberof PIXI.settings
      * @type {PIXI.SCALE_MODES}
      * @default PIXI.SCALE_MODES.LINEAR
@@ -163,6 +173,7 @@ export default {
      * Default specify float precision in vertex shader.
      *
      * @static
+     * @name PRECISION_VERTEX
      * @memberof PIXI.settings
      * @type {PIXI.PRECISION}
      * @default PIXI.PRECISION.HIGH
@@ -173,6 +184,7 @@ export default {
      * Default specify float precision in fragment shader.
      *
      * @static
+     * @name PRECISION_FRAGMENT
      * @memberof PIXI.settings
      * @type {PIXI.PRECISION}
      * @default PIXI.PRECISION.MEDIUM
@@ -183,7 +195,7 @@ export default {
      * Can we upload the same buffer in a single frame?
      *
      * @static
-     * @constant
+     * @name CAN_UPLOAD_SAME_BUFFER
      * @memberof PIXI.settings
      * @type {boolean}
      */
@@ -193,7 +205,7 @@ export default {
      * Enables bitmap creation before image load
      *
      * @static
-     * @constant
+     * @name CREATE_IMAGE_BITMAP
      * @memberof PIXI.settings
      * @type {boolean}
      * @default true

--- a/packages/ticker/src/settings.js
+++ b/packages/ticker/src/settings.js
@@ -4,6 +4,7 @@ import { settings } from '@pixi/settings';
  * Target frames per millisecond.
  *
  * @static
+ * @name TARGET_FPMS
  * @memberof PIXI.settings
  * @type {number}
  * @default 0.06

--- a/packages/utils/src/settings.js
+++ b/packages/utils/src/settings.js
@@ -4,12 +4,11 @@ import { settings } from '@pixi/settings';
  * The prefix that denotes a URL is for a retina asset.
  *
  * @static
- * @constant
  * @name RETINA_PREFIX
- * @memberof PIXI
+ * @memberof PIXI.settings
  * @type {RegExp}
- * @example `@2x`
  * @default /@([0-9\.]+)x/
+ * @example `@2x`
  */
 settings.RETINA_PREFIX = /@([0-9\.]+)x/;
 


### PR DESCRIPTION
Some jsdocs were incorrect (none are const, as they can all be overwritten by the user).
Corrected a namespace
Added @name onto them, so ensure that the jsdoc linking works correctly when @link or @see is used. I think this mainly applies to settings applied by importing `@pixi/settings` and adding to it rather than the settings package itself, but for consistency I've applied it to all settings