### PR TITLE
keep a origin values.

### DIFF
--- a/packages/math/src/ObservablePoint.js
+++ b/packages/math/src/ObservablePoint.js
@@ -79,6 +79,20 @@ export default class ObservablePoint
     }
 
     /**
+     * retore to default cache values
+     *
+     */
+    restore()
+    {
+        if (this._x !== this._xx || this._y !== this._yy)
+        {
+            this._x = this._xx;
+            this._y = this._yy;
+            this.cb.call(this.scope);
+        }
+    }
+
+    /**
      * Copies x and y from the given point
      *
      * @param {PIXI.Point} p - The point to copy from.

--- a/packages/math/src/ObservablePoint.js
+++ b/packages/math/src/ObservablePoint.js
@@ -18,6 +18,8 @@ export default class ObservablePoint
     {
         this._x = x;
         this._y = y;
+        this._xx = x;
+        this._yy = y;
 
         this.cb = cb;
         this.scope = scope;
@@ -45,10 +47,11 @@ export default class ObservablePoint
      * Sets the point to a new x and y position.
      * If y is omitted, both x and y will be set to x.
      *
-     * @param {number} [x=0] - position of the point on the x axis
-     * @param {number} [y=0] - position of the point on the y axis
+     * @param {number}  [x=0] - position of the point on the x axis
+     * @param {number}  [y=0] - position of the point on the y axis
+     * @param {boolean} [cache=false] - store origin value to find it in a moment
      */
-    set(x, y)
+    set(x, y, cache)
     {
         const _x = x || 0;
         const _y = y || ((y !== 0) ? _x : 0);
@@ -57,6 +60,10 @@ export default class ObservablePoint
         {
             this._x = _x;
             this._y = _y;
+            if(cache){
+                this._xx = _x;
+                this._yy = _y;
+            };
             this.cb.call(this.scope);
         }
     }

--- a/packages/math/src/ObservablePoint.js
+++ b/packages/math/src/ObservablePoint.js
@@ -69,6 +69,16 @@ export default class ObservablePoint
     }
 
     /**
+     * to trace the difference between current and cache points
+     *
+     * @return {PIXI.Point} - get valur between cache and current values
+     */
+    fromCache()
+    {
+        return new PIXI.Point(this._x-this._xx, this._y-this._yy);
+    }
+
+    /**
      * Copies x and y from the given point
      *
      * @param {PIXI.Point} p - The point to copy from.


### PR DESCRIPTION
I add a simple cache values to **observablePoint** in the v4 to manage more effectively my Tweens and my TimeLines, and give opportunity to trace the original values in time.
I do not know if the subject has already been addressed, so I want to propose the idea here.

The idea is to be able to store and keep a origin value.
Maybe also need to add it to constructor?