### PR TITLE
UV precision bug

### DIFF
--- a/src/core/textures/TextureUvs.js
+++ b/src/core/textures/TextureUvs.js
@@ -83,9 +83,9 @@ export default class TextureUvs
             this.y3 = (frame.y + frame.height) / th;
         }
 
-        this.uvsUint32[0] = (((this.y0 * 65535) & 0xFFFF) << 16) | ((this.x0 * 65535) & 0xFFFF);
-        this.uvsUint32[1] = (((this.y1 * 65535) & 0xFFFF) << 16) | ((this.x1 * 65535) & 0xFFFF);
-        this.uvsUint32[2] = (((this.y2 * 65535) & 0xFFFF) << 16) | ((this.x2 * 65535) & 0xFFFF);
-        this.uvsUint32[3] = (((this.y3 * 65535) & 0xFFFF) << 16) | ((this.x3 * 65535) & 0xFFFF);
+        this.uvsUint32[0] = ((Math.round(this.y0 * 65535) & 0xFFFF) << 16) | (Math.round(this.x0 * 65535) & 0xFFFF);
+        this.uvsUint32[1] = ((Math.round(this.y1 * 65535) & 0xFFFF) << 16) | (Math.round(this.x1 * 65535) & 0xFFFF);
+        this.uvsUint32[2] = ((Math.round(this.y2 * 65535) & 0xFFFF) << 16) | (Math.round(this.x2 * 65535) & 0xFFFF);
+        this.uvsUint32[3] = ((Math.round(this.y3 * 65535) & 0xFFFF) << 16) | (Math.round(this.x3 * 65535) & 0xFFFF);
     }
 }


### PR DESCRIPTION
# We lose one binary digit in UV's and its critical

This thing exists through all the life of pixi-v4, since 6 jan 2016, it leads to wrong rendering of sprites with LINEAR scaleMode (it is default!).

The thing is, for numbers like `1/1024` we always lose 1 digit, when we actually dont have to lose anything.

```
1/1024 - Math.round(1 / 1024 * 65535) / 65535 === -1.4901388570992546e-8
1/1024 - Math.floor(1 / 1024 * 65535) / 65535 === 1.5244120508125375e-5
```

For center pixel loss is the same for both algorithms:
```
0.5 - Math.round(0.5 * 65535) / 65535 === -7.629510948348184e-6
0.5 - Math.floor(0.5 * 65535) / 65535 === 7.629510948348184e-6
```

Size of pixel 1/1024 is `1e-3`  , one point of color is `2e-2` , if we multiply it we'll get `2e-5`, too close to our precision loss. Experiments show that 1 binary digit in the case is critical. We have to get rid of `1.5e-5`.

Lets put single pixel inside an atlas of size 1024 and render it: https://www.pixiplayground.com/#/edit/sr8e~10Ueu1aaaVlj~Rsd

We got alpha=247 and that number is even worse for size=2048. If we put the pixel to (1024,1024) instead of (1,1) we will get 251, which is still wrong!

We even lose on size=256!

You can also notice the shift in coords if we enlarge the pixel:

![image](https://user-images.githubusercontent.com/695831/48483182-d3389400-e823-11e8-9c3e-038424002e3e.png)

This is the bug we tried to fix with `PRECISION_FRAGMENT=HIGHP`. Docs say that on MEDIUMP we always have 16 binary digits which is exactly how much we use when we pack numbers in uint16. 

MEDIUMP (16 bits) is enough for sprite rendering, while 15 is not.