### PR TITLE
UpdateTexture should not switch FrameBuffer

### DIFF
--- a/src/core/renderers/webgl/TextureManager.js
+++ b/src/core/renderers/webgl/TextureManager.js
@@ -120,6 +120,12 @@ export default class TextureManager
                 renderTarget.resize(texture.width, texture.height);
                 texture._glRenderTargets[this.renderer.CONTEXT_UID] = renderTarget;
                 glTexture = renderTarget.texture;
+
+                // framebuffer constructor disactivates current framebuffer
+                if (!this.renderer._activeRenderTarget.root)
+                {
+                    this.renderer._activeRenderTarget.frameBuffer.bind();
+                }
             }
             else
             {

--- a/src/core/renderers/webgl/utils/RenderTarget.js
+++ b/src/core/renderers/webgl/utils/RenderTarget.js
@@ -138,7 +138,7 @@ export default class RenderTarget
          *
          * @member {boolean}
          */
-        this.root = root;
+        this.root = root || false;
 
         if (!this.root)
         {

--- a/src/core/renderers/webgl/utils/RenderTarget.js
+++ b/src/core/renderers/webgl/utils/RenderTarget.js
@@ -137,6 +137,7 @@ export default class RenderTarget
          * Whether this object is the root element or not
          *
          * @member {boolean}
+         * @default false
          */
         this.root = root || false;
 

--- a/src/core/textures/VideoBaseTexture.js
+++ b/src/core/textures/VideoBaseTexture.js
@@ -320,8 +320,9 @@ function createSource(path, type)
 {
     if (!type)
     {
-        path = path.split('?').shift().toLowerCase();
-        type = `video/${path.substr(path.lastIndexOf('.') + 1)}`;
+        const purePath = path.split('?').shift().toLowerCase();
+
+        type = `video/${purePath.substr(purePath.lastIndexOf('.') + 1)}`;
     }
 
     const source = document.createElement('source');


### PR DESCRIPTION
Bug was reported in RpkMaker MV year ago , fix appeared in [corescript](https://github.com/rpgtkoolmv/corescript/pull/194), then I found actual cause in [pixi-tilemap](https://github.com/pixijs/pixi-tilemap/commit/1053aab63a7a30004ca7ab249fafb31b8cc0dfe3)

https://www.pixiplayground.com/#/edit/j38lu2giZW7uyEBkI0Eab