### PR TITLE
If canvas has been resized , call `baseTexture.update`

### DIFF
--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -730,7 +730,7 @@ export default class BaseTexture extends EventEmitter
             baseTexture = new BaseTexture(canvas, scaleMode);
             BaseTexture.addToCache(baseTexture, canvas._pixiId);
         }
-        else if (canvas.width !== baseTexture.realWidth || canvas.height !== baseTexture.realHeight)
+        else if (baseTexture.realWidth !== canvas.width || baseTexture.realHeight !== canvas.height)
         {
             baseTexture.update();
         }

--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -730,6 +730,10 @@ export default class BaseTexture extends EventEmitter
             baseTexture = new BaseTexture(canvas, scaleMode);
             BaseTexture.addToCache(baseTexture, canvas._pixiId);
         }
+        else if (canvas.width !== baseTexture.source.width || canvas.height !== baseTexture.source.height)
+        {
+            baseTexture.update();
+        }
 
         return baseTexture;
     }

--- a/src/core/textures/BaseTexture.js
+++ b/src/core/textures/BaseTexture.js
@@ -730,7 +730,7 @@ export default class BaseTexture extends EventEmitter
             baseTexture = new BaseTexture(canvas, scaleMode);
             BaseTexture.addToCache(baseTexture, canvas._pixiId);
         }
-        else if (canvas.width !== baseTexture.source.width || canvas.height !== baseTexture.source.height)
+        else if (canvas.width !== baseTexture.realWidth || canvas.height !== baseTexture.realHeight)
         {
             baseTexture.update();
         }


### PR DESCRIPTION
I use 
```
var baseTexture = PIXI.BaseTexture.from(canvas);
var texture = new PIXI.Texture(baseTexture);
...
```

But the canvas would be changed , content or size.
If size changed , need to call `baseTexture.update`, otherwise will take some errors like this:
```
Texture.js:572 Uncaught Error: Texture Error: frame does not fit inside the base Texture dimensions: X: 0 + 700 = 700 > 600 and Y: 0 + 880 = 880 > 350
    at Texture.set (Texture.js:572)
    at new Texture (Texture.js:135)
```

