### PR TITLE
Fix Graphics _localBounds calculation

### DIFF
--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -1114,16 +1114,7 @@ export default class Graphics extends Container
                 const lineWidth = data.lineWidth;
                 const lineAlignment = data.lineAlignment;
 
-                let lineOffset = 0;
-
-                if (lineAlignment === 0.5)
-                {
-                    lineOffset = lineWidth / 2;
-                }
-                else if (lineAlignment === 1)
-                {
-                    lineOffset = lineWidth;
-                }
+                const lineOffset = lineWidth * lineAlignment;
 
                 shape = data.shape;
 

--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -1112,15 +1112,27 @@ export default class Graphics extends Container
                 const data = this.graphicsData[i];
                 const type = data.type;
                 const lineWidth = data.lineWidth;
+                const lineAlignment = data.lineAlignment;
+
+                let lineOffset = 0;
+
+                if (lineAlignment === 1)
+                {
+                    lineOffset = lineWidth;
+                }
+                else if (lineAlignment === 0.5)
+                {
+                    lineOffset = lineWidth / 2;
+                }
 
                 shape = data.shape;
 
                 if (type === SHAPES.RECT || type === SHAPES.RREC)
                 {
-                    x = shape.x - (lineWidth / 2);
-                    y = shape.y - (lineWidth / 2);
-                    w = shape.width + lineWidth;
-                    h = shape.height + lineWidth;
+                    x = shape.x - lineOffset;
+                    y = shape.y - lineOffset;
+                    w = shape.width + (lineOffset * 2);
+                    h = shape.height + (lineOffset * 2);
 
                     minX = x < minX ? x : minX;
                     maxX = x + w > maxX ? x + w : maxX;
@@ -1132,8 +1144,8 @@ export default class Graphics extends Container
                 {
                     x = shape.x;
                     y = shape.y;
-                    w = shape.radius + (lineWidth / 2);
-                    h = shape.radius + (lineWidth / 2);
+                    w = shape.radius + lineOffset;
+                    h = shape.radius + lineOffset;
 
                     minX = x - w < minX ? x - w : minX;
                     maxX = x + w > maxX ? x + w : maxX;
@@ -1145,8 +1157,8 @@ export default class Graphics extends Container
                 {
                     x = shape.x;
                     y = shape.y;
-                    w = shape.width + (lineWidth / 2);
-                    h = shape.height + (lineWidth / 2);
+                    w = shape.width + lineOffset;
+                    h = shape.height + lineOffset;
 
                     minX = x - w < minX ? x - w : minX;
                     maxX = x + w > maxX ? x + w : maxX;
@@ -1175,7 +1187,7 @@ export default class Graphics extends Container
                         y2 = points[j + 3];
                         dx = Math.abs(x2 - x);
                         dy = Math.abs(y2 - y);
-                        h = lineWidth;
+                        h = lineOffset * 2;
                         w = Math.sqrt((dx * dx) + (dy * dy));
 
                         if (w < 1e-9)

--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -1116,13 +1116,13 @@ export default class Graphics extends Container
 
                 let lineOffset = 0;
 
-                if (lineAlignment === 1)
-                {
-                    lineOffset = lineWidth;
-                }
-                else if (lineAlignment === 0.5)
+                if (lineAlignment === 0.5)
                 {
                     lineOffset = lineWidth / 2;
+                }
+                else if (lineAlignment === 1)
+                {
+                    lineOffset = lineWidth;
                 }
 
                 shape = data.shape;


### PR DESCRIPTION
Graphics bounds calc was broken after adding `lineAlignment` option for non-default values of `lineAlignment`. For example, this is what we getting when value is `1` (outer lines):
![image](https://user-images.githubusercontent.com/347668/48983229-20a6e200-f0fd-11e8-9dcb-6683ebca5600.png)
And this is for `0` (inner lines):\
![image](https://user-images.githubusercontent.com/347668/48983243-4c29cc80-f0fd-11e8-8956-c50a39938497.png)
Code in PR resolves this issue.