### PR TITLE
Fixes defaultAnchor cloning with Texture.clone

### DIFF
--- a/src/core/textures/Texture.js
+++ b/src/core/textures/Texture.js
@@ -274,7 +274,7 @@ export default class Texture extends EventEmitter
      */
     clone()
     {
-        return new Texture(this.baseTexture, this.frame, this.orig, this.trim, this.rotate);
+        return new Texture(this.baseTexture, this.frame, this.orig, this.trim, this.rotate, this.defaultAnchor);
     }
 
     /**

--- a/test/core/Texture.js
+++ b/test/core/Texture.js
@@ -134,4 +134,27 @@ describe('PIXI.Texture', function ()
         texture.destroy(true);
         texture.destroy(true);
     });
+
+    it('should clone a texture', function ()
+    {
+        const baseTexture = new PIXI.BaseTexture();
+        const frame = new PIXI.Rectangle();
+        const orig = new PIXI.Rectangle();
+        const trim = new PIXI.Rectangle();
+        const rotate = 2;
+        const anchor = new PIXI.Point(1, 0.5);
+        const texture = new PIXI.Texture(baseTexture, frame, orig, trim, rotate, anchor);
+        const clone = texture.clone();
+
+        expect(clone.baseTexture).to.equal(baseTexture);
+        expect(clone.defaultAnchor.x).to.equal(texture.defaultAnchor.x);
+        expect(clone.defaultAnchor.y).to.equal(texture.defaultAnchor.y);
+        expect(clone.frame).to.equal(texture.frame);
+        expect(clone.trim).to.equal(texture.trim);
+        expect(clone.orig).to.equal(texture.orig);
+        expect(clone.rotate).to.equal(texture.rotate);
+
+        clone.destroy();
+        texture.destroy(true);
+    });
 });


### PR DESCRIPTION
Follow up to #5011, where `Texture.clone` does not consider  copying `defaultAnchor`.