### PR TITLE
[next] Properly deprecate roundPixels Renderer option

### DIFF
--- a/packages/core/src/AbstractRenderer.js
+++ b/packages/core/src/AbstractRenderer.js
@@ -1,4 +1,4 @@
-import { hex2string, hex2rgb } from '@pixi/utils';
+import { hex2string, hex2rgb, deprecation } from '@pixi/utils';
 import { Matrix, Rectangle } from '@pixi/math';
 import { RENDERER_TYPE } from '@pixi/constants';
 import { settings } from '@pixi/settings';
@@ -55,9 +55,11 @@ export default class AbstractRenderer extends EventEmitter
         // Add the default render options
         options = Object.assign({}, settings.RENDER_OPTIONS, options);
 
+        // Deprecation notice for renderer roundPixels option
         if (options.roundPixels)
         {
-            // TODO - Log a warning to users telling them to use PIXI.settings.ROUND_PIXELS instead
+            settings.ROUND_PIXELS = options.roundPixels;
+            deprecation('5.0.0', 'Renderer roundPixels option is deprecated, please use PIXI.settings.ROUND_PIXELS', 2);
         }
 
         /**

--- a/packages/utils/src/logging/deprecation.js
+++ b/packages/utils/src/logging/deprecation.js
@@ -10,8 +10,10 @@ const warnings = {};
  * @function deprecation
  * @param {string} version - The version where the feature became deprecated
  * @param {string} message - Message should include what is deprecated, where, and the new solution
+ * @param {number} [ignoreDepth=3] - The number of steps to ignore at the top of the error stack
+ *        this is mostly to ignore internal deprecation calls.
  */
-export function deprecation(version, message)
+export function deprecation(version, message, ignoreDepth = 3)
 {
     // Ignore duplicat
     if (warnings[message])
@@ -30,7 +32,7 @@ export function deprecation(version, message)
     else
     {
         // chop off the stack trace which includes PixiJS internal calls
-        stack = stack.split('\n').splice(3).join('\n');
+        stack = stack.split('\n').splice(ignoreDepth).join('\n');
 
         if (console.groupCollapsed)
         {


### PR DESCRIPTION
Follow-up to #5057

### Changed

* Use of Renderer's `roundPixels` option will use PIXI.settings.ROUND_PIXELS instead
* Also, adds a small API improvement to `PIXI.utils.deprecation` to add custom ignore depth stack