### PR TITLE
Update ismobilejs

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "bit-twiddle": "^1.0.2",
     "earcut": "^2.1.4",
     "eventemitter3": "^2.0.0",
-    "ismobilejs": "^0.4.0",
+    "ismobilejs": "^0.5.1",
     "object-assign": "^4.0.1",
     "pixi-gl-core": "^1.1.4",
     "remove-array-items": "^1.0.0",


### PR DESCRIPTION
mobilejs has a vulnerability on versions <0.5.0. 
https://app.snyk.io/vuln/SNYK-JS-ISMOBILEJS-72624

Can we move this forward? I realize this pull request is incomplete. Just want to see if there are any objections first.

