### PR TITLE
Native Lines for v5 Graphics

### DIFF
--- a/packages/core/src/batch/BatchDrawCall.js
+++ b/packages/core/src/batch/BatchDrawCall.js
@@ -1,0 +1,20 @@
+/**
+ * Used by the batcher to draw batches
+ * each one of these contains all information required to draw a bound geometry.
+ *
+ * @class
+ * @memberof PIXI
+ */
+export default class BatchDrawCall
+{
+    constructor()
+    {
+        this.textures = [];
+        this.ids = [];
+        this.blend = 0;
+        this.textureCount = 0;
+        this.start = 0;
+        this.size = 0;
+        this.type = 4;
+    }
+}

--- a/packages/core/src/batch/BatchRenderer.js
+++ b/packages/core/src/batch/BatchRenderer.js
@@ -1,4 +1,6 @@
 import BatchGeometry from './BatchGeometry';
+import BatchDrawCall from './BatchDrawCall';
+
 import State from '../state/State';
 import ObjectRenderer from './ObjectRenderer';
 import checkMaxIfStatementsInShader from '../shader/utils/checkMaxIfStatementsInShader';
@@ -87,7 +89,7 @@ export default class BatchRenderer extends ObjectRenderer
 
         for (let k = 0; k < this.size / 4; k++)
         {
-            this.groups[k] = { textures: [], textureCount: 0, ids: [], size: 0, start: 0, blend: 0 };
+            this.groups[k] = new BatchDrawCall();
         }
 
         this.elements = [];

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -21,6 +21,7 @@ export { default as State } from './state/State';
 export { default as ObjectRenderer } from './batch/ObjectRenderer';
 export { default as BatchRenderer } from './batch/BatchRenderer';
 export { default as BatchGeometry } from './batch/BatchGeometry';
+export { default as BatchDrawCall } from './batch/BatchDrawCall';
 export { default as generateMultiTextureShader } from './batch/generateMultiTextureShader';
 export { default as Quad } from './utils/Quad';
 export { default as QuadUv } from './utils/QuadUv';

--- a/packages/graphics/src/utils/buildLine.js
+++ b/packages/graphics/src/utils/buildLine.js
@@ -246,7 +246,8 @@ function buildLine(graphicsData, graphicsGeometry)
 function buildNativeLine(graphicsData, graphicsGeometry)
 {
     let i = 0;
-    const points = graphicsData.points;
+
+    const points = graphicsData.points || graphicsData.shape.points;
 
     if (points.length === 0) return;
 


### PR DESCRIPTION
- Now respects native lines in `lineStyle`. Just like in v4 :)
- Also created `BatchDrawCall` class which removes the need for generic object in BatchRenderer and GraphicsGeometry

