### PR TITLE
[next] BlurFilter cleanup

### DIFF
--- a/packages/filters/filter-blur/src/BlurFilter.js
+++ b/packages/filters/filter-blur/src/BlurFilter.js
@@ -46,7 +46,7 @@ export default class BlurFilter extends Filter
 
         if (xStrength && yStrength)
         {
-            const renderTarget = filterManager.getFilterTexture(true);
+            const renderTarget = filterManager.getFilterTexture();
 
             this.blurXFilter.apply(filterManager, input, renderTarget, true);
             this.blurYFilter.apply(filterManager, renderTarget, output, false);
@@ -150,12 +150,12 @@ export default class BlurFilter extends Filter
      */
     get blendMode()
     {
-        return this.blurYFilter._blendMode;
+        return this.blurYFilter.blendMode;
     }
 
     set blendMode(value) // eslint-disable-line require-jsdoc
     {
-        this.blurYFilter._blendMode = value;
+        this.blurYFilter.blendMode = value;
     }
 
     /**

--- a/packages/filters/filter-blur/src/BlurFilter.js
+++ b/packages/filters/filter-blur/src/BlurFilter.js
@@ -25,7 +25,6 @@ export default class BlurFilter extends Filter
         this.blurXFilter = new BlurFilterPass(true, strength, quality, resolution, kernelSize);
         this.blurYFilter = new BlurFilterPass(false, strength, quality, resolution, kernelSize);
 
-        this._padding = 0;
         this.resolution = resolution || settings.RESOLUTION;
         this.quality = quality || 4;
         this.blur = strength || 8;

--- a/packages/filters/filter-blur/src/BlurFilterPass.js
+++ b/packages/filters/filter-blur/src/BlurFilterPass.js
@@ -2,7 +2,6 @@ import { Filter } from '@pixi/core';
 import { settings } from '@pixi/settings';
 import generateBlurVertSource from './generateBlurVertSource';
 import generateBlurFragSource from './generateBlurFragSource';
-import getMaxBlurKernelSize from './getMaxBlurKernelSize';
 
 /**
  * The BlurFilterPass applies a horizontal or vertical Gaussian blur to an object.
@@ -42,23 +41,10 @@ export default class BlurFilterPass extends Filter
         this.quality = quality || 4;
 
         this.blur = strength || 8;
-
-        this.firstRun = true;
     }
 
     apply(filterManager, input, output, clear)
     {
-        if (this.firstRun)
-        {
-            const gl = filterManager.renderer.gl;
-            const kernelSize = getMaxBlurKernelSize(gl);
-
-            this.vertexSrc = generateBlurVertSource(kernelSize, true);
-            this.fragmentSrc = generateBlurFragSource(kernelSize);
-
-            this.firstRun = false;
-        }
-
         if (output)
         {
             if (this.horizontal)

--- a/packages/filters/filter-blur/src/generateBlurFragSource.js
+++ b/packages/filters/filter-blur/src/generateBlurFragSource.js
@@ -19,7 +19,7 @@ const fragTemplate = [
 
 ].join('\n');
 
-export default function generateFragBlurSource(kernelSize)
+export default function generateBlurFragSource(kernelSize)
 {
     const kernel = GAUSSIAN_VALUES[kernelSize];
     const halfLength = kernel.length;

--- a/packages/filters/filter-blur/src/generateBlurVertSource.js
+++ b/packages/filters/filter-blur/src/generateBlurVertSource.js
@@ -31,7 +31,7 @@ const vertTemplate = `
         %blur%
     }`;
 
-export default function generateVertBlurSource(kernelSize, x)
+export default function generateBlurVertSource(kernelSize, x)
 {
     const halfLength = Math.ceil(kernelSize / 2);
 


### PR DESCRIPTION
I dont understand what `firstRun` was supposed to do, but in v5 its doing nothing. Please return it back if you figure out a way to determine `kernelSize` in constructor.

Also, because of that code in v4, `kernelSize` parameter was ignored, how did it even work? Had we always choose the slowest Blur method available?