### PR TITLE
 Intorduction of miter, bevel and round lineJoin

### DIFF
--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -74,6 +74,14 @@ export default class Graphics extends Container
         this.lineAlignment = 0.5;
 
         /**
+         * The style of line join ('miter', 'round', 'bevel')
+         *
+         * @member {string}
+         * @default 'miter'
+         */
+        this.lineJoin = 'miter';
+
+        /**
          * Graphics data
          *
          * @member {PIXI.GraphicsData[]}
@@ -225,6 +233,7 @@ export default class Graphics extends Container
         clone.boundsPadding = this.boundsPadding;
         clone.dirty = 0;
         clone.cachedSpriteDirty = this.cachedSpriteDirty;
+        clone.lineJoin = this.lineJoin;
 
         // copy graphics data
         for (let i = 0; i < this.graphicsData.length; ++i)
@@ -1245,7 +1254,8 @@ export default class Graphics extends Container
             this.filling,
             this.nativeLines,
             shape,
-            this.lineAlignment
+            this.lineAlignment,
+            this.lineJoin
         );
 
         this.graphicsData.push(data);

--- a/src/core/graphics/GraphicsData.js
+++ b/src/core/graphics/GraphicsData.js
@@ -17,8 +17,9 @@ export default class GraphicsData
      * @param {boolean} nativeLines - the method for drawing lines
      * @param {PIXI.Circle|PIXI.Rectangle|PIXI.Ellipse|PIXI.Polygon} shape - The shape object to draw.
      * @param {number} lineAlignment - the alignment of the line.
+     * @param {string} lineJoin - the join style of the line.
      */
-    constructor(lineWidth, lineColor, lineAlpha, fillColor, fillAlpha, fill, nativeLines, shape, lineAlignment)
+    constructor(lineWidth, lineColor, lineAlpha, fillColor, fillAlpha, fill, nativeLines, shape, lineAlignment, lineJoin)
     {
         /**
          * the width of the line to draw
@@ -79,6 +80,12 @@ export default class GraphicsData
         this._fillTint = fillColor;
 
         /**
+         * style of line join
+         * @member {string}
+         */
+        this.lineJoin = lineJoin;
+
+        /**
          * whether or not the shape is filled with a colour
          * @member {boolean}
          */
@@ -114,7 +121,9 @@ export default class GraphicsData
             this.fillAlpha,
             this.fill,
             this.nativeLines,
-            this.shape
+            this.shape,
+            this.lineAlignment,
+            this.lineJoin
         );
     }
 

--- a/src/core/graphics/webgl/utils/buildLine.js
+++ b/src/core/graphics/webgl/utils/buildLine.js
@@ -1,6 +1,11 @@
 import { Point } from '../../../math';
 import { hex2rgb } from '../../../utils';
 
+const TOLERANCE = 0.0001;
+const PIx2 = 2 * Math.PI;
+const PI_LBOUND = Math.PI - TOLERANCE;
+const PI_UBOUND = Math.PI + TOLERANCE;
+
 /**
  * Builds a line to draw
  *
@@ -102,10 +107,16 @@ function buildLine(graphicsData, webGLData)
     let perpy = p1x - p2x;
     let perp2x = 0;
     let perp2y = 0;
-    let perp3x = 0;
-    let perp3y = 0;
 
-    let dist = Math.sqrt((perpx * perpx) + (perpy * perpy));
+    let dist = len(perpx, perpy);
+
+    let midx = 0;
+    let midy = 0;
+
+    let dist12 = 0;
+    let dist23 = 0;
+    let distMid = 0;
+    let minDist = 0;
 
     perpx /= dist;
     perpy /= dist;
@@ -143,81 +154,172 @@ function buildLine(graphicsData, webGLData)
         perpx = -(p1y - p2y);
         perpy = p1x - p2x;
 
-        dist = Math.sqrt((perpx * perpx) + (perpy * perpy));
+        perp2x = -(p2y - p3y);
+        perp2y = p2x - p3x;
+
+        dist = len(perpx, perpy);
         perpx /= dist;
         perpy /= dist;
         perpx *= width;
         perpy *= width;
 
-        perp2x = -(p2y - p3y);
-        perp2y = p2x - p3x;
-
-        dist = Math.sqrt((perp2x * perp2x) + (perp2y * perp2y));
+        dist = len(perp2x, perp2y);
         perp2x /= dist;
         perp2y /= dist;
         perp2x *= width;
         perp2y *= width;
 
-        const a1 = (-perpy + p1y) - (-perpy + p2y);
-        const b1 = (-perpx + p2x) - (-perpx + p1x);
-        const c1 = ((-perpx + p1x) * (-perpy + p2y)) - ((-perpx + p2x) * (-perpy + p1y));
-        const a2 = (-perp2y + p3y) - (-perp2y + p2y);
-        const b2 = (-perp2x + p2x) - (-perp2x + p3x);
-        const c2 = ((-perp2x + p3x) * (-perp2y + p2y)) - ((-perp2x + p2x) * (-perp2y + p3y));
+        const a1 = p1y - p2y;
+        const b1 = p2x - p1x;
+        const a2 = p3y - p2y;
+        const b2 = p2x - p3x;
 
-        let denom = (a1 * b2) - (a2 * b1);
+        const denom = (a1 * b2) - (a2 * b1);
+        const join = graphicsData.lineJoin;
 
-        if (Math.abs(denom) < 0.1)
+        let px;
+        let py;
+        let pdist;
+
+        // parallel or almost parallel ~0 or ~180 deg
+        if (Math.abs(denom) < TOLERANCE)
         {
-            denom += 10.1;
-            verts.push(
-                p2x - (perpx * r1),
-                p2y - (perpy * r1),
-                r, g, b, alpha
-            );
+            // bevel, miter or round ~0deg
+            if (join !== 'round' || Math.abs(angleDiff(perpx, perpy, perp2x, perp2y)) < TOLERANCE)
+            {
+                verts.push(
+                    p2x - (perpx * r1),
+                    p2y - (perpy * r1),
+                    r, g, b, alpha
+                );
 
-            verts.push(
-                p2x + (perpx * r2),
-                p2y + (perpy * r2),
-                r, g, b, alpha
-            );
+                verts.push(
+                    p2x + (perpx * r2),
+                    p2y + (perpy * r2),
+                    r, g, b, alpha
+                );
 
-            continue;
-        }
-
-        const px = ((b1 * c2) - (b2 * c1)) / denom;
-        const py = ((a2 * c1) - (a1 * c2)) / denom;
-        const pdist = ((px - p2x) * (px - p2x)) + ((py - p2y) * (py - p2y));
-
-        if (pdist > (196 * width * width))
-        {
-            perp3x = perpx - perp2x;
-            perp3y = perpy - perp2y;
-
-            dist = Math.sqrt((perp3x * perp3x) + (perp3y * perp3y));
-            perp3x /= dist;
-            perp3y /= dist;
-            perp3x *= width;
-            perp3y *= width;
-
-            verts.push(p2x - (perp3x * r1), p2y - (perp3y * r1));
-            verts.push(r, g, b, alpha);
-
-            verts.push(p2x + (perp3x * r2), p2y + (perp3y * r2));
-            verts.push(r, g, b, alpha);
-
-            verts.push(p2x - (perp3x * r2 * r1), p2y - (perp3y * r1));
-            verts.push(r, g, b, alpha);
-
-            indexCount++;
+                continue;
+            }
+            else // round ~180deg
+            {
+                px = p2x;
+                py = p2y;
+                pdist = 0;
+            }
         }
         else
+        {
+            const c1 = ((-perpx + p1x) * (-perpy + p2y)) - ((-perpx + p2x) * (-perpy + p1y));
+            const c2 = ((-perp2x + p3x) * (-perp2y + p2y)) - ((-perp2x + p2x) * (-perp2y + p3y));
+
+            px = ((b1 * c2) - (b2 * c1)) / denom;
+            py = ((a2 * c1) - (a1 * c2)) / denom;
+            pdist = ((px - p2x) * (px - p2x)) + ((py - p2y) * (py - p2y));
+        }
+
+        // funky comparison to have backwards compat which will fall back by default to miter
+        if (join !== 'bevel' && join !== 'round' && pdist <= (196 * width * width)) // TODO: introduce miterLimit
         {
             verts.push(p2x + ((px - p2x) * r1), p2y + ((py - p2y) * r1));
             verts.push(r, g, b, alpha);
 
             verts.push(p2x - ((px - p2x) * r2), p2y - ((py - p2y) * r2));
             verts.push(r, g, b, alpha);
+        }
+        else
+        {
+            const flip = shouldFlip(p1x, p1y, p2x, p2y, p3x, p3y);
+
+            dist12 = len(p2x - p1x, p2y - p1y);
+            dist23 = len(p3x - p2x, p3y - p2y);
+            minDist = Math.min(dist12, dist23);
+
+            if (flip)
+            {
+                perpx = -perpx;
+                perpy = -perpy;
+                perp2x = -perp2x;
+                perp2y = -perp2y;
+
+                midx = (px - p2x) * r1;
+                midy = (py - p2y) * r1;
+                distMid = len(midx, midy);
+
+                if (minDist < distMid)
+                {
+                    midx /= distMid;
+                    midy /= distMid;
+                    midx *= minDist;
+                    midy *= minDist;
+                }
+
+                midx = p2x - midx;
+                midy = p2y - midy;
+            }
+            else
+            {
+                midx = (px - p2x) * r2;
+                midy = (py - p2y) * r2;
+                distMid = len(midx, midy);
+
+                if (minDist < distMid)
+                {
+                    midx /= distMid;
+                    midy /= distMid;
+                    midx *= minDist;
+                    midy *= minDist;
+                }
+
+                midx += p2x;
+                midy += p2y;
+            }
+
+            if (join === 'round')
+            {
+                const rad = flip ? r1 : r2;
+
+                indexCount += buildRoundCap(midx, midy,
+                                            p2x + (perpx * rad), p2y + (perpy * rad),
+                                            p2x + (perp2x * rad), p2y + (perp2y * rad),
+                                            p3x, p3y,
+                                            verts,
+                                            r, g, b, alpha,
+                                            flip);
+            }
+            else if (join === 'bevel' || pdist > (196 * width * width)) // TODO: introduce miterLimit
+            {
+                if (flip)
+                {
+                    verts.push(p2x + (perpx * r2), p2y + (perpy * r2));
+                    verts.push(r, g, b, alpha);
+
+                    verts.push(midx, midy);
+                    verts.push(r, g, b, alpha);
+
+                    verts.push(p2x + (perp2x * r2), p2y + (perp2y * r2));
+                    verts.push(r, g, b, alpha);
+
+                    verts.push(midx, midy);
+                    verts.push(r, g, b, alpha);
+                }
+                else
+                {
+                    verts.push(midx, midy);
+                    verts.push(r, g, b, alpha);
+
+                    verts.push(p2x + (perpx * r1), p2y + (perpy * r1));
+                    verts.push(r, g, b, alpha);
+
+                    verts.push(midx, midy);
+                    verts.push(r, g, b, alpha);
+
+                    verts.push(p2x + (perp2x * r1), p2y + (perp2y * r1));
+                    verts.push(r, g, b, alpha);
+                }
+
+                indexCount += 2;
+            }
         }
     }
 
@@ -230,7 +332,7 @@ function buildLine(graphicsData, webGLData)
     perpx = -(p1y - p2y);
     perpy = p1x - p2x;
 
-    dist = Math.sqrt((perpx * perpx) + (perpy * perpy));
+    dist = len(perpx, perpy);
     perpx /= dist;
     perpy /= dist;
     perpx *= width;
@@ -250,6 +352,135 @@ function buildLine(graphicsData, webGLData)
     }
 
     indices.push(indexStart - 1);
+}
+
+function len(x, y)
+{
+    return Math.sqrt((x * x) + (y * y));
+}
+
+/**
+ * Check turn direction. If counterclockwise, we must invert prep vectors, otherwise they point 'inwards' the angle,
+ * resulting in funky looking lines.
+ *
+ * @param {number} p0x
+ * @param {number} p0y
+ * @param {number} p1x
+ * @param {number} p1y
+ * @param {number} p2x
+ * @param {number} p2y
+ */
+function shouldFlip(p0x, p0y, p1x, p1y, p2x, p2y)
+{
+    return ((p1x - p0x) * (p2y - p0y)) - ((p2x - p0x) * (p1y - p0y)) < 0;
+}
+
+function angleDiff(p0x, p0y, p1x, p1y)
+{
+    const angle1 = Math.atan2(p0x, p0y);
+    const angle2 = Math.atan2(p1x, p1y);
+
+    if (angle2 > angle1)
+    {
+        if ((angle2 - angle1) >= PI_LBOUND)
+        {
+            return angle2 - PIx2 - angle1;
+        }
+    }
+    else if ((angle1 - angle2) >= PI_LBOUND)
+    {
+        return angle2 - (angle1 - PIx2);
+    }
+
+    return angle2 - angle1;
+}
+
+// eslint-disable-next-line max-params
+function buildRoundCap(cx, cy, p1x, p1y, p2x, p2y, nxtPx, nxtPy, verts, r, g, b, a, flipped)
+{
+    const cx2p0x = p1x - cx;
+    const cy2p0y = p1y - cy;
+
+    let angle0 = Math.atan2(cx2p0x, cy2p0y);
+    let angle1 = Math.atan2(p2x - cx, p2y - cy);
+
+    let startAngle = angle0;
+
+    if (angle1 > angle0)
+    {
+        if ((angle1 - angle0) >= PI_LBOUND)
+        {
+            angle1 = angle1 - PIx2;
+        }
+    }
+    else if ((angle0 - angle1) >= PI_LBOUND)
+    {
+        angle0 = angle0 - PIx2;
+    }
+
+    let angleDiff = angle1 - angle0;
+    const absAngleDiff = Math.abs(angleDiff);
+
+    if (absAngleDiff >= PI_LBOUND && absAngleDiff <= PI_UBOUND)
+    {
+        const r1x = cx - nxtPx;
+        const r1y = cy - nxtPy;
+
+        if (r1x === 0)
+        {
+            if (r1y > 0)
+            {
+                angleDiff = -angleDiff;
+            }
+        }
+        else if (r1x >= -TOLERANCE)
+        {
+            angleDiff = -angleDiff;
+        }
+    }
+
+    const radius = len(cx2p0x, cy2p0y);
+    const segCount = ((15 * absAngleDiff * Math.sqrt(radius) / Math.PI) >> 0) + 1;
+    const angleInc = angleDiff / segCount;
+
+    startAngle += angleInc;
+
+    if (flipped)
+    {
+        verts.push(p1x, p1y, r, g, b, a);
+        verts.push(cx, cy, r, g, b, a);
+
+        for (let i = 1, angle = startAngle; i < segCount; i++, angle += angleInc)
+        {
+            verts.push(cx + ((Math.sin(angle) * radius)),
+                       cy + ((Math.cos(angle) * radius)),
+                       r, g, b, a);
+            verts.push(cx, cy, r, g, b, a);
+        }
+
+        verts.push(p2x, p2y, r, g, b, a);
+        verts.push(cx, cy, r, g, b, a);
+    }
+    else
+    {
+        verts.push(cx, cy, r, g, b, a);
+        verts.push(p1x, p1y, r, g, b, a);
+
+        for (let i = 1, angle = startAngle; i < segCount; i++, angle += angleInc)
+        {
+            verts.push(cx, cy, r, g, b, a);
+            verts.push(cx + ((Math.sin(angle) * radius)),
+                       cy + ((Math.cos(angle) * radius)),
+                       r, g, b, a);
+        }
+
+        verts.push(cx, cy, r, g, b, a);
+        verts.push(cx + ((Math.sin(angle1) * radius)),
+                   cy + ((Math.cos(angle1) * radius)),
+                   r, g, b, a);
+    }
+
+    return segCount + 2;
 }
 
 /**

--- a/src/core/graphics/webgl/utils/buildLine.js
+++ b/src/core/graphics/webgl/utils/buildLine.js
@@ -363,12 +363,16 @@ function len(x, y)
  * Check turn direction. If counterclockwise, we must invert prep vectors, otherwise they point 'inwards' the angle,
  * resulting in funky looking lines.
  *
- * @param {number} p0x
- * @param {number} p0y
- * @param {number} p1x
- * @param {number} p1y
- * @param {number} p2x
- * @param {number} p2y
+ * @ignore
+ * @private
+ * @param {number} p0x - x of 1st point
+ * @param {number} p0y - y of 1st point
+ * @param {number} p1x - x of 2nd point
+ * @param {number} p1y - y of 2nd point
+ * @param {number} p2x - x of 3rd point
+ * @param {number} p2y - y of 3rd point
+ *
+ * @returns {boolean} true if perpendicular vectors should be flipped, otherwise false
  */
 function shouldFlip(p0x, p0y, p1x, p1y, p2x, p2y)
 {

--- a/test/core/Graphics.js
+++ b/test/core/Graphics.js
@@ -117,7 +117,7 @@ describe('PIXI.Graphics', function ()
             expect(graphics.currentPath.shape.points).to.deep.equal([0, 0, 10, 0]);
         });
 
-        describe('lineJoin', withGL(function ()
+        describe('lineJoin', function ()
         {
             const renderer = new PIXI.WebGLRenderer(200, 200, {});
 
@@ -132,7 +132,7 @@ describe('PIXI.Graphics', function ()
                     expect(graphics.lineJoin).to.be.equal('miter');
                 });
 
-                it('clockwise miter', function ()
+                it('clockwise miter', withGL(function ()
                 {
                     // given
                     const graphics = new PIXI.Graphics();
@@ -171,9 +171,9 @@ describe('PIXI.Graphics', function ()
 
                     expect(points[30], 'x6').to.be.eql(51);
                     expect(points[31], 'y6').to.be.eql(50);
-                });
+                }));
 
-                it('counterclockwise miter', function ()
+                it('counterclockwise miter', withGL(function ()
                 {
                     // given
                     const graphics = new PIXI.Graphics();
@@ -212,9 +212,9 @@ describe('PIXI.Graphics', function ()
 
                     expect(points[30], 'x6').to.be.eql(49);
                     expect(points[31], 'y6').to.be.eql(-50);
-                });
+                }));
 
-                it('flat line miter', function ()
+                it('flat line miter', withGL(function ()
                 {
                     // given
                     const graphics = new PIXI.Graphics();
@@ -253,9 +253,9 @@ describe('PIXI.Graphics', function ()
 
                     expect(points[30], 'x8').to.be.eql(100);
                     expect(points[31], 'y8').to.be.eql(-1);
-                });
+                }));
 
-                it('very sharp clockwise miter falling back to bevel', function ()
+                it('very sharp clockwise miter falling back to bevel', withGL(function ()
                 {
                     // given
                     const p1 = [0, 0];
@@ -307,9 +307,9 @@ describe('PIXI.Graphics', function ()
 
                     expect(points[42], 'x8').to.be.eql(p3[0] + perp2[0]);
                     expect(points[43], 'y8').to.be.eql(p3[1] + perp2[1]);
-                });
+                }));
 
-                it('very sharp counterclockwise miter falling back to bevel', function ()
+                it('very sharp counterclockwise miter falling back to bevel', withGL(function ()
                 {
                     // given
                     const p1 = [0, 0];
@@ -361,9 +361,9 @@ describe('PIXI.Graphics', function ()
 
                     expect(points[42], 'x8').to.be.eql(p3[0] - perp2[0]);
                     expect(points[43], 'y8').to.be.eql(p3[1] - perp2[1]);
-                });
+                }));
 
-                it('miter join paralel lines', function ()
+                it('miter join paralel lines', withGL(function ()
                 {
                     // given
                     const p1 = [0, 0];
@@ -407,12 +407,12 @@ describe('PIXI.Graphics', function ()
 
                     expect(points[30], 'x6').to.be.eql(p3[0] + perp2[0]);
                     expect(points[31], 'y6').to.be.eql(p3[1] + perp2[1]);
-                });
+                }));
             });
 
             describe('bevel', function ()
             {
-                it('clockwise bevel', function ()
+                it('clockwise bevel', withGL(function ()
                 {
                     // given
                     const graphics = new PIXI.Graphics();
@@ -457,9 +457,9 @@ describe('PIXI.Graphics', function ()
 
                     expect(points[42], 'x8').to.be.eql(51);
                     expect(points[43], 'y8').to.be.eql(50);
-                });
+                }));
 
-                it('counterclockwise bevel', function ()
+                it('counterclockwise bevel', withGL(function ()
                 {
                     // given
                     const graphics = new PIXI.Graphics();
@@ -504,9 +504,9 @@ describe('PIXI.Graphics', function ()
 
                     expect(points[42], 'x8').to.be.eql(49);
                     expect(points[43], 'y8').to.be.eql(-50);
-                });
+                }));
 
-                it('bevel join paralel lines', function ()
+                it('bevel join paralel lines', withGL(function ()
                 {
                     // given
                     const p1 = [0, 0];
@@ -550,9 +550,9 @@ describe('PIXI.Graphics', function ()
 
                     expect(points[30], 'x6').to.be.eql(p3[0] + perp2[0]);
                     expect(points[31], 'y6').to.be.eql(p3[1] + perp2[1]);
-                });
+                }));
 
-                it('flat line bevel', function ()
+                it('flat line bevel', withGL(function ()
                 {
                     // given
                     const graphics = new PIXI.Graphics();
@@ -591,12 +591,12 @@ describe('PIXI.Graphics', function ()
 
                     expect(points[30], 'x8').to.be.eql(100);
                     expect(points[31], 'y8').to.be.eql(-1);
-                });
+                }));
             });
 
             describe('round', function ()
             {
-                it('round join clockwise', function ()
+                it('round join clockwise', withGL(function ()
                 {
                     // given
                     const p1 = [0, 0];
@@ -683,9 +683,9 @@ describe('PIXI.Graphics', function ()
 
                     expect(points[90], 'x[last]').to.be.eql(p3[0] + perp2[0]);
                     expect(points[91], 'y[last]').to.be.eql(p3[1] + perp2[1]);
-                });
+                }));
 
-                it('round join counterclockwise', function ()
+                it('round join counterclockwise', withGL(function ()
                 {
                     // given
                     const p1 = [0, 0];
@@ -772,9 +772,9 @@ describe('PIXI.Graphics', function ()
 
                     expect(points[90], 'x[last]').to.be.eql(p3[0] - perp2[0]);
                     expect(points[91], 'y[last]').to.be.eql(p3[1] - perp2[1]);
-                });
+                }));
 
-                it('round join back and forth', function ()
+                it('round join back and forth', withGL(function ()
                 {
                     // given
                     const p1 = [0, 0];
@@ -842,9 +842,9 @@ describe('PIXI.Graphics', function ()
 
                     expect(points[len - 6], 'x[last]').to.be.eql(p3[0] + perp2[0]);
                     expect(points[len - 5], 'y[last]').to.be.eql(p3[1] + perp2[1]);
-                });
+                }));
 
-                it('round join back and forth other way around', function ()
+                it('round join back and forth other way around', withGL(function ()
                 {
                     // given
                     const p1 = [0, 0];
@@ -912,8 +912,9 @@ describe('PIXI.Graphics', function ()
 
                     expect(points[len - 6], 'x[last]').to.be.eql(p3[0] + perp2[0]);
                     expect(points[len - 5], 'y[last]').to.be.eql(p3[1] + perp2[1]);
-                });
-                it('flat line round', function ()
+                }));
+
+                it('flat line round', withGL(function ()
                 {
                     // given
                     const graphics = new PIXI.Graphics();
@@ -952,9 +953,9 @@ describe('PIXI.Graphics', function ()
 
                     expect(points[30], 'x6').to.be.eql(100);
                     expect(points[31], 'y6').to.be.eql(-1);
-                });
+                }));
             });
-        }));
+        });
     });
 
     describe('containsPoint', function ()

--- a/test/core/Graphics.js
+++ b/test/core/Graphics.js
@@ -117,7 +117,7 @@ describe('PIXI.Graphics', function ()
             expect(graphics.currentPath.shape.points).to.deep.equal([0, 0, 10, 0]);
         });
 
-        describe('lineJoin', function ()
+        describe('lineJoin', withGL(function ()
         {
             const renderer = new PIXI.WebGLRenderer(200, 200, {});
 
@@ -954,7 +954,7 @@ describe('PIXI.Graphics', function ()
                     expect(points[31], 'y6').to.be.eql(-1);
                 });
             });
-        });
+        }));
     });
 
     describe('containsPoint', function ()

--- a/test/core/Graphics.js
+++ b/test/core/Graphics.js
@@ -119,8 +119,6 @@ describe('PIXI.Graphics', function ()
 
         describe('lineJoin', function ()
         {
-            const renderer = new PIXI.WebGLRenderer(200, 200, {});
-
             describe('miter', function ()
             {
                 it('is miter by default (backwards compatible)', function ()
@@ -135,6 +133,7 @@ describe('PIXI.Graphics', function ()
                 it('clockwise miter', withGL(function ()
                 {
                     // given
+                    const renderer = new PIXI.WebGLRenderer(200, 200, {});
                     const graphics = new PIXI.Graphics();
 
                     graphics.lineStyle(2, 0, 1, 0.5);
@@ -176,6 +175,7 @@ describe('PIXI.Graphics', function ()
                 it('counterclockwise miter', withGL(function ()
                 {
                     // given
+                    const renderer = new PIXI.WebGLRenderer(200, 200, {});
                     const graphics = new PIXI.Graphics();
 
                     graphics.lineStyle(2, 0, 1, 0.5);
@@ -217,6 +217,7 @@ describe('PIXI.Graphics', function ()
                 it('flat line miter', withGL(function ()
                 {
                     // given
+                    const renderer = new PIXI.WebGLRenderer(200, 200, {});
                     const graphics = new PIXI.Graphics();
 
                     graphics.lineStyle(2, 0, 1, 0.5);
@@ -265,6 +266,7 @@ describe('PIXI.Graphics', function ()
                     const perp1 = [0, 0.5];
                     const perp2 = [0.019984019174435787, 0.4996004793608947]; // [0.039968038348871575, 0.9992009587217894];
                     const anchor = [24.990003996803196, 0.5];
+                    const renderer = new PIXI.WebGLRenderer(200, 200, {});
                     const graphics = new PIXI.Graphics();
 
                     graphics.lineStyle(1, 0, 1, 0.5);
@@ -319,6 +321,7 @@ describe('PIXI.Graphics', function ()
                     const perp1 = [0, 0.5];
                     const perp2 = [0.019984019174435787, -0.4996004793608947];
                     const anchor = [24.990003996803196, -0.5];
+                    const renderer = new PIXI.WebGLRenderer(200, 200, {});
                     const graphics = new PIXI.Graphics();
 
                     graphics.lineStyle(1, 0, 1, 0.5);
@@ -372,6 +375,7 @@ describe('PIXI.Graphics', function ()
                     // normalized perpendicular vectors
                     const perp1 = [0, 1];
                     const perp2 = [0, -1];
+                    const renderer = new PIXI.WebGLRenderer(200, 200, {});
                     const graphicsMiter = new PIXI.Graphics();
 
                     graphicsMiter.lineStyle(2, 0, 1, 0.5);
@@ -415,6 +419,7 @@ describe('PIXI.Graphics', function ()
                 it('clockwise bevel', withGL(function ()
                 {
                     // given
+                    const renderer = new PIXI.WebGLRenderer(200, 200, {});
                     const graphics = new PIXI.Graphics();
 
                     graphics.lineStyle(2, 0, 1, 0.5);
@@ -462,6 +467,7 @@ describe('PIXI.Graphics', function ()
                 it('counterclockwise bevel', withGL(function ()
                 {
                     // given
+                    const renderer = new PIXI.WebGLRenderer(200, 200, {});
                     const graphics = new PIXI.Graphics();
 
                     graphics.lineStyle(2, 0, 1, 0.5);
@@ -515,6 +521,7 @@ describe('PIXI.Graphics', function ()
                     // normalized perpendicular vectors
                     const perp1 = [0, 1];
                     const perp2 = [0, -1];
+                    const renderer = new PIXI.WebGLRenderer(200, 200, {});
                     const graphicsMiter = new PIXI.Graphics();
 
                     graphicsMiter.lineStyle(2, 0, 1, 0.5);
@@ -555,6 +562,7 @@ describe('PIXI.Graphics', function ()
                 it('flat line bevel', withGL(function ()
                 {
                     // given
+                    const renderer = new PIXI.WebGLRenderer(200, 200, {});
                     const graphics = new PIXI.Graphics();
 
                     graphics.lineStyle(2, 0, 1, 0.5);
@@ -611,6 +619,7 @@ describe('PIXI.Graphics', function ()
                     const r = 2.23606797749979; // sqrt(1^2 + 2^2)
                     const angleIncrease = -0.12870022175865686; // anlge diff / 5
                     let angle = 2.677945044588987; // Math.atan2(1, -2)
+                    const renderer = new PIXI.WebGLRenderer(200, 200, {});
                     const graphics = new PIXI.Graphics();
 
                     graphics.lineStyle(2, 0, 1, 0.5);
@@ -700,6 +709,7 @@ describe('PIXI.Graphics', function ()
                     const r = 2.23606797749979; // sqrt(1^2 + 2^2)
                     const angleIncrease = 0.12870022175865686; // anlge diff / 5
                     let angle = 0.4636476090008061; // Math.atan2(1, -2)
+                    const renderer = new PIXI.WebGLRenderer(200, 200, {});
                     const graphics = new PIXI.Graphics();
 
                     graphics.lineStyle(2, 0, 1, 0.5);
@@ -789,6 +799,7 @@ describe('PIXI.Graphics', function ()
                     const r = 1;
                     const angleIncrease = -0.20943951023931953;
                     let angle = 3.141592653589793;
+                    const renderer = new PIXI.WebGLRenderer(200, 200, {});
                     const graphics = new PIXI.Graphics();
 
                     graphics.lineStyle(2, 0, 1, 0.5);
@@ -859,6 +870,7 @@ describe('PIXI.Graphics', function ()
                     const r = 1;
                     const angleIncrease = -0.20943951023931953;
                     let angle = 0;
+                    const renderer = new PIXI.WebGLRenderer(200, 200, {});
                     const graphics = new PIXI.Graphics();
 
                     graphics.lineStyle(2, 0, 1, 0.5);
@@ -917,6 +929,7 @@ describe('PIXI.Graphics', function ()
                 it('flat line round', withGL(function ()
                 {
                     // given
+                    const renderer = new PIXI.WebGLRenderer(200, 200, {});
                     const graphics = new PIXI.Graphics();
 
                     graphics.lineStyle(2, 0, 1, 0.5);


### PR DESCRIPTION
Adresses pixijs/pixi.js#1637

- introduces lineJoin param for Graphics with possible values: miter, bevel, round
- defaults are backward compatible, falling back to miter
- among many it is heavy inspiration comes from https://hypertolosana.wordpress.com/2015/03/10/efficient-webgl-stroking/
- includes bunch of unit tests which cover most of the introduced branches in code
- changes look of bevel line join in case of `pdist > 196 * width * width` see image in the [link](https://www.dropbox.com/s/f83spsboyoaixvo/pixi-bevel-line-join-before-n-after.png?dl=0)

PS: round lineJoin implementation is more or less prepared for reuse in round lineCap