### PR TITLE
Fixes issue where antialiasing setting is always true regardless of options passed in 

### DIFF
--- a/packages/core/src/Renderer.js
+++ b/packages/core/src/Renderer.js
@@ -60,6 +60,9 @@ export default class Renderer extends AbstractRenderer
     {
         super('WebGL', options, arg2, arg3);
 
+        // the options will have been modified here in the super constructor with pixi's default settings..
+        options = this.options;
+
         /**
          * The type of this renderer as a standardized const
          *


### PR DESCRIPTION
Seems we were adding default properties to options in the abstract class, but using the original in the webgl renderer.

all fixed 👍 