### PR TITLE
Stencil RenderBuffer leak

### DIFF
--- a/src/core/renderers/webgl/utils/RenderTarget.js
+++ b/src/core/renderers/webgl/utils/RenderTarget.js
@@ -326,6 +326,10 @@ export default class RenderTarget
      */
     destroy()
     {
+        if (this.frameBuffer.stencil)
+        {
+            this.gl.deleteRenderBuffer(this.frameBuffer.stencil);
+        }
         this.frameBuffer.destroy();
 
         this.frameBuffer = null;


### PR DESCRIPTION
That's the problem. #5321 

build is here: https://pixijs.download/dev-renderbuffer-destroy/pixi.js

leaking fiddle: https://jsfiddle.net/1pdscnzv/

fixed: https://jsfiddle.net/1pdscnzv/1/