### PR TITLE
A batch of small fixes and tweaks for v5

### DIFF
--- a/packages/core/src/Renderer.js
+++ b/packages/core/src/Renderer.js
@@ -60,6 +60,9 @@ export default class Renderer extends AbstractRenderer
     {
         super('WebGL', options, arg2, arg3);
 
+        // the options will have been modified here in the super constructor with pixi's default settings..
+        options = this.options;
+
         /**
          * The type of this renderer as a standardized const
          *

--- a/packages/core/src/geometry/GeometrySystem.js
+++ b/packages/core/src/geometry/GeometrySystem.js
@@ -193,14 +193,14 @@ export default class GeometrySystem extends System
 
                 // TODO can cache this on buffer! maybe added a getter / setter?
                 const type = buffer.index ? gl.ELEMENT_ARRAY_BUFFER : gl.ARRAY_BUFFER;
-                const drawType = buffer.static ? gl.STATIC_DRAW : gl.DYNAMIC_DRAW;
 
-                if (this.boundBuffers[type] !== glBuffer)
-                {
-                    this.boundBuffers[type] = glBuffer;
-
-                    gl.bindBuffer(type, glBuffer.buffer);
-                }
+                // TODO this could change if the VAO changes...
+                // need to come up with a better way to cache..
+                // if (this.boundBuffers[type] !== glBuffer)
+                // {
+                // this.boundBuffers[type] = glBuffer;
+                gl.bindBuffer(type, glBuffer.buffer);
+                // }
 
                 this._boundBuffer = glBuffer;
 
@@ -211,6 +211,8 @@ export default class GeometrySystem extends System
                 }
                 else
                 {
+                    const drawType = buffer.static ? gl.STATIC_DRAW : gl.DYNAMIC_DRAW;
+
                     glBuffer.byteLength = buffer.data.byteLength;
                     gl.bufferData(type, buffer.data, drawType);
                 }

--- a/packages/core/src/shader/Program.js
+++ b/packages/core/src/shader/Program.js
@@ -41,11 +41,13 @@ class Program
          */
         this.fragmentSrc = fragmentSrc || Program.defaultFragmentSrc;
 
-        this.vertexSrc = setPrecision(this.vertexSrc, settings.PRECISION_VERTEX);
-        this.fragmentSrc = setPrecision(this.fragmentSrc, settings.PRECISION_FRAGMENT);
+        name = name.replace(/\s+/g, '-');
 
         this.vertexSrc = `#define SHADER_NAME ${name}-${this.id}\n${this.vertexSrc}`;
         this.fragmentSrc = `#define SHADER_NAME ${name}-${this.id}\n${this.fragmentSrc}`;
+
+        this.vertexSrc = setPrecision(this.vertexSrc, settings.PRECISION_VERTEX);
+        this.fragmentSrc = setPrecision(this.fragmentSrc, settings.PRECISION_FRAGMENT);
 
         // currently this does not extract structs only default types
         this.extractData(this.vertexSrc, this.fragmentSrc);

--- a/packages/core/src/shader/utils/setPrecision.js
+++ b/packages/core/src/shader/utils/setPrecision.js
@@ -9,7 +9,7 @@ export default function setPrecision(src, precision)
 {
     src = src.trim();
 
-    if (src.substring(0, 9) !== 'precision' && src.substring(0, 1) !== '#')
+    if (src.substring(0, 9) !== 'precision')// && src.substring(0, 1) !== '#')
     {
         return `precision ${precision} float;\n${src}`;
     }

--- a/packages/core/src/textures/TextureSystem.js
+++ b/packages/core/src/textures/TextureSystem.js
@@ -108,13 +108,14 @@ export default class TextureSystem extends System
 
                 const glTexture = texture._glTextures[this.CONTEXT_UID] || this.initTexture(texture);
 
-                this.currentLocation = location;
-                gl.activeTexture(gl.TEXTURE0 + location);
+                if (this.currentLocation !== location)
+                {
+                    this.currentLocation = location;
+                    gl.activeTexture(gl.TEXTURE0 + location);
+                }
 
                 if (this.boundTextures[location] !== texture)
                 {
-                    //  if (this.currentLocation !== location)
-
                     gl.bindTexture(texture.target, glTexture.texture);
                 }
 

--- a/packages/sprite/src/Sprite.js
+++ b/packages/sprite/src/Sprite.js
@@ -217,17 +217,18 @@ export default class Sprite extends Container
      */
     calculateVertices()
     {
-        if (this._transformID === this.transform._worldID && this._textureID === this._texture._updateID)
+        const texture = this._texture;
+
+        if (this._transformID === this.transform._worldID && this._textureID === texture._updateID)
         {
             return;
         }
 
         this._transformID = this.transform._worldID;
-        this._textureID = this._texture._updateID;
+        this._textureID = texture._updateID;
 
         // set the vertex data
 
-        const texture = this._texture;
         const wt = this.transform.worldTransform;
         const a = wt.a;
         const b = wt.b;


### PR DESCRIPTION
- bugfix, removed geometry buffer cache. This could fall out of sync as setting VAOs could change the buffer outside of the specific function for doing so.

- bugfix, automatically setting precision was a bit borked as it was ending up below the name of the shader (causing it to fail to compile).

- optimisation - added a texture location cache - so we only call ``activeTexture`` if we need to.

- optimisation - TINY tweak to sprite, moved texture prop to the top in ``calculateVertices``.

enjoy!