### PR TITLE
Dev renderbuffer destroy

### DIFF
--- a/src/core/renderers/webgl/utils/RenderTarget.js
+++ b/src/core/renderers/webgl/utils/RenderTarget.js
@@ -328,7 +328,7 @@ export default class RenderTarget
     {
         if (this.frameBuffer.stencil)
         {
-            this.gl.deleteRenderBuffer(this.frameBuffer.stencil);
+            this.gl.deleteRenderbuffer(this.frameBuffer.stencil);
         }
         this.frameBuffer.destroy();
 


### PR DESCRIPTION
#5321, take two. Last time I did not look up console errors and I'm sorry.

build is here: https://pixijs.download/dev-renderbuffer-destroy/pixi.js

leaking fiddle: https://jsfiddle.net/1pdscnzv/

fixed: https://jsfiddle.net/1pdscnzv/1/