### PR TITLE
Fix text displaying bug for browsers that block canvas data extraction

### DIFF
--- a/packages/text/src/TextMetrics.js
+++ b/packages/text/src/TextMetrics.js
@@ -49,6 +49,13 @@ export default class TextMetrics
         wordWrap = (wordWrap === undefined || wordWrap === null) ? style.wordWrap : wordWrap;
         const font = style.toFontString();
         const fontProperties = TextMetrics.measureFont(font);
+
+        if (fontProperties.fontSize === 0)
+        {
+            fontProperties.fontSize = style.fontSize;
+            fontProperties.ascent = style.fontSize;
+        }
+
         const context = canvas.getContext('2d');
 
         context.font = font;


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
There is some privacy-focused browsers(Firefox 58+, Tor) that disallow canvas data extraction(_toDataURL_, _getImageData_) by default(not really disallow, just return white picture), i.e. they ask for permission to do so(although i don't have a permission request on localhost). **TextMetrics.js** is using _getImageData_ in static function called _measureFont_ to calculates the ascent, descent and font size of a font-style, but when user decline permission request or just ignore it function return zeroes for ascent, descent and font size, then text element became 1px tall(not visible on screen). No need to use _measureFont_ if we can't, there is fallback in commit that allow to show text if we can't extract canvas data.
##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
