### PR TITLE
Enables WebGL test on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
     - "8"
 
 env:
-  - CXX=g++-4.8 DISABLE_WEBGL=true
+  - CXX=g++-4.8
 
 addons:
   apt:

--- a/packages/core/test/Renderer.js
+++ b/packages/core/test/Renderer.js
@@ -5,14 +5,9 @@ const { skipHello } = require('@pixi/utils');
 
 skipHello();
 
-function withGL(fn)
-{
-    return !process.env.DISABLE_WEBGL ? (fn || true) : undefined;
-}
-
 describe('PIXI.Renderer', function ()
 {
-    it('setting option legacy should disable VAOs and SPRITE_MAX_TEXTURES', withGL(function ()
+    it('setting option legacy should disable VAOs and SPRITE_MAX_TEXTURES', function ()
     {
         settings.PREFER_ENV = ENV.WEBGL_LEGACY;
         const renderer = new Renderer(1, 1);
@@ -27,9 +22,9 @@ describe('PIXI.Renderer', function ()
             renderer.destroy();
         }
         settings.PREFER_ENV = ENV.WEBGL2;
-    }));
+    });
 
-    it('should allow clear() to work despite no containers added to the renderer', withGL(function ()
+    it('should allow clear() to work despite no containers added to the renderer', function ()
     {
         const renderer = new Renderer(1, 1);
 
@@ -41,53 +36,50 @@ describe('PIXI.Renderer', function ()
         {
             renderer.destroy();
         }
-    }));
+    });
 
     describe('.setObjectRenderer()', function ()
     {
-        if (withGL())
+        before(function ()
         {
-            before(function ()
-            {
-                this.renderer = new Renderer();
-            });
+            this.renderer = new Renderer();
+        });
 
-            beforeEach(function ()
-            {
-                this.curRenderer = {
-                    start: sinon.spy(),
-                    stop: sinon.spy(),
-                };
-                this.objRenderer = {
-                    start: sinon.spy(),
-                    stop: sinon.spy(),
-                };
-                this.renderer.batch.currentRenderer = this.curRenderer;
-            });
+        beforeEach(function ()
+        {
+            this.curRenderer = {
+                start: sinon.spy(),
+                stop: sinon.spy(),
+            };
+            this.objRenderer = {
+                start: sinon.spy(),
+                stop: sinon.spy(),
+            };
+            this.renderer.batch.currentRenderer = this.curRenderer;
+        });
 
-            after(function ()
-            {
-                this.renderer.destroy();
-                this.renderer = null;
-                this.curRenderer = null;
-                this.objRenderer = null;
-            });
-        }
+        after(function ()
+        {
+            this.renderer.destroy();
+            this.renderer = null;
+            this.curRenderer = null;
+            this.objRenderer = null;
+        });
 
-        it('should set objectRenderer as new current renderer', withGL(function ()
+        it('should set objectRenderer as new current renderer', function ()
         {
             this.renderer.batch.setObjectRenderer(this.objRenderer);
             expect(this.curRenderer.stop).to.be.calledOnce;
             expect(this.renderer.batch.currentRenderer).to.be.equal(this.objRenderer);
             expect(this.objRenderer.start).to.be.calledOnce;
-        }));
+        });
 
-        it('should do nothing if objectRenderer is already used as current', withGL(function ()
+        it('should do nothing if objectRenderer is already used as current', function ()
         {
             this.renderer.batch.setObjectRenderer(this.curRenderer);
             expect(this.renderer.batch.currentRenderer).to.be.equal(this.curRenderer);
             expect(this.curRenderer.stop).to.not.be.called;
             expect(this.curRenderer.start).to.not.be.called;
-        }));
+        });
     });
 });

--- a/packages/graphics/test/index.js
+++ b/packages/graphics/test/index.js
@@ -9,11 +9,6 @@ Renderer.registerPlugin('batch', BatchRenderer);
 
 skipHello();
 
-function withGL(fn)
-{
-    return !process.env.DISABLE_WEBGL ? (fn || true) : undefined;
-}
-
 describe('PIXI.Graphics', function ()
 {
     describe('constructor', function ()
@@ -299,7 +294,7 @@ describe('PIXI.Graphics', function ()
 
     describe('drawCircle', function ()
     {
-        it('should have no gaps in line border', withGL(function ()
+        it('should have no gaps in line border', function ()
         {
             const renderer = new Renderer(200, 200, {});
 
@@ -325,12 +320,12 @@ describe('PIXI.Graphics', function ()
             {
                 renderer.destroy();
             }
-        }));
+        });
     });
 
     describe('startPoly', function ()
     {
-        it('should fill two triangles', withGL(function ()
+        it('should fill two triangles', function ()
         {
             const graphics = new Graphics();
 
@@ -351,9 +346,9 @@ describe('PIXI.Graphics', function ()
             expect(data.length).to.equals(2);
             expect(data[0].shape.points).to.eql([50, 50, 250, 50, 100, 100, 50, 50]);
             expect(data[1].shape.points).to.eql([250, 50, 450, 50, 300, 100, 250, 50]);
-        }));
+        });
 
-        it('should honor lineStyle break', withGL(function ()
+        it('should honor lineStyle break', function ()
         {
             const graphics = new Graphics();
 
@@ -370,6 +365,6 @@ describe('PIXI.Graphics', function ()
             expect(data.length).to.equals(2);
             expect(data[0].shape.points).to.eql([50, 50, 250, 50]);
             expect(data[1].shape.points).to.eql([250, 50, 100, 100, 50, 50]);
-        }));
+        });
     });
 });

--- a/packages/mesh-extras/test/Plane.js
+++ b/packages/mesh-extras/test/Plane.js
@@ -6,15 +6,10 @@ const { RenderTexture, Texture } = require('@pixi/core');
 
 skipHello();
 
-function withGL(fn)
-{
-    return !process.env.DISABLE_WEBGL ? fn : undefined;
-}
-
 // TODO: fix with webglrenderer
 describe('PIXI.SimplePlane', function ()
 {
-    it('should create a plane from an external image', withGL(function (done)
+    it('should create a plane from an external image', function (done)
     {
         const loader = new Loader();
 
@@ -27,34 +22,34 @@ describe('PIXI.SimplePlane', function ()
                 expect(plane.geometry.segHeight).to.equal(100);
                 done();
             });
-    }));
+    });
 
-    it('should create a new empty textured SimplePlane', withGL(function ()
+    it('should create a new empty textured SimplePlane', function ()
     {
         const plane = new SimplePlane(Texture.EMPTY, 100, 100);
 
         expect(plane.geometry.segWidth).to.equal(100);
         expect(plane.geometry.segHeight).to.equal(100);
-    }));
+    });
 
     describe('containsPoint', function ()
     {
-        it('should return true when point inside', withGL(function ()
+        it('should return true when point inside', function ()
         {
             const point = new Point(10, 10);
             const texture = new RenderTexture.create(20, 30);
             const plane = new SimplePlane(texture, 100, 100);
 
             expect(plane.containsPoint(point)).to.be.true;
-        }));
+        });
 
-        it('should return false when point outside', withGL(function ()
+        it('should return false when point outside', function ()
         {
             const point = new Point(100, 100);
             const texture = new RenderTexture.create(20, 30);
             const plane = new SimplePlane(texture, 100, 100);
 
             expect(plane.containsPoint(point)).to.be.false;
-        }));
+        });
     });
 });


### PR DESCRIPTION
# :tada: :clap:

Umm, so apparently this is a thing now. WebGL tests run using Electron on Travis.

```
545 passing (4s)
```

* Removes environment setting for disabling WebGL tests
* Removes WebGL test gates from unit-tests