### PR TITLE
Remove accessibility manager hook div from dom on destruction

### DIFF
--- a/packages/accessibility/src/AccessibilityManager.js
+++ b/packages/accessibility/src/AccessibilityManager.js
@@ -144,6 +144,7 @@ export default class AccessibilityManager
     /**
      * Creates the touch hooks.
      *
+     * @private
      */
     createTouchHook()
     {
@@ -172,6 +173,7 @@ export default class AccessibilityManager
     /**
      * Destroys the touch hooks.
      *
+     * @private
      */
     destroyTouchHook()
     {

--- a/packages/accessibility/src/AccessibilityManager.js
+++ b/packages/accessibility/src/AccessibilityManager.js
@@ -41,6 +41,11 @@ export default class AccessibilityManager
      */
     constructor(renderer)
     {
+        /**
+         * @type {?HTMLElement}
+         * @private
+         */
+        this._hookDiv = null;
         if ((Device.tablet || Device.phone) && !navigator.isCocoonJS)
         {
             this.createTouchHook();
@@ -157,10 +162,25 @@ export default class AccessibilityManager
         {
             this.isMobileAccessibility = true;
             this.activate();
-            document.body.removeChild(hookDiv);
+            this.destroyTouchHook();
         });
 
         document.body.appendChild(hookDiv);
+        this._hookDiv = hookDiv;
+    }
+
+    /**
+     * Destroys the touch hooks.
+     *
+     */
+    destroyTouchHook()
+    {
+        if (!this._hookDiv)
+        {
+            return;
+        }
+        document.body.removeChild(this._hookDiv);
+        this._hookDiv = null;
     }
 
     /**
@@ -529,6 +549,7 @@ export default class AccessibilityManager
      */
     destroy()
     {
+        this.destroyTouchHook();
         this.div = null;
 
         for (let i = 0; i < this.children.length; i++)

--- a/packages/accessibility/test/AccessibilityManager.js
+++ b/packages/accessibility/test/AccessibilityManager.js
@@ -1,5 +1,6 @@
 const { AccessibilityManager } = require('../');
 const { CanvasRenderer } = require('@pixi/canvas-renderer');
+const Device = require('ismobilejs');
 
 describe('PIXI.accessibility.AccessibilityManager', function ()
 {
@@ -24,5 +25,20 @@ describe('PIXI.accessibility.AccessibilityManager', function ()
 
         expect(renderer.plugins.accessibility).to.be.instanceof(AccessibilityManager);
         renderer.destroy();
+    });
+
+    it('should remove touch hook when destroyed', function ()
+    {
+        const phone = Device.phone;
+
+        Device.phone = true;
+        const manager = new AccessibilityManager();
+        const hookDiv = manager._hookDiv;
+
+        expect(hookDiv).to.be.instanceof(HTMLElement);
+        expect(document.body.contains(hookDiv)).to.be.true;
+        manager.destroy();
+        expect(document.body.contains(hookDiv)).to.be.false;
+        Device.phone = phone;
     });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

When running on phone or tablet accessibility manager creates hook div that doesn't removes when manager dies before the hook has been focused.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
