### PR TITLE
Proper disposal for mesh and graphics geometries

### DIFF
--- a/packages/core/src/geometry/Buffer.js
+++ b/packages/core/src/geometry/Buffer.js
@@ -80,17 +80,6 @@ export default class Buffer
     }
 
     /**
-     * Marks this buffer as shared, it wont be disposed at the same time as geometry
-     * @returns {PIXI.Buffer}
-     */
-    markShared()
-    {
-        this.shared = true;
-
-        return this;
-    }
-
-    /**
      * Helper function that creates a buffer based on an array or TypedArray
      *
      * @static

--- a/packages/core/src/geometry/Buffer.js
+++ b/packages/core/src/geometry/Buffer.js
@@ -39,12 +39,6 @@ export default class Buffer
 
         this.static = _static;
 
-        /**
-         * How many geometries with existing VAO's referenced this Buffer
-         * @member {boolean}
-         */
-        this.refCount = 0;
-
         this.id = UID++;
 
         this.disposeRunner = new Runner('disposeBuffer', 2);

--- a/packages/core/src/geometry/Buffer.js
+++ b/packages/core/src/geometry/Buffer.js
@@ -15,9 +15,8 @@ export default class Buffer
      * @param {ArrayBuffer| SharedArrayBuffer|ArrayBufferView} data the data to store in the buffer.
      * @param {boolean} [_static=true] `true` for static buffer
      * @param {boolean} [index=false] `true` for index buffer
-     * @param {boolean} [shared=false] if `true`, buffer will stay alive when geometry is disposed
      */
-    constructor(data, _static = true, index = false, shared = false)
+    constructor(data, _static = true, index = false)
     {
         /**
          * The data in the buffer, as a typed array
@@ -41,10 +40,10 @@ export default class Buffer
         this.static = _static;
 
         /**
-         * If `true`, it wont be destroyed at the same time as geometry
+         * How many geometries with existing VAO's referenced this Buffer
          * @member {boolean}
          */
-        this.shared = shared;
+        this.refCount = 0;
 
         this.id = UID++;
 

--- a/packages/core/src/geometry/GLBuffer.js
+++ b/packages/core/src/geometry/GLBuffer.js
@@ -5,5 +5,6 @@ export default class GLBuffer
         this.buffer = buffer;
         this.updateID = -1;
         this.byteLength = -1;
+        this.refCount = 0;
     }
 }

--- a/packages/core/src/geometry/Geometry.js
+++ b/packages/core/src/geometry/Geometry.js
@@ -42,9 +42,8 @@ export default class Geometry
     /**
      * @param {PIXI.Buffer[]} [buffers]  an array of buffers. optional.
      * @param {object} [attributes] of the geometry, optional structure of the attributes layout
-     * @param {boolean} [shared=false] Geometry is shared between multiple meshes
      */
-    constructor(buffers = [], attributes = {}, shared = false)
+    constructor(buffers = [], attributes = {})
     {
         this.buffers = buffers;
 
@@ -71,10 +70,10 @@ export default class Geometry
         this.disposeRunner = new Runner('disposeGeometry', 2);
 
         /**
-         * If `true`, it wont be destroyed at the same time as mesh
+         * Count of existing (not destroyed) meshes that reference this geometry
          * @member {boolean}
          */
-        this.shared = shared;
+        this.refCount = 0;
     }
 
     /**
@@ -263,7 +262,9 @@ export default class Geometry
 
         for (let i = 0; i < this.buffers.length; i++)
         {
-            if (!this.buffers[i].shared)
+            this.buffers[i].refCount--;
+
+            if (this.buffers[i].refCount === 0)
             {
                 this.buffers[i].dispose();
             }
@@ -276,14 +277,6 @@ export default class Geometry
     destroy()
     {
         this.dispose();
-
-        for (let i = 0; i < this.buffers.length; i++)
-        {
-            if (!this.buffers[i].shared)
-            {
-                this.buffers[i].destroy();
-            }
-        }
 
         this.buffers = null;
         this.indexBuffer.destroy();

--- a/packages/core/src/geometry/Geometry.js
+++ b/packages/core/src/geometry/Geometry.js
@@ -80,7 +80,7 @@ export default class Geometry
 
     /**
      * Marks this buffer as shared, it wont be destroyed at the same time as meshes
-     * @returns {PIXI.Buffer}
+     * @returns {PIXI.Geometry}
      */
     markShared()
     {

--- a/packages/core/src/geometry/Geometry.js
+++ b/packages/core/src/geometry/Geometry.js
@@ -79,17 +79,6 @@ export default class Geometry
     }
 
     /**
-     * Marks this buffer as shared, it wont be destroyed at the same time as meshes
-     * @returns {PIXI.Geometry}
-     */
-    markShared()
-    {
-        this.shared = true;
-
-        return this;
-    }
-
-    /**
     *
     * Adds an attribute to the geometry
     *

--- a/packages/core/src/geometry/Geometry.js
+++ b/packages/core/src/geometry/Geometry.js
@@ -259,16 +259,6 @@ export default class Geometry
     dispose()
     {
         this.disposeRunner.run(this, false);
-
-        for (let i = 0; i < this.buffers.length; i++)
-        {
-            this.buffers[i].refCount--;
-
-            if (this.buffers[i].refCount === 0)
-            {
-                this.buffers[i].dispose();
-            }
-        }
     }
 
     /**

--- a/packages/core/src/geometry/GeometrySystem.js
+++ b/packages/core/src/geometry/GeometrySystem.js
@@ -375,6 +375,8 @@ export default class GeometrySystem extends System
         {
             const buffer = buffers[i];
 
+            buffer.refCount++;
+
             if (!buffer._glBuffers[CONTEXT_UID])
             {
                 buffer._glBuffers[CONTEXT_UID] = new GLBuffer(gl.createBuffer());

--- a/packages/core/src/geometry/GeometrySystem.js
+++ b/packages/core/src/geometry/GeometrySystem.js
@@ -43,6 +43,20 @@ export default class GeometrySystem extends System
          * @readonly
          */
         this.boundBuffers = {};
+
+        /**
+         * Cache for all geometries by id, used in case renderer gets destroyed or for profiling
+         * @member {object}
+         * @readonly
+         */
+        this.managedGeometries = {};
+
+        /**
+         * Cache for all buffers by id, used in case renderer gets destroyed or for profiling
+         * @member {object}
+         * @readonly
+         */
+        this.managedBuffers = {};
     }
 
     /**
@@ -50,6 +64,8 @@ export default class GeometrySystem extends System
      */
     contextChange()
     {
+        this.disposeAll(true);
+
         const gl = this.gl = this.renderer.gl;
 
         this.CONTEXT_UID = this.renderer.CONTEXT_UID;
@@ -138,6 +154,8 @@ export default class GeometrySystem extends System
 
         if (!vaos)
         {
+            this.managedGeometries[geometry.id] = geometry;
+            geometry.disposeRunner.add(this);
             geometry.glVertexArrayObjects[this.CONTEXT_UID] = vaos = {};
         }
 
@@ -246,7 +264,7 @@ export default class GeometrySystem extends System
      * Takes a geometry and program and generates a unique signature for them.
      *
      * @param {PIXI.Geometry} geometry to get signature from
-     * @param {PIXI.Program} prgram to test geometry against
+     * @param {PIXI.Program} program to test geometry against
      * @returns {String} Unique signature of the geometry and program
      * @protected
      */
@@ -255,7 +273,7 @@ export default class GeometrySystem extends System
         const attribs = geometry.attributes;
         const shaderAttributes = program.attributeData;
 
-        const strings = [geometry.id];
+        const strings = ['g', geometry.id];
 
         for (const i in attribs)
         {
@@ -358,6 +376,8 @@ export default class GeometrySystem extends System
             if (!buffer._glBuffers[CONTEXT_UID])
             {
                 buffer._glBuffers[CONTEXT_UID] = new GLBuffer(gl.createBuffer());
+                this.managedBuffers[buffer.id] = buffer;
+                buffer.disposeRunner.add(this);
             }
         }
 
@@ -373,6 +393,96 @@ export default class GeometrySystem extends System
         vaoObjectHash[signature] = vao;
 
         return vao;
+    }
+
+    /**
+     * Disposes buffer
+     * @param {PIXI.Buffer} buffer buffer with data
+     * @param {boolean} [contextLost=false] If context was lost, we suppress deleteVertexArray
+     */
+    disposeBuffer(buffer, contextLost)
+    {
+        if (!this.managedBuffers[buffer.id])
+        {
+            return;
+        }
+
+        delete this.managedBuffers[buffer.id];
+
+        const glBuffer = buffer._glBuffers[this.CONTEXT_UID];
+        const gl = this.gl;
+
+        buffer.disposeRunner.remove(this);
+
+        if (!glBuffer)
+        {
+            return;
+        }
+
+        if (!contextLost)
+        {
+            gl.deleteBuffer(glBuffer.buffer);
+        }
+
+        delete buffer._glBuffers[this.CONTEXT_UID];
+    }
+
+    /**
+     * Disposes geometry
+     * @param {PIXI.Geometry} geometry Geometry with buffers. Only VAO will be disposed
+     * @param {boolean} [contextLost=false] If context was lost, we suppress deleteVertexArray
+     */
+    disposeGeometry(geometry, contextLost)
+    {
+        if (!this.managedGeometries[geometry.id])
+        {
+            return;
+        }
+
+        delete this.managedGeometries[geometry.id];
+
+        const vaos = geometry.glVertexArrayObjects[this.CONTEXT_UID];
+        const gl = this.gl;
+
+        geometry.disposeRunner.remove(this);
+
+        if (!vaos)
+        {
+            return;
+        }
+
+        if (!contextLost)
+        {
+            for (const vaoId in vaos)
+            {
+                // delete only signatures, everything else are copies
+                if (vaoId[0] === 'g')
+                {
+                    gl.deleteVertexArray(vaos[vaoId]);
+                }
+            }
+        }
+
+        delete geometry.glVertexArrayObjects[this.CONTEXT_UID];
+    }
+
+    /**
+     * dispose all WebGL resources of all managed geometries and buffers
+     * @param {boolean} [contextLost=false] If context was lost, we suppress `gl.delete` calls
+     */
+    disposeAll(contextLost)
+    {
+        let all = Object.keys(this.managedGeometries);
+
+        for (let i = 0; i < all.length; i++)
+        {
+            this.disposeGeometry(this.managedGeometries[all[i]], contextLost);
+        }
+        all = Object.keys(this.managedBuffers);
+        for (let i = 0; i < all.length; i++)
+        {
+            this.disposeBuffer(this.managedBuffers[all[i]], contextLost);
+        }
     }
 
     /**

--- a/packages/graphics/src/Graphics.js
+++ b/packages/graphics/src/Graphics.js
@@ -51,6 +51,7 @@ export default class Graphics extends Container
          * custom attributes within buffers, reducing the cost of passing all
          * this data to the GPU. Can be shared between multiple Mesh or Graphics objects.
          * @member {PIXI.Geometry}
+         * @readonly
          */
         this.geometry = geometry || new GraphicsGeometry();
 

--- a/packages/graphics/src/Graphics.js
+++ b/packages/graphics/src/Graphics.js
@@ -1108,6 +1108,9 @@ export default class Graphics extends Container
      */
     destroy(options)
     {
+        super.destroy(options);
+
+        this.geometry.refCount--;
         if (this.geometry.refCount === 0)
         {
             this.geometry.dispose();

--- a/packages/graphics/src/Graphics.js
+++ b/packages/graphics/src/Graphics.js
@@ -69,14 +69,6 @@ export default class Graphics extends Container
         this.state = State.for2d();
 
         /**
-         * If this Graphics object owns the GraphicsGeometry
-         *
-         * @member {boolean}
-         * @protected
-         */
-        this._ownsGeometry = geometry === null;
-
-        /**
          * Current fill style
          *
          * @member {PIXI.FillStyle}
@@ -1112,14 +1104,10 @@ export default class Graphics extends Container
      *  Should it destroy the texture of the child sprite
      * @param {boolean} [options.baseTexture=false] - Only used for child Sprites if options.children is set to true
      *  Should it destroy the base texture of the child sprite
-     * @param {boolean} [options.geometry=false] - if set to true, the geometry object will be
-     *  be destroyed.
      */
     destroy(options)
     {
-        const destroyGeometry = typeof options === 'boolean' ? options : options && options.geometry;
-
-        if (destroyGeometry || this._ownsGeometry)
+        if (!this.geometry.shared)
         {
             this.geometry.destroy();
         }

--- a/packages/graphics/src/Graphics.js
+++ b/packages/graphics/src/Graphics.js
@@ -54,6 +54,8 @@ export default class Graphics extends Container
          */
         this.geometry = geometry || new GraphicsGeometry();
 
+        this.geometry.refCount++;
+
         /**
          * Represents the vertex and fragment shaders that processes the geometry and runs on the GPU.
          * Can be shared between multiple Graphics objects.
@@ -1105,9 +1107,9 @@ export default class Graphics extends Container
      */
     destroy(options)
     {
-        if (!this.geometry.shared)
+        if (this.geometry.refCount === 0)
         {
-            this.geometry.destroy();
+            this.geometry.dispose();
         }
 
         this._matrix = null;

--- a/packages/mesh/src/Mesh.js
+++ b/packages/mesh/src/Mesh.js
@@ -44,6 +44,7 @@ export default class Mesh extends Container
          * custom attributes within buffers, reducing the cost of passing all
          * this data to the GPU. Can be shared between multiple Mesh objects.
          * @member {PIXI.Geometry}
+         * @readonly
          */
         this.geometry = geometry;
 

--- a/packages/mesh/src/Mesh.js
+++ b/packages/mesh/src/Mesh.js
@@ -47,6 +47,8 @@ export default class Mesh extends Container
          */
         this.geometry = geometry;
 
+        geometry.refCount++;
+
         /**
          * Represents the vertex and fragment shaders that processes the geometry and runs on the GPU.
          * Can be shared between multiple Mesh objects.
@@ -465,9 +467,10 @@ export default class Mesh extends Container
     {
         super.destroy(options);
 
-        if (!this.geometry.shared)
+        this.geometry.refCount--;
+        if (this.geometry.refCount === 0)
         {
-            this.geometry.destroy();
+            this.geometry.dispose();
         }
 
         this.geometry = null;

--- a/packages/mesh/src/Mesh.js
+++ b/packages/mesh/src/Mesh.js
@@ -462,6 +462,11 @@ export default class Mesh extends Container
     {
         super.destroy(options);
 
+        if (!this.geometry.shared)
+        {
+            this.geometry.destroy();
+        }
+
         this.geometry = null;
         this.shader = null;
         this.state = null;


### PR DESCRIPTION
We have to discuss API, I've added `shared` field to Buffer and Geometry, and dev can mark them with `markShared()` method.

Demo:
https://www.pixiplayground.com/#/edit/YqUB4vUo8_Qcyqh6Z~PPT

You can see in the console that each second either strip either all geometries are disposed and it works. Extra VAO that is destroyed in apocalyptic event belongs to BatchRenderer.

Next step after this PR is fix of texture and shader disposal, and `contextLost` test.