### PR TITLE
Allows developer to limit the texture update rate of videos

### DIFF
--- a/packages/core/src/textures/resources/autoDetectResource.js
+++ b/packages/core/src/textures/resources/autoDetectResource.js
@@ -52,6 +52,9 @@ export const INSTALLED = [];
  * @param {number} [options.scale=1] - SVG source scale
  * @param {boolean} [options.createBitmap=true] - Image option to create Bitmap object
  * @param {boolean} [options.crossorigin=true] - Image and Video option to set crossOrigin
+ * @param {boolean} [options.autoPlay=true] - Video option to start playing video immediately
+ * @param {number} [options.updateFPS=0] - Video option to update how many times a second the
+ *        texture should be updated from the video. Leave at 0 to update at every render
  * @return {PIXI.resources.Resource} The created resource.
  */
 export function autoDetectResource(source, options)

--- a/packages/core/test/VideoResource.js
+++ b/packages/core/test/VideoResource.js
@@ -61,5 +61,23 @@ describe('PIXI.resources.VideoResource', function ()
 
         resource.destroy();
     });
+
+    it('should respect the updateFPS settings property and getter / setter', function ()
+    {
+        const resource = new VideoResource(this.videoUrl, {
+            autoLoad: false,
+            autoPlay: false,
+            updateFPS: 30,
+        });
+
+        return resource.load().then((res) =>
+        {
+            expect(res).to.equal(resource);
+            expect(res.updateFPS).to.equal(30);
+            res.updateFPS = 20;
+            expect(res.updateFPS).to.equal(20);
+            resource.destroy();
+        });
+    });
 });
 


### PR DESCRIPTION
Can really help the performance; no need to be updating the texture when no change to the video has occured
https://github.com/pixijs/pixi.js/issues/4789
