### PR TITLE
DisplayObject is not sprite by default

### DIFF
--- a/packages/display/src/DisplayObject.js
+++ b/packages/display/src/DisplayObject.js
@@ -158,7 +158,7 @@ export default class DisplayObject extends EventEmitter
          * used to fast check if a sprite is.. a sprite!
          * @member {boolean}
          */
-        this.isSprite = true;
+        this.isSprite = false;
     }
 
     /**

--- a/packages/display/src/DisplayObject.js
+++ b/packages/display/src/DisplayObject.js
@@ -115,7 +115,7 @@ export default class DisplayObject extends EventEmitter
         /**
          * The bounds object, this is used to calculate and store the bounds of the displayObject.
          *
-         * @member {PIXI.Rectangle}
+         * @member {PIXI.Bounds}
          * @protected
          */
         this._bounds = new Bounds();


### PR DESCRIPTION
I made a mistake in #5345, I added that field to DisplayObject with default value `true` instead of `false`. It affects masks.