### PR TITLE
Framebuffer resize doesn't work with masks

### DIFF
--- a/packages/core/src/framebuffer/FramebufferSystem.js
+++ b/packages/core/src/framebuffer/FramebufferSystem.js
@@ -84,7 +84,7 @@ export default class FramebufferSystem extends System
                 else if (fbo.dirtySize !== framebuffer.dirtySize)
                 {
                     fbo.dirtySize = framebuffer.dirtySize;
-                    this.resizeFramebuffer(framebuffer);
+                    this.resizeFramebuffer(framebuffer, fbo);
                 }
             }
 
@@ -215,14 +215,15 @@ export default class FramebufferSystem extends System
      *
      * @protected
      * @param {PIXI.Framebuffer} framebuffer
+     * @param {object} fbo Framebuffer object corresponding to renderer context
      */
-    resizeFramebuffer(framebuffer)
+    resizeFramebuffer(framebuffer, fbo)
     {
         const { gl } = this;
 
-        if (framebuffer.stencil || framebuffer.depth)
+        if (fbo.stencil)
         {
-            gl.bindRenderbuffer(gl.RENDERBUFFER, this.stencil);
+            gl.bindRenderbuffer(gl.RENDERBUFFER, fbo.stencil);
             gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_STENCIL, framebuffer.width, framebuffer.height);
         }
     }

--- a/packages/core/src/framebuffer/FramebufferSystem.js
+++ b/packages/core/src/framebuffer/FramebufferSystem.js
@@ -217,14 +217,28 @@ export default class FramebufferSystem extends System
      * @param {PIXI.Framebuffer} framebuffer
      * @param {object} fbo Framebuffer object corresponding to renderer context
      */
-    resizeFramebuffer(framebuffer, fbo)
+    resizeFramebuffer(framebuffer)
     {
         const { gl } = this;
+
+        const fbo = framebuffer.glFramebuffers[this.CONTEXT_UID];
 
         if (fbo.stencil)
         {
             gl.bindRenderbuffer(gl.RENDERBUFFER, fbo.stencil);
             gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_STENCIL, framebuffer.width, framebuffer.height);
+        }
+
+        const colorTextures = framebuffer.colorTextures;
+
+        for (let i = 0; i < colorTextures.length; i++)
+        {
+            this.renderer.texture.bind(colorTextures[i], 0);
+        }
+
+        if (framebuffer.depthTexture)
+        {
+            this.renderer.texture.bind(framebuffer.depthTexture, 0);
         }
     }
 
@@ -303,7 +317,7 @@ export default class FramebufferSystem extends System
             }
         }
 
-        if (framebuffer.stencil || framebuffer.depth)
+        if (!fbo.stencil && (framebuffer.stencil || framebuffer.depth))
         {
             fbo.stencil = gl.createRenderbuffer();
 

--- a/packages/math/src/shapes/Rectangle.js
+++ b/packages/math/src/shapes/Rectangle.js
@@ -219,7 +219,7 @@ export default class Rectangle
 
         if (this.x + this.width > rectangle.x + rectangle.width)
         {
-            this.width = rectangle.width - this.x;
+            this.width = rectangle.x + rectangle.width - this.x;
             if (this.width < 0)
             {
                 this.width = 0;
@@ -228,7 +228,7 @@ export default class Rectangle
 
         if (this.y + this.height > rectangle.y + rectangle.height)
         {
-            this.height = rectangle.height - this.y;
+            this.height = rectangle.y + rectangle.height - this.y;
             if (this.height < 0)
             {
                 this.height = 0;

--- a/packages/math/src/shapes/Rectangle.js
+++ b/packages/math/src/shapes/Rectangle.js
@@ -219,7 +219,7 @@ export default class Rectangle
 
         if (this.x + this.width > rectangle.x + rectangle.width)
         {
-            this.width = rectangle.x + rectangle.width - this.x;
+            this.width = rectangle.width - this.x;
             if (this.width < 0)
             {
                 this.width = 0;
@@ -228,7 +228,7 @@ export default class Rectangle
 
         if (this.y + this.height > rectangle.y + rectangle.height)
         {
-            this.height = rectangle.y + rectangle.height - this.y;
+            this.height = rectangle.height - this.y;
             if (this.height < 0)
             {
                 this.height = 0;


### PR DESCRIPTION
Demo: https://www.pixiplayground.com/#/edit/iC8~ZgJkLzuEvAFkSTM9a

produces console error 

```
FramebufferSystem.js:226 WebGL: INVALID_OPERATION: renderbufferStorage: no bound renderbuffer
```