### PR TITLE
V4 rectangle fit

### DIFF
--- a/src/core/math/shapes/Rectangle.js
+++ b/src/core/math/shapes/Rectangle.js
@@ -179,44 +179,15 @@ export default class Rectangle
      */
     fit(rectangle)
     {
-        if (this.x < rectangle.x)
-        {
-            this.width += this.x;
-            if (this.width < 0)
-            {
-                this.width = 0;
-            }
+        const x1 = Math.max(this.x, rectangle.x);
+        const x2 = Math.min(this.x + this.width, rectangle.x + rectangle.width);
+        const y1 = Math.max(this.y, rectangle.y);
+        const y2 = Math.min(this.y + this.height, rectangle.y + rectangle.height);
 
-            this.x = rectangle.x;
-        }
-
-        if (this.y < rectangle.y)
-        {
-            this.height += this.y;
-            if (this.height < 0)
-            {
-                this.height = 0;
-            }
-            this.y = rectangle.y;
-        }
-
-        if (this.x + this.width > rectangle.x + rectangle.width)
-        {
-            this.width = rectangle.x + rectangle.width - this.x;
-            if (this.width < 0)
-            {
-                this.width = 0;
-            }
-        }
-
-        if (this.y + this.height > rectangle.y + rectangle.height)
-        {
-            this.height = rectangle.y + rectangle.height - this.y;
-            if (this.height < 0)
-            {
-                this.height = 0;
-            }
-        }
+        this.x = x1;
+        this.width = Math.max(x2 - x1, 0);
+        this.y = y1;
+        this.height = Math.max(y2 - y1, 0);
     }
 
     /**

--- a/src/core/math/shapes/Rectangle.js
+++ b/src/core/math/shapes/Rectangle.js
@@ -202,7 +202,7 @@ export default class Rectangle
 
         if (this.x + this.width > rectangle.x + rectangle.width)
         {
-            this.width = rectangle.width - this.x;
+            this.width = rectangle.x + rectangle.width - this.x;
             if (this.width < 0)
             {
                 this.width = 0;
@@ -211,7 +211,7 @@ export default class Rectangle
 
         if (this.y + this.height > rectangle.y + rectangle.height)
         {
-            this.height = rectangle.height - this.y;
+            this.height = rectangle.y + rectangle.height - this.y;
             if (this.height < 0)
             {
                 this.height = 0;

--- a/test/core/Rectangle.js
+++ b/test/core/Rectangle.js
@@ -162,8 +162,28 @@ describe('PIXI.Rectangle', function ()
 
         expect(rect3.left).to.equal(10);
         expect(rect3.top).to.equal(0);
-        expect(rect3.right).to.equal(30);
+        expect(rect3.right).to.equal(20);
         expect(rect3.bottom).to.equal(20);
+
+        const rect5 = new PIXI.Rectangle(10, 10, 20, 25);
+        const rect6 = new PIXI.Rectangle(22, 24, 20, 20);
+
+        rect5.fit(rect6);
+
+        expect(rect5.left).to.equal(22);
+        expect(rect5.top).to.equal(24);
+        expect(rect5.right).to.equal(30);
+        expect(rect5.bottom).to.equal(35);
+
+        const rect7 = new PIXI.Rectangle(11, 10, 20, 25);
+        const rect8 = new PIXI.Rectangle(10, 9, 13, 10);
+
+        rect7.fit(rect8);
+
+        expect(rect7.left).to.equal(11);
+        expect(rect7.top).to.equal(10);
+        expect(rect7.right).to.equal(23);
+        expect(rect7.bottom).to.equal(19);
     });
 
     it('should generate an empty rectangle', function ()


### PR DESCRIPTION
This bug affected FilterManager for 3 years.

Sometimes filterArea is enlarged, sometimes its entirely gone.

@GoodBoyDigital introduced that function in https://github.com/pixijs/pixi.js/commit/35af42ef1b147f3750323a9ebb1469c2dfe72dc5#diff-02fe1864d0a7cfbb4d01dbc448e82f9dR123

@madclem made a fix: https://github.com/pixijs/pixi.js/commit/ef6df3d5f63d8b6d85efdc2067a336407f804344#diff-02fe1864d0a7cfbb4d01dbc448e82f9dR120
 
@out-of-band and @bigtimebuddy made tests for it, unfortunately, there was a bug too: https://github.com/pixijs/pixi.js/commit/5f76782f2b1e898a5b32f584bc4b6faab88c4bdb#diff-ecddd9adab4c39b456488ad40a0fc0dbR155

Please make a parallel PR for v5.