### PR TITLE
BasePrepare was imbedding settings rather than having a settings.js file like other classes

### DIFF
--- a/packages/prepare/src/BasePrepare.js
+++ b/packages/prepare/src/BasePrepare.js
@@ -6,19 +6,10 @@ import { Text, TextStyle, TextMetrics } from '@pixi/text';
 import CountLimiter from './CountLimiter';
 
 /**
- * Default number of uploads per frame using prepare plugin.
+ * The prepare manager provides functionality to upload content to the GPU.
  *
- * @static
- * @memberof PIXI.settings
- * @name UPLOADS_PER_FRAME
- * @type {number}
- * @default 4
- */
-settings.UPLOADS_PER_FRAME = 4;
-
-/**
- * The prepare manager provides functionality to upload content to the GPU. BasePrepare handles
- * basic queuing functionality and is extended by {@link PIXI.prepare.WebGLPrepare} and {@link PIXI.prepare.CanvasPrepare}
+ * BasePrepare handles basic queuing functionality and is extended by
+ * {@link PIXI.prepare.WebGLPrepare} and {@link PIXI.prepare.CanvasPrepare}
  * to provide preparation capabilities specific to their respective renderers.
  *
  * @example

--- a/packages/prepare/src/index.js
+++ b/packages/prepare/src/index.js
@@ -1,6 +1,6 @@
 /**
  * The prepare namespace provides renderer-specific plugins for pre-rendering DisplayObjects. These plugins are useful for
- * asynchronously preparing assets, textures, graphics waiting to be displayed.
+ * asynchronously preparing and uploading to the GPU assets, textures, graphics waiting to be displayed.
  *
  * Do not instantiate these plugins directly. It is available from the `renderer.plugins` property.
  * See {@link PIXI.CanvasRenderer#plugins} or {@link PIXI.Renderer#plugins}.
@@ -26,6 +26,8 @@
  * });
  * @namespace PIXI.prepare
  */
+import './settings';
+
 export { default as Prepare } from './Prepare';
 export { default as BasePrepare } from './BasePrepare';
 export { default as CountLimiter } from './CountLimiter';

--- a/packages/prepare/src/settings.js
+++ b/packages/prepare/src/settings.js
@@ -1,0 +1,14 @@
+import { settings } from '@pixi/settings';
+
+/**
+ * Default number of uploads per frame using prepare plugin.
+ *
+ * @static
+ * @memberof PIXI.settings
+ * @name UPLOADS_PER_FRAME
+ * @type {number}
+ * @default 4
+ */
+settings.UPLOADS_PER_FRAME = 4;
+
+export { settings };

--- a/packages/ticker/src/index.js
+++ b/packages/ticker/src/index.js
@@ -1,5 +1,5 @@
+import './settings';
+
 export { default as Ticker } from './Ticker';
 export { default as TickerPlugin } from './TickerPlugin';
 export * from './const';
-
-import './settings';

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -63,6 +63,8 @@ export { mixins };
  * @param {number} [dimensions=2] The number of coordinates per vertex in the input array
  * @return {number[]} Triangulated polygon
  */
+import './settings';
+
 import earcut from 'earcut';
 export { earcut };
 
@@ -73,5 +75,3 @@ export * from './media';
 export * from './network';
 export * from './const';
 export * from './logging';
-
-import './settings';

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -63,10 +63,10 @@ export { mixins };
  * @param {number} [dimensions=2] The number of coordinates per vertex in the input array
  * @return {number[]} Triangulated polygon
  */
-import './settings';
-
 import earcut from 'earcut';
 export { earcut };
+
+import './settings';
 
 export * from './browser';
 export * from './color';


### PR DESCRIPTION
Also moved import of settings higher in other index files. Might have been ok where it was, but logically makes sense to import them as early as possible