### PR TITLE
V5/docs description update

### DIFF
--- a/packages/accessibility/src/AccessibilityManager.js
+++ b/packages/accessibility/src/AccessibilityManager.js
@@ -22,14 +22,13 @@ const DIV_HOOK_POS_Y = -1000;
 const DIV_HOOK_ZINDEX = 2;
 
 /**
- * The Accessibility manager recreates the ability to tab and have content read by screen
- * readers. This is very important as it can possibly help people with disabilities access pixi
- * content.
+ * The Accessibility manager recreates the ability to tab and have content read by screen readers.
+ * This is very important as it can possibly help people with disabilities access PixiJS content.
  *
- * Much like interaction any DisplayObject can be made accessible. This manager will map the
+ * A DisplayObject can be made accessible just like it can be made interactive. This manager will map the
  * events as if the mouse was being used, minimizing the effort required to implement.
  *
- * An instance of this class is automatically created by default, and can be found at renderer.plugins.accessibility
+ * An instance of this class is automatically created by default, and can be found at `renderer.plugins.accessibility`
  *
  * @class
  * @memberof PIXI.accessibility
@@ -186,8 +185,8 @@ export default class AccessibilityManager
     }
 
     /**
-     * Activating will cause the Accessibility layer to be shown. This is called when a user
-     * presses the tab key.
+     * Activating will cause the Accessibility layer to be shown.
+     * This is called when a user presses the tab key.
      *
      * @private
      */
@@ -212,8 +211,8 @@ export default class AccessibilityManager
     }
 
     /**
-     * Deactivating will cause the Accessibility layer to be hidden. This is called when a user moves
-     * the mouse.
+     * Deactivating will cause the Accessibility layer to be hidden.
+     * This is called when a user moves the mouse.
      *
      * @private
      */
@@ -360,9 +359,9 @@ export default class AccessibilityManager
     }
 
     /**
-     * TODO: docs.
+     * Adjust the hit area based on the bounds of a display object
      *
-     * @param {Rectangle} hitArea - TODO docs
+     * @param {Rectangle} hitArea - Bounds of the child
      */
     capHitArea(hitArea)
     {

--- a/packages/accessibility/src/index.js
+++ b/packages/accessibility/src/index.js
@@ -1,6 +1,5 @@
 /**
- * This namespace contains a renderer plugin for interaction accessibility for end-users
- * with physical impairments which require screen-renders, keyboard navigation, etc.
+ * This namespace contains an accessibility plugin for allowing interaction via the keyboard.
  *
  * Do not instantiate this plugin directly. It is available from the `renderer.plugins` property.
  * See {@link PIXI.CanvasRenderer#plugins} or {@link PIXI.Renderer#plugins}.

--- a/packages/app/src/Application.js
+++ b/packages/app/src/Application.js
@@ -4,8 +4,8 @@ import { Renderer } from '@pixi/core';
 
 /**
  * Convenience class to create a new PIXI application.
- * This class automatically creates the renderer, ticker
- * and root container.
+ *
+ * This class automatically creates the renderer, ticker and root container.
  *
  * @example
  * // Create the application
@@ -22,7 +22,6 @@ import { Renderer } from '@pixi/core';
  */
 export default class Application
 {
-    // eslint-disable-next-line valid-jsdoc
     /**
      * @param {object} [options] - The optional renderer parameters.
      * @param {boolean} [options.autoStart=true] - Automatically starts the rendering after the construction.

--- a/packages/canvas/canvas-extract/src/CanvasExtract.js
+++ b/packages/canvas/canvas-extract/src/CanvasExtract.js
@@ -7,7 +7,7 @@ const TEMP_RECT = new Rectangle();
 /**
  * The extract manager provides functionality to export content from the renderers.
  *
- * An instance of this class is automatically created by default, and can be found at renderer.plugins.extract
+ * An instance of this class is automatically created by default, and can be found at `renderer.plugins.extract`
  *
  * @class
  * @memberof PIXI.extract

--- a/packages/canvas/canvas-mesh/src/index.js
+++ b/packages/canvas/canvas-mesh/src/index.js
@@ -1,6 +1,7 @@
 export { default as CanvasMeshRenderer } from './CanvasMeshRenderer';
 
 import './settings';
+
 import './MeshMaterial';
 import './NineSlicePlane';
 import './Mesh';

--- a/packages/canvas/canvas-prepare/src/CanvasPrepare.js
+++ b/packages/canvas/canvas-prepare/src/CanvasPrepare.js
@@ -4,12 +4,12 @@ import { BasePrepare } from '@pixi/prepare';
 const CANVAS_START_SIZE = 16;
 
 /**
- * The prepare manager provides functionality to upload content to the GPU
- * This cannot be done directly for Canvas like in WebGL, but the effect can be achieved by drawing
- * textures to an offline canvas.
- * This draw call will force the texture to be moved onto the GPU.
+ * The prepare manager provides functionality to upload content to the GPU.
  *
- * An instance of this class is automatically created by default, and can be found at renderer.plugins.prepare
+ * This cannot be done directly for Canvas like in WebGL, but the effect can be achieved by drawing
+ * textures to an offline canvas. This draw call will force the texture to be moved onto the GPU.
+ *
+ * An instance of this class is automatically created by default, and can be found at `renderer.plugins.prepare`
  *
  * @class
  * @extends PIXI.prepare.BasePrepare

--- a/packages/canvas/canvas-renderer/src/CanvasRenderer.js
+++ b/packages/canvas/canvas-renderer/src/CanvasRenderer.js
@@ -6,9 +6,10 @@ import { RENDERER_TYPE, SCALE_MODES, BLEND_MODES } from '@pixi/constants';
 import { settings } from '@pixi/settings';
 
 /**
- * The CanvasRenderer draws the scene and all its content onto a 2d canvas. This renderer should
- * be used for browsers that do not support WebGL. Don't forget to add the CanvasRenderer.view to
- * your DOM or you will not see anything :)
+ * The CanvasRenderer draws the scene and all its content onto a 2d canvas.
+ *
+ * This renderer should be used for browsers that do not support WebGL.
+ * Don't forget to add the CanvasRenderer.view to your DOM or you will not see anything!
  *
  * @class
  * @memberof PIXI
@@ -16,7 +17,6 @@ import { settings } from '@pixi/settings';
  */
 export default class CanvasRenderer extends AbstractRenderer
 {
-    // eslint-disable-next-line valid-jsdoc
     /**
      * @param {object} [options] - The optional renderer parameters
      * @param {number} [options.width=800] - the width of the screen

--- a/packages/canvas/canvas-renderer/src/autoDetectRenderer.js
+++ b/packages/canvas/canvas-renderer/src/autoDetectRenderer.js
@@ -2,10 +2,9 @@ import { isWebGLSupported } from '@pixi/utils';
 import { Renderer } from '@pixi/core';
 import CanvasRenderer from './CanvasRenderer';
 
-// eslint-disable-next-line valid-jsdoc
 /**
  * This helper function will automatically detect which renderer you should be using.
- * WebGL is the preferred renderer as it is a lot faster. If webGL is not supported by
+ * WebGL is the preferred renderer as it is a lot faster. If WebGL is not supported by
  * the browser then this function will return a canvas renderer
  *
  * @memberof PIXI

--- a/packages/canvas/canvas-renderer/src/utils/CanvasMaskManager.js
+++ b/packages/canvas/canvas-renderer/src/utils/CanvasMaskManager.js
@@ -3,6 +3,8 @@ import { SHAPES } from '@pixi/math';
 /**
  * A set of functions used to handle masking.
  *
+ * Sprite masking is not supported on the CanvasRenderer.
+ *
  * @class
  * @memberof PIXI
  */

--- a/packages/canvas/canvas-sprite/src/CanvasTinter.js
+++ b/packages/canvas/canvas-sprite/src/CanvasTinter.js
@@ -4,6 +4,9 @@ import { canUseNewCanvasBlendModes } from '@pixi/canvas-renderer';
 /**
  * Utility methods for Sprite/Texture tinting.
  *
+ * Tinting with the CanvasRenderer involves creating a new canvas to use as a texture,
+ * so be aware of the performance implications.
+ *
  * @class
  * @memberof PIXI
  */

--- a/packages/constants/src/index.js
+++ b/packages/constants/src/index.js
@@ -211,7 +211,7 @@ export const SCALE_MODES = {
  *
  * The {@link PIXI.settings.WRAP_MODE} wrap mode affects the default wrapping mode of future operations.
  * It can be re-assigned to either CLAMP or REPEAT, depending upon suitability.
- * If the texture is non power of two then clamp will be used regardless as webGL can
+ * If the texture is non power of two then clamp will be used regardless as WebGL can
  * only use REPEAT if the texture is po2.
  *
  * This property only affects WebGL.

--- a/packages/core/src/AbstractRenderer.js
+++ b/packages/core/src/AbstractRenderer.js
@@ -19,7 +19,6 @@ const tempMatrix = new Matrix();
  */
 export default class AbstractRenderer extends EventEmitter
 {
-    // eslint-disable-next-line valid-jsdoc
     /**
      * @param {string} system - The name of the system this renderer is for.
      * @param {object} [options] - The optional renderer parameters.

--- a/packages/core/src/Renderer.js
+++ b/packages/core/src/Renderer.js
@@ -19,10 +19,12 @@ import { Matrix } from '@pixi/math';
 import Runner from 'mini-runner';
 
 /**
- * The Renderer draws the scene and all its content onto a WebGL enabled canvas. This renderer
- * should be used for browsers that support WebGL. This renderer works by automatically managing WebGLBatches.
- * So no need for Sprite Batches or Sprite Clouds.
- * Don't forget to add the view to your DOM or you will not see anything :).
+ * The Renderer draws the scene and all its content onto a WebGL enabled canvas.
+ *
+ * This renderer should be used for browsers that support WebGL.
+ *
+ * This renderer works by automatically managing WebGLBatchesm, so no need for Sprite Batches or Sprite Clouds.
+ * Don't forget to add the view to your DOM or you will not see anything!
  *
  * @class
  * @memberof PIXI
@@ -30,9 +32,7 @@ import Runner from 'mini-runner';
  */
 export default class Renderer extends AbstractRenderer
 {
-    // eslint-disable-next-line valid-jsdoc
     /**
-     *
      * @param {object} [options] - The optional renderer parameters.
      * @param {number} [options.width=800] - The width of the screen.
      * @param {number} [options.height=600] - The height of the screen.

--- a/packages/core/src/Renderer.js
+++ b/packages/core/src/Renderer.js
@@ -196,6 +196,7 @@ export default class Renderer extends AbstractRenderer
              * @readonly
              */
             .addSystem(RenderTextureSystem, 'renderTexture')
+
             /**
              * Batch system instance
              * @member {PIXI.systems.BatchSystem} batch

--- a/packages/core/src/System.js
+++ b/packages/core/src/System.js
@@ -1,5 +1,6 @@
 /**
  * System is a base class used for extending systems used by the {@link PIXI.Renderer}
+ *
  * @see PIXI.Renderer#addSystem
  * @class
  * @memberof PIXI
@@ -23,6 +24,7 @@ export default class System
 
     /**
      * Generic method called when there is a WebGL context change.
+     *
      * @param {WebGLRenderingContext} gl new webgl context
      */
     contextChange(gl) // eslint-disable-line no-unused-vars
@@ -32,7 +34,6 @@ export default class System
 
     /**
      * Generic destroy methods to be overridden by the subclass
-     *
      */
     destroy()
     {

--- a/packages/core/src/batch/BatchBuffer.js
+++ b/packages/core/src/batch/BatchBuffer.js
@@ -1,4 +1,6 @@
 /**
+ * Used by the BatchRenderer
+ *
  * @class
  * @memberof PIXI
  */

--- a/packages/core/src/batch/BatchDrawCall.js
+++ b/packages/core/src/batch/BatchDrawCall.js
@@ -1,6 +1,6 @@
 /**
- * Used by the batcher to draw batches
- * each one of these contains all information required to draw a bound geometry.
+ * Used by the batcher to draw batches.
+ * Each one of these contains all information required to draw a bound geometry.
  *
  * @class
  * @memberof PIXI

--- a/packages/core/src/batch/BatchGeometry.js
+++ b/packages/core/src/batch/BatchGeometry.js
@@ -3,7 +3,8 @@ import Geometry from '../geometry/Geometry';
 import Buffer from '../geometry/Buffer';
 
 /**
- * Geometry used to batch standard PixiJS content (e.g., Mesh, Sprite, Graphics objects).
+ * Geometry used to batch standard PIXI content (e.g. Mesh, Sprite, Graphics objects).
+ *
  * @class
  * @memberof PIXI
  */
@@ -19,6 +20,7 @@ export default class BatchGeometry extends Geometry
 
         /**
          * Buffer used for position, color, texture IDs
+         *
          * @member {PIXI.Buffer}
          * @protected
          */
@@ -26,6 +28,7 @@ export default class BatchGeometry extends Geometry
 
         /**
          * Index buffer data
+         *
          * @member {PIXI.Buffer}
          * @protected
          */

--- a/packages/core/src/batch/BatchRenderer.js
+++ b/packages/core/src/batch/BatchRenderer.js
@@ -255,7 +255,6 @@ export default class BatchRenderer extends ObjectRenderer
 
         let i;
 
-        // console.log("<>")
         for (i = 0; i < this.currentIndex; ++i)
         {
             // upload the sprite elements...
@@ -402,7 +401,6 @@ export default class BatchRenderer extends ObjectRenderer
         const argb = alpha < 1.0 && element._texture.baseTexture.premultiplyAlpha ? premultiplyTint(element._tintRGB, alpha)
             : element._tintRGB + (alpha * 255 << 24);
 
-        //        console.log(element._texture.baseTexture.premultiplyAlpha);
         // lets not worry about tint! for now..
         for (let i = 0; i < vertexData.length; i += 2)
         {

--- a/packages/core/src/batch/BatchSystem.js
+++ b/packages/core/src/batch/BatchSystem.js
@@ -2,6 +2,8 @@ import System from '../System';
 import ObjectRenderer from './ObjectRenderer';
 
 /**
+ * System plugin to the renderer to manage batching.
+ *
  * @class
  * @extends PIXI.System
  * @memberof PIXI.systems
@@ -9,7 +11,7 @@ import ObjectRenderer from './ObjectRenderer';
 export default class BatchSystem extends System
 {
     /**
-     * @param {PIXI.Renderer} renderer - The renderer this manager works for.
+     * @param {PIXI.Renderer} renderer - The renderer this System works for.
      */
     constructor(renderer)
     {
@@ -51,13 +53,15 @@ export default class BatchSystem extends System
     /**
      * This should be called if you wish to do some custom rendering
      * It will basically render anything that may be batched up such as sprites
-     *
      */
     flush()
     {
         this.setObjectRenderer(this.emptyRenderer);
     }
 
+    /**
+     * Reset the system to an empty renderer
+     */
     reset()
     {
         this.setObjectRenderer(this.emptyRenderer);

--- a/packages/core/src/context/ContextSystem.js
+++ b/packages/core/src/context/ContextSystem.js
@@ -100,7 +100,7 @@ export default class ContextSystem extends System
     }
 
     /**
-     * Helper class to create a webGL Context
+     * Helper class to create a WebGL Context
      *
      * @param canvas {HTMLCanvasElement} the canvas element that we will get the context from
      * @param options {object} An options object that gets passed in to the canvas element containing the context attributes
@@ -130,7 +130,7 @@ export default class ContextSystem extends System
             if (!gl)
             {
                 // fail, not able to get a context
-                throw new Error('This browser does not support webGL. Try using the canvas renderer');
+                throw new Error('This browser does not support WebGL. Try using the canvas renderer');
             }
         }
 
@@ -148,7 +148,7 @@ export default class ContextSystem extends System
      */
     getExtensions()
     {
-        // time to set up default extensions that pixi uses..
+        // time to set up default extensions that Pixi uses.
         const { gl } = this;
 
         if (this.webGLVersion === 1)

--- a/packages/core/src/context/ContextSystem.js
+++ b/packages/core/src/context/ContextSystem.js
@@ -5,6 +5,8 @@ import { ENV } from '@pixi/constants';
 let CONTEXT_UID = 0;
 
 /**
+ * System plugin to the renderer to manage the context.
+ *
  * @class
  * @extends PIXI.System
  * @memberof PIXI.systems

--- a/packages/core/src/filters/Filter.js
+++ b/packages/core/src/filters/Filter.js
@@ -6,15 +6,16 @@ import defaultVertex from './defaultFilter.vert';
 import defaultFragment from './defaultFilter.frag';
 
 /**
- * Filter is a special type of shader that is applied to the screen.
+ * Filter is a special type of WebGL shader that is applied to the screen.
+ *
  * {@link http://pixijs.io/examples/#/filters/blur-filter.js Example} of the
  * {@link PIXI.filters.BlurFilter BlurFilter}.
  *
  * ### Usage
- * Filters can be applied to any DisplayObject or Container. PixiJS' `FilterSystem`
- * renders the container into temporary Framebuffer, then filter
- * renders it to the screen. Multiple filters can be added to the `filters` property
- * and stacked on each other.
+ * Filters can be applied to any DisplayObject or Container.
+ * PixiJS' `FilterSystem` renders the container into temporary Framebuffer,
+ * then filter renders it to the screen.
+ * Multiple filters can be added to the `filters` array property and stacked on each other.
  *
  * ```
  * const filter = new PIXI.Filter(myShaderVert, myShaderFrag, { myUniform: 0.5 });
@@ -26,12 +27,12 @@ import defaultFragment from './defaultFilter.frag';
  *
  * In PixiJS **v3**, a filter was always applied to _whole screen_.
  *
- * In PixiJS **v4**, a filter can be applied _only part of the screen_, developers
- * had to create a set of uniforms to deal with coordinates.
+ * In PixiJS **v4**, a filter can be applied _only part of the screen_.
+ * Developers had to create a set of uniforms to deal with coordinates.
  *
- * In PixiJS **v5** combines _both approaches_, developers can use normal coordinates of
- * v3 and then allow filter to use partial Framebuffers, bringing those extra
- * uniforms into account.
+ * In PixiJS **v5** combines _both approaches_.
+ * Developers can use normal coordinates of v3 and then allow filter to use partial Framebuffers,
+ * bringing those extra uniforms into account.
  *
  * ### Built-in Uniforms
  *
@@ -41,7 +42,7 @@ import defaultFragment from './defaultFilter.frag';
  * **uSampler**
  *
  * The most important uniform is the input texture that container was rendered into.
- * _Important note: as with all PixiJS' Framebuffers, both input and output are
+ * _Important note: as with all Framebuffers in PixiJS, both input and output are
  * premultiplied by alpha._
  *
  * By default, input Framebuffer space coordinates are passed to fragment shader with `vTextureCoord`.
@@ -127,12 +128,11 @@ import defaultFragment from './defaultFilter.frag';
  *
  * ### Additional Information
  *
- * Complete documentation on Filter usage is located in
+ * Complete documentation on Filter usage is located in the
  * {@link https://github.com/pixijs/pixi.js/wiki/v5-Creating-filters Wiki}.
  *
- * Since PixiJS only had a handful of built-in filters, additional filters
- * can be downloaded {@link https://github.com/pixijs/pixi-filters here} from the
- * PixiJS Filters repository.
+ * Since PixiJS only had a handful of built-in filters, additional filters can be downloaded
+ * {@link https://github.com/pixijs/pixi-filters here} from the PixiJS Filters repository.
  *
  * @class
  * @memberof PIXI
@@ -192,7 +192,7 @@ export default class Filter extends Shader
         this.legacy = !!this.program.attributeData.aTextureCoord;
 
         /**
-         * the webGL state the filter requires to render
+         * The WebGL state the filter requires to render
          * @member {PIXI.State}
          */
         this.state = new State();

--- a/packages/core/src/filters/FilterSystem.js
+++ b/packages/core/src/filters/FilterSystem.js
@@ -10,7 +10,8 @@ import UniformGroup from '../shader/UniformGroup';
 import { DRAW_MODES } from '@pixi/constants';
 
 /**
- * Internal class to manage filter state
+ * System plugin to the renderer to manage filter states.
+ *
  * @class
  * @private
  */
@@ -84,7 +85,8 @@ class FilterState
 const screenKey = 'screen';
 
 /**
- * Manage the rendering of filters within PixiJS
+ * System plugin to the renderer to manage the filters.
+ *
  * @class
  * @memberof PIXI.systems
  * @extends PIXI.System

--- a/packages/core/src/filters/spriteMask/SpriteMaskFilter.js
+++ b/packages/core/src/filters/spriteMask/SpriteMaskFilter.js
@@ -5,7 +5,9 @@ import fragment from './spriteMaskFilter.frag';
 import { default as TextureMatrix } from '../../textures/TextureMatrix';
 
 /**
- * The SpriteMaskFilter class
+ * This handles a Sprite acting as a mask, as opposed to a Graphic.
+ *
+ * WebGL only.
  *
  * @class
  * @extends PIXI.Filter

--- a/packages/core/src/framebuffer/Framebuffer.js
+++ b/packages/core/src/framebuffer/Framebuffer.js
@@ -2,12 +2,17 @@ import Texture from '../textures/BaseTexture';
 import { FORMATS, TYPES } from '@pixi/constants';
 
 /**
- * Frame buffer
+ * Frame buffer used by the BaseRenderTexture
+ *
  * @class
  * @memberof PIXI
  */
 export default class Framebuffer
 {
+    /**
+     * @param {number} width - Width of the frame buffer
+     * @param {number} height - Height of the frame buffer
+     */
     constructor(width, height)
     {
         this.width = Math.ceil(width || 100);
@@ -26,15 +31,27 @@ export default class Framebuffer
         this.glFramebuffers = {};
     }
 
+    /**
+     * Reference to the colorTexture.
+     *
+     * @member {PIXI.Texture[]}
+     * @readonly
+     */
     get colorTexture()
     {
         return this.colorTextures[0];
     }
 
-    addColorTexture(index, texture)
+    /**
+     * Add texture to the colorTexture array
+     *
+     * @param {number} [index=0] - Index of the array to add the texture to
+     * @param {PIXI.Texture} [texture] - Texture to add to the array
+     */
+    addColorTexture(index = 0, texture)
     {
         // TODO add some validation to the texture - same width / height etc?
-        this.colorTextures[index || 0] = texture || new Texture(null, { scaleMode: 0,
+        this.colorTextures[index] = texture || new Texture(null, { scaleMode: 0,
             resolution: 1,
             mipmap: false,
             width: this.width,
@@ -46,6 +63,11 @@ export default class Framebuffer
         return this;
     }
 
+    /**
+     * Add a depth texture to the frame buffer
+     *
+     * @param {PIXI.Texture} [texture] - Texture to add
+     */
     addDepthTexture(texture)
     {
         /* eslint-disable max-len */
@@ -63,6 +85,9 @@ export default class Framebuffer
         return this;
     }
 
+    /**
+     * Enable depth on the frame buffer
+     */
     enableDepth()
     {
         this.depth = true;
@@ -73,6 +98,9 @@ export default class Framebuffer
         return this;
     }
 
+    /**
+     * Enable stencil on the frame buffer
+     */
     enableStencil()
     {
         this.stencil = true;
@@ -83,6 +111,12 @@ export default class Framebuffer
         return this;
     }
 
+    /**
+     * Resize the frame buffer
+     *
+     * @param {number} width - Width of the frame buffer to resize to
+     * @param {number} height - Height of the frame buffer to resize to
+     */
     resize(width, height)
     {
         width = Math.ceil(width);

--- a/packages/core/src/framebuffer/FramebufferSystem.js
+++ b/packages/core/src/framebuffer/FramebufferSystem.js
@@ -4,7 +4,8 @@ import { ENV } from '@pixi/constants';
 import { settings } from '../settings';
 
 /**
- * Framebuffer system
+ * System plugin to the renderer to manage framebuffers.
+ *
  * @class
  * @extends PIXI.System
  * @memberof PIXI.systems

--- a/packages/core/src/geometry/Attribute.js
+++ b/packages/core/src/geometry/Attribute.js
@@ -1,9 +1,10 @@
 /* eslint-disable max-len */
 
 /**
- * holds the information for a single attribute structure required to render geometry.
- * this does not contain the actual data, but instead has a buffer id that maps to a {@link PIXI.Buffer}
- * This can include anything from positions, uvs, normals, colors etc..
+ * Holds the information for a single attribute structure required to render geometry.
+ *
+ * This does not contain the actual data, but instead has a buffer id that maps to a {@link PIXI.Buffer}
+ * This can include anything from positions, uvs, normals, colors etc.
  *
  * @class
  * @memberof PIXI

--- a/packages/core/src/geometry/Buffer.js
+++ b/packages/core/src/geometry/Buffer.js
@@ -2,7 +2,7 @@ let UID = 0;
 /* eslint-disable max-len */
 
 /**
- * A wrapper for data so that it can be used and uploaded by webGL
+ * A wrapper for data so that it can be used and uploaded by WebGL
  *
  * @class
  * @memberof PIXI

--- a/packages/core/src/geometry/Geometry.js
+++ b/packages/core/src/geometry/Geometry.js
@@ -19,10 +19,9 @@ const map = {
 
 /**
  * The Geometry represents a model. It consists of two components:
- * GeometryStyle - The structure of the model such as the attributes layout
- * GeometryData - the data of the model - this consists of buffers.
- *
- * This can include anything from positions, uvs, normals, colors etc..
+ * - GeometryStyle - The structure of the model such as the attributes layout
+ * - GeometryData - the data of the model - this consists of buffers.
+ * This can include anything from positions, uvs, normals, colors etc.
  *
  * Geometry can be defined without passing in a style or data if required (thats how I prefer!)
  *

--- a/packages/core/src/geometry/GeometrySystem.js
+++ b/packages/core/src/geometry/GeometrySystem.js
@@ -6,6 +6,8 @@ import { settings } from '../settings';
 const byteSizeMap = { 5126: 4, 5123: 2, 5121: 1 };
 
 /**
+ * System plugin to the renderer to manage geometry.
+ *
  * @class
  * @extends PIXI.System
  * @memberof PIXI.systems

--- a/packages/core/src/mask/MaskSystem.js
+++ b/packages/core/src/mask/MaskSystem.js
@@ -2,6 +2,8 @@ import System from '../System';
 import SpriteMaskFilter from '../filters/spriteMask/SpriteMaskFilter';
 
 /**
+ * System plugin to the renderer to manage masks.
+ *
  * @class
  * @extends PIXI.System
  * @memberof PIXI.systems

--- a/packages/core/src/mask/StencilSystem.js
+++ b/packages/core/src/mask/StencilSystem.js
@@ -1,6 +1,8 @@
 import System from '../System';
 
 /**
+ * System plugin to the renderer to manage stencils (used for masks).
+ *
  * @class
  * @extends PIXI.System
  * @memberof PIXI.systems

--- a/packages/core/src/projection/ProjectionSystem.js
+++ b/packages/core/src/projection/ProjectionSystem.js
@@ -2,6 +2,8 @@ import System from '../System';
 import { Matrix } from '@pixi/math';
 
 /**
+ * System plugin to the renderer to manage the projection matrix.
+ *
  * @class
  * @extends PIXI.System
  * @memberof PIXI.systems

--- a/packages/core/src/renderTexture/RenderTextureSystem.js
+++ b/packages/core/src/renderTexture/RenderTextureSystem.js
@@ -4,6 +4,8 @@ import { Rectangle } from '@pixi/math';
 const tempRect = new Rectangle();
 
 /**
+ * System plugin to the renderer to manage render textures.
+ *
  * @class
  * @extends PIXI.System
  * @memberof PIXI.systems

--- a/packages/core/src/shader/GLProgram.js
+++ b/packages/core/src/shader/GLProgram.js
@@ -1,5 +1,5 @@
 /**
- * Helper class to create a webGL Program
+ * Helper class to create a WebGL Program
  *
  * @class
  * @memberof PIXI
@@ -7,7 +7,8 @@
 export default class GLProgram
 {
     /**
-     * makes new pixi program
+     * Makes a new Pixi program
+     *
      * @param program {WebGLProgram} webgl program
      * @param uniformData {Object} uniforms
      */
@@ -37,7 +38,6 @@ export default class GLProgram
 
     /**
      * Destroys this program
-     * TODO
      */
     destroy()
     {

--- a/packages/core/src/shader/Program.js
+++ b/packages/core/src/shader/Program.js
@@ -15,6 +15,8 @@ let UID = 0;
 const nameCache = {};
 
 /**
+ * Helper class to create a shader program.
+ *
  * @class
  * @memberof PIXI
  */
@@ -108,8 +110,8 @@ export default class Program
      * returns the attribute data from the program
      * @private
      *
-     * @param {WebGLProgram} [program] - the webgl program
-     * @param {WebGLRenderingContext} [gl] - the webGL context
+     * @param {WebGLProgram} [program] - the WebGL program
+     * @param {WebGLRenderingContext} [gl] - the WebGL context
      *
      * @returns {object} the attribute data for this program
      */
@@ -153,7 +155,7 @@ export default class Program
      * @private
      *
      * @param {webGL-program} [program] - the webgl program
-     * @param {context} [gl] - the webGL context
+     * @param {context} [gl] - the WebGL context
      *
      * @returns {object} the uniform data for this program
      */
@@ -220,7 +222,7 @@ export default class Program
      * @param {string} [fragmentSrc] - The source of the fragment shader.
      * @param {object} [uniforms] - Custom uniforms to use to augment the built-in ones.
      *
-     * @returns {PIXI.Shader} an shiny new pixi shader!
+     * @returns {PIXI.Shader} an shiny new Pixi shader!
      */
     static from(vertexSrc, fragmentSrc, name)
     {

--- a/packages/core/src/shader/Shader.js
+++ b/packages/core/src/shader/Shader.js
@@ -1,8 +1,9 @@
 import Program from './Program';
 import UniformGroup from './UniformGroup';
 
-// let math = require('../../../math');
 /**
+ * A helper class for shaders
+ *
  * @class
  * @memberof PIXI
  */
@@ -94,7 +95,7 @@ class Shader
      * @param {string} [fragmentSrc] - The source of the fragment shader.
      * @param {object} [uniforms] - Custom uniforms to use to augment the built-in ones.
      *
-     * @returns {PIXI.Shader} an shiny new pixi shader!
+     * @returns {PIXI.Shader} an shiny new Pixi shader!
      */
     static from(vertexSrc, fragmentSrc, uniforms)
     {

--- a/packages/core/src/shader/ShaderSystem.js
+++ b/packages/core/src/shader/ShaderSystem.js
@@ -7,7 +7,7 @@ import { generateUniformsSync,
 let UID = 0;
 
 /**
- * Helper class to create a WebGL Texture
+ * System plugin to the renderer to manage shaders.
  *
  * @class
  * @memberof PIXI.systems
@@ -16,7 +16,7 @@ let UID = 0;
 export default class ShaderSystem extends System
 {
     /**
-     * @param {PIXI.Renderer} renderer - A reference to the current renderer
+     * @param {PIXI.Renderer} renderer - The renderer this System works for.
      */
     constructor(renderer)
     {

--- a/packages/core/src/shader/ShaderSystem.js
+++ b/packages/core/src/shader/ShaderSystem.js
@@ -7,7 +7,7 @@ import { generateUniformsSync,
 let UID = 0;
 
 /**
- * Helper class to create a webGL Texture
+ * Helper class to create a WebGL Texture
  *
  * @class
  * @memberof PIXI.systems
@@ -63,7 +63,7 @@ export default class ShaderSystem extends System
 
         this.shader = shader;
 
-        // TODO - some current pixi plugins bypass this.. so it not safe to use yet..
+        // TODO - some current Pixi plugins bypass this.. so it not safe to use yet..
         if (this.program !== program)
         {
             this.program = program;

--- a/packages/core/src/shader/UniformGroup.js
+++ b/packages/core/src/shader/UniformGroup.js
@@ -1,15 +1,14 @@
 let UID = 0;
 
-// let math = require('../../../math');
 /**
+ * Uniform group holds uniform map and some ID's for work
+ *
  * @class
  * @memberof PIXI
  */
 class UniformGroup
 {
     /**
-     * Uniform group holds uniform map and some ID's for work
-     *
      * @param {object} [uniforms] - Custom uniforms to use to augment the built-in ones.
      * @param {boolean} [_static] - Uniforms wont be changed after creation
      */
@@ -21,6 +20,7 @@ class UniformGroup
          * @readonly
          */
         this.uniforms = uniforms;
+
         /**
          * Its a group and not a single uniforms
          * @member {boolean}
@@ -28,8 +28,10 @@ class UniformGroup
          * @default true
          */
         this.group = true;
+
         // lets generate this when the shader ?
         this.syncUniforms = {};
+
         /**
          * dirty version
          * @protected

--- a/packages/core/src/shader/utils/generateUniformsSync.js
+++ b/packages/core/src/shader/utils/generateUniformsSync.js
@@ -224,8 +224,5 @@ export default function generateUniformsSync(group, uniformData)
         }
     }
 
-    // console.log(' --------------- ')
-    // console.log(func);
-
     return new Function('ud', 'uv', 'renderer', func); // eslint-disable-line no-new-func
 }

--- a/packages/core/src/shader/utils/getTestContext.js
+++ b/packages/core/src/shader/utils/getTestContext.js
@@ -4,7 +4,7 @@ import { ENV } from '@pixi/constants';
 let context = null;
 
 /**
- * returns a little webGL context to use for program inspection.
+ * returns a little WebGL context to use for program inspection.
  *
  * @static
  * @private
@@ -31,7 +31,7 @@ export default function getTestContext()
             if (!gl)
             {
                 // fail, not able to get a context
-                throw new Error('This browser does not support webGL. Try using the canvas renderer');
+                throw new Error('This browser does not support WebGL. Try using the canvas renderer');
             }
             else
             {

--- a/packages/core/src/state/State.js
+++ b/packages/core/src/state/State.js
@@ -7,8 +7,9 @@ const DEPTH_TEST = 3;
 const WINDING = 4;
 
 /**
- * This is a webGL state. It is passed The WebGL StateManager.
- * Each mesh rendered may require webGL to be in a different state.
+ * This is a WebGL state, and is is passed The WebGL StateManager.
+ *
+ * Each mesh rendered may require WebGL to be in a different state.
  * For example you may want different blend mode or to enable polygon offsets
  *
  * @class
@@ -16,9 +17,6 @@ const WINDING = 4;
  */
 export default class State
 {
-    /**
-     *
-     */
     constructor()
     {
         this.data = 0;

--- a/packages/core/src/state/StateSystem.js
+++ b/packages/core/src/state/StateSystem.js
@@ -9,7 +9,7 @@ const DEPTH_TEST = 3;
 const WINDING = 4;
 
 /**
- * A WebGL state machines
+ * System plugin to the renderer to manage WebGL state machines.
  *
  * @class
  * @extends PIXI.System
@@ -18,7 +18,7 @@ const WINDING = 4;
 export default class StateSystem extends System
 {
     /**
-     * @param {PIXI.Renderer} renderer - Reference to renderer
+     * @param {PIXI.Renderer} renderer - The renderer this System works for.
      */
     constructor(renderer)
     {

--- a/packages/core/src/textures/BaseTexture.js
+++ b/packages/core/src/textures/BaseTexture.js
@@ -15,7 +15,9 @@ const defaultBufferOptions = {
 };
 
 /**
- * A texture stores the information that represents an image. All textures have a base texture.
+ * A Texture stores the information that represents an image.
+ * All textures have a base texture, which contains information about the source.
+ * Therefore you can have many textures all using a single BaseTexture
  *
  * @class
  * @extends PIXI.utils.EventEmitter
@@ -301,7 +303,7 @@ export default class BaseTexture extends EventEmitter
     /**
      * Changes style options of BaseTexture
      *
-     * @param {PIXI.SCALE_MODES} [scaleMode] - pixi scalemode
+     * @param {PIXI.SCALE_MODES} [scaleMode] - Pixi scalemode
      * @param {boolean} [mipmap] - enable mipmaps
      * @returns {BaseTexture} this
      */
@@ -480,7 +482,7 @@ export default class BaseTexture extends EventEmitter
             this.cacheId = null;
         }
 
-        // finally let the webGL renderer know..
+        // finally let the WebGL renderer know..
         this.dispose();
 
         BaseTexture.removeFromCache(this);

--- a/packages/core/src/textures/CubeTexture.js
+++ b/packages/core/src/textures/CubeTexture.js
@@ -2,7 +2,7 @@ import BaseTexture from './BaseTexture';
 import CubeResource from './resources/CubeResource';
 
 /**
- * Texture that depends on six other resources.
+ * A Texture that depends on six other resources.
  *
  * @class
  * @extends PIXI.BaseTexture

--- a/packages/core/src/textures/Texture.js
+++ b/packages/core/src/textures/Texture.js
@@ -10,9 +10,10 @@ import { uid, TextureCache, getResolutionOfUrl } from '@pixi/utils';
 const DEFAULT_UVS = new TextureUvs();
 
 /**
- * A texture stores the information that represents an image or part of an image. It cannot be added
- * to the display list directly. Instead use it as the texture for a Sprite. If no frame is provided
- * then the whole image is used.
+ * A texture stores the information that represents an image or part of an image.
+ *
+ * It cannot be added to the display list directly; instead use it as the texture for a Sprite.
+ * If no frame is provided for a texture, then the whole image is used.
  *
  * You can directly create a texture from an image and then reuse it multiple times like this :
  *

--- a/packages/core/src/textures/Texture.js
+++ b/packages/core/src/textures/Texture.js
@@ -98,7 +98,7 @@ export default class Texture extends EventEmitter
         this.valid = false;
 
         /**
-         * This will let a renderer know that a texture has been updated (used mainly for webGL uv updates)
+         * This will let a renderer know that a texture has been updated (used mainly for WebGL uv updates)
          *
          * @member {boolean}
          */
@@ -357,12 +357,10 @@ export default class Texture extends EventEmitter
      */
     static fromLoader(source, imageUrl, name)
     {
-        // console.log('added from loader...')
         const resource = new ImageResource(source);
 
         resource.url = imageUrl;
 
-        //  console.log('base resource ' + resource.width);
         const baseTexture = new BaseTexture(resource, {
             scaleMode: settings.SCALE_MODE,
             resolution: getResolutionOfUrl(imageUrl),

--- a/packages/core/src/textures/TextureGCSystem.js
+++ b/packages/core/src/textures/TextureGCSystem.js
@@ -3,8 +3,8 @@ import { GC_MODES } from '@pixi/constants';
 import { settings } from '@pixi/settings';
 
 /**
- * TextureGarbageCollector. This class manages the GPU and ensures that it does not get clogged
- * up with textures that are no longer being used.
+ * System plugin to the renderer to manage texture garbage collection on the GPU,
+ * ensuring that it does not get clogged up with textures that are no longer being used.
  *
  * @class
  * @memberof PIXI.systems

--- a/packages/core/src/textures/TextureMatrix.js
+++ b/packages/core/src/textures/TextureMatrix.js
@@ -4,8 +4,8 @@ const tempMat = new Matrix();
 
 /**
  * Class controls uv mapping from Texture normal space to BaseTexture normal space.
- * Takes `trim` and `rotate` into account.
- * May contain clamp settings for Meshes and TilingSprite.
+ *
+ * Takes `trim` and `rotate` into account. May contain clamp settings for Meshes and TilingSprite.
  *
  * Can be used in Texture `uvMatrix` field, or separately, you can use different clamp settings on the same texture.
  * If you want to add support for texture region of certain feature or filter, that's what you're looking for.

--- a/packages/core/src/textures/TextureSystem.js
+++ b/packages/core/src/textures/TextureSystem.js
@@ -4,6 +4,8 @@ import { removeItems } from '@pixi/utils';
 import { WRAP_MODES } from '@pixi/constants';
 
 /**
+ * System plugin to the renderer to manage textures.
+ *
  * @class
  * @extends PIXI.System
  * @memberof PIXI.systems

--- a/packages/core/src/textures/TextureUvs.js
+++ b/packages/core/src/textures/TextureUvs.js
@@ -9,9 +9,6 @@ import { GroupD8 } from '@pixi/math';
  */
 export default class TextureUvs
 {
-    /**
-     *
-     */
     constructor()
     {
         this.x0 = 0;

--- a/packages/core/src/textures/resources/ArrayResource.js
+++ b/packages/core/src/textures/resources/ArrayResource.js
@@ -4,7 +4,7 @@ import { TARGETS } from '@pixi/constants';
 import { autoDetectResource } from './autoDetectResource';
 
 /**
- * Resource for a CubeTexture which contains six resources.
+ * A resource that contains a number of sources.
  *
  * @class
  * @extends PIXI.resources.Resource

--- a/packages/core/src/textures/resources/CubeResource.js
+++ b/packages/core/src/textures/resources/CubeResource.js
@@ -39,6 +39,7 @@ export default class CubeResource extends ArrayResource
 
     /**
      * Add binding
+     *
      * @override
      * @param {PIXI.BaseTexture} baseTexture - parent base texture
      */
@@ -51,6 +52,7 @@ export default class CubeResource extends ArrayResource
 
     /**
      * Upload the resource
+     *
      * @returns {boolean} true is success
      */
     upload(renderer, baseTexture, glTexture)
@@ -81,6 +83,7 @@ export default class CubeResource extends ArrayResource
 
 /**
  * Number of texture sides to store for CubeResources
+ *
  * @name PIXI.resources.CubeResource.SIDES
  * @static
  * @member {number}

--- a/packages/core/src/textures/resources/Resource.js
+++ b/packages/core/src/textures/resources/Resource.js
@@ -1,8 +1,10 @@
 import Runner from 'mini-runner';
 
 /**
- * Base Texture resource class, manages validation and upload depends on its type.
- * upload is required.
+ * Base resource class for textures that manages validation and uploading, depending on its type.
+ *
+ * Uploading of a base texture to the GPU is required.
+ *
  * @class
  * @memberof PIXI.resources
  */

--- a/packages/core/src/textures/resources/index.js
+++ b/packages/core/src/textures/resources/index.js
@@ -9,6 +9,7 @@ import VideoResource from './VideoResource';
 
 /**
  * Collection of base resource types supported by PixiJS.
+ *
  * Resources are used by {@link PIXI.BaseTexture} to handle different media types
  * such as images, video, SVG graphics, etc. In most use-cases, you should not
  * instantiate the resources directly. The easy thing is to use

--- a/packages/core/src/utils/Quad.js
+++ b/packages/core/src/utils/Quad.js
@@ -8,9 +8,6 @@ import Geometry from '../geometry/Geometry';
  */
 export default class Quad extends Geometry
 {
-    /**
-     * just a quad
-     */
     constructor()
     {
         super();

--- a/packages/display/src/Bounds.js
+++ b/packages/display/src/Bounds.js
@@ -1,18 +1,16 @@
 import { Rectangle } from '@pixi/math';
 
 /**
- * 'Builder' pattern for bounds rectangles
- * Axis-Aligned Bounding Box
- * It is not a shape! Its mutable thing, no 'EMPTY' or that kind of problems
+ * 'Builder' pattern for bounds rectangles.
+ *
+ * This could be called an Axis-Aligned Bounding Box.
+ * It is not an actual shape. It is a mutable thing; no 'EMPTY' or those kind of problems.
  *
  * @class
  * @memberof PIXI
  */
 export default class Bounds
 {
-    /**
-     *
-     */
     constructor()
     {
         /**

--- a/packages/display/src/Container.js
+++ b/packages/display/src/Container.js
@@ -14,7 +14,8 @@ function sortChildren(a, b)
 
 /**
  * A Container represents a collection of display objects.
- * It is the base class of all display objects that act as a container for other objects.
+ *
+ * It is the base class of all display objects that act as a container for other objects (like Sprites).
  *
  *```js
  * let container = new PIXI.Container();
@@ -27,9 +28,6 @@ function sortChildren(a, b)
  */
 export default class Container extends DisplayObject
 {
-    /**
-     *
-     */
     constructor()
     {
         super();

--- a/packages/display/src/DisplayObject.js
+++ b/packages/display/src/DisplayObject.js
@@ -5,7 +5,8 @@ import Bounds from './Bounds';
 
 /**
  * The base class for all objects that are rendered on the screen.
- * This is an abstract class and should not be used on its own rather it should be extended.
+ *
+ * This is an abstract class and should not be used on its own; rather it should be extended.
  *
  * @class
  * @extends PIXI.utils.EventEmitter
@@ -13,9 +14,6 @@ import Bounds from './Bounds';
  */
 export default class DisplayObject extends EventEmitter
 {
-    /**
-     *
-     */
     constructor()
     {
         super();
@@ -98,7 +96,7 @@ export default class DisplayObject extends EventEmitter
          *
          * Also works as an interaction mask.
          *
-         * @member {PIXI.Rectangle}
+         * @member {?PIXI.Rectangle}
          */
         this.filterArea = null;
 
@@ -107,7 +105,7 @@ export default class DisplayObject extends EventEmitter
          * * IMPORTANT: This is a WebGL only feature and will be ignored by the canvas renderer.
          * To remove filters simply set this property to `'null'`.
          *
-         * @member {PIXI.Filter[]}
+         * @member {?PIXI.Filter[]}
          */
         this.filters = null;
         this._enabledFilters = null;
@@ -640,7 +638,7 @@ export default class DisplayObject extends EventEmitter
 
     /**
      * Sets a mask for the displayObject. A mask is an object that limits the visibility of an
-     * object to the shape of the mask applied to it. In PIXI a regular mask must be a
+     * object to the shape of the mask applied to it. In PixiJS a regular mask must be a
      * {@link PIXI.Graphics} or a {@link PIXI.Sprite} object. This allows for much faster masking in canvas as it
      * utilities shape clipping. To remove a mask, set this property to `null`.
      *

--- a/packages/extract/src/Extract.js
+++ b/packages/extract/src/Extract.js
@@ -8,7 +8,7 @@ const BYTES_PER_PIXEL = 4;
 /**
  * The extract manager provides functionality to export content from the renderers.
  *
- * An instance of this class is automatically created by default, and can be found at renderer.plugins.extract
+ * An instance of this class is automatically created by default, and can be found at `renderer.plugins.extract`
  *
  * @class
  * @memberof PIXI.extract

--- a/packages/filters/filter-alpha/src/AlphaFilter.js
+++ b/packages/filters/filter-alpha/src/AlphaFilter.js
@@ -3,7 +3,7 @@ import { defaultVertex } from '@pixi/fragments';
 import fragment from './alpha.frag';
 
 /**
- * Simplest filter - applies alpha
+ * Simplest filter - applies alpha.
  *
  * Use this instead of Container's alpha property to avoid visual layering of individual elements.
  * AlphaFilter applies alpha evenly across the entire display object and any opaque elements it contains.

--- a/packages/filters/filter-blur/src/BlurFilter.js
+++ b/packages/filters/filter-blur/src/BlurFilter.js
@@ -4,7 +4,8 @@ import BlurFilterPass from './BlurFilterPass';
 
 /**
  * The BlurFilter applies a Gaussian blur to an object.
- * The strength of the blur can be set for x- and y-axis separately.
+ *
+ * The strength of the blur can be set for the x-axis and y-axis separately.
  *
  * @class
  * @extends PIXI.Filter

--- a/packages/filters/filter-color-matrix/src/ColorMatrixFilter.js
+++ b/packages/filters/filter-color-matrix/src/ColorMatrixFilter.js
@@ -19,9 +19,6 @@ import fragment from './colorMatrix.frag';
  */
 export default class ColorMatrixFilter extends Filter
 {
-    /**
-     *
-     */
     constructor()
     {
         const uniforms = {

--- a/packages/filters/filter-displacement/src/DisplacementFilter.js
+++ b/packages/filters/filter-displacement/src/DisplacementFilter.js
@@ -5,10 +5,11 @@ import fragment from './displacement.frag';
 
 /**
  * The DisplacementFilter class uses the pixel values from the specified texture
- * (called the displacement map) to perform a displacement of an object. You can
- * use this filter to apply all manor of crazy warping effects. Currently the r
- * property of the texture is used to offset the x and the g property of the texture
- * is used to offset the y.
+ * (called the displacement map) to perform a displacement of an object.
+ *
+ * You can use this filter to apply all manor of crazy warping effects.
+ * Currently the `r` property of the texture is used to offset the `x`
+ * and the `g` property of the texture is used to offset the `y`.
  *
  * @class
  * @extends PIXI.Filter

--- a/packages/filters/filter-fxaa/src/FXAAFilter.js
+++ b/packages/filters/filter-fxaa/src/FXAAFilter.js
@@ -3,10 +3,8 @@ import vertex from './fxaa.vert';
 import fragment from './fxaa.frag';
 
 /**
- *
- * Basic FXAA implementation based on the code on geeks3d.com with the
- * modification that the texture2DLod stuff was removed since it's
- * unsupported by WebGL.
+ * Basic FXAA (Fast Approximate Anti-Aliasing) implementation based on the code on geeks3d.com
+ * with the modification that the texture2DLod stuff was removed since it is unsupported by WebGL.
  *
  * @see https://github.com/mitsuhiko/webgl-meincraft
  *
@@ -17,9 +15,6 @@ import fragment from './fxaa.frag';
  */
 export default class FXAAFilter extends Filter
 {
-    /**
-     *
-     */
     constructor()
     {
         // TODO - needs work

--- a/packages/graphics/src/Graphics.js
+++ b/packages/graphics/src/Graphics.js
@@ -62,7 +62,7 @@ export default class Graphics extends Container
         this.shader = null;
 
         /**
-         * Represents the webGL state the Graphics required to render, excludes shader and geometry. E.g.,
+         * Represents the WebGL state the Graphics required to render, excludes shader and geometry. E.g.,
          * blend mode, culling, depth testing, direction of rendering triangles, backface, etc.
          * @member {PIXI.State}
          */
@@ -734,7 +734,6 @@ export default class Graphics extends Container
         }
         else
         {
-            //  console.log('HOLE');
             this.geometry.drawHole(shape, this._matrix);
         }
 
@@ -1033,7 +1032,6 @@ export default class Graphics extends Container
 
         let count = 0;
 
-        // console.log('.,', data.length);
         for (let i = 0; i < data.length; i += 2)
         {
             const x = data[i];

--- a/packages/graphics/src/GraphicsData.js
+++ b/packages/graphics/src/GraphicsData.js
@@ -1,5 +1,5 @@
 /**
- * A GraphicsData object.
+ * A class to contain data useful for Graphics objects
  *
  * @class
  * @memberof PIXI

--- a/packages/graphics/src/GraphicsGeometry.js
+++ b/packages/graphics/src/GraphicsGeometry.js
@@ -30,6 +30,7 @@ fillCommands[SHAPES.RREC] = buildRoundedRectangle;
 
 /**
  * A little internal structure to hold interim batch objects.
+ *
  * @private
  */
 class BatchPart
@@ -46,10 +47,10 @@ class BatchPart
 
 /**
  * The Graphics class contains methods used to draw primitive shapes such as lines, circles and
- * rectangles to the display, and to color and fill them. GraphicsGeometry
- * is designed to not be continually update the geometry since it's expensive
- * to re-tesselate using **earcut**. Consider using {@link PIXI.Mesh} for this
- * use-case, it's much faster.
+ * rectangles to the display, and to color and fill them.
+ *
+ * GraphicsGeometry is designed to not be continually updating the geometry since it's expensive
+ * to re-tesselate using **earcut**. Consider using {@link PIXI.Mesh} for this use-case, it's much faster.
  *
  * @class
  * @extends PIXI.BatchGeometry
@@ -63,6 +64,7 @@ export default class GraphicsGeometry extends BatchGeometry
 
         /**
          * An array of points to draw
+         *
          * @member {PIXI.Point[]}
          * @protected
          */
@@ -70,6 +72,7 @@ export default class GraphicsGeometry extends BatchGeometry
 
         /**
          * The collection of colors
+         *
          * @member {number[]}
          * @protected
          */
@@ -77,6 +80,7 @@ export default class GraphicsGeometry extends BatchGeometry
 
         /**
          * The UVs collection
+         *
          * @member {number[]}
          * @protected
          */
@@ -84,6 +88,7 @@ export default class GraphicsGeometry extends BatchGeometry
 
         /**
          * The indices of the vertices
+         *
          * @member {number[]}
          * @protected
          */
@@ -91,6 +96,7 @@ export default class GraphicsGeometry extends BatchGeometry
 
         /**
          * Reference to the texture IDs.
+         *
          * @member {number[]}
          * @protected
          */
@@ -138,7 +144,7 @@ export default class GraphicsGeometry extends BatchGeometry
         this.cacheDirty = -1;
 
         /**
-         * Used to detect if we clear the graphics webGL data.
+         * Used to detect if we clear the graphics WebGL data.
          *
          * @member {number}
          * @default 0

--- a/packages/graphics/src/styles/FillStyle.js
+++ b/packages/graphics/src/styles/FillStyle.js
@@ -2,6 +2,7 @@ import { Texture } from '@pixi/core';
 
 /**
  * Fill style object for Graphics.
+ *
  * @class
  * @memberof PIXI
  */

--- a/packages/graphics/src/utils/buildCircle.js
+++ b/packages/graphics/src/utils/buildCircle.js
@@ -8,8 +8,8 @@ import { SHAPES } from '@pixi/math';
  * @ignore
  * @private
  * @param {PIXI.WebGLGraphicsData} graphicsData - The graphics object to draw
- * @param {object} webGLData - an object containing all the webGL-specific information to create this shape
- * @param {object} webGLDataNativeLines - an object containing all the webGL-specific information to create nativeLines
+ * @param {object} webGLData - an object containing all the WebGL-specific information to create this shape
+ * @param {object} webGLDataNativeLines - an object containing all the WebGL-specific information to create nativeLines
  */
 export default {
 

--- a/packages/graphics/src/utils/buildComplexPoly.js
+++ b/packages/graphics/src/utils/buildComplexPoly.js
@@ -8,7 +8,7 @@ import { hex2rgb } from '@pixi/utils';
  * @ignore
  * @private
  * @param {PIXI.Graphics} graphicsData - The graphics object containing all the necessary properties
- * @param {object} webGLData - an object containing all the webGL-specific information to create this shape
+ * @param {object} webGLData - an object containing all the WebGL-specific information to create this shape
  */
 export default function buildComplexPoly(graphicsData, webGLData)
 {

--- a/packages/graphics/src/utils/buildLine.js
+++ b/packages/graphics/src/utils/buildLine.js
@@ -8,8 +8,8 @@ import { Point } from '@pixi/math';
  * @ignore
  * @private
  * @param {PIXI.WebGLGraphicsData} graphicsData - The graphics object containing all the necessary properties
- * @param {object} webGLData - an object containing all the webGL-specific information to create this shape
- * @param {object} webGLDataNativeLines - an object containing all the webGL-specific information to create nativeLines
+ * @param {object} webGLData - an object containing all the WebGL-specific information to create this shape
+ * @param {object} webGLDataNativeLines - an object containing all the WebGL-specific information to create nativeLines
  */
 export default function (graphicsData, graphicsGeometry)
 {
@@ -31,7 +31,7 @@ export default function (graphicsData, graphicsGeometry)
  * @ignore
  * @private
  * @param {PIXI.WebGLGraphicsData} graphicsData - The graphics object containing all the necessary properties
- * @param {object} webGLData - an object containing all the webGL-specific information to create this shape
+ * @param {object} webGLData - an object containing all the WebGL-specific information to create this shape
  */
 function buildLine(graphicsData, graphicsGeometry)
 {
@@ -241,7 +241,7 @@ function buildLine(graphicsData, graphicsGeometry)
  * @ignore
  * @private
  * @param {PIXI.WebGLGraphicsData} graphicsData - The graphics object containing all the necessary properties
- * @param {object} webGLData - an object containing all the webGL-specific information to create this shape
+ * @param {object} webGLData - an object containing all the WebGL-specific information to create this shape
  */
 function buildNativeLine(graphicsData, graphicsGeometry)
 {

--- a/packages/graphics/src/utils/buildPoly.js
+++ b/packages/graphics/src/utils/buildPoly.js
@@ -8,8 +8,8 @@ import { earcut } from '@pixi/utils';
  * @ignore
  * @private
  * @param {PIXI.WebGLGraphicsData} graphicsData - The graphics object containing all the necessary properties
- * @param {object} webGLData - an object containing all the webGL-specific information to create this shape
- * @param {object} webGLDataNativeLines - an object containing all the webGL-specific information to create nativeLines
+ * @param {object} webGLData - an object containing all the WebGL-specific information to create this shape
+ * @param {object} webGLDataNativeLines - an object containing all the WebGL-specific information to create nativeLines
  */
 export default {
 

--- a/packages/graphics/src/utils/buildRectangle.js
+++ b/packages/graphics/src/utils/buildRectangle.js
@@ -6,8 +6,8 @@
  * @ignore
  * @private
  * @param {PIXI.WebGLGraphicsData} graphicsData - The graphics object containing all the necessary properties
- * @param {object} webGLData - an object containing all the webGL-specific information to create this shape
- * @param {object} webGLDataNativeLines - an object containing all the webGL-specific information to create nativeLines
+ * @param {object} webGLData - an object containing all the WebGL-specific information to create this shape
+ * @param {object} webGLDataNativeLines - an object containing all the WebGL-specific information to create nativeLines
  */
 export default {
 

--- a/packages/graphics/src/utils/buildRoundedRectangle.js
+++ b/packages/graphics/src/utils/buildRoundedRectangle.js
@@ -8,8 +8,8 @@ import { earcut } from '@pixi/utils';
  * @ignore
  * @private
  * @param {PIXI.WebGLGraphicsData} graphicsData - The graphics object containing all the necessary properties
- * @param {object} webGLData - an object containing all the webGL-specific information to create this shape
- * @param {object} webGLDataNativeLines - an object containing all the webGL-specific information to create nativeLines
+ * @param {object} webGLData - an object containing all the WebGL-specific information to create this shape
+ * @param {object} webGLDataNativeLines - an object containing all the WebGL-specific information to create nativeLines
  */
 export default {
 

--- a/packages/interaction/src/InteractionData.js
+++ b/packages/interaction/src/InteractionData.js
@@ -8,9 +8,6 @@ import { Point } from '@pixi/math';
  */
 export default class InteractionData
 {
-    /**
-     *
-     */
     constructor()
     {
         /**

--- a/packages/interaction/src/InteractionEvent.js
+++ b/packages/interaction/src/InteractionEvent.js
@@ -6,9 +6,6 @@
  */
 export default class InteractionEvent
 {
-    /**
-     *
-     */
     constructor()
     {
         /**

--- a/packages/interaction/src/InteractionManager.js
+++ b/packages/interaction/src/InteractionManager.js
@@ -25,11 +25,13 @@ const hitTestEvent = {
 };
 
 /**
- * The interaction manager deals with mouse, touch and pointer events. Any DisplayObject can be interactive
- * if its interactive parameter is set to true
+ * The interaction manager deals with mouse, touch and pointer events.
+ *
+ * Any DisplayObject can be interactive if its `interactive` property is set to true.
+ *
  * This manager also supports multitouch.
  *
- * An instance of this class is automatically created by default, and can be found at renderer.plugins.interaction
+ * An instance of this class is automatically created by default, and can be found at `renderer.plugins.interaction`
  *
  * @class
  * @extends PIXI.utils.EventEmitter

--- a/packages/loaders/src/Loader.js
+++ b/packages/loaders/src/Loader.js
@@ -4,7 +4,6 @@ import { blobMiddlewareFactory } from 'resource-loader/lib/middlewares/parsing/b
 import TextureLoader from './TextureLoader';
 
 /**
- *
  * The new loader, extends Resource Loader by Chad Engler: https://github.com/englercj/resource-loader
  *
  * ```js

--- a/packages/math/src/Matrix.js
+++ b/packages/math/src/Matrix.js
@@ -2,12 +2,14 @@ import Point from './Point';
 import { PI_2 } from './const';
 
 /**
- * The PixiJS Matrix class as an object, which makes it a lot faster,
- * here is a representation of it :
+ * The PixiJS Matrix as a class makes it a lot faster.
+ *
+ * Here is a representation of it:
+ * ```js
  * | a | c | tx|
  * | b | d | ty|
  * | 0 | 0 | 1 |
- *
+ * ```
  * @class
  * @memberof PIXI
  */

--- a/packages/math/src/ObservablePoint.js
+++ b/packages/math/src/ObservablePoint.js
@@ -1,7 +1,8 @@
 /**
  * The Point object represents a location in a two-dimensional coordinate system, where x represents
  * the horizontal axis and y represents the vertical axis.
- * An observable point is a point that triggers a callback when the point's position is changed.
+ *
+ * An ObservablePoint is a point that triggers a callback when the point's position is changed.
  *
  * @class
  * @memberof PIXI

--- a/packages/math/src/Transform.js
+++ b/packages/math/src/Transform.js
@@ -9,9 +9,6 @@ import Matrix from './Matrix';
  */
 export default class Transform
 {
-    /**
-     *
-     */
     constructor()
     {
         /**

--- a/packages/math/src/shapes/Circle.js
+++ b/packages/math/src/shapes/Circle.js
@@ -2,7 +2,7 @@ import Rectangle from './Rectangle';
 import { SHAPES } from '../const';
 
 /**
- * The Circle object can be used to specify a hit area for displayObjects
+ * The Circle object is used to help draw graphics and can also be used to specify a hit area for displayObjects.
  *
  * @class
  * @memberof PIXI

--- a/packages/math/src/shapes/Ellipse.js
+++ b/packages/math/src/shapes/Ellipse.js
@@ -2,7 +2,7 @@ import Rectangle from './Rectangle';
 import { SHAPES } from '../const';
 
 /**
- * The Ellipse object can be used to specify a hit area for displayObjects
+ * The Ellipse object is used to help draw graphics and can also be used to specify a hit area for displayObjects.
  *
  * @class
  * @memberof PIXI

--- a/packages/math/src/shapes/Polygon.js
+++ b/packages/math/src/shapes/Polygon.js
@@ -2,6 +2,8 @@ import Point from '../Point';
 import { SHAPES } from '../const';
 
 /**
+ * A class to define a shape via user defined co-orinates.
+ *
  * @class
  * @memberof PIXI
  */

--- a/packages/mesh-extras/src/SimpleMesh.js
+++ b/packages/mesh-extras/src/SimpleMesh.js
@@ -2,9 +2,9 @@ import { Mesh, MeshGeometry, MeshMaterial } from '@pixi/mesh';
 import { Texture } from '@pixi/core';
 
 /**
- * Simple Mesh class mimics mesh in PixiJS v4, provides
- * easy-to-use constructor arguments. For more robust
- * customization, use {@link PIXI.Mesh}.
+ * The Simple Mesh class mimics Mesh in PixiJS v4, providing easy-to-use constructor arguments.
+ * For more robust customization, use {@link PIXI.Mesh}.
+ *
  * @class
  * @extends PIXI.Mesh
  * @memberof PIXI

--- a/packages/mesh-extras/src/SimplePlane.js
+++ b/packages/mesh-extras/src/SimplePlane.js
@@ -3,7 +3,7 @@ import { Mesh, MeshMaterial } from '@pixi/mesh';
 import PlaneGeometry from './geometry/PlaneGeometry';
 
 /**
- * The Plane allows you to draw a texture across several points and them manipulate these points
+ * The Plane allows you to draw a texture across several points and then manipulate these points
  *
  *```js
  * for (let i = 0; i < 20; i++) {

--- a/packages/mesh-extras/src/SimpleRope.js
+++ b/packages/mesh-extras/src/SimpleRope.js
@@ -2,7 +2,7 @@ import { Mesh, MeshMaterial } from '@pixi/mesh';
 import RopeGeometry from './geometry/RopeGeometry';
 
 /**
- * The rope allows you to draw a texture across several points and them manipulate these points
+ * The rope allows you to draw a texture across several points and then manipulate these points
  *
  *```js
  * for (let i = 0; i < 20; i++) {
@@ -31,6 +31,7 @@ export default class SimpleRope extends Mesh
 
         /**
          * re-calculate vertices by rope points each frame
+         *
          * @member {boolean}
          */
         this.autoUpdate = true;

--- a/packages/mesh-extras/src/geometry/PlaneGeometry.js
+++ b/packages/mesh-extras/src/geometry/PlaneGeometry.js
@@ -12,7 +12,6 @@ export default class PlaneGeometry extends MeshGeometry
         this.width = width;
         this.height = height;
 
-        // console.log('>>>>>', segWidth, segHeight);
         this.build();
     }
 

--- a/packages/mesh-extras/src/geometry/RopeGeometry.js
+++ b/packages/mesh-extras/src/geometry/RopeGeometry.js
@@ -1,6 +1,6 @@
 import { MeshGeometry } from '@pixi/mesh';
 /**
- * The rope allows you to draw a texture across several points and them manipulate these points
+ * The rope allows you to draw a texture across several points and then manipulate these points
  *
  *```js
  * for (let i = 0; i < 20; i++) {

--- a/packages/mesh/src/Mesh.js
+++ b/packages/mesh/src/Mesh.js
@@ -9,14 +9,17 @@ const tempPoint = new Point();
 const tempPolygon = new Polygon();
 
 /**
- * Base mesh class
- * The reason for this class is to empower you to have maximum flexibility to render any kind of webGL you can think of.
- * This class assumes a certain level of webGL knowledge.
+ * Base mesh class.
+ *
+ * This class empowers you to have maximum flexibility to render any kind of WebGL visuals you can think of.
+ * This class assumes a certain level of WebGL knowledge.
  * If you know a bit this should abstract enough away to make you life easier!
+ *
  * Pretty much ALL WebGL can be broken down into the following:
- * Geometry - The structure and data for the mesh. This can include anything from positions, uvs, normals, colors etc..
- * Shader - This is the shader that pixi will render the geometry with. (attributes in the shader must match the geometry!)
- * State - This is the state of WebGL required to render the mesh.
+ * - Geometry - The structure and data for the mesh. This can include anything from positions, uvs, normals, colors etc..
+ * - Shader - This is the shader that PixiJS will render the geometry with (attributes in the shader must match the geometry)
+ * - State - This is the state of WebGL required to render the mesh.
+ *
  * Through a combination of the above elements you can render anything you want, 2D or 3D!
  *
  * @class
@@ -28,7 +31,7 @@ export default class Mesh extends Container
     /**
      * @param {PIXI.Geometry} geometry  the geometry the mesh will use
      * @param {PIXI.Shader|PIXI.MeshMaterial} shader  the shader the mesh will use
-     * @param {PIXI.State} [state] the state that the webGL context is required to be in to render the mesh
+     * @param {PIXI.State} [state] the state that the WebGL context is required to be in to render the mesh
      *        if no state is provided, uses {@link PIXI.State.for2d} to create a 2D state for PixiJS.
      * @param {number} [drawMode=PIXI.DRAW_MODES.TRIANGLES] the drawMode, can be any of the PIXI.DRAW_MODES consts
      */
@@ -52,7 +55,7 @@ export default class Mesh extends Container
         this.shader = shader;
 
         /**
-         * Represents the webGL state the Mesh required to render, excludes shader and geometry. E.g.,
+         * Represents the WebGL state the Mesh required to render, excludes shader and geometry. E.g.,
          * blend mode, culling, depth testing, direction of rendering triangles, backface, etc.
          * @member {PIXI.State}
          */

--- a/packages/mixin-cache-as-bitmap/src/index.js
+++ b/packages/mixin-cache-as-bitmap/src/index.js
@@ -19,9 +19,6 @@ DisplayObject.prototype._cacheData = false;
  */
 class CacheData
 {
-    /**
-     *
-     */
     constructor()
     {
         this.textureCacheId = null;
@@ -185,7 +182,7 @@ DisplayObject.prototype._initCachedDisplayObject = function _initCachedDisplayOb
 
     bounds.ceil(settings.RESOLUTION);
 
-    // for now we cache the current renderTarget that the webGL renderer is currently using.
+    // for now we cache the current renderTarget that the WebGL renderer is currently using.
     // this could be more elegant..
     const cachedRenderTarget = renderer._activeRenderTarget;
     // We also store the filter stack - I will definitely look to change how this works a little later down the line.
@@ -279,7 +276,7 @@ DisplayObject.prototype._renderCachedCanvas = function _renderCachedCanvas(rende
     this._cacheData.sprite._renderCanvas(renderer);
 };
 
-// TODO this can be the same as the webGL version.. will need to do a little tweaking first though..
+// TODO this can be the same as the WebGL version.. will need to do a little tweaking first though..
 /**
  * Prepares the Canvas renderer to cache the sprite
  *

--- a/packages/particles/src/ParticleContainer.js
+++ b/packages/particles/src/ParticleContainer.js
@@ -4,13 +4,15 @@ import { Container } from '@pixi/display';
 
 /**
  * The ParticleContainer class is a really fast version of the Container built solely for speed,
- * so use when you need a lot of sprites or particles. The tradeoff of the ParticleContainer is that most advanced
- * functionality will not work. ParticleContainer implements the basic object transform (position, scale, rotation)
+ * so use when you need a lot of sprites or particles.
+ *
+ * The tradeoff of the ParticleContainer is that most advanced functionality will not work.
+ * ParticleContainer implements the basic object transform (position, scale, rotation)
  * and some advanced functionality like tint (as of v4.5.6).
+ *
  * Other more advanced functionality like masking, children, filters, etc will not work on sprites in this batch.
  *
- * It's extremely easy to use :
- *
+ * It's extremely easy to use:
  * ```js
  * let container = new ParticleContainer();
  *
@@ -193,7 +195,7 @@ export default class ParticleContainer extends Container
     /**
      * The tint applied to the container. This is a hex value.
      * A value of 0xFFFFFF will remove any tint effect.
-     ** IMPORTANT: This is a webGL only feature and will be ignored by the canvas renderer.
+     ** IMPORTANT: This is a WebGL only feature and will be ignored by the canvas renderer.
      * @member {number}
      * @default 0xFFFFFF
      */

--- a/packages/particles/src/ParticleRenderer.js
+++ b/packages/particles/src/ParticleRenderer.js
@@ -19,6 +19,7 @@ import fragment from './particles.frag';
  */
 
 /**
+ * Renderer for Particles that is designer for speed over feature set.
  *
  * @class
  * @memberof PIXI
@@ -281,6 +282,7 @@ export default class ParticleRenderer extends ObjectRenderer
     }
 
     /**
+     * Uploads the position.
      *
      * @param {PIXI.DisplayObject[]} children - the array of display objects to render
      * @param {number} startIndex - the index to start from in the children array
@@ -312,6 +314,7 @@ export default class ParticleRenderer extends ObjectRenderer
     }
 
     /**
+     * Uploads the rotiation.
      *
      * @param {PIXI.DisplayObject[]} children - the array of display objects to render
      * @param {number} startIndex - the index to start from in the children array
@@ -336,6 +339,7 @@ export default class ParticleRenderer extends ObjectRenderer
     }
 
     /**
+     * Uploads the Uvs
      *
      * @param {PIXI.DisplayObject[]} children - the array of display objects to render
      * @param {number} startIndex - the index to start from in the children array
@@ -387,6 +391,7 @@ export default class ParticleRenderer extends ObjectRenderer
     }
 
     /**
+     * Uploads the tint.
      *
      * @param {PIXI.DisplayObject[]} children - the array of display objects to render
      * @param {number} startIndex - the index to start from in the children array
@@ -417,7 +422,6 @@ export default class ParticleRenderer extends ObjectRenderer
 
     /**
      * Destroys the ParticleRenderer.
-     *
      */
     destroy()
     {

--- a/packages/prepare/src/Prepare.js
+++ b/packages/prepare/src/Prepare.js
@@ -5,7 +5,7 @@ import BasePrepare from './BasePrepare';
 /**
  * The prepare manager provides functionality to upload content to the GPU.
  *
- * An instance of this class is automatically created by default, and can be found at renderer.plugins.prepare
+ * An instance of this class is automatically created by default, and can be found at `renderer.plugins.prepare`
  *
  * @class
  * @extends PIXI.prepare.BasePrepare

--- a/packages/sprite/src/Sprite.js
+++ b/packages/sprite/src/Sprite.js
@@ -17,7 +17,8 @@ const indices = new Uint16Array([0, 1, 2, 0, 2, 3]);
  * let sprite = new PIXI.Sprite.from('assets/image.png');
  * ```
  *
- * The more efficient way to create sprites is using a {@link PIXI.Spritesheet}:
+ * The more efficient way to create sprites is using a {@link PIXI.Spritesheet},
+ * as swapping base textures when rendering to the screen is inefficient.
  *
  * ```js
  * PIXI.loader.add("assets/spritesheet.json").load(setup);

--- a/packages/spritesheet/src/SpritesheetLoader.js
+++ b/packages/spritesheet/src/SpritesheetLoader.js
@@ -3,10 +3,11 @@ import { LoaderResource } from '@pixi/loaders';
 import Spritesheet from './Spritesheet';
 
 /**
- * {@link PIXI.Loader Loader} middleware for loading
- * texture atlases that have been created with TexturePacker or
- * similar JSON-based spritesheet. This automatically generates
- * Texture resources.
+ * {@link PIXI.Loader Loader} middleware for loading texture atlases that have been created with
+ * TexturePacker or similar JSON-based spritesheet.
+ *
+ * This middleware automatically generates Texture resources.
+ *
  * @class
  * @memberof PIXI
  * @implements PIXI.ILoaderPlugin

--- a/packages/text-bitmap/src/BitmapText.js
+++ b/packages/text-bitmap/src/BitmapText.js
@@ -7,7 +7,11 @@ import { removeItems, getResolutionOfUrl } from '@pixi/utils';
 
 /**
  * A BitmapText object will create a line or multiple lines of text using bitmap font. To
- * split a line you can use '\n', '\r' or '\r\n' in your string. You can generate the fnt files using:
+ * split a line you can use '\n', '\r' or '\r\n' in your string.
+ *
+ * You can generate the fnt files using
+ * http://www.angelcode.com/products/bmfont/ for Windows or
+ * http://www.bmglyph.com/ for Mac.
  *
  * A BitmapText can only be created when the font is loaded
  *
@@ -16,9 +20,7 @@ import { removeItems, getResolutionOfUrl } from '@pixi/utils';
  * let bitmapText = new PIXI.BitmapText("text using a fancy font!", {font: "35px Desyrel", align: "right"});
  * ```
  *
- * http://www.angelcode.com/products/bmfont/ for Windows or
- *
- * http://www.bmglyph.com/ for Mac.
+
  *
  * @class
  * @extends PIXI.Container

--- a/packages/text-bitmap/src/BitmapText.js
+++ b/packages/text-bitmap/src/BitmapText.js
@@ -6,14 +6,21 @@ import { Sprite } from '@pixi/sprite';
 import { removeItems, getResolutionOfUrl } from '@pixi/utils';
 
 /**
- * A BitmapText object will create a line or multiple lines of text using bitmap font. To
- * split a line you can use '\n', '\r' or '\r\n' in your string.
+ * A BitmapText object will create a line or multiple lines of text using bitmap font.
+ *
+ * The primary advantage of this class over Text is that all of your textures are pre-generated and loading,
+ * meaning that rendering is fast, and changing text has no performance implications.
+ *
+ * The primary disadvantage is that you need to preload the bitmap font assets, and thus the styling is set in stone.
+ * Supporting character sets other than latin, such as CJK languages, may be impractical due to the number of characters.
+ *
+ * To split a line you can use '\n', '\r' or '\r\n' in your string.
  *
  * You can generate the fnt files using
  * http://www.angelcode.com/products/bmfont/ for Windows or
  * http://www.bmglyph.com/ for Mac.
  *
- * A BitmapText can only be created when the font is loaded
+ * A BitmapText can only be created when the font is loaded.
  *
  * ```js
  * // in this case the font is in a file called 'desyrel.fnt'

--- a/packages/text/src/Text.js
+++ b/packages/text/src/Text.js
@@ -15,8 +15,18 @@ const defaultDestroyOptions = {
 };
 
 /**
- * A Text Object will create a line or multiple lines of text. To split a line you can use '\n' in your text string,
- * or add a wordWrap property set to true and and wordWrapWidth property with a value in the style object.
+ * A Text Object will create a line or multiple lines of text.
+ *
+ * The text is created using the [Canvas API](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API).
+ *
+ * The primary advantage of this class over BitmapText is that you have great control over the style of the next,
+ * which you can change at runtime.
+ *
+ * The primary disadvantages is that each piece of text has it's own texture, which can use more memory.
+ * When text changes, this texture has to be re-generated and re-uploaded to the GPU, taking up time.
+ *
+ * To split a line you can use '\n' in your text string, or, on the `style` object,
+ * change its `wordWrap` property to true and and give the `wordWrapWidth` property a value.
  *
  * A Text can be created directly from a string and a style object,
  * which can be generated [here](https://pixijs.io/pixi-text-style).

--- a/packages/text/src/TextMetrics.js
+++ b/packages/text/src/TextMetrics.js
@@ -637,11 +637,13 @@ export default class TextMetrics
 
 /**
  * Internal return object for {@link PIXI.TextMetrics.measureFont `TextMetrics.measureFont`}.
- * @class FontMetrics
- * @memberof PIXI.TextMetrics
+ *
+ * @typedef {object} FontMetrics
  * @property {number} ascent - The ascent distance
  * @property {number} descent - The descent distance
  * @property {number} fontSize - Font size from ascent to descent
+ * @memberof PIXI.TextMetrics
+ * @private
  */
 
 const canvas = document.createElement('canvas');

--- a/packages/text/src/TextStyle.js
+++ b/packages/text/src/TextStyle.js
@@ -37,9 +37,11 @@ const defaultStyle = {
 };
 
 /**
- * A TextStyle Object decorates a Text Object. It can be shared between
- * multiple Text objects. Changing the style will update all text objects using it.
- * It can be generated [here](https://pixijs.io/pixi-text-style).
+ * A TextStyle Object contains information to decorate a Text objects.
+ *
+ * An instance can be shared between multiple Text objects; then changing the style will update all text objects using it.
+ *
+ * A tool can be used to generate a text style [here](https://pixijs.io/pixi-text-style).
  *
  * @class
  * @memberof PIXI

--- a/packages/ticker/src/Ticker.js
+++ b/packages/ticker/src/Ticker.js
@@ -4,10 +4,9 @@ import TickerListener from './TickerListener';
 
 /**
  * A Ticker class that runs an update loop that other objects listen to.
- * This class is composed around listeners
- * meant for execution on the next requested animation frame.
- * Animation frames are requested only when necessary,
- * e.g. When the ticker is started and the emitter has listeners.
+ *
+ * This class is composed around listeners meant for execution on the next requested animation frame.
+ * Animation frames are requested only when necessary, e.g. When the ticker is started and the emitter has listeners.
  *
  * @class
  * @memberof PIXI

--- a/packages/ticker/src/Ticker.js
+++ b/packages/ticker/src/Ticker.js
@@ -14,9 +14,6 @@ import TickerListener from './TickerListener';
  */
 export default class Ticker
 {
-    /**
-     *
-     */
     constructor()
     {
         /**

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -18,6 +18,8 @@
  */
 
 /**
+ * A simple JS library that detects mobile devices
+ *
  * @see {@link https://github.com/kaimallea/isMobile}
  *
  * @memberof PIXI.utils
@@ -28,6 +30,8 @@ import isMobile from 'ismobilejs';
 export { isMobile };
 
 /**
+ * Remove items from a javascript array without generating garbage
+ *
  * @see {@link https://github.com/mreinstein/remove-array-items}
  *
  * @memberof PIXI.utils
@@ -38,6 +42,8 @@ import removeItems from 'remove-array-items';
 export { removeItems };
 
 /**
+ * A high performance event emitter
+ *
  * @see {@link https://github.com/primus/eventemitter3}
  *
  * @memberof PIXI.utils
@@ -54,6 +60,8 @@ import * as mixins from './mixins';
 export { mixins };
 
 /**
+ * A polygon triangulation library
+ *
  * @see {@link https://github.com/mapbox/earcut}
  *
  * @memberof PIXI.utils

--- a/packages/utils/src/media/CanvasRenderTarget.js
+++ b/packages/utils/src/media/CanvasRenderTarget.js
@@ -1,7 +1,7 @@
 import { settings } from '@pixi/settings';
 
 /**
- * Creates a Canvas element of the given size.
+ * Creates a Canvas element of the given size to be used as a target for rendering to.
  *
  * @class
  * @memberof PIXI.utils


### PR DESCRIPTION
A run through all the descriptions in the generated docs to re-format / re-word / correct / add.

For example, with http://pixijs.download/dev/docs/PIXI.Matrix.html the description has a useful example for the matrix, but it doesn't show up in the proper format. These things are fixed.

There are a few changes within the docs themselves, but not much at this stage. That'll be another pass through later on.