### PR TITLE
Fixes CanvasExtract plugin canvas method without target

### DIFF
--- a/src/extract/canvas/CanvasExtract.js
+++ b/src/extract/canvas/CanvasExtract.js
@@ -93,7 +93,7 @@ export default class CanvasExtract
         else
         {
             context = renderer.rootContext;
-
+            resolution = renderer.resolution;
             frame = TEMP_RECT;
             frame.width = this.renderer.width;
             frame.height = this.renderer.height;


### PR DESCRIPTION
Fixes #5361

**Broken:** https://pixiplayground.com/#/edit/D7Ej6bF7gjJ34LbtCSTHj
**Fixed:** https://pixiplayground.com/#/edit/5H8_X0gjLAU8iePgEw4_N
