### PR TITLE
A system ticker to sit alongside the shared ticker.

### DIFF
--- a/packages/interaction/src/InteractionManager.js
+++ b/packages/interaction/src/InteractionManager.js
@@ -711,7 +711,7 @@ export default class InteractionManager extends EventEmitter
             return;
         }
 
-        Ticker.shared.add(this.update, this, UPDATE_PRIORITY.INTERACTION);
+        Ticker.system.add(this.update, this, UPDATE_PRIORITY.INTERACTION);
 
         if (window.navigator.msPointerEnabled)
         {
@@ -774,7 +774,7 @@ export default class InteractionManager extends EventEmitter
             return;
         }
 
-        Ticker.shared.remove(this.update, this);
+        Ticker.system.remove(this.update, this);
 
         if (window.navigator.msPointerEnabled)
         {
@@ -819,7 +819,7 @@ export default class InteractionManager extends EventEmitter
 
     /**
      * Updates the state of interactive objects.
-     * Invoked by a throttled ticker update from {@link PIXI.Ticker.shared}.
+     * Invoked by a throttled ticker update from {@link PIXI.Ticker.system}.
      *
      * @param {number} deltaTime - time delta since last tick
      */

--- a/packages/interaction/test/MockPointer.js
+++ b/packages/interaction/test/MockPointer.js
@@ -1,7 +1,7 @@
 const { CanvasRenderer } = require('@pixi/canvas-renderer');
 const { Ticker } = require('@pixi/ticker');
 const { Rectangle } = require('@pixi/math');
-const { shared } = Ticker;
+const { system } = Ticker;
 
 /**
  * Use this to mock mouse/touch/pointer events
@@ -39,7 +39,7 @@ class MockPointer
         this.renderer.sayHello = () => { /* empty */ };
         this.interaction = this.renderer.plugins.interaction;
         this.interaction.supportsTouchEvents = true;
-        shared.remove(this.interaction.update, this.interaction);
+        system.remove(this.interaction.update, this.interaction);
     }
 
     /**

--- a/packages/prepare/src/BasePrepare.js
+++ b/packages/prepare/src/BasePrepare.js
@@ -161,7 +161,7 @@ export default class BasePrepare
             if (!this.ticking)
             {
                 this.ticking = true;
-                Ticker.shared.addOnce(this.tick, this, UPDATE_PRIORITY.UTILITY);
+                Ticker.system.addOnce(this.tick, this, UPDATE_PRIORITY.UTILITY);
             }
         }
         else if (done)
@@ -231,7 +231,7 @@ export default class BasePrepare
         else
         {
             // if we are not finished, on the next rAF do this again
-            Ticker.shared.addOnce(this.tick, this, UPDATE_PRIORITY.UTILITY);
+            Ticker.system.addOnce(this.tick, this, UPDATE_PRIORITY.UTILITY);
         }
     }
 
@@ -308,7 +308,7 @@ export default class BasePrepare
     {
         if (this.ticking)
         {
-            Ticker.shared.remove(this.tick, this);
+            Ticker.system.remove(this.tick, this);
         }
         this.ticking = false;
         this.addHooks = null;

--- a/packages/prepare/test/BasePrepare.js
+++ b/packages/prepare/test/BasePrepare.js
@@ -159,7 +159,7 @@ describe('PIXI.prepare.BasePrepare', function ()
         prep.destroy();
     });
 
-    it('should attach to SharedTicker', function (done)
+    it('should attach to the system ticker', function (done)
     {
         const prep = new BasePrepare();
 

--- a/packages/ticker/src/Ticker.js
+++ b/packages/ticker/src/Ticker.js
@@ -537,11 +537,13 @@ export default class Ticker
     }
 
     /**
-     * The shared ticker instance used by {@link PIXI.AnimatedSprite}.
-     * and by {@link PIXI.interaction.InteractionManager}.
-     * The property {@link PIXI.Ticker#autoStart} is set to `true`
-     * for this instance. Please follow the examples for usage, including
-     * how to opt-out of auto-starting the shared ticker.
+     * The shared ticker instance used by {@link PIXI.AnimatedSprite} and by
+     * {@link PIXI.VideoResource} to update animation frames / video textures.
+     *
+     * It may also be used by {@link PIXI.Application} if created with the `sharedTicker` option property set to true.
+     *
+     * The property {@link PIXI.Ticker#autoStart} is set to `true` for this instance.
+     * Please follow the examples for usage, including how to opt-out of auto-starting the shared ticker.
      *
      * @example
      * let ticker = PIXI.Ticker.shared;
@@ -558,7 +560,6 @@ export default class Ticker
      * // You may use the shared ticker to render...
      * let renderer = PIXI.autoDetectRenderer(800, 600);
      * let stage = new PIXI.Container();
-     * let interactionManager = PIXI.interaction.InteractionManager(renderer);
      * document.body.appendChild(renderer.view);
      * ticker.add(function (time) {
      *     renderer.render(stage);
@@ -589,5 +590,28 @@ export default class Ticker
         }
 
         return Ticker._shared;
+    }
+
+    /**
+     * The system ticker instance used by {@link PIXI.interaction.InteractionManager} and by
+     * {@link PIXI.BasePrepare} for core timing functionality that shouldn't usually need to be paused,
+     * unlike the `shared` ticker which drives visual animations and rendering which may want to be paused.
+     *
+     * The property {@link PIXI.Ticker#autoStart} is set to `true` for this instance.
+     *
+     * @member {PIXI.Ticker}
+     * @static
+     */
+    static get system()
+    {
+        if (!Ticker._system)
+        {
+            const system = Ticker._system = new Ticker();
+
+            system.autoStart = true;
+            system._protected = true;
+        }
+
+        return Ticker._system;
     }
 }

--- a/packages/ticker/src/TickerPlugin.js
+++ b/packages/ticker/src/TickerPlugin.js
@@ -3,10 +3,12 @@ import { UPDATE_PRIORITY } from './const';
 
 /**
  * Middleware for for Application Ticker.
+ *
  * @example
  * import {TickerPlugin} from '@pixi/ticker';
  * import {Application} from '@pixi/app';
  * Application.registerPlugin(TickerPlugin);
+ *
  * @class
  * @memberof PIXI
  */
@@ -14,6 +16,7 @@ export default class TickerPlugin
 {
     /**
      * Initialize the plugin with scope of application instance
+     *
      * @static
      * @private
      * @param {object} [options] - See application options
@@ -49,6 +52,7 @@ export default class TickerPlugin
 
         /**
          * Convenience method for stopping the render.
+         *
          * @method PIXI.Application#stop
          */
         this.stop = () =>
@@ -58,6 +62,7 @@ export default class TickerPlugin
 
         /**
          * Convenience method for starting the render.
+         *
          * @method PIXI.Application#start
          */
         this.start = () =>
@@ -66,7 +71,8 @@ export default class TickerPlugin
         };
 
         /**
-         * Internal reference to the ticker
+         * Internal reference to the ticker.
+         *
          * @type {PIXI.Ticker}
          * @name _ticker
          * @memberof PIXI.Application#
@@ -76,6 +82,7 @@ export default class TickerPlugin
 
         /**
          * Ticker for doing render updates.
+         *
          * @type {PIXI.Ticker}
          * @name ticker
          * @memberof PIXI.Application#
@@ -91,7 +98,8 @@ export default class TickerPlugin
     }
 
     /**
-     * Clean up the ticker, scoped to application
+     * Clean up the ticker, scoped to application.
+     *
      * @static
      * @private
      */

--- a/packages/ticker/test/Ticker.js
+++ b/packages/ticker/test/Ticker.js
@@ -1,5 +1,5 @@
 const { Ticker, UPDATE_PRIORITY } = require('../');
-const { shared } = Ticker;
+const { shared, system } = Ticker;
 
 describe('PIXI.Ticker', function ()
 {
@@ -31,6 +31,7 @@ describe('PIXI.Ticker', function ()
     {
         expect(Ticker).to.be.a.function;
         expect(shared).to.be.an.instanceof(Ticker);
+        expect(system).to.be.an.instanceof(Ticker);
     });
 
     it('should create a new ticker and destroy it', function ()
@@ -62,6 +63,16 @@ describe('PIXI.Ticker', function ()
         shared.destroy();
         expect(shared._head).to.not.be.null;
         expect(shared.started).to.be.true;
+    });
+
+    it('should protect destroying system ticker', function ()
+    {
+        const listener = sinon.spy();
+
+        system.add(listener); // needed to autoStart
+        system.destroy();
+        expect(system._head).to.not.be.null;
+        expect(system.started).to.be.true;
     });
 
     it('should add and remove listener', function ()


### PR DESCRIPTION
The shared ticker is tricky atm because you may want to pause the visuals on screen, but you don't want to effect the interactions or core system behaviour.
So having this system ticker separate means that you can now safely pause the shared ticker without worrying about it effecting that system behaviour

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
