### PR TITLE
Updated README example to use new PIXI.Loader.shared method

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ const app = new PIXI.Application();
 document.body.appendChild(app.view);
 
 // load the texture we need
-PIXI.loader.add('bunny', 'bunny.png').load((loader, resources) => {
+PIXI.Loader.shared.add('bunny', 'bunny.png').load((loader, resources) => {
     // This creates a texture from a 'bunny.png' image
     const bunny = new PIXI.Sprite(resources.bunny.texture);
 


### PR DESCRIPTION


<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

First, hello I am new to this project!

I wanted to give this a whirl and noticed that the README had a bootstrap example, but I was getting an ugly deprecated warning within my IDE.

So I simply updated the README to use the newer non deprecated 

`PIXI.Loader.shared.add`

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
