### PR TITLE
v5 - Fixes Text drop shadows

### DIFF
--- a/packages/text/src/Text.js
+++ b/packages/text/src/Text.js
@@ -3,7 +3,7 @@ import { Sprite } from '@pixi/sprite';
 import { Texture } from '@pixi/core';
 import { settings } from '@pixi/settings';
 import { Rectangle } from '@pixi/math';
-import { sign, trimCanvas } from '@pixi/utils';
+import { sign, trimCanvas, hex2rgb, string2hex } from '@pixi/utils';
 import { TEXT_GRADIENT } from './const';
 import TextStyle from './TextStyle';
 import TextMetrics from './TextMetrics';
@@ -172,56 +172,21 @@ export default class Text extends Sprite
 
         if (style.dropShadow)
         {
-            context.fillStyle = style.dropShadowColor;
-            context.globalAlpha = style.dropShadowAlpha;
+            const dropShadowColor = style.dropShadowColor;
+            const rgb = hex2rgb(typeof dropShadowColor === 'number' ? dropShadowColor : string2hex(dropShadowColor));
+
+            context.shadowColor = `rgba(${rgb[0] * 255},${rgb[1] * 255},${rgb[2] * 255},${style.dropShadowAlpha})`;
             context.shadowBlur = style.dropShadowBlur;
-
-            if (style.dropShadowBlur > 0)
-            {
-                context.shadowColor = style.dropShadowColor;
-            }
-
-            const xShadowOffset = Math.cos(style.dropShadowAngle) * style.dropShadowDistance;
-            const yShadowOffset = Math.sin(style.dropShadowAngle) * style.dropShadowDistance;
-
-            for (let i = 0; i < lines.length; i++)
-            {
-                linePositionX = style.strokeThickness / 2;
-                linePositionY = ((style.strokeThickness / 2) + (i * lineHeight)) + fontProperties.ascent;
-
-                if (style.align === 'right')
-                {
-                    linePositionX += maxLineWidth - lineWidths[i];
-                }
-                else if (style.align === 'center')
-                {
-                    linePositionX += (maxLineWidth - lineWidths[i]) / 2;
-                }
-
-                if (style.fill)
-                {
-                    this.drawLetterSpacing(
-                        lines[i],
-                        linePositionX + xShadowOffset + style.padding, linePositionY + yShadowOffset + style.padding
-                    );
-
-                    if (style.stroke && style.strokeThickness)
-                    {
-                        context.strokeStyle = style.dropShadowColor;
-                        this.drawLetterSpacing(
-                            lines[i],
-                            linePositionX + xShadowOffset + style.padding, linePositionY + yShadowOffset + style.padding,
-                            true
-                        );
-                        context.strokeStyle = style.stroke;
-                    }
-                }
-            }
+            context.shadowOffsetX = Math.cos(style.dropShadowAngle) * style.dropShadowDistance;
+            context.shadowOffsetY = Math.sin(style.dropShadowAngle) * style.dropShadowDistance;
         }
-
-        // reset the shadow blur and alpha that was set by the drop shadow, for the regular text
-        context.shadowBlur = 0;
-        context.globalAlpha = 1;
+        else
+        {
+            context.shadowColor = 0;
+            context.shadowBlur = 0;
+            context.shadowOffsetX = 0;
+            context.shadowOffsetY = 0;
+        }
 
         // set canvas text styles
         context.fillStyle = this._generateFillStyle(style, lines);

--- a/packages/utils/src/color/hex.js
+++ b/packages/utils/src/color/hex.js
@@ -35,6 +35,24 @@ export function hex2string(hex)
 }
 
 /**
+ * Converts a hex string to a hex color number.
+ *
+ * @memberof PIXI.utils
+ * @function string2hex
+ * @param {string} The string color that starts with #
+ * @return {number} hex - Number in hex
+ */
+export function string2hex(string)
+{
+    if (typeof string === 'string' && string[0] === '#')
+    {
+        string = string.substr(1);
+    }
+
+    return parseInt(string, 16);
+}
+
+/**
  * Converts a color as an [R, G, B] array to a hex number
  *
  * @memberof PIXI.utils


### PR DESCRIPTION
Uses the canvas api for applying the drop shadow functionality, rather than adding it via extra draw calls.
This should be quicker to draw, as well as giving more accurate results; fixing issues such as https://github.com/pixijs/pixi.js/issues/4772