### PR TITLE
there is no BLEND_MODES.NONE

### DIFF
--- a/packages/constants/src/index.js
+++ b/packages/constants/src/index.js
@@ -59,6 +59,10 @@ export const RENDERER_TYPE = {
  * @property {number} SATURATION
  * @property {number} COLOR
  * @property {number} LUMINOSITY
+ * @property {number} NORMAL_NPM
+ * @property {number} ADD_NPM
+ * @property {number} SCREEN_NPM
+ * @property {number} NONE
  */
 export const BLEND_MODES = {
     NORMAL:         0,
@@ -81,6 +85,7 @@ export const BLEND_MODES = {
     NORMAL_NPM:     17,
     ADD_NPM:        18,
     SCREEN_NPM:     19,
+    NONE:           20
 };
 
 /**

--- a/packages/constants/src/index.js
+++ b/packages/constants/src/index.js
@@ -85,7 +85,7 @@ export const BLEND_MODES = {
     NORMAL_NPM:     17,
     ADD_NPM:        18,
     SCREEN_NPM:     19,
-    NONE:           20
+    NONE:           20,
 };
 
 /**

--- a/packages/core/src/state/State.js
+++ b/packages/core/src/state/State.js
@@ -1,3 +1,5 @@
+import { BLEND_MODES } from '@pixi/constants';
+
 /* eslint-disable max-len */
 
 const BLEND = 0;
@@ -21,7 +23,7 @@ export default class State
     {
         this.data = 0;
 
-        this.blendMode = 0;
+        this.blendMode = BLEND_MODES.NORMAL;
         this.polygonOffset = 0;
 
         this.blend = true;
@@ -136,8 +138,7 @@ export default class State
 
     set blendMode(value) // eslint-disable-line require-jsdoc
     {
-        // 17 is NO BLEND
-        this.blend = (value !== 17);
+        this.blend = (value !== BLEND_MODES.NONE);
         this._blendMode = value;
     }
 

--- a/packages/core/src/state/utils/mapWebGLBlendModesToPixi.js
+++ b/packages/core/src/state/utils/mapWebGLBlendModesToPixi.js
@@ -31,7 +31,6 @@ export default function mapWebGLBlendModesToPixi(gl, array = [])
     array[BLEND_MODES.SATURATION] = [gl.ONE, gl.ONE_MINUS_SRC_ALPHA];
     array[BLEND_MODES.COLOR] = [gl.ONE, gl.ONE_MINUS_SRC_ALPHA];
     array[BLEND_MODES.LUMINOSITY] = [gl.ONE, gl.ONE_MINUS_SRC_ALPHA];
-    array[BLEND_MODES.NONE] = [0, 0];
 
     // not-premultiplied blend modes
     array[BLEND_MODES.NORMAL_NPM] = [gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA];

--- a/packages/core/src/state/utils/mapWebGLBlendModesToPixi.js
+++ b/packages/core/src/state/utils/mapWebGLBlendModesToPixi.js
@@ -31,6 +31,7 @@ export default function mapWebGLBlendModesToPixi(gl, array = [])
     array[BLEND_MODES.SATURATION] = [gl.ONE, gl.ONE_MINUS_SRC_ALPHA];
     array[BLEND_MODES.COLOR] = [gl.ONE, gl.ONE_MINUS_SRC_ALPHA];
     array[BLEND_MODES.LUMINOSITY] = [gl.ONE, gl.ONE_MINUS_SRC_ALPHA];
+    array[BLEND_MODES.NONE] = [0, 0];
 
     // not-premultiplied blend modes
     array[BLEND_MODES.NORMAL_NPM] = [gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA];


### PR DESCRIPTION
As seen [here](https://github.com/pixijs/pixi.js/blob/dev/packages/constants/src/index.js#L63-L83), there is no `BLEND_MODES.NONE`