### PR TITLE
Zero point manage

### DIFF
--- a/packages/math/src/ObservablePoint.js
+++ b/packages/math/src/ObservablePoint.js
@@ -136,7 +136,7 @@ export default class ObservablePoint
         !this.zero && this.zeroSet();
         continuity = continuity? this.clone() : this.zero;
         this.copy(this.zero);
-        this.zero = continuity;
+        this.zero.copy(continuity);
         return this;
     }
 

--- a/packages/math/src/ObservablePoint.js
+++ b/packages/math/src/ObservablePoint.js
@@ -103,6 +103,58 @@ export default class ObservablePoint
     {
         return (p.x === this._x) && (p.y === this._y);
     }
+    
+    /**
+     * Store zero x, y in ObservablePoint
+     *
+     * @param {number} [x=this._x] - store zero x from parent, value or PIXI.Point
+     * @param {number} [y=this._y] - store zero y from parent, value or PIXI.Point
+     * @returns {scope} Return ObservablePoint scope for chaining.
+     */
+    zeroSet(x, y, z)
+    {   
+        this.zero = this.zero || new PIXI.Point();
+        if(!arguments.length){
+            this.zero.copy(this);
+        }else
+        if(isNaN(x)){
+            this.zero.copy.copy(x);
+        }else{
+            this.zero.set(...arguments);
+        };
+        return this;
+    }
+
+    /**
+     * Compute difference between zero and current values
+     *
+     * @param {boolean} continuity - store current value in zero point
+     * @returns {scope} Return ObservablePoint scope for chaining.
+     */
+    zeroApply(continuity)
+    {       
+        !this.zero && this.zeroSet();
+        continuity = continuity? this.clone() : this.zero;
+        this.copy(this.zero);
+        this.zero = continuity;
+        return this;
+    }
+
+    /**
+     * Compute difference between zero and current values
+     *
+     * @param {boolean} abs - use Math.abs on values
+     * @returns {PIXI.Point} Return values in PIXI.Point.
+     */
+    zeroDiff(abs)
+    {   
+        !this.zero && this.zeroSet();
+        let x = this.zero && this.zero.x || this._x;
+        let y = this.zero && this.zero.y || this._y;
+        x = abs? Math.abs(this._x-x):this._x-x;
+        y = abs? Math.abs(this._y-y):this._y-y;
+        return new PIXI.Point(x,y);
+    }
 
     /**
      * The position of the displayObject on the x axis relative to the local coordinates of the parent.


### PR DESCRIPTION
My ideas are a little more clear,
here is the feature I would like to see in pixijs for the management of value in ObservablePoint
:)
the only small problem is that it can not take into account the `rotation`, and the `colors` attributs, 
maybe a new feature request for make this in future can be cool. 
ObservablePoint
`rotation : angle,degree`
`colors: tint,rgb,alpha`
thank you all for your great work


##### Description of change
<!-- Provide a description of the change below this comment. -->

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included `not avaible`
- [ ] Documentation is changed or added `yes`
- [ ] Lint process passed (`npm run lint`) ``
```
  106:1   warning  Trailing spaces not allowed                                            no-trailing-spaces
  114:16  warning  'y' is defined but never used                                          no-unused-vars
  114:19  warning  'z' is defined but never used                                          no-unused-vars
  115:6   warning  Trailing spaces not allowed                                            no-trailing-spaces
  116:38  warning  'PIXI' is not defined                                                  no-undef
  117:9   warning  Expected space(s) after "if"                                           keyword-spacing
  117:30  warning  Missing space before opening brace                                     space-before-blocks
  117:30  warning  Opening curly brace appears on the same line as controlling statement  brace-style
  119:9   warning  Closing curly brace appears on the same line as the subsequent block   brace-style
  119:10  warning  Expected space(s) before "else"                                        keyword-spacing
  120:9   warning  Expected space(s) after "if"                                           keyword-spacing
  120:21  warning  Missing space before opening brace                                     space-before-blocks
  120:21  warning  Opening curly brace appears on the same line as controlling statement  brace-style
  122:9   warning  Closing curly brace appears on the same line as the subsequent block   brace-style
  122:10  warning  Expected space(s) before "else"                                        keyword-spacing
  122:10  warning  Expected space(s) after "else"                                         keyword-spacing
  122:14  warning  Opening curly brace appears on the same line as controlling statement  brace-style
  124:10  warning  Unnecessary semicolon                                                  no-extra-semi
  124:10  warning  Using 'EmptyStatement' is not allowed                                  no-restricted-syntax
  125:9   warning  Expected newline before return statement                               newline-before-return
  135:6   warning  Trailing spaces not allowed                                            no-trailing-spaces
  136:9   warning  Expected an assignment or function call and instead saw an expression  no-unused-expressions
  137:32  warning  Operator '?' must be spaced                                            space-infix-ops
  140:9   warning  Expected newline before return statement                               newline-before-return
  150:6   warning  Trailing spaces not allowed                                            no-trailing-spaces
  151:9   warning  Expected an assignment or function call and instead saw an expression  no-unused-expressions
  152:27  warning  Unexpected mix of '&&' and '||'                                        no-mixed-operators
  152:42  warning  Unexpected mix of '&&' and '||'                                        no-mixed-operators
  153:9   warning  Expected blank line after variable declarations                        newline-after-var
  153:27  warning  Unexpected mix of '&&' and '||'                                        no-mixed-operators
  153:42  warning  Unexpected mix of '&&' and '||'                                        no-mixed-operators
  154:16  warning  Operator '?' must be spaced                                            space-infix-ops
  154:34  warning  Operator '-' must be spaced                                            space-infix-ops
  154:45  warning  Operator '-' must be spaced                                            space-infix-ops
  155:16  warning  Operator '?' must be spaced                                            space-infix-ops
  155:34  warning  Operator '-' must be spaced                                            space-infix-ops
  155:45  warning  Operator '-' must be spaced                                            space-infix-ops
  156:9   warning  Expected newline before return statement                               newline-before-return
  156:20  warning  'PIXI' is not defined                                                  no-undef
  156:32  warning  A space is required after ','                                          comma-spacing
```

