### PR TITLE
dispose framebuffer like in v4

### DIFF
--- a/packages/core/src/framebuffer/Framebuffer.js
+++ b/packages/core/src/framebuffer/Framebuffer.js
@@ -1,3 +1,4 @@
+import Runner from 'mini-runner';
 import Texture from '../textures/BaseTexture';
 import { FORMATS, TYPES } from '@pixi/constants';
 
@@ -29,6 +30,8 @@ export default class Framebuffer
         this.colorTextures = [];
 
         this.glFramebuffers = {};
+
+        this.disposeRunner = new Runner('disposeFramebuffer', 2);
     }
 
     /**
@@ -139,5 +142,13 @@ export default class Framebuffer
         {
             this.depthTexture.setSize(width, height);
         }
+    }
+
+    /**
+     * disposes WebGL resources that are connected to this geometry
+     */
+    dispose()
+    {
+        this.disposeRunner.run(this, false);
     }
 }

--- a/packages/core/src/renderTexture/BaseRenderTexture.js
+++ b/packages/core/src/renderTexture/BaseRenderTexture.js
@@ -85,7 +85,7 @@ export default class BaseRenderTexture extends BaseTexture
 
         this.clearColor = [0, 0, 0, 0];
 
-        this.frameBuffer = new Framebuffer(this.width * this.resolution, this.height * this.resolution)
+        this.framebuffer = new Framebuffer(this.width * this.resolution, this.height * this.resolution)
             .addColorTexture(0, this)
             .enableStencil();
 
@@ -116,7 +116,21 @@ export default class BaseRenderTexture extends BaseTexture
     {
         width = Math.ceil(width);
         height = Math.ceil(height);
-        this.frameBuffer.resize(width * this.resolution, height * this.resolution);
+        this.framebuffer.resize(width * this.resolution, height * this.resolution);
+    }
+
+    /**
+     * Frees the texture and framebuffer from WebGL memory without destroying this texture object.
+     * This means you can still use the texture later which will upload it to GPU
+     * memory again.
+     *
+     * @fires PIXI.BaseTexture#dispose
+     */
+    dispose()
+    {
+        this.framebuffer.dispose();
+
+        super.dispose();
     }
 
     /**
@@ -126,6 +140,9 @@ export default class BaseRenderTexture extends BaseTexture
     destroy()
     {
         super.destroy(true);
+
+        this.framebuffer = null;
+
         this.renderer = null;
     }
 }

--- a/packages/core/src/renderTexture/RenderTextureSystem.js
+++ b/packages/core/src/renderTexture/RenderTextureSystem.js
@@ -92,7 +92,7 @@ export default class RenderTextureSystem extends System
                 sourceFrame = destinationFrame;
             }
 
-            this.renderer.framebuffer.bind(baseTexture.frameBuffer, destinationFrame);
+            this.renderer.framebuffer.bind(baseTexture.framebuffer, destinationFrame);
 
             this.renderer.projection.update(destinationFrame, sourceFrame, resolution, false);
             this.renderer.stencil.setMaskStack(baseTexture.stencilMaskStack);

--- a/packages/core/src/textures/TextureGCSystem.js
+++ b/packages/core/src/textures/TextureGCSystem.js
@@ -93,7 +93,7 @@ export default class TextureGCSystem extends System
             const texture = managedTextures[i];
 
             // only supports non generated textures at the moment!
-            if (!texture.frameBuffer && this.count - texture.touched > this.maxIdle)
+            if (!texture.framebuffer && this.count - texture.touched > this.maxIdle)
             {
                 tm.destroyTexture(texture, true);
                 managedTextures[i] = null;


### PR DESCRIPTION
Fiddle from https://github.com/pixijs/pixi.js/pull/5328 , check that shift+escape in chrome dont give you 1 extra gig in GPU memory.

https://jsfiddle.net/Hackerham/w6y12rag/1/