### PR TITLE
V4.x nineslice tint

### DIFF
--- a/src/mesh/NineSlicePlane.js
+++ b/src/mesh/NineSlicePlane.js
@@ -108,15 +108,15 @@ export default class NineSlicePlane extends Plane
          * Cached tint value so we can tell when the tint is changed.
          *
          * @member {number}
-         * @memberof PIXI.NineSlicePlane#
+         * @protected
          */
         this._cachedTint = 0xFFFFFF;
 
         /**
          * Cached tinted texture.
          *
-         * @member {undefined|PIXI.Texture}
-         * @memberof PIXI.NineSlicePlane#
+         * @member {HTMLCanvasElement}
+         * @protected
          */
         this._tintedTexture = null;
 
@@ -381,7 +381,6 @@ export default class NineSlicePlane extends Plane
 
         this.dirty++;
 
-        // Normal mult UVs behaviour for WebGL renderer
         this.multiplyUvs();
     }
 }

--- a/src/mesh/NineSlicePlane.js
+++ b/src/mesh/NineSlicePlane.js
@@ -120,7 +120,13 @@ export default class NineSlicePlane extends Plane
          */
         this._tintedTexture = null;
 
-        this._canvasCoords = null;
+        /**
+         * Temporary storage for canvas source coords
+         *
+         * @member {number[]}
+         * @private
+         */
+        this._canvasUvs = null;
 
         this.refresh(true);
     }

--- a/src/mesh/NineSlicePlane.js
+++ b/src/mesh/NineSlicePlane.js
@@ -118,25 +118,9 @@ export default class NineSlicePlane extends Plane
          * @member {undefined|PIXI.Texture}
          * @memberof PIXI.NineSlicePlane#
          */
-        this._tintedTexture = undefined;
+        this._tintedTexture = null;
 
-        /**
-         * Cache a copy of premultiplied UV coords for the canvas renderer
-         *
-         * @member {Float32Array}
-         * @memberof PIXI.NineSlicePlane
-         * @private
-         */
-        this._canvasPreMultUvs = undefined;
-
-        /**
-         * Cache a copy of non-premultiplied UV coords for the canvas renderer
-         *
-         * @member {Float32Array}
-         * @memberof PIXI.NineSlicePlane
-         * @private
-         */
-        this._canvasNonPreMultUvs = undefined;
+        this._canvasCoords = null;
 
         this.refresh(true);
     }
@@ -182,26 +166,54 @@ export default class NineSlicePlane extends Plane
     _renderCanvas(renderer)
     {
         const context = renderer.context;
+        const transform = this.worldTransform;
+        const res = renderer.resolution;
+        const isTinted = this.tint !== 0xFFFFFF;
+        const texture = this._texture;
 
         // Work out tinting
-        if (this.tint !== 0xFFFFFF)
+        if (isTinted)
         {
-            if (this.tint !== this._cachedTint)
+            if (this._cachedTint !== this.tint)
             {
                 // Tint has changed, need to update the tinted texture and use that instead
 
                 this._cachedTint = this.tint;
 
                 this._tintedTexture = CanvasTinter.getTintedTexture(this, this.tint);
-                this._refresh();
             }
+        }
+
+        const textureSource = !isTinted ? texture.baseTexture.source : this._tintedTexture;
+
+        if (!this._canvasUvs)
+        {
+            this._canvasUvs = [0, 0, 0, 0, 0, 0, 0, 0];
+        }
+
+        const vertices = this.vertices;
+        const uvs = this._canvasUvs;
+        const u0 = isTinted ? 0 : texture.frame.x;
+        const v0 = isTinted ? 0 : texture.frame.y;
+        const u1 = u0 + texture.frame.width;
+        const v1 = v0 + texture.frame.height;
+
+        uvs[0] = u0;
+        uvs[1] = u0 + this._leftWidth;
+        uvs[2] = u1 - this._rightWidth;
+        uvs[3] = u1;
+        uvs[4] = v0;
+        uvs[5] = v0 + this._topHeight;
+        uvs[6] = v1 - this._bottomHeight;
+        uvs[7] = v1;
+
+        for (let i = 0; i < 8; i++)
+        {
+            uvs[i] *= texture.baseTexture.resolution;
         }
 
         context.globalAlpha = this.worldAlpha;
         renderer.setBlendMode(this.blendMode);
-
-        const transform = this.worldTransform;
-        const res = renderer.resolution;
 
         if (renderer.roundPixels)
         {
@@ -226,74 +238,20 @@ export default class NineSlicePlane extends Plane
             );
         }
 
-        const isTinted = this.tint !== 0xFFFFFF;
-        const base = this._texture.baseTexture;
-        const textureSource = !isTinted ? base.source : this._tintedTexture;
-        const w = (!isTinted ? base.width : this._tintedTexture.width) * base.resolution;
-        const h = (!isTinted ? base.height : this._tintedTexture.height) * base.resolution;
-
-        this.drawSegment(context, textureSource, w, h, 0, 1, 10, 11);
-        this.drawSegment(context, textureSource, w, h, 2, 3, 12, 13);
-        this.drawSegment(context, textureSource, w, h, 4, 5, 14, 15);
-        this.drawSegment(context, textureSource, w, h, 8, 9, 18, 19);
-        this.drawSegment(context, textureSource, w, h, 10, 11, 20, 21);
-        this.drawSegment(context, textureSource, w, h, 12, 13, 22, 23);
-        this.drawSegment(context, textureSource, w, h, 16, 17, 26, 27);
-        this.drawSegment(context, textureSource, w, h, 18, 19, 28, 29);
-        this.drawSegment(context, textureSource, w, h, 20, 21, 30, 31);
-    }
-
-    /**
-     * Renders one segment of the plane.
-     * to mimic the exact drawing behavior of stretching the image like WebGL does, we need to make sure
-     * that the source area is at least 1 pixel in size, otherwise nothing gets drawn when a slice size of 0 is used.
-     *
-     * @private
-     * @param {CanvasRenderingContext2D} context - The context to draw with.
-     * @param {CanvasImageSource} textureSource - The source to draw.
-     * @param {number} w - width of the texture
-     * @param {number} h - height of the texture
-     * @param {number} x1 - x index 1
-     * @param {number} y1 - y index 1
-     * @param {number} x2 - x index 2
-     * @param {number} y2 - y index 2
-     */
-    drawSegment(context, textureSource, w, h, x1, y1, x2, y2)
-    {
-        // Pick pre-mult or non-premult based on if we're currently tinted
-        // Tinted will use a canvas containing just that texture, so uses non-premult UVs
-        const uvs = this.tint === 0xFFFFFF ? this._canvasPreMultUvs : this._canvasNonPreMultUvs;
-        const vertices = this.vertices;
-
-        let sw = (uvs[x2] - uvs[x1]) * w;
-        let sh = (uvs[y2] - uvs[y1]) * h;
-        let dw = vertices[x2] - vertices[x1];
-        let dh = vertices[y2] - vertices[y1];
-
-        // make sure the source is at least 1 pixel wide and high, otherwise nothing will be drawn.
-        if (sw < 1)
+        for (let row = 0; row < 3; row++)
         {
-            sw = 1;
-        }
+            for (let col = 0; col < 3; col++)
+            {
+                const ind = (col * 2) + (row * 8);
+                const sw = Math.max(1, uvs[col + 1] - uvs[col]);
+                const sh = Math.max(1, uvs[row + 5] - uvs[row + 4]);
+                const dw = Math.max(1, vertices[ind + 10] - vertices[ind]);
+                const dh = Math.max(1, vertices[ind + 11] - vertices[ind + 1]);
 
-        if (sh < 1)
-        {
-            sh = 1;
+                context.drawImage(textureSource, uvs[col], uvs[row + 4], sw, sh,
+                    vertices[ind], vertices[ind + 1], dw, dh);
+            }
         }
-
-        // make sure destination is at least 1 pixel wide and high, otherwise you get
-        // lines when rendering close to original size.
-        if (dw < 1)
-        {
-            dw = 1;
-        }
-
-        if (dh < 1)
-        {
-            dh = 1;
-        }
-
-        context.drawImage(textureSource, uvs[x1] * w, uvs[y1] * h, sw, sh, vertices[x1], vertices[y1], dw, dh);
     }
 
     /**
@@ -423,14 +381,7 @@ export default class NineSlicePlane extends Plane
 
         this.dirty++;
 
-        // Get copies of the UVs for the canvas renderer before we do any premult
-        this._canvasPreMultUvs = Float32Array.from(this.uvs);
-        this._canvasNonPreMultUvs = Float32Array.from(this.uvs);
-
         // Normal mult UVs behaviour for WebGL renderer
         this.multiplyUvs();
-
-        // Manually apply uvs for stored canvas premults
-        this._uvTransform.multiplyUvs(this._canvasPreMultUvs);
     }
 }


### PR DESCRIPTION
My version of #5371 by @TheWyo , that fixes #3862.

`drawSegment` removed, and `_renderCanvas` has its own temporary uv's. That calls for more optimizations of this function in the future, like custom logic for roundPixels.

I've made an example that uses both resolution and frame cut, based on another old NineSlicePlane example: [https://www.pixiplayground.com/#/edit/HrETbRGJmES~XExxtdFy~](https://www.pixiplayground.com/#/edit/HrETbRGJmES~XExxtdFy~)

There are two renderers (WebGL and canvas2d, left and right), and I cut nineSlice texture exactly on the middle of the border.
