### PR TITLE
Fixes depthTexture to work properly

### DIFF
--- a/packages/core/src/framebuffer/Framebuffer.js
+++ b/packages/core/src/framebuffer/Framebuffer.js
@@ -1,5 +1,6 @@
 import Runner from 'mini-runner';
 import Texture from '../textures/BaseTexture';
+import DepthResource from '../textures/resources/DepthResource';
 import { FORMATS, TYPES } from '@pixi/constants';
 
 /**
@@ -74,7 +75,7 @@ export default class Framebuffer
     addDepthTexture(texture)
     {
         /* eslint-disable max-len */
-        this.depthTexture = texture || new Texture(null, { scaleMode: 0,
+        this.depthTexture = texture || new Texture(new DepthResource(null, { width: this.width, height: this.height }), { scaleMode: 0,
             resolution: 1,
             width: this.width,
             height: this.height,

--- a/packages/core/src/framebuffer/FramebufferSystem.js
+++ b/packages/core/src/framebuffer/FramebufferSystem.js
@@ -352,7 +352,8 @@ export default class FramebufferSystem extends System
             gl.bindRenderbuffer(gl.RENDERBUFFER, fbo.stencil);
 
             // TODO.. this is depth AND stencil?
-            if (!framebuffer.depthTexture) { // you can't have both, so one should take priority if enabled
+            if (!framebuffer.depthTexture)
+            { // you can't have both, so one should take priority if enabled
                 gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.RENDERBUFFER, fbo.stencil);
             }
             gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_STENCIL, framebuffer.width, framebuffer.height);

--- a/packages/core/src/textures/resources/DepthResource.js
+++ b/packages/core/src/textures/resources/DepthResource.js
@@ -8,7 +8,6 @@ import BufferResource from './BufferResource';
  */
 export default class DepthResource extends BufferResource
 {
-
     /**
      * Upload the texture to the GPU.
      * @param {PIXI.Renderer} renderer Upload to the renderer

--- a/packages/core/src/textures/resources/DepthResource.js
+++ b/packages/core/src/textures/resources/DepthResource.js
@@ -1,0 +1,59 @@
+import BufferResource from './BufferResource';
+
+/**
+ * Resource type for DepthTexture.
+ * @class
+ * @extends PIXI.resources.BufferResource
+ * @memberof PIXI.resources
+ */
+export default class DepthResource extends BufferResource
+{
+
+    /**
+     * Upload the texture to the GPU.
+     * @param {PIXI.Renderer} renderer Upload to the renderer
+     * @param {PIXI.BaseTexture} baseTexture Reference to parent texture
+     * @param {PIXI.GLTexture} glTexture glTexture
+     * @returns {boolean} true is success
+     */
+    upload(renderer, baseTexture, glTexture)
+    {
+        const gl = renderer.gl;
+
+        gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, baseTexture.premultiplyAlpha);
+
+        if (glTexture.width === baseTexture.width && glTexture.height === baseTexture.height)
+        {
+            gl.texSubImage2D(
+                baseTexture.target,
+                0,
+                0,
+                0,
+                baseTexture.width,
+                baseTexture.height,
+                baseTexture.format,
+                baseTexture.type,
+                this.data
+            );
+        }
+        else
+        {
+            glTexture.width = baseTexture.width;
+            glTexture.height = baseTexture.height;
+
+            gl.texImage2D(
+                baseTexture.target,
+                0,
+                gl.DEPTH_COMPONENT16, // Needed for depth to render properly in webgl2.0
+                baseTexture.width,
+                baseTexture.height,
+                0,
+                baseTexture.format,
+                baseTexture.type,
+                this.data
+            );
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
This is the start of  enabling depthTexture support.

This fixes the depthTexture from not being written to at all, and adds a depthResource that is used to fix the internalType needed for webgl2.0

This is a first pass at it, to get it working fully in webgl2.0. Then Ill move to 1.0 + extensions.

The depth resource is also something I'd like to instead be a option we can pass into either Resource itself as a property (internalFormat) or as a property for baseTexture. For now tho it'll have to do.

<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
