### PR TITLE
Renamed LoaderPlugin to AppLoaderPlugin

### DIFF
--- a/packages/loaders/README.md
+++ b/packages/loaders/README.md
@@ -21,10 +21,10 @@ loader.load(() => {});
 Using the loader as an Application plugin:
 
 ```js 
-import { LoaderPlugin } from '@pixi/loaders';
+import { AppLoaderPlugin } from '@pixi/loaders';
 import { Application } from '@pixi/app';
 
-Application.registerPlugin(LoaderPlugin);
+Application.registerPlugin(AppLoaderPlugin);
 
 const app = new Application();
 app.loader.add('path/to/file.jpg');


### PR DESCRIPTION
This was updated in a previous PR, just fixing the README.