### PR TITLE
Update docs for Application.antialias

### DIFF
--- a/packages/app/src/Application.js
+++ b/packages/app/src/Application.js
@@ -33,7 +33,7 @@ export default class Application
      * @param {boolean} [options.transparent=false] - If the render view is transparent.
      * @param {boolean} [options.autoDensity=false] - Resizes renderer view in CSS pixels to allow for
      *   resolutions other than 1.
-     * @param {boolean} [options.antialias=false] - Sets antialias (only applicable in Chrome at the moment).
+     * @param {boolean} [options.antialias=false] - Sets antialias
      * @param {boolean} [options.preserveDrawingBuffer=false] - Enables drawing buffer preservation, enable this if you
      *  need to call toDataUrl on the WebGL context.
      * @param {number} [options.resolution=1] - The resolution / device pixel ratio of the renderer, retina would be 2.

--- a/packages/canvas/canvas-renderer/src/CanvasRenderer.js
+++ b/packages/canvas/canvas-renderer/src/CanvasRenderer.js
@@ -25,7 +25,7 @@ export default class CanvasRenderer extends AbstractRenderer
      * @param {boolean} [options.transparent=false] - If the render view is transparent, default false
      * @param {boolean} [options.autoDensity=false] - Resizes renderer view in CSS pixels to allow for
      *   resolutions other than 1
-     * @param {boolean} [options.antialias=false] - sets antialias (only applicable in chrome at the moment)
+     * @param {boolean} [options.antialias=false] - sets antialias
      * @param {number} [options.resolution=1] - The resolution / device pixel ratio of the renderer. The
      *  resolution of the renderer retina would be 2.
      * @param {boolean} [options.preserveDrawingBuffer=false] - enables drawing buffer preservation,

--- a/packages/canvas/canvas-renderer/src/autoDetectRenderer.js
+++ b/packages/canvas/canvas-renderer/src/autoDetectRenderer.js
@@ -16,7 +16,7 @@ import CanvasRenderer from './CanvasRenderer';
  * @param {boolean} [options.transparent=false] - If the render view is transparent, default false
  * @param {boolean} [options.autoDensity=false] - Resizes renderer view in CSS pixels to allow for
  *   resolutions other than 1
- * @param {boolean} [options.antialias=false] - sets antialias (only applicable in chrome at the moment)
+ * @param {boolean} [options.antialias=false] - sets antialias
  * @param {boolean} [options.preserveDrawingBuffer=false] - enables drawing buffer preservation, enable this if you
  *  need to call toDataUrl on the webgl context
  * @param {number} [options.backgroundColor=0x000000] - The background color of the rendered area

--- a/packages/core/src/AbstractRenderer.js
+++ b/packages/core/src/AbstractRenderer.js
@@ -28,7 +28,7 @@ export default class AbstractRenderer extends EventEmitter
      * @param {boolean} [options.transparent=false] - If the render view is transparent.
      * @param {boolean} [options.autoDensity=false] - Resizes renderer view in CSS pixels to allow for
      *   resolutions other than 1.
-     * @param {boolean} [options.antialias=false] - Sets antialias (only applicable in Chrome at the moment).
+     * @param {boolean} [options.antialias=false] - Sets antialias
      * @param {number} [options.resolution=1] - The resolution / device pixel ratio of the renderer. The
      *  resolution of the renderer retina would be 2.
      * @param {boolean} [options.preserveDrawingBuffer=false] - Enables drawing buffer preservation,


### PR DESCRIPTION
This flag seems to have an effect in Firefox as well as Chrome, so this
caveat in the docs is no longer relevant.

For example, on Firefox 60.5.0 on my Debian system:

Without `antialias`:
![2019-02-06-160259_225x203_scrot](https://user-images.githubusercontent.com/59292/52373731-64856400-2a29-11e9-89d7-9598525ea6cb.png)

With `antialias`:
![2019-02-06-160251_228x205_scrot](https://user-images.githubusercontent.com/59292/52373750-6f3ff900-2a29-11e9-9222-c33c29b30ff1.png)


##### Pre-Merge Checklist
- [x] Documentation is changed or added