### PR TITLE
Added option to update anchor with defaultAnchor when frame changes.

### DIFF
--- a/src/extras/AnimatedSprite.js
+++ b/src/extras/AnimatedSprite.js
@@ -90,10 +90,15 @@ export default class AnimatedSprite extends core.Sprite
         /**
          * Update anchor to [Texture's defaultAnchor]{@link PIXI.Texture#defaultAnchor} when frame changes.
          *
+         * Useful with [sprite sheet animations]{@link PIXI.Spritesheet#animations} created with tools.
+         * Changing anchor for each frame allows to pin sprite origin to certain moving feature of the frame (e.g. left foot).
+         *
+         * Note: Enabling this will override any previously set `anchor` on each frame change.
+         *
          * @member {boolean}
          * @default false
          */
-        this.animateAnchor = false;
+        this.updateAnchor = false;
 
         /**
          * Function to call when a AnimatedSprite finishes playing
@@ -294,7 +299,7 @@ export default class AnimatedSprite extends core.Sprite
         this._textureID = -1;
         this.cachedTint = 0xFFFFFF;
 
-        if (this.animateAnchor)
+        if (this.updateAnchor)
         {
             this._anchor.copy(this._texture.defaultAnchor);
         }

--- a/src/extras/AnimatedSprite.js
+++ b/src/extras/AnimatedSprite.js
@@ -91,7 +91,8 @@ export default class AnimatedSprite extends core.Sprite
          * Update anchor to [Texture's defaultAnchor]{@link PIXI.Texture#defaultAnchor} when frame changes.
          *
          * Useful with [sprite sheet animations]{@link PIXI.Spritesheet#animations} created with tools.
-         * Changing anchor for each frame allows to pin sprite origin to certain moving feature of the frame (e.g. left foot).
+         * Changing anchor for each frame allows to pin sprite origin to certain moving feature
+         * of the frame (e.g. left foot).
          *
          * Note: Enabling this will override any previously set `anchor` on each frame change.
          *

--- a/src/extras/AnimatedSprite.js
+++ b/src/extras/AnimatedSprite.js
@@ -88,6 +88,14 @@ export default class AnimatedSprite extends core.Sprite
         this.loop = true;
 
         /**
+         * Update anchor to [Texture's defaultAnchor]{@link PIXI.Texture#defaultAnchor} when frame changes.
+         *
+         * @member {boolean}
+         * @default false
+         */
+        this.animateAnchor = false;
+
+        /**
          * Function to call when a AnimatedSprite finishes playing
          *
          * @member {Function}
@@ -285,6 +293,11 @@ export default class AnimatedSprite extends core.Sprite
         this._texture = this._textures[this.currentFrame];
         this._textureID = -1;
         this.cachedTint = 0xFFFFFF;
+
+        if (this.animateAnchor)
+        {
+            this._anchor.copy(this._texture.defaultAnchor);
+        }
 
         if (this.onFrameChange)
         {


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
Each texture in animation can have different defaultAnchor.
This change allows AnimatedSprite's anchor to be updated on each frame.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
