### PR TITLE
Mipmap pow2 compatibility

### DIFF
--- a/packages/constants/src/index.js
+++ b/packages/constants/src/index.js
@@ -257,9 +257,9 @@ export const WRAP_MODES = {
 };
 
 /**
- * The wrap modes that are supported by pixi.
+ * Mipmap filtering modes that are supported by pixi.
  *
- * The {@link PIXI.settings.MIPMAP_TEXTURES} affects the texture filtering.
+ * The {@link PIXI.settings.MIPMAP_TEXTURES} affects default texture filtering.
  * Mipmaps are generated for a baseTexture if its `mipmap` field is `ON`,
  * or its `POW2` and texture dimensions are powers of 2.
  * Due to platform restriction, `ON` option will work like `POW2` for webgl-1.

--- a/packages/constants/src/index.js
+++ b/packages/constants/src/index.js
@@ -270,9 +270,9 @@ export const WRAP_MODES = {
  * @memberof PIXI
  * @static
  * @enum {number}
- * @property {number} OFF - The textures uvs are clamped
- * @property {number} POW2 - Only pow2
- * @property {number} ON - Texture has mipmaps
+ * @property {number} OFF - No mipmaps
+ * @property {number} POW2 - Generate mipmaps if texture dimensions are pow2
+ * @property {number} ON - Always generate mipmaps
  */
 export const MIPMAP_MODES = {
     OFF: 0,

--- a/packages/constants/src/index.js
+++ b/packages/constants/src/index.js
@@ -257,6 +257,30 @@ export const WRAP_MODES = {
 };
 
 /**
+ * The wrap modes that are supported by pixi.
+ *
+ * The {@link PIXI.settings.MIPMAP_TEXTURES} affects the texture filtering.
+ * Mipmaps are generated for a baseTexture if its `mipmap` field is `ON`,
+ * or its `POW2` and texture dimensions are powers of 2.
+ * Due to platform restriction, `ON` option will work like `POW2` for webgl-1.
+ *
+ * This property only affects WebGL.
+ *
+ * @name MIPMAP_MODES
+ * @memberof PIXI
+ * @static
+ * @enum {number}
+ * @property {number} OFF - The textures uvs are clamped
+ * @property {number} POW2 - Only pow2
+ * @property {number} ON - Texture has mipmaps
+ */
+export const MIPMAP_MODES = {
+    OFF: 0,
+    POW2: 1,
+    ON: 2,
+};
+
+/**
  * The gc modes that are supported by pixi.
  *
  * The {@link PIXI.settings.GC_MODE} Garbage Collection mode for PixiJS textures is AUTO

--- a/packages/core/src/textures/BaseTexture.js
+++ b/packages/core/src/textures/BaseTexture.js
@@ -26,7 +26,7 @@ const defaultBufferOptions = {
  *        The current resource to use, for things that aren't Resource objects, will be converted
  *        into a Resource.
  * @param {Object} [options] - Collection of options
- * @param {boolean} [options.mipmap=PIXI.settings.MIPMAP_TEXTURES] - If mipmapping is enabled for texture
+ * @param {PIXI.MIPMAP_MODES} [options.mipmap=PIXI.settings.MIPMAP_TEXTURES] - If mipmapping is enabled for texture
  * @param {PIXI.WRAP_MODES} [options.wrapMode=PIXI.settings.WRAP_MODE] - Wrap mode for textures
  * @param {PIXI.SCALE_MODES} [options.scaleMode=PIXI.settings.SCALE_MODE] - Default scale mode, linear, nearest
  * @param {PIXI.FORMATS} [options.format=PIXI.FORMATS.RGBA] - GL format type
@@ -81,9 +81,10 @@ export default class BaseTexture extends EventEmitter
         this.resolution = resolution || settings.RESOLUTION;
 
         /**
-         * If mipmapping was used for this texture, enable and disable with enableMipmap()
+         * Mipmap mode of the texture, affects downscaled images
          *
-         * @member {boolean}
+         * @member {PIXI.MIPMAP_MODES}
+         * @default PIXI.settings.MIPMAP_TEXTURES
          */
         this.mipmap = mipmap !== undefined ? mipmap : settings.MIPMAP_TEXTURES;
 
@@ -96,9 +97,8 @@ export default class BaseTexture extends EventEmitter
         /**
          * The scale mode to apply when scaling this texture
          *
-         * @member {number}
+         * @member {PIXI.SCALE_MODES}
          * @default PIXI.settings.SCALE_MODE
-         * @see PIXI.SCALE_MODES
          */
         this.scaleMode = scaleMode !== undefined ? scaleMode : settings.SCALE_MODE;
 
@@ -304,7 +304,7 @@ export default class BaseTexture extends EventEmitter
      * Changes style options of BaseTexture
      *
      * @param {PIXI.SCALE_MODES} [scaleMode] - Pixi scalemode
-     * @param {boolean} [mipmap] - enable mipmaps
+     * @param {PIXI.MIPMAP_MODES} [mipmap] - enable mipmaps
      * @returns {BaseTexture} this
      */
     setStyle(scaleMode, mipmap)

--- a/packages/core/src/textures/TextureSystem.js
+++ b/packages/core/src/textures/TextureSystem.js
@@ -1,7 +1,7 @@
 import System from '../System';
 import GLTexture from './GLTexture';
 import { removeItems } from '@pixi/utils';
-import { WRAP_MODES } from '@pixi/constants';
+import { MIPMAP_MODES, WRAP_MODES } from '@pixi/constants';
 
 /**
  * System plugin to the renderer to manage textures.
@@ -282,14 +282,14 @@ export default class TextureSystem extends System
             return;
         }
 
-        if (this.webGLVersion !== 2 && !texture.isPowerOfTwo)
+        if ((texture.mipmap === MIPMAP_MODES.POW2 || this.webGLVersion !== 2) && !texture.isPowerOfTwo)
         {
-            glTexture.mipmap = false;
+            glTexture.mipmap = 0;
             glTexture.wrapMode = WRAP_MODES.CLAMP;
         }
         else
         {
-            glTexture.mipmap = texture.mipmap;
+            glTexture.mipmap = texture.mipmap >= 1;
             glTexture.wrapMode = texture.wrapMode;
         }
 

--- a/packages/settings/src/settings.js
+++ b/packages/settings/src/settings.js
@@ -23,16 +23,16 @@ export default {
      * @static
      * @name MIPMAP_TEXTURES
      * @memberof PIXI.settings
-     * @type {boolean}
-     * @default true
+     * @type {PIXI.MIPMAP_MODES}
+     * @default PIXI.MIPMAP_MODES.POW2
      */
-    MIPMAP_TEXTURES: true,
+    MIPMAP_TEXTURES: 1,
 
     /**
      * Default resolution / device pixel ratio of the renderer.
      *
      * @static
-     * @name RESOLTION
+     * @name RESOLUTION
      * @memberof PIXI.settings
      * @type {number}
      * @default 1


### PR DESCRIPTION
Fixes #5407

This is compatibility PR, that way webgl1 and webgl2 produce the same result. If someone want non-pow2 texture to have mipmaps, they'll have to specify it.

```js
baseTexture.mipmap = PIXI.MIPMAP_MODES.ON;
```

The values are compatible with booleans in v4. `false` is `OFF=0`, `true` is `POW2=1`.

Demo: https://www.pixiplayground.com/#/edit/jk06IGwLU1Q9yT41pv7_j

V4: https://www.pixiplayground.com/#/edit/BuGK_ogiBOqaXCsSHyCe7

First and third colums are the same in V4 and V5, second is `mipmap=ON` for non-pow2 texture. As you see, webgl2 mipmaps are almost the same as webgl1 for enlarged textures.

I propose we use `POW2` mode by default for compatibility, right column for pow2 textures and left for everything else, like in v4.

![image](https://user-images.githubusercontent.com/695831/52522134-348cc980-2c92-11e9-9719-559eeff72257.png)

