### PR TITLE
[v4] cacheAsBitmap fix calculateBounds problem

### DIFF
--- a/src/extras/cacheAsBitmap.js
+++ b/src/extras/cacheAsBitmap.js
@@ -28,6 +28,7 @@ class CacheData
         this.originalRenderWebGL = null;
         this.originalRenderCanvas = null;
         this.originalCalculateBounds = null;
+        this.originalCalculateBounds2 = null;
         this.originalGetLocalBounds = null;
 
         this.originalUpdateTransform = null;
@@ -81,7 +82,8 @@ Object.defineProperties(DisplayObject.prototype, {
                 data.originalRenderCanvas = this.renderCanvas;
 
                 data.originalUpdateTransform = this.updateTransform;
-                data.originalCalculateBounds = this._calculateBounds;
+                data.originalCalculateBounds = this.calculateBounds;
+                data.originalCalculateBounds2 = this._calculateBounds;
                 data.originalGetLocalBounds = this.getLocalBounds;
 
                 data.originalDestroy = this.destroy;
@@ -107,7 +109,8 @@ Object.defineProperties(DisplayObject.prototype, {
 
                 this.renderWebGL = data.originalRenderWebGL;
                 this.renderCanvas = data.originalRenderCanvas;
-                this._calculateBounds = data.originalCalculateBounds;
+                this.calculateBounds = data.originalCalculateBounds;
+                this._calculateBounds = data.originalCalculateBounds2;
                 this.getLocalBounds = data.originalGetLocalBounds;
 
                 this.destroy = data.originalDestroy;

--- a/src/extras/cacheAsBitmap.js
+++ b/src/extras/cacheAsBitmap.js
@@ -219,7 +219,10 @@ DisplayObject.prototype._initCachedDisplayObject = function _initCachedDisplayOb
     renderer.filterManager.filterStack = stack;
 
     this.renderWebGL = this._renderCachedWebGL;
+    // the rest is the same as for Canvas
     this.updateTransform = this.displayObjectUpdateTransform;
+    this.calculateBounds = this._calculateCachedBounds;
+    this.getLocalBounds = this._getCachedLocalBounds;
 
     this._mask = null;
     this.filterArea = null;
@@ -232,10 +235,6 @@ DisplayObject.prototype._initCachedDisplayObject = function _initCachedDisplayOb
     cachedSprite.anchor.y = -(bounds.y / bounds.height);
     cachedSprite.alpha = cacheAlpha;
     cachedSprite._bounds = this._bounds;
-
-    // easy bounds..
-    this.calculateBounds = this._calculateCachedBounds;
-    this.getLocalBounds = this._getCachedLocalBounds;
 
     this._cacheData.sprite = cachedSprite;
 
@@ -331,7 +330,10 @@ DisplayObject.prototype._initCachedDisplayObjectCanvas = function _initCachedDis
     renderer.context = cachedRenderTarget;
 
     this.renderCanvas = this._renderCachedCanvas;
+    // the rest is the same as for WebGL
+    this.updateTransform = this.displayObjectUpdateTransform;
     this.calculateBounds = this._calculateCachedBounds;
+    this.getLocalBounds = this._getCachedLocalBounds;
 
     this._mask = null;
     this.filterArea = null;
@@ -342,9 +344,13 @@ DisplayObject.prototype._initCachedDisplayObjectCanvas = function _initCachedDis
     cachedSprite.transform.worldTransform = this.transform.worldTransform;
     cachedSprite.anchor.x = -(bounds.x / bounds.width);
     cachedSprite.anchor.y = -(bounds.y / bounds.height);
-    cachedSprite._bounds = this._bounds;
     cachedSprite.alpha = cacheAlpha;
+    cachedSprite._bounds = this._bounds;
 
+    this._cacheData.sprite = cachedSprite;
+
+    this.transform._parentID = -1;
+    // restore the transform of the cached sprite to avoid the nasty flicker..
     if (!this.parent)
     {
         this.parent = renderer._tempDisplayObjectParent;
@@ -356,10 +362,7 @@ DisplayObject.prototype._initCachedDisplayObjectCanvas = function _initCachedDis
         this.updateTransform();
     }
 
-    this.updateTransform = this.displayObjectUpdateTransform;
-
-    this._cacheData.sprite = cachedSprite;
-
+    // map the hit test..
     this.containsPoint = cachedSprite.containsPoint.bind(cachedSprite);
 };
 

--- a/src/extras/cacheAsBitmap.js
+++ b/src/extras/cacheAsBitmap.js
@@ -83,7 +83,6 @@ Object.defineProperties(DisplayObject.prototype, {
 
                 data.originalUpdateTransform = this.updateTransform;
                 data.originalCalculateBounds = this.calculateBounds;
-                data.originalCalculateBounds2 = this._calculateBounds;
                 data.originalGetLocalBounds = this.getLocalBounds;
 
                 data.originalDestroy = this.destroy;
@@ -110,7 +109,6 @@ Object.defineProperties(DisplayObject.prototype, {
                 this.renderWebGL = data.originalRenderWebGL;
                 this.renderCanvas = data.originalRenderCanvas;
                 this.calculateBounds = data.originalCalculateBounds;
-                this._calculateBounds = data.originalCalculateBounds2;
                 this.getLocalBounds = data.originalGetLocalBounds;
 
                 this.destroy = data.originalDestroy;
@@ -237,7 +235,7 @@ DisplayObject.prototype._initCachedDisplayObject = function _initCachedDisplayOb
     cachedSprite._bounds = this._bounds;
 
     // easy bounds..
-    this._calculateBounds = this._calculateCachedBounds;
+    this.calculateBounds = this._calculateCachedBounds;
     this.getLocalBounds = this._getCachedLocalBounds;
 
     this._cacheData.sprite = cachedSprite;

--- a/src/extras/cacheAsBitmap.js
+++ b/src/extras/cacheAsBitmap.js
@@ -28,7 +28,6 @@ class CacheData
         this.originalRenderWebGL = null;
         this.originalRenderCanvas = null;
         this.originalCalculateBounds = null;
-        this.originalCalculateBounds2 = null;
         this.originalGetLocalBounds = null;
 
         this.originalUpdateTransform = null;


### PR DESCRIPTION
Fix #5416.

Example by @takopus.

Crash Bug, 4.x: https://www.pixiplayground.com/#/edit/UFD711FVtXRvwA~8mIQie 

Press button 4 times, and it'll crash.

Shift Bug, 4.8.1: https://www.pixiplayground.com/#/edit/rIVogz0N~JfQQKR3ItYUc

Press button, sprite shifts.

Fixed: https://www.pixiplayground.com/#/edit/8~rAjGg3Bgicd9o050tKs

Old tests from #5298: 

https://www.pixiplayground.com/#/edit/jg7WEsoNFL1Cy55HB9f69 - shift in 4.8.1

https://www.pixiplayground.com/#/edit/T6MYvWjSO9EXakjVaTHSF - was cut in 4.8.1

https://www.pixiplayground.com/#/edit/~vUkTrNV9CYlxgR_lS_Ue - wrong bounds in 4.8.1

Everything passes on my comp, both Canvas and WebGL.

Also need to cherry-pick it to v5, file looks the same.

I marked it as High, because cacheAsBitmap crashes on CanvasRenderer. 

Lines 84 and 110 are real changes, the rest are refactoring so canvas behaves the same way as webgl.