### PR TITLE
Make `reset` work like in v4.

### DIFF
--- a/packages/core/src/framebuffer/FramebufferSystem.js
+++ b/packages/core/src/framebuffer/FramebufferSystem.js
@@ -35,7 +35,7 @@ export default class FramebufferSystem extends System
         const gl = this.gl = this.renderer.gl;
 
         this.CONTEXT_UID = this.renderer.CONTEXT_UID;
-        this.current = null;
+        this.current = {};
         this.viewport = new Rectangle();
         this.hasMRT = true;
 
@@ -72,7 +72,7 @@ export default class FramebufferSystem extends System
      * Bind a framebuffer
      *
      * @param {PIXI.Framebuffer} framebuffer
-     * @param {PIXI.Rectangle} frame
+     * @param {PIXI.Rectangle} [frame] frame, default is framebuffer size
      */
     bind(framebuffer, frame)
     {
@@ -400,5 +400,16 @@ export default class FramebufferSystem extends System
         {
             this.disposeFramebuffer(list[i], contextLost);
         }
+    }
+
+    /**
+     * resets framebuffer stored state, binds screen framebuffer
+     *
+     * should be called before renderTexture reset()
+     */
+    reset()
+    {
+        this.current = {};
+        this.viewport = new Rectangle();
     }
 }

--- a/packages/core/src/framebuffer/FramebufferSystem.js
+++ b/packages/core/src/framebuffer/FramebufferSystem.js
@@ -32,7 +32,7 @@ export default class FramebufferSystem extends System
          * @member {Framebuffer}
          * @readonly
          */
-        this.undefinedFramebuffer = new Framebuffer(10, 10);
+        this.unknownFramebuffer = new Framebuffer(10, 10);
     }
 
     /**
@@ -43,7 +43,7 @@ export default class FramebufferSystem extends System
         const gl = this.gl = this.renderer.gl;
 
         this.CONTEXT_UID = this.renderer.CONTEXT_UID;
-        this.current = this.undefinedFramebuffer;
+        this.current = this.unknownFramebuffer;
         this.viewport = new Rectangle();
         this.hasMRT = true;
 
@@ -423,7 +423,7 @@ export default class FramebufferSystem extends System
      */
     reset()
     {
-        this.current = this.undefinedFramebuffer;
+        this.current = this.unknownFramebuffer;
         this.viewport = new Rectangle();
     }
 }

--- a/packages/core/src/framebuffer/FramebufferSystem.js
+++ b/packages/core/src/framebuffer/FramebufferSystem.js
@@ -2,6 +2,7 @@ import System from '../System';
 import { Rectangle } from '@pixi/math';
 import { ENV } from '@pixi/constants';
 import { settings } from '../settings';
+import Framebuffer from './Framebuffer';
 
 /**
  * System plugin to the renderer to manage framebuffers.
@@ -25,6 +26,13 @@ export default class FramebufferSystem extends System
          * @readonly
          */
         this.managedFramebuffers = [];
+
+        /**
+         * Framebuffer value that shows that we don't know what is bound
+         * @member {Framebuffer}
+         * @readonly
+         */
+        this.undefinedFramebuffer = new Framebuffer(10, 10);
     }
 
     /**
@@ -35,7 +43,7 @@ export default class FramebufferSystem extends System
         const gl = this.gl = this.renderer.gl;
 
         this.CONTEXT_UID = this.renderer.CONTEXT_UID;
-        this.current = {};
+        this.current = this.undefinedFramebuffer;
         this.viewport = new Rectangle();
         this.hasMRT = true;
 
@@ -409,7 +417,7 @@ export default class FramebufferSystem extends System
      */
     reset()
     {
-        this.current = {};
+        this.current = this.undefinedFramebuffer;
         this.viewport = new Rectangle();
     }
 }

--- a/packages/core/src/renderTexture/RenderTextureSystem.js
+++ b/packages/core/src/renderTexture/RenderTextureSystem.js
@@ -63,7 +63,7 @@ export default class RenderTextureSystem extends System
      * @param {PIXI.Rectangle} sourceFrame
      * @param {PIXI.Rectangle} destinationFrame
      */
-    bind(renderTexture, sourceFrame, destinationFrame)
+    bind(renderTexture = null, sourceFrame, destinationFrame)
     {
         // TODO - do we want this??
         if (this.current === renderTexture) return;

--- a/packages/core/src/renderTexture/RenderTextureSystem.js
+++ b/packages/core/src/renderTexture/RenderTextureSystem.js
@@ -63,7 +63,7 @@ export default class RenderTextureSystem extends System
      * @param {PIXI.Rectangle} sourceFrame
      * @param {PIXI.Rectangle} destinationFrame
      */
-    bind(renderTexture = null, sourceFrame, destinationFrame)
+    bind(renderTexture, sourceFrame, destinationFrame)
     {
         // TODO - do we want this??
         if (this.current === renderTexture) return;
@@ -155,7 +155,6 @@ export default class RenderTextureSystem extends System
     resize()// screenWidth, screenHeight)
     {
         // resize the root only!
-        this.current = {};
         this.bind(null);
     }
 

--- a/packages/core/src/renderTexture/RenderTextureSystem.js
+++ b/packages/core/src/renderTexture/RenderTextureSystem.js
@@ -155,6 +155,17 @@ export default class RenderTextureSystem extends System
     resize()// screenWidth, screenHeight)
     {
         // resize the root only!
+        this.current = {};
+        this.bind(null);
+    }
+
+    /**
+     * Resets renderTexture state
+     */
+    reset()
+    {
+        // Use empty object to force the change
+        this.current = {};
         this.bind(null);
     }
 }

--- a/packages/core/src/renderTexture/RenderTextureSystem.js
+++ b/packages/core/src/renderTexture/RenderTextureSystem.js
@@ -6,6 +6,8 @@ const tempRect = new Rectangle();
 /**
  * System plugin to the renderer to manage render textures.
  *
+ * Should be added after FramebufferSystem
+ *
  * @class
  * @extends PIXI.System
  * @memberof PIXI.systems
@@ -163,8 +165,6 @@ export default class RenderTextureSystem extends System
      */
     reset()
     {
-        // Use empty object to force the change
-        this.current = {};
         this.bind(null);
     }
 }

--- a/packages/core/src/shader/ShaderSystem.js
+++ b/packages/core/src/shader/ShaderSystem.js
@@ -202,6 +202,15 @@ export default class ShaderSystem extends System
     }
 
     /**
+     * Resets ShaderSystem state, does not affect WebGL state
+     */
+    reset()
+    {
+        this.program = null;
+        this.shader = null;
+    }
+
+    /**
      * Destroys this System and removes all its textures
      */
     destroy()

--- a/packages/core/src/state/StateSystem.js
+++ b/packages/core/src/state/StateSystem.js
@@ -148,9 +148,10 @@ export default class StateSystem extends System
      *
      * @param {*} state - The state to set
      */
-    forceState(state) {
+    forceState(state)
+    {
         state = state || this.defaultState;
-        for (let i=0; i<this.map.length; i++)
+        for (let i = 0; i < this.map.length; i++)
         {
             this.map[i].call(this, !!(state.data & (1 << i)));
         }

--- a/packages/core/src/state/StateSystem.js
+++ b/packages/core/src/state/StateSystem.js
@@ -33,29 +33,6 @@ export default class StateSystem extends System
         this.gl = null;
 
         /**
-         * Return from MAX_VERTEX_ATTRIBS
-         * @member {number}
-         * @readonly
-         */
-        this.maxAttribs = null;
-
-        /**
-         * Check we have vao
-         * @member {OES_vertex_array_object}
-         * @readonly
-         */
-        this.nativeVaoExtension = null;
-
-        /**
-         * Attribute state
-         * @member {object}
-         * @readonly
-         * @property {number[]} tempAttribState
-         * @property {number[]} attribState
-         */
-        this.attribState = null;
-
-        /**
          * State ID
          * @member {number}
          * @readonly
@@ -119,20 +96,6 @@ export default class StateSystem extends System
     {
         this.gl = gl;
 
-        this.maxAttribs = gl.getParameter(gl.MAX_VERTEX_ATTRIBS);
-
-        // check we have vao..
-        this.nativeVaoExtension = (
-            gl.getExtension('OES_vertex_array_object')
-            || gl.getExtension('MOZ_OES_vertex_array_object')
-            || gl.getExtension('WEBKIT_OES_vertex_array_object')
-        );
-
-        this.attribState = {
-            tempAttribState: new Array(this.maxAttribs),
-            attribState: new Array(this.maxAttribs),
-        };
-
         this.blendModes = mapWebGLBlendModesToPixi(gl);
 
         this.setState(this.defaultState);
@@ -178,6 +141,25 @@ export default class StateSystem extends System
         {
             this.checks[i](this, state);
         }
+    }
+
+    /**
+     * Sets the state, when previous state is unknown
+     *
+     * @param {*} state - The state to set
+     */
+    forceState(state) {
+        state = state || this.defaultState;
+        for (let i=0; i<this.map.length; i++)
+        {
+            this.map[i].call(this, !!(state.data & (1 << i)));
+        }
+        for (let i = 0; i < this.checks.length; i++)
+        {
+            this.checks[i](this, state);
+        }
+
+        this.stateId = state.data;
     }
 
     /**
@@ -280,52 +262,19 @@ export default class StateSystem extends System
         this.gl.polygonOffset(value, scale);
     }
 
-    /**
-     * Disables all the vaos in use
-     *
-     */
-    resetAttributes()
-    {
-        for (let i = 0; i < this.attribState.tempAttribState.length; i++)
-        {
-            this.attribState.tempAttribState[i] = 0;
-        }
-
-        for (let i = 0; i < this.attribState.attribState.length; i++)
-        {
-            this.attribState.attribState[i] = 0;
-        }
-
-        // im going to assume one is always active for performance reasons.
-        for (let i = 1; i < this.maxAttribs; i++)
-        {
-            this.gl.disableVertexAttribArray(i);
-        }
-    }
-
     // used
     /**
      * Resets all the logic and disables the vaos
      */
     reset()
     {
-        // unbind any VAO if they exist..
-        if (this.nativeVaoExtension)
-        {
-            this.nativeVaoExtension.bindVertexArrayOES(null);
-        }
-
-        // reset all attributes..
-        this.resetAttributes();
-
         this.gl.pixelStorei(this.gl.UNPACK_FLIP_Y_WEBGL, false);
 
+        this.forceState(0);
+
         this._blendEq = true;
-
+        this.blendMode = -1;
         this.setBlendMode(0);
-
-        // TODO?
-        // this.setState(this.defaultState);
     }
 
     /**

--- a/packages/core/src/textures/TextureSystem.js
+++ b/packages/core/src/textures/TextureSystem.js
@@ -149,6 +149,11 @@ export default class TextureSystem extends System
         }
     }
 
+    /**
+     * Resets texture location and bound textures
+     *
+     * Actual `bind(null, i)` calls will be performed at next `unbind()` call
+     */
     reset()
     {
         this._unknownBoundTextures = true;

--- a/packages/core/src/textures/TextureSystem.js
+++ b/packages/core/src/textures/TextureSystem.js
@@ -1,4 +1,5 @@
 import System from '../System';
+import BaseTexture from './BaseTexture';
 import GLTexture from './GLTexture';
 import { removeItems } from '@pixi/utils';
 import { WRAP_MODES } from '@pixi/constants';
@@ -45,7 +46,14 @@ export default class TextureSystem extends System
          * @member {boolean}
          * @private
          */
-        this._unknownBoundTextures = false;
+        this._undefinedBoundTextures = false;
+
+        /**
+         * BaseTexture value that shows that we don't know what is bound
+         * @member {PIXI.BaseTexture}
+         * @readonly
+         */
+        this.undefinedTexture = new BaseTexture();
     }
 
     /**
@@ -156,12 +164,12 @@ export default class TextureSystem extends System
      */
     reset()
     {
-        this._unknownBoundTextures = true;
+        this._undefinedBoundTextures = true;
         this.currentLocation = -1;
 
         for (let i = 0; i < this.boundTextures.length; i++)
         {
-            this.boundTextures[i] = null;
+            this.boundTextures[i] = this.undefinedTexture;
         }
     }
 
@@ -173,14 +181,14 @@ export default class TextureSystem extends System
     {
         const { gl, boundTextures } = this;
 
-        if (this._unknownBoundTextures)
+        if (this._undefinedBoundTextures)
         {
-            this._unknownBoundTextures = false;
+            this._undefinedBoundTextures = false;
             // someone changed webGL state,
             // we have to be sure that our texture does not appear in multi-texture renderer samplers
             for (let i = 0; i < boundTextures.length; i++)
             {
-                if (!boundTextures[i])
+                if (boundTextures[i] === this.undefinedTexture)
                 {
                     this.bind(null, i);
                 }

--- a/packages/core/src/textures/TextureSystem.js
+++ b/packages/core/src/textures/TextureSystem.js
@@ -46,14 +46,14 @@ export default class TextureSystem extends System
          * @member {boolean}
          * @private
          */
-        this._undefinedBoundTextures = false;
+        this._unknownBoundTextures = false;
 
         /**
          * BaseTexture value that shows that we don't know what is bound
          * @member {PIXI.BaseTexture}
          * @readonly
          */
-        this.undefinedTexture = new BaseTexture();
+        this.unknownTexture = new BaseTexture();
     }
 
     /**
@@ -164,12 +164,12 @@ export default class TextureSystem extends System
      */
     reset()
     {
-        this._undefinedBoundTextures = true;
+        this._unknownBoundTextures = true;
         this.currentLocation = -1;
 
         for (let i = 0; i < this.boundTextures.length; i++)
         {
-            this.boundTextures[i] = this.undefinedTexture;
+            this.boundTextures[i] = this.unknownTexture;
         }
     }
 
@@ -181,14 +181,14 @@ export default class TextureSystem extends System
     {
         const { gl, boundTextures } = this;
 
-        if (this._undefinedBoundTextures)
+        if (this._unknownBoundTextures)
         {
-            this._undefinedBoundTextures = false;
+            this._unknownBoundTextures = false;
             // someone changed webGL state,
             // we have to be sure that our texture does not appear in multi-texture renderer samplers
             for (let i = 0; i < boundTextures.length; i++)
             {
-                if (boundTextures[i] === this.undefinedTexture)
+                if (boundTextures[i] === this.unknownTexture)
                 {
                     this.bind(null, i);
                 }

--- a/packages/core/src/textures/TextureSystem.js
+++ b/packages/core/src/textures/TextureSystem.js
@@ -98,6 +98,8 @@ export default class TextureSystem extends System
     /**
      * Bind a texture to a specific location
      *
+     * If you want to unbind something, please use `unbind(texture)` instead of `bind(null, textureLocation)`
+     *
      * @param {PIXI.Texture|PIXI.BaseTexture} texture - Texture to bind
      * @param {number} [location=0] - Location to bind at
      */
@@ -150,6 +152,7 @@ export default class TextureSystem extends System
     reset()
     {
         this._unknownBoundTextures = true;
+        this.currentLocation = -1;
 
         for (let i = 0; i < this.boundTextures.length; i++)
         {

--- a/packages/core/src/textures/TextureSystem.js
+++ b/packages/core/src/textures/TextureSystem.js
@@ -39,6 +39,13 @@ export default class TextureSystem extends System
          * @readonly
          */
         this.managedTextures = [];
+
+        /**
+         * Did someone temper with textures state? We'll overwrite them when we need to unbind something.
+         * @member {boolean}
+         * @private
+         */
+        this._unknownBoundTextures = false;
     }
 
     /**
@@ -140,17 +147,41 @@ export default class TextureSystem extends System
         }
     }
 
+    reset()
+    {
+        this._unknownBoundTextures = true;
+
+        for (let i = 0; i < this.boundTextures.length; i++)
+        {
+            this.boundTextures[i] = null;
+        }
+    }
+
     /**
      * Unbind a texture
      * @param {PIXI.Texture|PIXI.BaseTexture} texture - Texture to bind
      */
     unbind(texture)
     {
-        const { gl } = this;
+        const { gl, boundTextures } = this;
 
-        for (let i = 0; i < this.boundTextures.length; i++)
+        if (this._unknownBoundTextures)
         {
-            if (this.boundTextures[i] === texture)
+            this._unknownBoundTextures = false;
+            // someone changed webGL state,
+            // we have to be sure that our texture does not appear in multi-texture renderer samplers
+            for (let i = 0; i < boundTextures.length; i++)
+            {
+                if (!boundTextures[i])
+                {
+                    this.bind(null, i);
+                }
+            }
+        }
+
+        for (let i = 0; i < boundTextures.length; i++)
+        {
+            if (boundTextures[i] === texture)
             {
                 if (this.currentLocation !== i)
                 {
@@ -159,7 +190,7 @@ export default class TextureSystem extends System
                 }
 
                 gl.bindTexture(gl.TEXTURE_2D, this.emptyTextures[texture.target].texture);
-                this.boundTextures[i] = null;
+                boundTextures[i] = null;
             }
         }
     }


### PR DESCRIPTION
It started in #5427, then I found out that we dont have enough `reset` methods.

IT WORKS! https://www.pixiplayground.com/#/edit/h9BQpJ3scsslkT~RO2JkM

And now, the old pixiJS-threeJS demo, but for V5 and ThreeJS 101. https://www.pixiplayground.com/#/edit/sPigqH5G1ogJ_5pocOs42