### PR TITLE
RenderTextureSystem invalidation problem

### DIFF
--- a/packages/core/src/framebuffer/FramebufferSystem.js
+++ b/packages/core/src/framebuffer/FramebufferSystem.js
@@ -78,15 +78,17 @@ export default class FramebufferSystem extends System
     {
         const { gl } = this;
 
-        this.current = framebuffer;
-
         if (framebuffer)
         {
             // TODO caching layer!
 
             const fbo = framebuffer.glFramebuffers[this.CONTEXT_UID] || this.initFramebuffer(framebuffer);
 
-            gl.bindFramebuffer(gl.FRAMEBUFFER, fbo.framebuffer);
+            if (this.current !== framebuffer)
+            {
+                this.current = framebuffer;
+                gl.bindFramebuffer(gl.FRAMEBUFFER, fbo.framebuffer);
+            }
             // make sure all textures are unbound..
 
             // now check for updates...
@@ -134,7 +136,11 @@ export default class FramebufferSystem extends System
         }
         else
         {
-            gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+            if (this.current)
+            {
+                this.current = null;
+                gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+            }
 
             if (frame)
             {

--- a/packages/core/src/renderTexture/RenderTextureSystem.js
+++ b/packages/core/src/renderTexture/RenderTextureSystem.js
@@ -63,7 +63,7 @@ export default class RenderTextureSystem extends System
      * @param {PIXI.Rectangle} sourceFrame
      * @param {PIXI.Rectangle} destinationFrame
      */
-    bind(renderTexture, sourceFrame, destinationFrame)
+    bind(renderTexture = null, sourceFrame, destinationFrame)
     {
         // TODO - do we want this??
         if (this.current === renderTexture) return;
@@ -154,6 +154,7 @@ export default class RenderTextureSystem extends System
 
     resize()// screenWidth, screenHeight)
     {
+        this.current = {};
         // resize the root only!
         this.bind(null);
     }

--- a/packages/core/src/renderTexture/RenderTextureSystem.js
+++ b/packages/core/src/renderTexture/RenderTextureSystem.js
@@ -65,8 +65,6 @@ export default class RenderTextureSystem extends System
      */
     bind(renderTexture = null, sourceFrame, destinationFrame)
     {
-        // TODO - do we want this??
-        if (this.current === renderTexture) return;
         this.current = renderTexture;
 
         const renderer = this.renderer;
@@ -154,7 +152,6 @@ export default class RenderTextureSystem extends System
 
     resize()// screenWidth, screenHeight)
     {
-        this.current = {};
         // resize the root only!
         this.bind(null);
     }


### PR DESCRIPTION
We should perform all renderTexture checks even if its the same as we bound before. Our `renderer.resize` worked only because `renderer.render` passed `undefined` in this parameter, while `resize` was using `null`.

Try render null's: https://www.pixiplayground.com/#/edit/UomPY6pRxm6qncEEWxl2m
Rendertexture resize after render bug: https://www.pixiplayground.com/#/edit/dCYHcHa~UaegyTf9jDlr2

Those cases are rare, but its better if we cleanup the code.

`current` check is moved to framebuffer.

If we bind the renderTexture second time in a row, there's only one downside of this PR: pixi will check global uniforms projectionMatrix and reupload it. It wont rebind the framebuffer, and it wont call `gl.viewport`.