### PR TITLE
v4.x - SpriteMaskFilter clear param

### DIFF
--- a/src/core/renderers/webgl/filters/spriteMask/SpriteMaskFilter.js
+++ b/src/core/renderers/webgl/filters/spriteMask/SpriteMaskFilter.js
@@ -37,8 +37,9 @@ export default class SpriteMaskFilter extends Filter
      * @param {PIXI.FilterManager} filterManager - The renderer to retrieve the filter from
      * @param {PIXI.RenderTarget} input - The input render target.
      * @param {PIXI.RenderTarget} output - The target to output to.
+     * @param {boolean} clear - Should the output be cleared before rendering to it
      */
-    apply(filterManager, input, output)
+    apply(filterManager, input, output, clear)
     {
         const maskSprite = this.maskSprite;
         const tex = this.maskSprite.texture;
@@ -61,6 +62,6 @@ export default class SpriteMaskFilter extends Filter
         this.uniforms.alpha = maskSprite.worldAlpha;
         this.uniforms.maskClamp = tex.transform.uClampFrame;
 
-        filterManager.applyFilter(this, input, output);
+        filterManager.applyFilter(this, input, output, clear);
     }
 }


### PR DESCRIPTION
#5435 but for v4. Fix is the same, but example is more difficult due to differences in FilterManager. This one has a hackfix!

https://www.pixiplayground.com/#/edit/ZmKDR08Ibz2~HBfdNm167