### PR TITLE
Adaptive curve formulas fix

### DIFF
--- a/packages/graphics/src/const.js
+++ b/packages/graphics/src/const.js
@@ -14,13 +14,13 @@
  * @property {number} maxSegments=2048 - maximal number of segments in the curve (if adaptive = false, ignored)
  */
 export const GRAPHICS_CURVES = {
-    adaptive: false,
+    adaptive: true,
     maxLength: 10,
     minSegments: 8,
     maxSegments: 2048,
     _segmentsCount(length, defaultSegments = 20)
     {
-        if (this.adaptive)
+        if (!this.adaptive)
         {
             return defaultSegments;
         }

--- a/packages/graphics/src/utils/QuadraticUtils.js
+++ b/packages/graphics/src/utils/QuadraticUtils.js
@@ -23,10 +23,10 @@ export default class QuadraticUtils
      */
     static curveLength(fromX, fromY, cpX, cpY, toX, toY)
     {
-        const ax = fromX - ((2.0 * cpX) + toX);
-        const ay = fromY - ((2.0 * cpY) + toY);
-        const bx = 2.0 * ((cpX - 2.0) * fromX);
-        const by = 2.0 * ((cpY - 2.0) * fromY);
+        const ax = fromX - (2.0 * cpX) + toX;
+        const ay = fromY - (2.0 * cpY) + toY;
+        const bx = (2.0 * cpX) - (2.0 * fromX);
+        const by = (2.0 * cpY) - (2.0 * fromY);
         const a = 4.0 * ((ax * ax) + (ay * ay));
         const b = 4.0 * ((ax * bx) + (ay * by));
         const c = (bx * bx) + (by * by);

--- a/packages/graphics/test/index.js
+++ b/packages/graphics/test/index.js
@@ -1,6 +1,6 @@
 // const MockPointer = require('../interaction/MockPointer');
 const { Renderer, BatchRenderer } = require('@pixi/core');
-const { Graphics } = require('../');
+const { Graphics, GRAPHICS_CURVES } = require('../');
 const { BLEND_MODES } = require('@pixi/constants');
 const { Point } = require('@pixi/math');
 const { skipHello } = require('@pixi/utils');
@@ -366,5 +366,29 @@ describe('PIXI.Graphics', function ()
             expect(data[0].shape.points).to.eql([50, 50, 250, 50]);
             expect(data[1].shape.points).to.eql([250, 50, 100, 100, 50, 50]);
         });
+    });
+
+    describe('should support adaptive curves', function ()
+    {
+        const defMode = GRAPHICS_CURVES.adaptive;
+        const defMaxLen = GRAPHICS_CURVES.maxLength;
+        const myMaxLen = GRAPHICS_CURVES.maxLength = 1.0;
+        const graphics = new Graphics();
+
+        GRAPHICS_CURVES.adaptive = true;
+
+        graphics.beginFill(0xffffff, 1.0);
+        graphics.moveTo(610, 500);
+        graphics.quadraticCurveTo(600, 510, 590, 500);
+        graphics.endFill();
+
+        const pointsLen = graphics.geometry.graphicsData[0].shape.points.length / 2;
+        const arcLen = Math.PI / 2 * Math.sqrt(200);
+        const estimate = Math.ceil(arcLen / myMaxLen) + 1;
+
+        expect(pointsLen).to.be.closeTo(estimate, 2.0);
+
+        GRAPHICS_CURVES.adaptive = defMode;
+        GRAPHICS_CURVES.maxLength = defMaxLen;
     });
 });


### PR DESCRIPTION
Because of bug in formula, curves that had big coords (>100) were divided by 2048 small segments.

Because of another bug in `pixi-const` v5 had adaptive curves enabled by default. Gladly, adaptive mode wasn't enabled by default in pixi-v4.

When we reviewed #4658 everyone, including the math guy (me), somehow didnt see obviously wrong equation. Obviously wrong because of `(cpX - 2.0)` , a constant subtracted from coordinate.

This PR fixes parenthesis order, that @icosaeder put there to fit it in our lint "no-mixed-operators" rule.

Demo has more than 32 arcs, that's more than 65536 vertices => 16-bit index buffer fails. We can see how its failing exactly on 32-th arc.

Demo 5.0.0-rc: https://www.pixiplayground.com/#/edit/9KVY7oZCiJ7lUG4Zx3bID

Demo this branch: https://www.pixiplayground.com/#/edit/5o26V7Jn9yCl28wub4mYI

Good:

![image](https://user-images.githubusercontent.com/695831/52792486-924b5800-307c-11e9-9e0e-bb082565ac9b.png)

Broken:

![image](https://user-images.githubusercontent.com/695831/52792437-75168980-307c-11e9-8318-9fb3a8169f23.png)

Low-poly:

![image](https://user-images.githubusercontent.com/695831/52792530-a1caa100-307c-11e9-8ef3-c9002b390452.png)
