### PR TITLE
Update hard coded vertSize's in BatchRenderer.js

### DIFF
--- a/packages/core/src/batch/BatchRenderer.js
+++ b/packages/core/src/batch/BatchRenderer.js
@@ -310,7 +310,7 @@ export default class BatchRenderer extends ObjectRenderer
             this.packGeometry(sprite, float32View, uint32View, indexBuffer, index, indexCount);// argb, nextTexture._id, float32View, uint32View, indexBuffer, index, indexCount);
 
             // push a graphics..
-            index += (sprite.vertexData.length / 2) * 6;
+            index += (sprite.vertexData.length / 2) * this.vertSize;
             indexCount += sprite.indices.length;
         }
 
@@ -390,7 +390,7 @@ export default class BatchRenderer extends ObjectRenderer
 
     packGeometry(element, float32View, uint32View, indexBuffer, index, indexCount)
     {
-        const p = index / 6;// float32View.length / 6 / 2;
+        const p = index / this.vertSize;// float32View.length / 6 / 2;
         const uvs = element.uvs;
         const indicies = element.indices;// geometry.getIndex().data;// indicies;
         const vertexData = element.vertexData;


### PR DESCRIPTION
Fixes some hard coded vertsize 6's to be this.vertSize.

Had some issues with a custom sprite renderer due to not noticing these. 



<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`) //this fails on default pixi without any changes right now
