### PR TITLE
Unused dependency. Canvas-renderer goes into all es builds

### DIFF
--- a/packages/sprite/package.json
+++ b/packages/sprite/package.json
@@ -25,7 +25,6 @@
     "lib"
   ],
   "dependencies": {
-    "@pixi/canvas-renderer": "^5.0.0-rc.2",
     "@pixi/constants": "^5.0.0-rc.2",
     "@pixi/core": "^5.0.0-rc.2",
     "@pixi/display": "^5.0.0-rc.2",


### PR DESCRIPTION
@rsferreira11 found it.