### PR TITLE
Avoid equal compare between float number

### DIFF
--- a/src/core/sprites/webgl/generateMultiTextureShader.js
+++ b/src/core/sprites/webgl/generateMultiTextureShader.js
@@ -10,7 +10,6 @@ const fragTemplate = [
 
     'void main(void){',
     'vec4 color;',
-    'float textureId = floor(vTextureId+0.5);',
     '%forloop%',
     'gl_FragColor = color * vColor;',
     '}',
@@ -55,7 +54,7 @@ function generateSampleSrc(maxTextures)
 
         if (i < maxTextures - 1)
         {
-            src += `if(textureId == ${i}.0)`;
+            src += `if(vTextureId < ${i}.5)`;
         }
 
         src += '\n{';


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

Avoid equal compare between float number.

In extreme conditions, precision conversion can cause some strange problems.

```cpp
// vTextureId = 2.0
float textureId = floor(vTextureId + 0.5);
bool isEqual = textureId == 2.0; // isEqual = false
```
##### solution
```js
if (i < maxTextures - 1) {
  src += `if (vTextureId < ${i}.5)`;
}
```

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
