### PR TITLE
Remove canvas-renderer from @pixi/prepare dependency

### DIFF
--- a/packages/prepare/package.json
+++ b/packages/prepare/package.json
@@ -25,7 +25,6 @@
     "lib"
   ],
   "dependencies": {
-    "@pixi/canvas-renderer": "^5.0.0-rc.2",
     "@pixi/core": "^5.0.0-rc.2",
     "@pixi/display": "^5.0.0-rc.2",
     "@pixi/graphics": "^5.0.0-rc.2",


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
Remove unused "@pixi/canvas-renderer" dependency from the package "@pixi/prepare".
