### PR TITLE
Moved resolution check to when a texture is created

### DIFF
--- a/packages/core/src/textures/Texture.js
+++ b/packages/core/src/textures/Texture.js
@@ -299,11 +299,6 @@ export default class Texture extends EventEmitter
         if (typeof source === 'string')
         {
             cacheId = source;
-
-            if (!options.resolution)
-            {
-                options.resolution = getResolutionOfUrl(source);
-            }
         }
         else
         {
@@ -319,6 +314,11 @@ export default class Texture extends EventEmitter
 
         if (!texture)
         {
+            if (!options.resolution)
+            {
+                options.resolution = getResolutionOfUrl(source);
+            }
+
             texture = new Texture(new BaseTexture(source, options));
             texture.baseTexture.cacheId = cacheId;
 


### PR DESCRIPTION
Tiny tweak that saves us having to needlessly call `getResolutionOfUrl` each time `Texture.from` is called.