### PR TITLE
Fix a bug when resizing render texture with resolution other than one

### DIFF
--- a/packages/core/src/framebuffer/Framebuffer.js
+++ b/packages/core/src/framebuffer/Framebuffer.js
@@ -134,7 +134,7 @@ export default class Framebuffer
         this.dirtyId++;
         this.dirtySize++;
 
-         for (let i = 0; i < this.colorTextures.length; i++)
+        for (let i = 0; i < this.colorTextures.length; i++)
         {
             const texture = this.colorTextures[i];
             const resolution = texture.resolution;

--- a/packages/core/src/framebuffer/Framebuffer.js
+++ b/packages/core/src/framebuffer/Framebuffer.js
@@ -134,14 +134,20 @@ export default class Framebuffer
         this.dirtyId++;
         this.dirtySize++;
 
-        for (let i = 0; i < this.colorTextures.length; i++)
+         for (let i = 0; i < this.colorTextures.length; i++)
         {
-            this.colorTextures[i].setSize(width, height);
+            const texture = this.colorTextures[i];
+            const resolution = texture.resolution;
+
+            // take into acount the fact the texture may have a different resolution..
+            texture.setSize(width / resolution, height / resolution);
         }
 
         if (this.depthTexture)
         {
-            this.depthTexture.setSize(width, height);
+            const resolution = this.depthTexture.resolution;
+
+            this.depthTexture.setSize(width / resolution, height / resolution);
         }
     }
 


### PR DESCRIPTION
Howdy! Currently in v5 if you resize a renterTexture with a resolution different from 1 then the frame buffer breaks.. 

This is because the resolution  of the textures was not being taken into account when resizing the frame buffers (which are always resolution 1)

This fixes it 👍 

Here is an example of it busted:

https://www.pixiplayground.com/#/edit/gvG2JWZw7xSdCQIn8LaBB

running with this branch fixes it :)