### PR TITLE
Don't use webgl2 on mobiles by default

### DIFF
--- a/packages/core/src/settings.js
+++ b/packages/core/src/settings.js
@@ -18,6 +18,6 @@ import { isMobile } from '@pixi/utils';
  * @type {number}
  * @default PIXI.ENV.WEBGL2
  */
-settings.PREFER_ENV = isMobile.any ? ENV.WEBGL : ENV.WEBGL2;
+settings.PREFER_ENV = !isMobile.any || isMobile.apple.device ? ENV.WEBGL2 : ENV.WEBGL;
 
 export { settings };

--- a/packages/core/src/settings.js
+++ b/packages/core/src/settings.js
@@ -10,7 +10,7 @@ import { isMobile } from '@pixi/utils';
  * baseline, prefer a lower environment.
  *
  * Due to {@link https://bugs.chromium.org/p/chromium/issues/detail?id=934823|bug in chromium}
- * we disabled webgl2 by default on all mobile devices except apples.
+ * we disable webgl2 by default for all non-apple mobile devices.
  *
  * @static
  * @name PREFER_ENV

--- a/packages/core/src/settings.js
+++ b/packages/core/src/settings.js
@@ -10,7 +10,7 @@ import { isMobile } from '@pixi/utils';
  * baseline, prefer a lower environment.
  *
  * Due to {@link https://bugs.chromium.org/p/chromium/issues/detail?id=934823|bug in chromium}
- * we disabled webgl2 by default for all mobile devices.
+ * we disabled webgl2 by default on non-apple devices.
  *
  * @static
  * @name PREFER_ENV

--- a/packages/core/src/settings.js
+++ b/packages/core/src/settings.js
@@ -1,5 +1,6 @@
 import { settings } from '@pixi/settings';
 import { ENV } from '@pixi/constants';
+import { isMobile } from '@pixi/utils';
 
 /**
  * The maximum support for using WebGL. If a device does not
@@ -8,12 +9,15 @@ import { ENV } from '@pixi/constants';
  * explicitly remove feature support to target a more stable
  * baseline, prefer a lower environment.
  *
+ * Due to {@link https://bugs.chromium.org/p/chromium/issues/detail?id=934823|bug in chromium}
+ * we disabled webgl2 by default for all mobile devices.
+ *
  * @static
  * @name PREFER_ENV
  * @memberof PIXI.settings
  * @type {number}
  * @default PIXI.ENV.WEBGL2
  */
-settings.PREFER_ENV = ENV.WEBGL2;
+settings.PREFER_ENV = isMobile.any ? ENV.WEBGL : ENV.WEBGL2;
 
 export { settings };

--- a/packages/core/src/settings.js
+++ b/packages/core/src/settings.js
@@ -18,6 +18,6 @@ import { isMobile } from '@pixi/utils';
  * @type {number}
  * @default PIXI.ENV.WEBGL2
  */
-settings.PREFER_ENV = !isMobile.any || isMobile.apple.device ? ENV.WEBGL2 : ENV.WEBGL;
+settings.PREFER_ENV = isMobile.any ? ENV.WEBGL : ENV.WEBGL2;
 
 export { settings };

--- a/packages/core/src/settings.js
+++ b/packages/core/src/settings.js
@@ -10,7 +10,7 @@ import { isMobile } from '@pixi/utils';
  * baseline, prefer a lower environment.
  *
  * Due to {@link https://bugs.chromium.org/p/chromium/issues/detail?id=934823|bug in chromium}
- * we disabled webgl2 by default on non-apple devices.
+ * we disabled webgl2 by default on all mobile devices except apples.
  *
  * @static
  * @name PREFER_ENV


### PR DESCRIPTION
If anyone has better idea how to detect chromium on mobiles, feel free to alter this PR.

https://bugs.chromium.org/p/chromium/issues/detail?id=934823