### PR TITLE
beginTextureFill partial support of texture regions

### DIFF
--- a/packages/graphics/src/GraphicsGeometry.js
+++ b/packages/graphics/src/GraphicsGeometry.js
@@ -938,6 +938,8 @@ export default class GraphicsGeometry extends BatchGeometry
     addUvs(verts, uvs, texture, start, size, matrix)
     {
         let index = 0;
+        const uvsStart = uvs.length;
+        const frame = texture.frame;
 
         while (index < size)
         {
@@ -954,9 +956,46 @@ export default class GraphicsGeometry extends BatchGeometry
 
             index++;
 
-            const frame = texture.frame;
-
             uvs.push(x / frame.width, y / frame.height);
+        }
+
+        const baseTexture = texture.baseTexture;
+
+        if (frame.width < baseTexture.width
+            || frame.height < baseTexture.height)
+        {
+            this.adjustUvs(uvs, texture, uvsStart, size);
+        }
+    }
+
+    /**
+     * Modify uvs array according to position of texture region
+     * Does not work with
+     * @param {number} uvs array
+     * @param {PIXI.Texture} texture region
+     * @param {number} start starting index for uvs
+     * @param {number} size how many points to adjust
+     */
+    adjustUvs(uvs, texture, start, size)
+    {
+        const baseTexture = texture.baseTexture;
+        const eps = 1e-6;
+        const resizeX = texture.frame.width / baseTexture.width;
+        const resizeY = texture.frame.height / baseTexture.height;
+
+        let minX = Math.floor(uvs[start] + eps);
+        let minY = Math.floor(uvs[start + 1] + eps);
+
+        for (let i = 0; i < size; i++)
+        {
+            minX = Math.min(minX, Math.floor(uvs[i * 2] + eps));
+            minY = Math.min(minY, Math.floor(uvs[(i * 2) + 1] + eps));
+        }
+
+        for (let i = 0; i < size; i++)
+        {
+            uvs[i * 2] = (uvs[i] - minX) * resizeX;
+            uvs[(i * 2) + 1] = (uvs[(i * 2) + 1] - minY) * resizeY;
         }
     }
 }

--- a/packages/graphics/src/GraphicsGeometry.js
+++ b/packages/graphics/src/GraphicsGeometry.js
@@ -980,10 +980,12 @@ export default class GraphicsGeometry extends BatchGeometry
     {
         const baseTexture = texture.baseTexture;
         const eps = 1e-6;
-        const resizeX = texture.frame.width / baseTexture.width;
-        const resizeY = texture.frame.height / baseTexture.height;
         const finish = start + (size * 2);
-
+        const frame = texture.frame;
+        const scaleX = frame.width / baseTexture.width;
+        const scaleY = frame.height / baseTexture.height;
+        let offsetX = frame.x / frame.width;
+        let offsetY = frame.y / frame.width;
         let minX = Math.floor(uvs[start] + eps);
         let minY = Math.floor(uvs[start + 1] + eps);
 
@@ -992,11 +994,12 @@ export default class GraphicsGeometry extends BatchGeometry
             minX = Math.min(minX, Math.floor(uvs[i] + eps));
             minY = Math.min(minY, Math.floor(uvs[i + 1] + eps));
         }
-
+        offsetX -= minX;
+        offsetY -= minY;
         for (let i = start; i < finish; i += 2)
         {
-            uvs[i] = (uvs[i] - minX) * resizeX;
-            uvs[i + 1] = (uvs[i + 1] - minY) * resizeY;
+            uvs[i] = (uvs[i] + offsetX) * scaleX;
+            uvs[i + 1] = (uvs[i + 1] + offsetY) * scaleY;
         }
     }
 }

--- a/packages/graphics/src/GraphicsGeometry.js
+++ b/packages/graphics/src/GraphicsGeometry.js
@@ -982,20 +982,21 @@ export default class GraphicsGeometry extends BatchGeometry
         const eps = 1e-6;
         const resizeX = texture.frame.width / baseTexture.width;
         const resizeY = texture.frame.height / baseTexture.height;
+        const finish = start + (size * 2);
 
         let minX = Math.floor(uvs[start] + eps);
         let minY = Math.floor(uvs[start + 1] + eps);
 
-        for (let i = 0; i < size; i++)
+        for (let i = start + 2; i < finish; i += 2)
         {
-            minX = Math.min(minX, Math.floor(uvs[i * 2] + eps));
-            minY = Math.min(minY, Math.floor(uvs[(i * 2) + 1] + eps));
+            minX = Math.min(minX, Math.floor(uvs[i] + eps));
+            minY = Math.min(minY, Math.floor(uvs[i + 1] + eps));
         }
 
-        for (let i = 0; i < size; i++)
+        for (let i = start; i < finish; i += 2)
         {
-            uvs[i * 2] = (uvs[i] - minX) * resizeX;
-            uvs[(i * 2) + 1] = (uvs[(i * 2) + 1] - minY) * resizeY;
+            uvs[i] = (uvs[i] - minX) * resizeX;
+            uvs[i + 1] = (uvs[i + 1] - minY) * resizeY;
         }
     }
 }

--- a/packages/graphics/src/GraphicsGeometry.js
+++ b/packages/graphics/src/GraphicsGeometry.js
@@ -970,7 +970,7 @@ export default class GraphicsGeometry extends BatchGeometry
 
     /**
      * Modify uvs array according to position of texture region
-     * Does not work with
+     * Does not work with rotated or trimmed textures
      * @param {number} uvs array
      * @param {PIXI.Texture} texture region
      * @param {number} start starting index for uvs


### PR DESCRIPTION
Fixes #5503 . 

Algorithm works only if path does not cross edge of the texture.

Demo: https://www.pixiplayground.com/#/edit/M1BjLnu5mYIhqlNOdhMkJ

Thanks to @M00nR4bb1t