### PR TITLE
Only call preventDefault on normalised events if the browser allows it.

### DIFF
--- a/packages/interaction/src/InteractionManager.js
+++ b/packages/interaction/src/InteractionManager.js
@@ -1160,7 +1160,12 @@ export default class InteractionManager extends EventEmitter
 
         if (this.autoPreventDefault && events[0].isNormalized)
         {
-            originalEvent.preventDefault();
+            const cancelable = originalEvent.cancelable || !('cancelable' in originalEvent);
+
+            if (cancelable)
+            {
+                originalEvent.preventDefault();
+            }
         }
 
         const eventLen = events.length;

--- a/packages/text-bitmap/src/BitmapText.js
+++ b/packages/text-bitmap/src/BitmapText.js
@@ -27,8 +27,6 @@ import { removeItems, getResolutionOfUrl } from '@pixi/utils';
  * let bitmapText = new PIXI.BitmapText("text using a fancy font!", {font: "35px Desyrel", align: "right"});
  * ```
  *
-
- *
  * @class
  * @extends PIXI.Container
  * @memberof PIXI


### PR DESCRIPTION
Doesn't effect functionality, but will remove browser warning messages
Just implemented the suggested fix in the issue: https://github.com/pixijs/pixi.js/issues/5421

(ps. misc doc fix snuck in, no point in a full PR for it!)