### PR TITLE
Better support for IE 11, by moving polyfills to default bundle

### DIFF
--- a/bundles/pixi.js-legacy/package.json
+++ b/bundles/pixi.js-legacy/package.json
@@ -43,7 +43,6 @@
     "@pixi/canvas-renderer": "^5.0.0-rc.2",
     "@pixi/canvas-sprite": "^5.0.0-rc.2",
     "@pixi/canvas-sprite-tiling": "^5.0.0-rc.2",
-    "@pixi/polyfill": "^5.0.0-rc.2",
     "pixi.js": "^5.0.0-rc.2"
   },
   "devDependencies": {

--- a/bundles/pixi.js-legacy/src/index.js
+++ b/bundles/pixi.js-legacy/src/index.js
@@ -1,5 +1,3 @@
-import '@pixi/polyfill';
-
 import { Application, accessibility, interaction, prepare, extract } from 'pixi.js';
 import { autoDetectRenderer, CanvasRenderer, CanvasTinter } from '@pixi/canvas-renderer';
 import { CanvasMeshRenderer } from '@pixi/canvas-mesh';

--- a/bundles/pixi.js/package.json
+++ b/bundles/pixi.js/package.json
@@ -58,6 +58,7 @@
     "@pixi/mixin-get-child-by-name": "^5.0.0-rc.2",
     "@pixi/mixin-get-global-position": "^5.0.0-rc.2",
     "@pixi/particles": "^5.0.0-rc.2",
+    "@pixi/polyfill": "^5.0.0-rc.2",
     "@pixi/prepare": "^5.0.0-rc.2",
     "@pixi/runner": "^5.0.0-rc.2",
     "@pixi/settings": "^5.0.0-rc.2",

--- a/bundles/pixi.js/src/index.js
+++ b/bundles/pixi.js/src/index.js
@@ -1,3 +1,5 @@
+import '@pixi/polyfill';
+
 import * as accessibility from '@pixi/accessibility';
 import * as extract from '@pixi/extract';
 import * as interaction from '@pixi/interaction';


### PR DESCRIPTION
Many of the polyfills are required for IE 11 even though WebGL is supported like `Object.assign`, `Math.sign`, `Number.isInteger`, `Promise`. This moves the polyfills package to the default  bundle, not just the `pixi.js-legacy` bundle. In the future, we might want to revert this change. But for now we should try to broadly support all major browsers with WebGL.