### PR TITLE
Cleans up ICanvasImageSource typings/docs

### DIFF
--- a/packages/canvas/canvas-renderer/src/BaseTexture.js
+++ b/packages/canvas/canvas-renderer/src/BaseTexture.js
@@ -5,7 +5,7 @@ import { BaseTexture } from '@pixi/core';
  * for rendering with CanvasRenderer. Provided by **@pixi/canvas-renderer** package.
  * @method getDrawableSource
  * @memberof PIXI.BaseTexture#
- * @return {ICanvasImageSource} Source to render with CanvasRenderer
+ * @return {PIXI.ICanvasImageSource} Source to render with CanvasRenderer
  */
 BaseTexture.prototype.getDrawableSource = function getDrawableSource()
 {

--- a/packages/canvas/canvas-sprite/src/CanvasSpriteRenderer.js
+++ b/packages/canvas/canvas-sprite/src/CanvasSpriteRenderer.js
@@ -7,6 +7,7 @@ const canvasRenderWorldTransform = new Matrix();
 /**
  * Types that can be passed to drawImage
  * @typedef {HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | ImageBitmap} ICanvasImageSource
+ * @memberof PIXI
  */
 
 /**


### PR DESCRIPTION
### Changed

* Attaches `ICanvasImageSource` to the PIXI namespace for typings and to remove items from http://pixijs.download/dev/docs/global.html