### PR TITLE
Fixes premultiply docs

### DIFF
--- a/packages/utils/src/color/premultiply.js
+++ b/packages/utils/src/color/premultiply.js
@@ -62,6 +62,7 @@ export function correctBlendMode(blendMode, premultiplied)
  * combines rgb and alpha to out array
  *
  * @memberof PIXI.utils
+ * @function premultiplyRgba
  * @param {Float32Array|number[]} rgb input rgb
  * @param {number} alpha alpha param
  * @param {Float32Array} [out] output
@@ -92,6 +93,7 @@ export function premultiplyRgba(rgb, alpha, out, premultiply)
  * premultiplies tint
  *
  * @memberof PIXI.utils
+ * @function premultiplyTint
  * @param {number} tint integer RGB
  * @param {number} alpha floating point alpha (0.0-1.0)
  * @returns {number} tint multiplied by alpha
@@ -121,6 +123,7 @@ export function premultiplyTint(tint, alpha)
  * converts integer tint and float alpha to vec4 form, premultiplies by default
  *
  * @memberof PIXI.utils
+ * @function premultiplyTintToRgba
  * @param {number} tint input tint
  * @param {number} alpha alpha param
  * @param {Float32Array} [out] output


### PR DESCRIPTION
premultiply functions are incorrectly listed in the docs as:

```
exports.premultiplyRgba
exports.premultiplyTint
exports.premultiplyTintToRgba
```

Before: http://pixijs.download/dev/docs/PIXI.utils.html
After: http://pixijs.download/dev-fix-utils-docs/docs/PIXI.utils.html
