### PR TITLE
Add note about memory leaks to Graphics; make GraphicsGeometry useabl…

### DIFF
--- a/packages/graphics/src/Graphics.js
+++ b/packages/graphics/src/Graphics.js
@@ -36,7 +36,7 @@ let defaultShader = null;
  * Note that because Graphics can share a GraphicsGeometry with other instances,
  * it is necessary to call `destroy()` to properly dereference the underlying
  * GraphicsGeometry and avoid a memory leak. Alternatively, keep using the same
- * Graphics instance and call `clear()` between frames.
+ * Graphics instance and call `clear()` between redraws.
  *
  * @class
  * @extends PIXI.Container

--- a/packages/graphics/src/Graphics.js
+++ b/packages/graphics/src/Graphics.js
@@ -33,6 +33,11 @@ let defaultShader = null;
  * The Graphics class contains methods used to draw primitive shapes such as lines, circles and
  * rectangles to the display, and to color and fill them.
  *
+ * Note that because Graphics can share a GraphicsGeometry with other instances,
+ * it is necessary to call `destroy()` to properly dereference the underlying
+ * GraphicsGeometry and avoid a memory leak. Alternatively, keep using the same
+ * Graphics instance and call `clear()` between frames.
+ *
  * @class
  * @extends PIXI.Container
  * @memberof PIXI
@@ -50,7 +55,7 @@ export default class Graphics extends Container
          * Includes vertex positions, face indices, normals, colors, UVs, and
          * custom attributes within buffers, reducing the cost of passing all
          * this data to the GPU. Can be shared between multiple Mesh or Graphics objects.
-         * @member {PIXI.Geometry}
+         * @member {PIXI.GraphicsGeometry}
          * @readonly
          */
         this.geometry = geometry || new GraphicsGeometry();

--- a/packages/graphics/src/index.js
+++ b/packages/graphics/src/index.js
@@ -1,4 +1,6 @@
 export * from './const';
+export { default as FillStyle } from './styles/FillStyle';
 export { default as Graphics } from './Graphics';
 export { default as GraphicsData } from './GraphicsData';
 export { default as GraphicsGeometry } from './GraphicsGeometry';
+export { default as LineStyle } from './styles/LineStyle';


### PR DESCRIPTION
…e by endusers

##### Description of change

- Added a note about calling destroy() on Graphics to avoid memory leaks
- Fixed typing of geometry member
- Exported FillStyle and LineStyle so that endusers can call drawShape() on GraphicsGeometry

##### Pre-Merge Checklist

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
