### PR TITLE
Assure that TICK is different for multi-textured renderers

### DIFF
--- a/packages/core/src/batch/BatchRenderer.js
+++ b/packages/core/src/batch/BatchRenderer.js
@@ -250,7 +250,7 @@ export default class BatchRenderer extends ObjectRenderer
         currentGroup.start = 0;
         currentGroup.blend = blendMode;
 
-        let TICK = BaseTexture._batchBegin();
+        let TICK = ++BaseTexture._globalBatch;
 
         let i;
 
@@ -313,7 +313,7 @@ export default class BatchRenderer extends ObjectRenderer
             indexCount += sprite.indices.length;
         }
 
-        BaseTexture._batchEnd(TICK);
+        BaseTexture._globalBatch = TICK;
 
         currentGroup.size = indexCount - currentGroup.start;
 

--- a/packages/core/src/batch/BatchRenderer.js
+++ b/packages/core/src/batch/BatchRenderer.js
@@ -1,5 +1,6 @@
 import BatchGeometry from './BatchGeometry';
 import BatchDrawCall from './BatchDrawCall';
+import BaseTexture from '../textures/BaseTexture';
 
 import State from '../state/State';
 import ObjectRenderer from './ObjectRenderer';
@@ -11,8 +12,6 @@ import { premultiplyBlendMode, premultiplyTint, nextPow2, log2 } from '@pixi/uti
 import BatchBuffer from './BatchBuffer';
 import generateMultiTextureShader from './generateMultiTextureShader';
 import { ENV } from '@pixi/constants';
-
-let TICK = 0;
 
 /**
  * Renderer dedicated to drawing and batching sprites.
@@ -251,7 +250,7 @@ export default class BatchRenderer extends ObjectRenderer
         currentGroup.start = 0;
         currentGroup.blend = blendMode;
 
-        TICK++;
+        let TICK = BaseTexture._batchBegin();
 
         let i;
 
@@ -282,7 +281,7 @@ export default class BatchRenderer extends ObjectRenderer
             {
                 currentTexture = nextTexture;
 
-                if (nextTexture._enabled !== TICK)
+                if (nextTexture._batchEnabled !== TICK)
                 {
                     if (textureCount === MAX_TEXTURES)
                     {
@@ -299,7 +298,7 @@ export default class BatchRenderer extends ObjectRenderer
                     }
 
                     nextTexture.touched = touch;
-                    nextTexture._enabled = TICK;
+                    nextTexture._batchEnabled = TICK;
                     nextTexture._id = textureCount;
 
                     currentGroup.textures[currentGroup.textureCount++] = nextTexture;
@@ -313,6 +312,8 @@ export default class BatchRenderer extends ObjectRenderer
             index += (sprite.vertexData.length / 2) * this.vertSize;
             indexCount += sprite.indices.length;
         }
+
+        BaseTexture._batchEnd(TICK);
 
         currentGroup.size = indexCount - currentGroup.start;
 

--- a/packages/core/src/textures/BaseTexture.js
+++ b/packages/core/src/textures/BaseTexture.js
@@ -653,14 +653,13 @@ export default class BaseTexture extends EventEmitter
 
     /**
      * Called from multi-texture rendered to save the last batch number.
-     * Only first 32 bits matter.
      *
      * @static
      * @param {number} savedValue last used batch number
      */
     static _batchEnd(savedValue)
     {
-        BaseTexture._globalBatch = savedValue | 0;
+        BaseTexture._globalBatch = savedValue;
     }
 }
 

--- a/packages/core/src/textures/BaseTexture.js
+++ b/packages/core/src/textures/BaseTexture.js
@@ -226,7 +226,7 @@ export default class BaseTexture extends EventEmitter
         this.resource = null;
 
         /**
-         * Global number of the texture batch, used by multi-texture renderers
+         * Number of the texture batch, used by multi-texture renderers
          *
          * @member {number}
          */
@@ -639,28 +639,12 @@ export default class BaseTexture extends EventEmitter
 
         return null;
     }
-
-    /**
-     * Called from multi-texture rendered to get a new batch number.
-     *
-     * @static
-     * @return {number} new texture batch number
-     */
-    static _batchBegin()
-    {
-        return ++BaseTexture._globalBatch;
-    }
-
-    /**
-     * Called from multi-texture rendered to save the last batch number.
-     *
-     * @static
-     * @param {number} savedValue last used batch number
-     */
-    static _batchEnd(savedValue)
-    {
-        BaseTexture._globalBatch = savedValue;
-    }
 }
 
+/**
+ * Global number of the texture batch, used by multi-texture renderers
+ *
+ * @static
+ * @member {number} new texture batch number
+ */
 BaseTexture._globalBatch = 0;

--- a/packages/core/src/textures/BaseTexture.js
+++ b/packages/core/src/textures/BaseTexture.js
@@ -142,7 +142,7 @@ export default class BaseTexture extends EventEmitter
         this.uid = uid();
 
         /**
-         * TODO: fill in description
+         * Used by automatic texture Garbage Collection, stores last GC tick when it was bound
          *
          * @member {number}
          * @protected
@@ -224,6 +224,13 @@ export default class BaseTexture extends EventEmitter
          * @readonly
          */
         this.resource = null;
+
+        /**
+         * Global number of the texture batch, used by multi-texture renderers
+         *
+         * @member {number}
+         */
+        this._batchEnabled = 0;
 
         /**
          * Fired when a not-immediately-available source finishes loading.
@@ -632,4 +639,29 @@ export default class BaseTexture extends EventEmitter
 
         return null;
     }
+
+    /**
+     * Called from multi-texture rendered to get a new batch number.
+     *
+     * @static
+     * @return {number} new texture batch number
+     */
+    static _batchBegin()
+    {
+        return ++BaseTexture._globalBatch;
+    }
+
+    /**
+     * Called from multi-texture rendered to save the last batch number.
+     * Only first 32 bits matter.
+     *
+     * @static
+     * @param {number} savedValue last used batch number
+     */
+    static _batchEnd(savedValue)
+    {
+        BaseTexture._globalBatch = savedValue | 0;
+    }
 }
+
+BaseTexture._globalBatch = 0;

--- a/packages/graphics/src/GraphicsGeometry.js
+++ b/packages/graphics/src/GraphicsGeometry.js
@@ -579,7 +579,7 @@ export default class GraphicsGeometry extends BatchGeometry
      */
     buildDrawCalls()
     {
-        let TICK = BaseTexture._batchBegin();
+        let TICK = ++BaseTexture._globalBatch;
 
         for (let i = 0; i < this.drawCalls.length; i++)
         {
@@ -677,7 +677,7 @@ export default class GraphicsGeometry extends BatchGeometry
             this.addTextureIds(textureIds, textureId, data.attribSize);
         }
 
-        BaseTexture._batchEnd(TICK);
+        BaseTexture._globalBatch = TICK;
 
         // upload..
         // merge for now!

--- a/packages/graphics/src/GraphicsGeometry.js
+++ b/packages/graphics/src/GraphicsGeometry.js
@@ -1,6 +1,6 @@
 import { SHAPES } from '@pixi/math';
 import { Bounds } from '@pixi/display';
-import { BatchGeometry, BatchDrawCall } from '@pixi/core';
+import { BatchGeometry, BatchDrawCall, BaseTexture } from '@pixi/core';
 import { DRAW_MODES } from '@pixi/constants';
 
 import GraphicsData from './GraphicsData';
@@ -14,7 +14,6 @@ import { premultiplyTint } from '@pixi/utils';
 const BATCH_POOL = [];
 const DRAW_CALL_POOL = [];
 
-let TICK = 0;
 /**
  * Map of fill commands for each shape type.
  *
@@ -580,7 +579,7 @@ export default class GraphicsGeometry extends BatchGeometry
      */
     buildDrawCalls()
     {
-        TICK++;
+        let TICK = BaseTexture._batchBegin();
 
         for (let i = 0; i < this.drawCalls.length; i++)
         {
@@ -638,7 +637,7 @@ export default class GraphicsGeometry extends BatchGeometry
             {
                 currentTexture = nextTexture;
 
-                if (nextTexture._enabled !== TICK)
+                if (nextTexture._batchEnabled !== TICK)
                 {
                     if (textureCount === MAX_TEXTURES)
                     {
@@ -660,7 +659,7 @@ export default class GraphicsGeometry extends BatchGeometry
 
                     // TODO add this to the render part..
                     nextTexture.touched = 1;// touch;
-                    nextTexture._enabled = TICK;
+                    nextTexture._batchEnabled = TICK;
                     nextTexture._id = textureCount;
                     nextTexture.wrapMode = 10497;
 
@@ -677,6 +676,8 @@ export default class GraphicsGeometry extends BatchGeometry
             this.addColors(colors, style.color, style.alpha, data.attribSize);
             this.addTextureIds(textureIds, textureId, data.attribSize);
         }
+
+        BaseTexture._batchEnd(TICK);
 
         // upload..
         // merge for now!


### PR DESCRIPTION
Fixes #5520 

I added methods to BaseTexture because that's where `_batchEnabled` field is stored.

I also suggest that we expose those methods for plugin-makers but `_` means that it can be changed in any version without deprecation.

Broken: https://www.pixiplayground.com/#/edit/1WCb9fBbUQieUK2IdMKzR
Works: https://www.pixiplayground.com/#/edit/69HLoVsdpfl0NBwEyJws0