### PR TITLE
Properly deprecate BaseTexture v4 members and methods

### DIFF
--- a/bundles/pixi.js/src/useDeprecated.js
+++ b/bundles/pixi.js/src/useDeprecated.js
@@ -620,6 +620,39 @@ export default function useDeprecated()
         this.update();
     };
 
+    Object.defineProperties(BaseTexture.prototype, {
+        /**
+         * @name PIXI.BaseTexture#hasLoaded
+         * @type {boolean}
+         * @deprecated since 5.0.0
+         * @readonly
+         * @see PIXI.BaseTexture#valid
+         */
+        hasLoaded: {
+            get()
+            {
+                deprecation(v5, 'PIXI.BaseTexture#hasLoaded has been removed, used valid.');
+
+                return this.valid;
+            },
+        },
+        /**
+         * @name PIXI.BaseTexture#imageUrl
+         * @type {string}
+         * @deprecated since 5.0.0
+         * @readonly
+         * @see PIXI.resource.ImageResource#url
+         */
+        imageUrl: {
+            get()
+            {
+                deprecation(v5, 'PIXI.BaseTexture#imageUrl has been removed, used resource.url.');
+
+                return this.resource && this.resource.url;
+            },
+        },
+    });
+
     /**
      * @method fromImage
      * @static

--- a/bundles/pixi.js/src/useDeprecated.js
+++ b/bundles/pixi.js/src/useDeprecated.js
@@ -604,6 +604,23 @@ export default function useDeprecated()
     const { BaseTexture } = PIXI;
 
     /**
+     * @method loadSource
+     * @memberof PIXI.BaseTexture#
+     * @deprecated since 5.0.0
+     */
+    BaseTexture.prototype.loadSource = function loadSource(image)
+    {
+        deprecation(v5, 'PIXI.BaseTexture#loadSource has been deprecated');
+
+        const resource = PIXI.resources.autoDetectResource(image);
+
+        resource.internal = true;
+
+        this.setResource(resource);
+        this.update();
+    };
+
+    /**
      * @method fromImage
      * @static
      * @memberof PIXI.BaseTexture


### PR DESCRIPTION
Removes the need for [migration guide](https://github.com/pixijs/pixi.js/wiki/v5-Migration-Guide#basetexture-changes) step for BaseTexture's `loadSource` by providing a suitable workaround via deprecation.

Edit:
Also, deprecates `imageUrl` and `hasLoaded`.

cc @Adam13531