### PR TITLE
Fixes canvas and filters being copied

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lerna": "lerna",
     "predist": "rimraf dist/* && npm run build:prod",
     "dist": "npm run docs",
-    "postdist": "copyfiles -f bundles/*/dist/* dist && copyfiles -f packages/*/dist/* dist/packages",
+    "postdist": "copyfiles -f bundles/*/dist/* dist && copyfiles -f \"packages/**/dist/*\" dist/packages",
     "prerelease": "npm run clean:build && npm test",
     "postversion": "npm run build:prod",
     "release": "lerna publish"


### PR DESCRIPTION
Fixes an issue where `canvas-*` and `filter-*` dist files are not being copied and deployed on pixijs.download.

**Broken:**
http://pixijs.download/dev/packages/filter-alpha.js

**Fixed:**
http://pixijs.download/fix-copyfiles/packages/filter-alpha.js