### PR TITLE
Fixes the mixin bundles

### DIFF
--- a/packages/canvas/canvas-display/package.json
+++ b/packages/canvas/canvas-display/package.json
@@ -4,6 +4,7 @@
   "main": "lib/canvas-display.js",
   "module": "lib/canvas-display.es.js",
   "bundle": "dist/canvas-display.js",
+  "bundleNoExports": true,
   "description": "Canvas mixin for the display package",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/canvas/canvas-particles/package.json
+++ b/packages/canvas/canvas-particles/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@pixi/canvas-particles",
   "version": "5.0.0-rc.3",
-  "main": "lib/canvas-sprite-tiling.js",
-  "module": "lib/canvas-sprite-tiling.es.js",
-  "bundle": "dist/canvas-graphics.js",
+  "main": "lib/canvas-particles.js",
+  "module": "lib/canvas-particles.es.js",
+  "bundle": "dist/canvas-particles.js",
+  "bundleNoExports": true,
   "description": "Canvas mixin for the particles package",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/canvas/canvas-sprite-tiling/package.json
+++ b/packages/canvas/canvas-sprite-tiling/package.json
@@ -4,6 +4,7 @@
   "main": "lib/canvas-sprite-tiling.js",
   "module": "lib/canvas-sprite-tiling.es.js",
   "bundle": "dist/canvas-sprite-tiling.js",
+  "bundleNoExports": true,
   "description": "Canvas mixin for the sprite-tiling package",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/mixin-cache-as-bitmap/package.json
+++ b/packages/mixin-cache-as-bitmap/package.json
@@ -4,6 +4,7 @@
   "main": "lib/mixin-cache-as-bitmap.js",
   "module": "lib/mixin-cache-as-bitmap.es.js",
   "bundle": "dist/mixin-cache-as-bitmap.js",
+  "bundleNoExports": true,
   "description": "Mixin to allow caching container and its children to a bitmap texture",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/mixin-get-child-by-name/package.json
+++ b/packages/mixin-get-child-by-name/package.json
@@ -4,6 +4,7 @@
   "main": "lib/mixin-get-child-by-name.js",
   "module": "lib/mixin-get-child-by-name.es.js",
   "bundle": "dist/mixin-get-child-by-name.js",
+  "bundleNoExports": true,
   "description": "Mixin function to find a child DisplayObject by name",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/mixin-get-global-position/package.json
+++ b/packages/mixin-get-global-position/package.json
@@ -4,6 +4,7 @@
   "main": "lib/mixin-get-global-position.js",
   "module": "lib/mixin-get-global-position.es.js",
   "bundle": "dist/mixin-get-global-position.js",
+  "bundleNoExports": true,
   "description": "Mixin to find the global position of a DisplayObject",
   "author": "Mat Groves",
   "contributors": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -98,6 +98,7 @@ async function main()
             bundle,
             bundleInput,
             bundleOutput,
+            bundleNoExports,
             standalone } = pkgData[pkg.name];
         const freeze = false;
 
@@ -140,7 +141,10 @@ async function main()
             // as well as the bundles pixi.js and pixi.js-legacy
             if (!standalone)
             {
-                footer = `Object.assign(this.${ns}, ${name});`;
+                if (bundleNoExports !== true)
+                {
+                    footer = `Object.assign(this.${ns}, ${name});`;
+                }
 
                 if (ns.includes('.'))
                 {


### PR DESCRIPTION
Because of the custom Rollup that's happening, the browser bundles were broken for the following packages. These packages don't actually export anything and a `name` property was ignored. I made this explicit by declaring `bundleNoExports` option in the package.json for these packages.

* canvas-display
* canvas-particles (also the bundle name was copy-pasta error)
* canvas-sprite-tiling
* mixin-cache-as-bitmap
* mixin-get-child-by-name
* mixin-get-global-position

Here's an example that includes every bundle file (basically reproduces **pixi.js-legacy**):
https://jsfiddle.net/bigtimebuddy/h0ytpn48/