### PR TITLE
Geometry - Rename `getAttribute` to `getBuffer`. Added `getAttribute` method

### DIFF
--- a/packages/canvas/canvas-mesh/src/CanvasMeshRenderer.js
+++ b/packages/canvas/canvas-mesh/src/CanvasMeshRenderer.js
@@ -236,7 +236,7 @@ export default class CanvasMeshRenderer
     renderMeshFlat(mesh)
     {
         const context = this.renderer.context;
-        const vertices = mesh.geometry.getAttribute('aVertexPosition').data;
+        const vertices = mesh.geometry.getBuffer('aVertexPosition').data;
         const length = vertices.length / 2;
 
         // this.count++;

--- a/packages/canvas/canvas-mesh/src/SimpleMesh.js
+++ b/packages/canvas/canvas-mesh/src/SimpleMesh.js
@@ -12,7 +12,7 @@ SimpleMesh.prototype._renderCanvas = function _renderCanvas(renderer)
 {
     if (this.autoUpdate)
     {
-        this.geometry.getAttribute('aVertexPosition').update();
+        this.geometry.getBuffer('aVertexPosition').update();
     }
 
     if (this.shader.update)

--- a/packages/core/src/geometry/Buffer.js
+++ b/packages/core/src/geometry/Buffer.js
@@ -47,6 +47,7 @@ export default class Buffer
     // TODO could explore flagging only a partial upload?
     /**
      * flags this buffer as requiring an upload to the GPU
+     * @param {ArrayBuffer|SharedArrayBuffer|ArrayBufferView} [data] the data to update in the buffer.
      */
     update(data)
     {

--- a/packages/core/src/geometry/Geometry.js
+++ b/packages/core/src/geometry/Geometry.js
@@ -145,7 +145,18 @@ export default class Geometry
      */
     getAttribute(id)
     {
-        return this.buffers[this.attributes[id].buffer];
+        return this.attributes[id];
+    }
+
+    /**
+     * returns the requested buffer
+     *
+     * @param {String} id  the name of the buffer required
+     * @return {PIXI.Buffer} the buffer requested.
+     */
+    getBuffer(id)
+    {
+        return this.buffers[this.getAttribute(id).buffer];
     }
 
     /**

--- a/packages/mesh-extras/src/NineSlicePlane.js
+++ b/packages/mesh-extras/src/NineSlicePlane.js
@@ -110,12 +110,12 @@ export default class NineSlicePlane extends SimplePlane
 
     get vertices()
     {
-        return this.geometry.getAttribute('aVertexPosition').data;
+        return this.geometry.getBuffer('aVertexPosition').data;
     }
 
     set vertices(value)
     {
-        this.geometry.getAttribute('aVertexPosition').data = value;
+        this.geometry.getBuffer('aVertexPosition').data = value;
     }
 
     /**

--- a/packages/mesh-extras/src/SimpleMesh.js
+++ b/packages/mesh-extras/src/SimpleMesh.js
@@ -22,7 +22,7 @@ export default class SimpleMesh extends Mesh
     {
         const geometry = new MeshGeometry(vertices, uvs, indices);
 
-        geometry.getAttribute('aVertexPosition').static = false;
+        geometry.getBuffer('aVertexPosition').static = false;
 
         const meshMaterial = new MeshMaterial(texture);
 
@@ -41,18 +41,18 @@ export default class SimpleMesh extends Mesh
      */
     get vertices()
     {
-        return this.geometry.getAttribute('aVertexPosition').data;
+        return this.geometry.getBuffer('aVertexPosition').data;
     }
     set vertices(value)
     {
-        this.geometry.getAttribute('aVertexPosition').data = value;
+        this.geometry.getBuffer('aVertexPosition').data = value;
     }
 
     _render(renderer)
     {
         if (this.autoUpdate)
         {
-            this.geometry.getAttribute('aVertexPosition').update();
+            this.geometry.getBuffer('aVertexPosition').update();
         }
 
         super._render(renderer);

--- a/packages/mesh-extras/src/geometry/RopeGeometry.js
+++ b/packages/mesh-extras/src/geometry/RopeGeometry.js
@@ -51,8 +51,8 @@ export default class RopeGeometry extends MeshGeometry
 
         if (!points) return;
 
-        const vertexBuffer = this.getAttribute('aVertexPosition');
-        const uvBuffer = this.getAttribute('aTextureCoord');
+        const vertexBuffer = this.getBuffer('aVertexPosition');
+        const uvBuffer = this.getBuffer('aTextureCoord');
         const indexBuffer = this.getIndex();
 
         // if too little points, or texture hasn't got UVs set yet just move on.

--- a/packages/mesh/src/Mesh.js
+++ b/packages/mesh/src/Mesh.js
@@ -428,7 +428,7 @@ export default class Mesh extends Container
 
         this.worldTransform.applyInverse(point, tempPoint);
 
-        const vertices = this.geometry.getAttribute('aVertexPosition').data;
+        const vertices = this.geometry.getBuffer('aVertexPosition').data;
 
         const points = tempPolygon.points;
         const indices =  this.geometry.getIndex().data;


### PR DESCRIPTION
##### Description of change
Noticed that `Geometry::getAttribute` was actually returning a `PIXI.Buffer`. Renamed the function to `getBuffer` and fixed the types (docs). 

Also added an implementation of `getAttribute`.

Added types (docs) to `Buffer::update()`

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
