### PR TITLE
Adds format and quality options to extract plugins

### DIFF
--- a/packages/canvas/canvas-extract/src/CanvasExtract.js
+++ b/packages/canvas/canvas-extract/src/CanvasExtract.js
@@ -35,8 +35,8 @@ export default class CanvasExtract
      *
      * @param {PIXI.DisplayObject|PIXI.RenderTexture} target - A displayObject or renderTexture
      *  to convert. If left empty will use the main renderer
-     * @param {string} [format] - Image format, e.g. "image/jpeg".
-     * @param {number} [quality] - JPEG compression from 0 to 1, must specify format.
+     * @param {string} [format] - Image format, e.g. "image/jpeg" or "image/webp".
+     * @param {number} [quality] - JPEG or Webp compression from 0 to 1. Default is 0.92.
      * @return {HTMLImageElement} HTML Image of the target
      */
     image(target, format, quality)
@@ -54,8 +54,8 @@ export default class CanvasExtract
      *
      * @param {PIXI.DisplayObject|PIXI.RenderTexture} target - A displayObject or renderTexture
      *  to convert. If left empty will use the main renderer
-     * @param {string} [format] - Image format, e.g. "image/jpeg".
-     * @param {number} [quality] - JPEG compression from 0 to 1, must specify format.
+     * @param {string} [format] - Image format, e.g. "image/jpeg" or "image/webp".
+     * @param {number} [quality] - JPEG or Webp compression from 0 to 1. Default is 0.92.
      * @return {string} A base64 encoded string of the texture.
      */
     base64(target, format, quality)

--- a/packages/canvas/canvas-extract/src/CanvasExtract.js
+++ b/packages/canvas/canvas-extract/src/CanvasExtract.js
@@ -35,13 +35,15 @@ export default class CanvasExtract
      *
      * @param {PIXI.DisplayObject|PIXI.RenderTexture} target - A displayObject or renderTexture
      *  to convert. If left empty will use the main renderer
+     * @param {string} [format] - Image format, e.g. "image/jpeg".
+     * @param {number} [quality] - JPEG compression from 0 to 1, must specify format.
      * @return {HTMLImageElement} HTML Image of the target
      */
-    image(target)
+    image(target, format, quality)
     {
         const image = new Image();
 
-        image.src = this.base64(target);
+        image.src = this.base64(target, format, quality);
 
         return image;
     }
@@ -52,11 +54,13 @@ export default class CanvasExtract
      *
      * @param {PIXI.DisplayObject|PIXI.RenderTexture} target - A displayObject or renderTexture
      *  to convert. If left empty will use the main renderer
+     * @param {string} [format] - Image format, e.g. "image/jpeg".
+     * @param {number} [quality] - JPEG compression from 0 to 1, must specify format.
      * @return {string} A base64 encoded string of the texture.
      */
-    base64(target)
+    base64(target, format, quality)
     {
-        return this.canvas(target).toDataURL();
+        return this.canvas(target).toDataURL(format, quality);
     }
 
     /**

--- a/packages/extract/src/Extract.js
+++ b/packages/extract/src/Extract.js
@@ -36,13 +36,15 @@ export default class Extract
      *
      * @param {PIXI.DisplayObject|PIXI.RenderTexture} target - A displayObject or renderTexture
      *  to convert. If left empty will use the main renderer
+     * @param {string} [format] - Image format, e.g. "image/jpeg".
+     * @param {number} [quality] - JPEG compression from 0 to 1, must specify format.
      * @return {HTMLImageElement} HTML Image of the target
      */
-    image(target)
+    image(target, format, quality)
     {
         const image = new Image();
 
-        image.src = this.base64(target);
+        image.src = this.base64(target, format, quality);
 
         return image;
     }
@@ -53,11 +55,13 @@ export default class Extract
      *
      * @param {PIXI.DisplayObject|PIXI.RenderTexture} target - A displayObject or renderTexture
      *  to convert. If left empty will use the main renderer
+     * @param {string} [format] - Image format, e.g. "image/jpeg".
+     * @param {number} [quality] - JPEG compression from 0 to 1, must specify format.
      * @return {string} A base64 encoded string of the texture.
      */
-    base64(target)
+    base64(target, format, quality)
     {
-        return this.canvas(target).toDataURL();
+        return this.canvas(target).toDataURL(format, quality);
     }
 
     /**

--- a/packages/extract/src/Extract.js
+++ b/packages/extract/src/Extract.js
@@ -36,8 +36,8 @@ export default class Extract
      *
      * @param {PIXI.DisplayObject|PIXI.RenderTexture} target - A displayObject or renderTexture
      *  to convert. If left empty will use the main renderer
-     * @param {string} [format] - Image format, e.g. "image/jpeg".
-     * @param {number} [quality] - JPEG compression from 0 to 1, must specify format.
+     * @param {string} [format] - Image format, e.g. "image/jpeg" or "image/webp".
+     * @param {number} [quality] - JPEG or Webp compression from 0 to 1. Default is 0.92.
      * @return {HTMLImageElement} HTML Image of the target
      */
     image(target, format, quality)
@@ -55,8 +55,8 @@ export default class Extract
      *
      * @param {PIXI.DisplayObject|PIXI.RenderTexture} target - A displayObject or renderTexture
      *  to convert. If left empty will use the main renderer
-     * @param {string} [format] - Image format, e.g. "image/jpeg".
-     * @param {number} [quality] - JPEG compression from 0 to 1, must specify format.
+     * @param {string} [format] - Image format, e.g. "image/jpeg" or "image/webp".
+     * @param {number} [quality] - JPEG or Webp compression from 0 to 1. Default is 0.92.
      * @return {string} A base64 encoded string of the texture.
      */
     base64(target, format, quality)


### PR DESCRIPTION
Fixes #4846

Adds `format` and `quality` parameters to extract plugins. This is a pass-through for `toDataURL`, see: https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toDataURL
