### PR TITLE
Fix generic font families on v5

### DIFF
--- a/packages/text/src/TextStyle.js
+++ b/packages/text/src/TextStyle.js
@@ -36,6 +36,15 @@ const defaultStyle = {
     leading: 0,
 };
 
+const genericFontFamilies = [
+    'serif',
+    'sans-serif',
+    'monospace',
+    'cursive',
+    'fantasy',
+    'system-ui',
+]
+
 /**
  * A TextStyle Object contains information to decorate a Text objects.
  *
@@ -698,7 +707,7 @@ export default class TextStyle
             let fontFamily = fontFamilies[i].trim();
 
             // Check if font already contains strings
-            if (!(/([\"\'])[^\'\"]+\1/).test(fontFamily))
+            if (!(/([\"\'])[^\'\"]+\1/).test(fontFamily) && genericFontFamilies.indexOf(fontFamily) < 0)
             {
                 fontFamily = `"${fontFamily}"`;
             }

--- a/packages/text/test/TextStyle.js
+++ b/packages/text/test/TextStyle.js
@@ -39,7 +39,7 @@ describe('PIXI.TextStyle', function ()
             fontFamily: ['Georgia', 'Arial', 'sans-serif'],
         });
 
-        expect(style.toFontString()).to.have.string('"Georgia","Arial","sans-serif"');
+        expect(style.toFontString()).to.have.string('"Georgia","Arial",sans-serif');
     });
 
     it('should handle multiple fonts as string', function ()
@@ -48,7 +48,7 @@ describe('PIXI.TextStyle', function ()
             fontFamily: 'Georgia, "Arial", sans-serif',
         });
 
-        expect(style.toFontString()).to.have.string('"Georgia","Arial","sans-serif"');
+        expect(style.toFontString()).to.have.string('"Georgia","Arial",sans-serif');
     });
 
     it('should not shared array / object references between different instances', function ()
@@ -59,5 +59,34 @@ describe('PIXI.TextStyle', function ()
         expect(defaultStyle.fillGradientStops.length).to.equal(style.fillGradientStops.length);
         style.fillGradientStops.push(0);
         expect(defaultStyle.fillGradientStops.length).to.not.equal(style.fillGradientStops.length);
+    });
+
+    it('should not quote generic font families when calling toFontString', function ()
+    {
+        // Should match the list in TextStyle
+        const genericFontFamilies = [
+            'serif',
+            'sans-serif',
+            'monospace',
+            'cursive',
+            'fantasy',
+            'system-ui',
+        ];
+
+        // Regex to find any of the generic families surrounded by either type of quote mark
+        const incorrectRegexTemplate = '["\']FAMILY["\']';
+
+        for (const genericFamily of genericFontFamilies)
+        {
+            const style = new TextStyle({
+                fontFamily: ['Georgia', 'Arial', genericFamily],
+            });
+
+            // Create regex from template substituting target family
+            const regex = new RegExp(incorrectRegexTemplate.replace('FAMILY', genericFamily));
+            const result = style.toFontString().match(regex);
+
+            expect(result).to.be.null;
+        }
     });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
#4969 apparently didn't get put into v5, so here it is.  
Added a new unit test for it, and fixed 2 others who were expecting their result to have quoted generic families.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
   (not including ones already failing from a clean checkout of dev branch)
