### PR TITLE
Allow pointerdown & pointerup events to handle simultaneous presses

### DIFF
--- a/packages/interaction/package.json
+++ b/packages/interaction/package.json
@@ -31,6 +31,7 @@
     "@pixi/core": "^5.0.0-rc.3",
     "@pixi/display": "^5.0.0-rc.3",
     "@pixi/math": "^5.0.0-rc.3",
+    "@pixi/settings": "^5.0.0-rc.3",
     "@pixi/ticker": "^5.0.0-rc.3",
     "@pixi/utils": "^5.0.0-rc.3"
   },

--- a/packages/interaction/src/InteractionManager.js
+++ b/packages/interaction/src/InteractionManager.js
@@ -348,9 +348,6 @@ export default class InteractionManager extends EventEmitter
 
         /**
          * Fired when a pointer device button is released over the display object.
-         * Not always fired when some buttons are held down while others are released. In those cases,
-         * use [mousedown]{@link PIXI.interaction.InteractionManager#event:mousedown} and
-         * [mouseup]{@link PIXI.interaction.InteractionManager#event:mouseup} instead.
          *
          * @event PIXI.interaction.InteractionManager#pointerup
          * @param {PIXI.interaction.InteractionEvent} event - Interaction event

--- a/packages/interaction/src/index.js
+++ b/packages/interaction/src/index.js
@@ -5,6 +5,8 @@
  * See {@link PIXI.CanvasRenderer#plugins} or {@link PIXI.Renderer#plugins}.
  * @namespace PIXI.interaction
  */
+import './settings';
+
 export { default as InteractionData } from './InteractionData';
 export { default as InteractionManager } from './InteractionManager';
 export { default as interactiveTarget } from './interactiveTarget';

--- a/packages/interaction/src/settings.js
+++ b/packages/interaction/src/settings.js
@@ -1,0 +1,23 @@
+import { settings } from '@pixi/settings';
+
+/**
+ * Should PixiJS use the PointerEvent API instead of MouseEvent API when generating interaction events.
+ * This setting effects 'mouse' events only, not 'touch' events, which always use the TouchEvent API.
+ * Advantages to this are using the modern api with the extra properties it comes with, such as 'pressure'.
+ * Disadvantages are 'quirks' to how a PointerEvent works, such a down and up events not being fired if other
+ * buttons are already in a down state.
+ * Whether this is enabled or disabled, you can still listen to normalised events such as 'pointerdown',
+ * 'pointerup' - it's just that if it is disabled you will not be getting true PointerEvent behaviour.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent
+ *
+ * @static
+ * @constant
+ * @name USE_POINTER_EVENT_API
+ * @memberof PIXI.settings
+ * @type {boolean}
+ * @default false
+ */
+settings.USE_POINTER_EVENT_API = false;
+
+export { settings };

--- a/packages/interaction/src/settings.js
+++ b/packages/interaction/src/settings.js
@@ -4,8 +4,9 @@ import { settings } from '@pixi/settings';
  * Should PixiJS use the PointerEvent API instead of MouseEvent API when generating interaction events.
  * This setting effects 'mouse' events only, not 'touch' events, which always use the TouchEvent API.
  * Advantages to this are using the modern api with the extra properties it comes with, such as 'pressure'.
- * Disadvantages are 'quirks' to how a PointerEvent works, such a down and up events not being fired if other
- * buttons are already in a down state.
+ * It also allows 'touch' to work on Surface laptops that don't otherwise report as supporting touch.
+ * Disadvantages are 'quirks' to how a PointerEvent works for mice, such a down and up events not being
+ * fired if other buttons are already in a down state.
  * Whether this is enabled or disabled, you can still listen to normalised events such as 'pointerdown',
  * 'pointerup' - it's just that if it is disabled you will not be getting true PointerEvent behaviour.
  *
@@ -18,6 +19,6 @@ import { settings } from '@pixi/settings';
  * @type {boolean}
  * @default false
  */
-settings.USE_POINTER_EVENT_API = false;
+settings.USE_POINTER_EVENT_API = true;
 
 export { settings };

--- a/packages/interaction/test/InteractionManager.js
+++ b/packages/interaction/test/InteractionManager.js
@@ -250,7 +250,7 @@ describe('PIXI.interaction.InteractionManager', function ()
             const removeSpy = sinon.spy(window.document, 'removeEventListener');
 
             manager.interactionDOMElement = { style: {}, addEventListener: sinon.stub(), removeEventListener: sinon.stub() };
-            manager.supportsPointerEvents = true;
+            manager.usePointerEventAPI = true;
 
             manager.addEvents();
 
@@ -273,7 +273,7 @@ describe('PIXI.interaction.InteractionManager', function ()
             const removeSpy = sinon.spy(window, 'removeEventListener');
 
             manager.interactionDOMElement = { style: {}, addEventListener: sinon.stub(), removeEventListener: sinon.stub() };
-            manager.supportsPointerEvents = true;
+            manager.usePointerEventAPI = true;
 
             manager.addEvents();
 
@@ -297,7 +297,7 @@ describe('PIXI.interaction.InteractionManager', function ()
             const element = { style: {}, addEventListener: sinon.stub(), removeEventListener: sinon.stub() };
 
             manager.interactionDOMElement = element;
-            manager.supportsPointerEvents = true;
+            manager.usePointerEventAPI = true;
             manager.supportsTouchEvents = true;
 
             manager.addEvents();
@@ -331,7 +331,7 @@ describe('PIXI.interaction.InteractionManager', function ()
             const element = { style: {}, addEventListener: sinon.stub(), removeEventListener: sinon.stub() };
 
             manager.interactionDOMElement = element;
-            manager.supportsPointerEvents = true;
+            manager.usePointerEventAPI = true;
             manager.supportsTouchEvents = false;
 
             manager.addEvents();
@@ -356,7 +356,7 @@ describe('PIXI.interaction.InteractionManager', function ()
             const removeSpy = sinon.spy(window.document, 'removeEventListener');
 
             manager.interactionDOMElement = { style: {}, addEventListener: sinon.stub(), removeEventListener: sinon.stub() };
-            manager.supportsPointerEvents = false;
+            manager.usePointerEventAPI = false;
 
             manager.addEvents();
 
@@ -379,7 +379,7 @@ describe('PIXI.interaction.InteractionManager', function ()
             const removeSpy = sinon.spy(window, 'removeEventListener');
 
             manager.interactionDOMElement = { style: {}, addEventListener: sinon.stub(), removeEventListener: sinon.stub() };
-            manager.supportsPointerEvents = false;
+            manager.usePointerEventAPI = false;
 
             manager.addEvents();
 
@@ -401,7 +401,7 @@ describe('PIXI.interaction.InteractionManager', function ()
             const element = { style: {}, addEventListener: sinon.stub(), removeEventListener: sinon.stub() };
 
             manager.interactionDOMElement = element;
-            manager.supportsPointerEvents = false;
+            manager.usePointerEventAPI = false;
             manager.supportsTouchEvents = false;
 
             manager.addEvents();
@@ -425,7 +425,7 @@ describe('PIXI.interaction.InteractionManager', function ()
             const element = { style: {}, addEventListener: sinon.stub(), removeEventListener: sinon.stub() };
 
             manager.interactionDOMElement = element;
-            manager.supportsPointerEvents = false;
+            manager.usePointerEventAPI = false;
             manager.supportsTouchEvents = true;
 
             manager.addEvents();
@@ -449,7 +449,7 @@ describe('PIXI.interaction.InteractionManager', function ()
             const element = { style: {}, addEventListener: sinon.stub(), removeEventListener: sinon.stub() };
 
             manager.interactionDOMElement = element;
-            manager.supportsPointerEvents = true;
+            manager.usePointerEventAPI = true;
             manager.supportsTouchEvents = true;
 
             manager.addEvents();


### PR DESCRIPTION
##### Description of change
https://github.com/pixijs/pixi.js/issues/4048
https://github.com/pixijs/pixi.js/issues/4863
https://github.com/pixijs/pixi.js/issues/5384

Native pointer events only send a 'pointerdown' on the initial button being pressed.
Hold one mouse button down and press another, and you get a 'pointermove' instead.
Release that second mouse button whilst still holding the first, and again you get a 'pointermove' event.
So here, we will detect any change in the 'buttons' being pressed from last event to this move event.
If the number has changed, we know it's due to multiple mouse presses.

Goes slightly against the native pointerdown spec, but is much more useful for the developer

##### Pre-Merge Checklist
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)