### PR TITLE
Ensure that a mouseout is fired with masked containers

### DIFF
--- a/packages/interaction/src/InteractionManager.js
+++ b/packages/interaction/src/InteractionManager.js
@@ -1041,7 +1041,9 @@ export default class InteractionManager extends EventEmitter
             }
             interactiveParent = false;
         }
-        // If there is a mask, no need to test against anything else if the pointer is not within the mask
+        // If there is a mask, no need to hitTest against anything else if the pointer is not within the mask.
+        // We still want to hitTestChildren, however, to ensure a mouseout can still be generated.
+        // https://github.com/pixijs/pixi.js/issues/5135
         else if (displayObject._mask)
         {
             if (hitTest)
@@ -1049,7 +1051,6 @@ export default class InteractionManager extends EventEmitter
                 if (!(displayObject._mask.containsPoint && displayObject._mask.containsPoint(point)))
                 {
                     hitTest = false;
-                    hitTestChildren = false;
                 }
             }
         }


### PR DESCRIPTION
##### Description of change
We still require `hitTestChildren` to be true for events outside of a mask to make sure mouseouts are fired.
https://github.com/pixijs/pixi.js/issues/5135

##### Pre-Merge Checklist
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)