### PR TITLE
Fixes for pixi-spine

### DIFF
--- a/packages/core/src/textures/BaseTexture.js
+++ b/packages/core/src/textures/BaseTexture.js
@@ -645,6 +645,6 @@ export default class BaseTexture extends EventEmitter
  * Global number of the texture batch, used by multi-texture renderers
  *
  * @static
- * @member {number} new texture batch number
+ * @member {number}
  */
 BaseTexture._globalBatch = 0;

--- a/packages/mesh/src/Mesh.js
+++ b/packages/mesh/src/Mesh.js
@@ -144,7 +144,7 @@ export default class Mesh extends Container
      */
     get uvBuffer()
     {
-        return this.geometry.buffers[1].data;
+        return this.geometry.buffers[1];
     }
 
     /**
@@ -155,7 +155,7 @@ export default class Mesh extends Container
      */
     get verticesBuffer()
     {
-        return this.geometry.buffers[0].data;
+        return this.geometry.buffers[0];
     }
 
     /**


### PR DESCRIPTION
Found two problems while trying to debug pixi-spine for v5.

1. I failed typings in #5546 
2. uvBuffer() returns data instead of Buffer.

Now it works with pixi-spine, I'm uploading update to examples.

I dont want to return `mesh.uvs` prop because that way people wont learn how to use buffer and call `update()` function for it.