### PR TITLE
Add childrenToName [suggest]

### DIFF
--- a/packages/mixin-get-child-by-name/src/index.js
+++ b/packages/mixin-get-child-by-name/src/index.js
@@ -28,3 +28,23 @@ Container.prototype.getChildByName = function getChildByName(name)
 
     return null;
 };
+
+/**
+ * Add reference by name from children in child.
+ *
+ * @method childrenToName
+ * @memberof PIXI.Container#
+ * @return {Object.keys} Keys name.
+ */
+Container.prototype.childrenToName = function childrenToName()
+{   
+    this.child = {}; // clear
+    for (let i = 0; i < this.children.length; i++){
+        const name = this.children[i].name;
+        if(name){
+            if(object1.hasOwnProperty(name)){ throw console.error(`Conflic name alrealy exist ${name}`,this) };
+            this.child[name] = this.children[i]; // ref obj
+        }
+    };
+    return Object.keys(this.child);
+};

--- a/packages/mixin-get-child-by-name/src/index.js
+++ b/packages/mixin-get-child-by-name/src/index.js
@@ -42,7 +42,7 @@ Container.prototype.childrenToName = function childrenToName()
     for (let i = 0; i < this.children.length; i++){
         const name = this.children[i].name;
         if(name){
-            if(object1.hasOwnProperty(name)){ throw console.error(`Conflic name alrealy exist ${name}`,this) };
+            if(this.child.hasOwnProperty(name)){ throw console.error(`Conflic name alrealy exist ${name}`,this) };
             this.child[name] = this.children[i]; // ref obj
         }
     };


### PR DESCRIPTION
##### Description of change
Allow name of childrens , getChildByName are too heavy to call and bad performance.

Example:
```javascript
    initialize(){
        const master = new PIXI.Container();
        ['A','B','C','D'].forEach(n => {
            const cage = new PIXI.Container();
            cage.name = `blabla${n}`; // name the children
            master.addChild(cage);
        });
        master.childrenToName(); // store and ref child with name in .child
    };

// later , stuff ....
    event(e){
        const ee = e.currentTarget.child.blablaA; //good performance instead of getChildByName
        // ..... if no more need, maybe will need add a remover key in  removeChild?
        delete e.currentTarget.child.blablaA;
        e.currentTarget.removeChild(ee);
    };
```

- [ ] Tests and/or benchmarks are included
- [ x] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ x] Tests passed (`npm run test`)
