### PR TITLE
Temporary disable createImageBitmap in resources

### DIFF
--- a/packages/core/src/textures/resources/ImageResource.js
+++ b/packages/core/src/textures/resources/ImageResource.js
@@ -12,7 +12,7 @@ export default class ImageResource extends BaseImageResource
     /**
      * @param {HTMLImageElement|string} source - image source or URL
      * @param {boolean} [options.autoLoad=true] start loading process
-     * @param {boolean} [options.createBitmap=true] whether its required to create
+     * @param {boolean} [options.createBitmap=false] whether its required to create
      *        a bitmap before upload defaults true
      * @param {boolean} [options.crossorigin=true] - Load image using cross origin
      * @param {boolean} [options.premultiplyAlpha=true] - Premultiply image alpha in bitmap
@@ -58,7 +58,7 @@ export default class ImageResource extends BaseImageResource
          * @member {boolean}
          * @default PIXI.settings.CREATE_IMAGE_BITMAP
          */
-        this.createBitmap = options.createBitmap !== false && settings.CREATE_IMAGE_BITMAP && !!window.createImageBitmap;
+        this.createBitmap = (options.createBitmap || settings.CREATE_IMAGE_BITMAP) && !!window.createImageBitmap;
 
         /**
          * Controls texture premultiplyAlpha field

--- a/packages/core/src/textures/resources/ImageResource.js
+++ b/packages/core/src/textures/resources/ImageResource.js
@@ -12,8 +12,8 @@ export default class ImageResource extends BaseImageResource
     /**
      * @param {HTMLImageElement|string} source - image source or URL
      * @param {boolean} [options.autoLoad=true] start loading process
-     * @param {boolean} [options.createBitmap=false] whether its required to create
-     *        a bitmap before upload defaults true
+     * @param {boolean} [options.createBitmap=PIXI.settings.CREATE_IMAGE_BITMAP] whether its required to create
+     *        a bitmap before upload
      * @param {boolean} [options.crossorigin=true] - Load image using cross origin
      * @param {boolean} [options.premultiplyAlpha=true] - Premultiply image alpha in bitmap
      */

--- a/packages/core/src/textures/resources/ImageResource.js
+++ b/packages/core/src/textures/resources/ImageResource.js
@@ -58,7 +58,8 @@ export default class ImageResource extends BaseImageResource
          * @member {boolean}
          * @default PIXI.settings.CREATE_IMAGE_BITMAP
          */
-        this.createBitmap = (options.createBitmap || settings.CREATE_IMAGE_BITMAP) && !!window.createImageBitmap;
+        this.createBitmap = (options.createBitmap !== undefined
+            ? options.createBitmap : settings.CREATE_IMAGE_BITMAP) && !!window.createImageBitmap;
 
         /**
          * Controls texture premultiplyAlpha field

--- a/packages/core/src/textures/resources/autoDetectResource.js
+++ b/packages/core/src/textures/resources/autoDetectResource.js
@@ -50,7 +50,7 @@ export const INSTALLED = [];
  * @param {number} [options.height] - BufferResource's height
  * @param {boolean} [options.autoLoad=true] - Image, SVG and Video flag to start loading
  * @param {number} [options.scale=1] - SVG source scale
- * @param {boolean} [options.createBitmap=true] - Image option to create Bitmap object
+ * @param {boolean} [options.createBitmap=false] - Image option to create Bitmap object
  * @param {boolean} [options.crossorigin=true] - Image and Video option to set crossOrigin
  * @param {boolean} [options.autoPlay=true] - Video option to start playing video immediately
  * @param {number} [options.updateFPS=0] - Video option to update how many times a second the

--- a/packages/core/src/textures/resources/autoDetectResource.js
+++ b/packages/core/src/textures/resources/autoDetectResource.js
@@ -50,7 +50,7 @@ export const INSTALLED = [];
  * @param {number} [options.height] - BufferResource's height
  * @param {boolean} [options.autoLoad=true] - Image, SVG and Video flag to start loading
  * @param {number} [options.scale=1] - SVG source scale
- * @param {boolean} [options.createBitmap=false] - Image option to create Bitmap object
+ * @param {boolean} [options.createBitmap=PIXI.settings.CREATE_IMAGE_BITMAP] - Image option to create Bitmap object
  * @param {boolean} [options.crossorigin=true] - Image and Video option to set crossOrigin
  * @param {boolean} [options.autoPlay=true] - Video option to start playing video immediately
  * @param {number} [options.updateFPS=0] - Video option to update how many times a second the

--- a/packages/core/test/ImageResource.js
+++ b/packages/core/test/ImageResource.js
@@ -55,7 +55,7 @@ describe('PIXI.resources.ImageResource', function ()
 
         const resource = new ImageResource(image, {
             autoLoad: false,
-            createImage: true,
+            createBitmap: true,
         });
 
         return resource.load().then((res) =>

--- a/packages/core/test/ImageResource.js
+++ b/packages/core/test/ImageResource.js
@@ -53,7 +53,10 @@ describe('PIXI.resources.ImageResource', function ()
 
         image.src = this.slugUrl;
 
-        const resource = new ImageResource(image, { autoLoad: false });
+        const resource = new ImageResource(image, {
+            autoLoad: false,
+            createImage: true,
+        });
 
         return resource.load().then((res) =>
         {

--- a/packages/core/test/ImageResource.js
+++ b/packages/core/test/ImageResource.js
@@ -1,4 +1,5 @@
 const { resources } = require('../');
+const { settings } = require('@pixi/settings');
 const { ImageResource } = resources;
 const path = require('path');
 
@@ -86,6 +87,50 @@ describe('PIXI.resources.ImageResource', function ()
             expect(resource.height).to.equal(100);
             expect(resource.valid).to.be.true;
             expect(resource.bitmap).to.be.null;
+        });
+    });
+
+    it('should handle the loaded event with createBitmapImage using global setting', function ()
+    {
+        const old = settings.CREATE_IMAGE_BITMAP;
+        const image = new Image();
+
+        settings.CREATE_IMAGE_BITMAP = true;
+        image.src = this.slugUrl;
+
+        const resource = new ImageResource(image, { autoLoad: false });
+
+        return resource.load().then((res) =>
+        {
+            expect(res).to.equal(resource);
+            expect(resource.createBitmap).to.equal(true);
+            expect(resource.width).to.equal(100);
+            expect(resource.height).to.equal(100);
+            expect(resource.valid).to.be.true;
+            expect(resource.bitmap).to.be.instanceof(ImageBitmap);
+            settings.CREATE_IMAGE_BITMAP = old;
+        });
+    });
+
+    it('should handle the loaded event with no createBitmapImage using global setting', function ()
+    {
+        const old = settings.CREATE_IMAGE_BITMAP;
+        const image = new Image();
+
+        settings.CREATE_IMAGE_BITMAP = false;
+        image.src = this.slugUrl;
+
+        const resource = new ImageResource(image, { autoLoad: false });
+
+        return resource.load().then((res) =>
+        {
+            expect(res).to.equal(resource);
+            expect(resource.createBitmap).to.equal(false);
+            expect(resource.width).to.equal(100);
+            expect(resource.height).to.equal(100);
+            expect(resource.valid).to.be.true;
+            expect(resource.bitmap).to.be.null;
+            settings.CREATE_IMAGE_BITMAP = old;
         });
     });
 });

--- a/packages/settings/src/settings.js
+++ b/packages/settings/src/settings.js
@@ -201,15 +201,15 @@ export default {
     CAN_UPLOAD_SAME_BUFFER: canUploadSameBuffer(),
 
     /**
-     * Enables bitmap creation before image load
+     * Enables bitmap creation before image load. This feature is experimental.
      *
      * @static
      * @name CREATE_IMAGE_BITMAP
      * @memberof PIXI.settings
      * @type {boolean}
-     * @default true
+     * @default false
      */
-    CREATE_IMAGE_BITMAP: true,
+    CREATE_IMAGE_BITMAP: false,
 
     /**
      * If true PixiJS will Math.floor() x/y values when rendering, stopping pixel interpolation.


### PR DESCRIPTION
Partially fixes #5626 
There are some issues with using `createImageBitmap` for now, we'll disable and use v4 functionality.