### PR TITLE
Texture destroy throws a deprecation warning

### DIFF
--- a/packages/core/src/textures/Texture.js
+++ b/packages/core/src/textures/Texture.js
@@ -229,11 +229,13 @@ export default class Texture extends EventEmitter
         {
             if (destroyBase)
             {
+                const { resource } = this.baseTexture;
+
                 // delete the texture if it exists in the texture cache..
                 // this only needs to be removed if the base texture is actually destroyed too..
-                if (TextureCache[this.baseTexture.imageUrl])
+                if (resource && TextureCache[resource.url])
                 {
-                    Texture.removeFromCache(this.baseTexture.imageUrl);
+                    Texture.removeFromCache(resource.url);
                 }
 
                 this.baseTexture.destroy();


### PR DESCRIPTION
Fixes #5632

Internal PixiJS code should NOT be using deprecated properties. This will fail for users that try to import `@pixi/core` and destroy a RenderTexture. Only will work with **pixi.js** or **pixi.js-legacy**

**Broken**: https://pixiplayground.com/#/edit/PP6wCar~eanphFaVq41pZ
**Fixed**: https://pixiplayground.com/#/edit/gG5G1F0fQfK7yhq3EbaJM