### PR TITLE
Adds name to root package.json so Lerna lifecycle hooks are used

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "pixi.js-monorepo",
   "private": true,
   "scripts": {
     "start": "npm run watch",


### PR DESCRIPTION
Fixes #5634 

## Overview

Without a `name` field in the **package.json**, Lerna does the npm default behavior and uses the name of the folder (e.g. `npm init --yes`). Unfortunately, this conflicts with the name of a child package (e.g. **bundles/pixi.js**) which causes the root-level lifecycle methods to be skipped. I'm not sure if this is an error with Lerna, but the workaround seems to be: add a unique `name` in the root **package.json**.

I did a test run locally by running `npm run release` and then killing my internet connection just before publishing. The `postversion` lifecycle method was invoked correctly.