### PR TITLE
Minor doc fixes for TypeScript definitions

### DIFF
--- a/packages/loaders/src/Loader.js
+++ b/packages/loaders/src/Loader.js
@@ -187,3 +187,28 @@ Loader.registerPlugin(TextureLoader);
  * @param {PIXI.LoaderResource} resource
  * @param {function} next
  */
+
+/**
+ * @memberof PIXI.Loader#
+ * @member {object} onStart
+ */
+
+/**
+ * @memberof PIXI.Loader#
+ * @member {object} onProgress
+ */
+
+/**
+ * @memberof PIXI.Loader#
+ * @member {object} onError
+ */
+
+/**
+ * @memberof PIXI.Loader#
+ * @member {object} onLoad
+ */
+
+/**
+ * @memberof PIXI.Loader#
+ * @member {object} onComplete
+ */

--- a/packages/sprite/src/Sprite.js
+++ b/packages/sprite/src/Sprite.js
@@ -391,7 +391,7 @@ export default class Sprite extends Container
     /**
      * Gets the local bounds of the sprite object.
      *
-     * @param {PIXI.Rectangle} rect - The output rectangle.
+     * @param {PIXI.Rectangle} [rect] - The output rectangle.
      * @return {PIXI.Rectangle} The bounds.
      */
     getLocalBounds(rect)

--- a/packages/text/src/TextMetrics.js
+++ b/packages/text/src/TextMetrics.js
@@ -24,14 +24,67 @@ export default class TextMetrics
      */
     constructor(text, style, width, height, lines, lineWidths, lineHeight, maxLineWidth, fontProperties)
     {
+        /**
+         * The text that was measured
+         *
+         * @member {string}
+         */
         this.text = text;
+
+        /**
+         * The style that was measured
+         *
+         * @member {PIXI.TextStyle}
+         */
         this.style = style;
+
+        /**
+         * The measured width of the text
+         *
+         * @member {number}
+         */
         this.width = width;
+
+        /**
+         * The measured height of the text
+         *
+         * @member {number}
+         */
         this.height = height;
+
+        /**
+         * An array of lines of the text broken by new lines and wrapping is specified in style
+         *
+         * @member {string[]}
+         */
         this.lines = lines;
+
+        /**
+         * An array of the line widths for each line matched to `lines`
+         *
+         * @member {number[]}
+         */
         this.lineWidths = lineWidths;
+
+        /**
+         * The measured line height for this style
+         *
+         * @member {number}
+         */
         this.lineHeight = lineHeight;
+
+        /**
+         * The maximum line width for all measured lines
+         *
+         * @member {number}
+         */
         this.maxLineWidth = maxLineWidth;
+
+        /**
+         * The font properties object from TextMetrics.measureFont
+         *
+         * @member {PIXI.IFontMetrics}
+         */
         this.fontProperties = fontProperties;
     }
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

Just a few minor fixes for TS definitions I've spotted while upgrading from v4 and @types/pixi.js to v5.
- Added object type for on(Start/Progress/Error/Load/Complete) signals on Loader.
  - If there's a better type/method for this let me know, couldn't find a type name that'd actually use the doc from MiniSignal.
- Sprite.getLocalBounds - Rect argument isn't required.
- TextMetrics - Constructor's jsdoc comment doesn't add member properties to the type, so added those to the assignments within the constructor.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
