### PR TITLE
Fixes video not working in 5.0.1

### DIFF
--- a/packages/core/src/textures/resources/BaseImageResource.js
+++ b/packages/core/src/textures/resources/BaseImageResource.js
@@ -14,7 +14,10 @@ export default class BaseImageResource extends Resource
      */
     constructor(source)
     {
-        super(source.width, source.height);
+        const width = source.naturalWidth || source.videoWidth || source.width;
+        const height = source.naturalHeight || source.videoHeight || source.height;
+
+        super(width, height);
 
         /**
          * The source element
@@ -87,7 +90,10 @@ export default class BaseImageResource extends Resource
             return;
         }
 
-        this.resize(this.source.width, this.source.height);
+        const width = this.source.naturalWidth || this.source.videoWidth || this.source.width;
+        const height = this.source.naturalHeight || this.source.videoHeight || this.source.height;
+
+        this.resize(width, height);
 
         super.update();
     }


### PR DESCRIPTION
Fixes https://github.com/pixijs/pixi.js/issues/5659

After the PR @ https://github.com/pixijs/pixi.js/pull/5643,
`this.resize(this.source.width, this.source.height);` 
in BaseImageResource is sending source.width and source.height, both of which are 0 in a video. We should be using videoWidth and videoHeight instead. I've copied over what was done in v4 to ensure the right properties are picked up (https://github.com/pixijs/pixi.js/blob/v4.8.7/src/core/textures/BaseTexture.js#L266)

Previously in 5.0.0, it got away with it as `onBaseTextureUpdated` function would get the correct dimensions as set by the video resource, but the base texture was never flagged as 'updated' after that.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
