### PR TITLE
copy sourceFrame only after resolution was adjusted

### DIFF
--- a/packages/core/src/renderTexture/RenderTextureSystem.js
+++ b/packages/core/src/renderTexture/RenderTextureSystem.js
@@ -123,13 +123,13 @@ export default class RenderTextureSystem extends System
             this.renderer.stencil.setMaskStack(this.defaultMaskStack);
         }
 
-        this.sourceFrame.copyFrom(sourceFrame);
-
         this.destinationFrame.x = destinationFrame.x / resolution;
         this.destinationFrame.y = destinationFrame.y / resolution;
 
         this.destinationFrame.width = destinationFrame.width / resolution;
         this.destinationFrame.height = destinationFrame.height / resolution;
+
+        this.sourceFrame.copyFrom(sourceFrame);
     }
 
     /**

--- a/packages/core/src/renderTexture/RenderTextureSystem.js
+++ b/packages/core/src/renderTexture/RenderTextureSystem.js
@@ -123,13 +123,18 @@ export default class RenderTextureSystem extends System
             this.renderer.stencil.setMaskStack(this.defaultMaskStack);
         }
 
+        this.sourceFrame.copyFrom(sourceFrame);
+
         this.destinationFrame.x = destinationFrame.x / resolution;
         this.destinationFrame.y = destinationFrame.y / resolution;
 
         this.destinationFrame.width = destinationFrame.width / resolution;
         this.destinationFrame.height = destinationFrame.height / resolution;
 
-        this.sourceFrame.copyFrom(sourceFrame);
+        if (sourceFrame === destinationFrame)
+        {
+            this.sourceFrame.copyFrom(this.destinationFrame);
+        }
     }
 
     /**


### PR DESCRIPTION
@fanjules strikes again.

Fixes #5674

res=0.5: https://www.pixiplayground.com/#/edit/WG2cvHNUbaPQQ_dt041Xp

res=5, bunny scale=50, bunny exceeds 4096 while the canvas is not: https://www.pixiplayground.com/#/edit/EMIDJrfi6kHQykA7LlksD

Both are fixed:
res=0.5, https://www.pixiplayground.com/#/edit/6Z9XI6VBtIzkmr_CfEDXD
res=5. https://www.pixiplayground.com/#/edit/Vplnql8HgViuQR~42iSPm

@GoodBoyDigital we certainly need more tests for ProjectionSystem. I dont understand the logic you made there for resolutions but at least i can fix it temporarily.
