### PR TITLE
finally actually added the polygon offset check :)

### DIFF
--- a/packages/core/src/state/StateSystem.js
+++ b/packages/core/src/state/StateSystem.js
@@ -182,6 +182,8 @@ export default class StateSystem extends System
      */
     setOffset(value)
     {
+        this.updateCheck(StateSystem.checkPolygonOffset, value);
+
         this.gl[value ? 'enable' : 'disable'](this.gl.POLYGON_OFFSET_FILL);
     }
 
@@ -314,5 +316,16 @@ export default class StateSystem extends System
         system.setBlendMode(state.blendMode);
     }
 
-    // TODO - add polygon offset?
+    /**
+     * A private little wrapper function that we call to check the polygon offset.
+     *
+     * @static
+     * @private
+     * @param {PIXI.StateSystem} System  the System to perform the state check on
+     * @param {PIXI.State} state  the state that the blendMode will pulled from
+     */
+    static checkPolygonOffset(system, state)
+    {
+        system.setPolygonOffset(state.polygonOffset, 0);
+    }
 }


### PR DESCRIPTION
Polygon offset never actually got set, just was activated.
This PR means that the following now works:

```
const state = new PIXI.State();
state.polygonOffset = 10
```

this basically adds an offset to the pixel as it depth is calculated. 