### PR TITLE
Fixes regression on CanvasRenderer using tint with Sprite, AnimatedSprite and TilingSprite, BitmapText

### DIFF
--- a/packages/canvas/canvas-sprite-tiling/src/TilingSprite.js
+++ b/packages/canvas/canvas-sprite-tiling/src/TilingSprite.js
@@ -29,7 +29,7 @@ TilingSprite.prototype._renderCanvas = function _renderCanvas(renderer)
     const modY = ((this.tilePosition.y / this.tileScale.y) % texture._frame.height) * baseTextureResolution;
 
     // create a nice shiny pattern!
-    if (this._textureID !== this._texture._updateID || this.cachedTint !== this.tint)
+    if (this._textureID !== this._texture._updateID || this._cachedTint !== this.tint)
     {
         this._textureID = this._texture._updateID;
         // cut an object from a spritesheet..
@@ -48,7 +48,7 @@ TilingSprite.prototype._renderCanvas = function _renderCanvas(renderer)
             tempCanvas.context.drawImage(source,
                 -texture._frame.x * baseTextureResolution, -texture._frame.y * baseTextureResolution);
         }
-        this.cachedTint = this.tint;
+        this._cachedTint = this.tint;
         this._canvasPattern = tempCanvas.context.createPattern(tempCanvas.canvas, 'repeat');
     }
 

--- a/packages/canvas/canvas-sprite/src/CanvasSpriteRenderer.js
+++ b/packages/canvas/canvas-sprite/src/CanvasSpriteRenderer.js
@@ -159,7 +159,7 @@ export default class CanvasSpriteRenderer
             }
 
             context.drawImage(
-                source,
+                sprite._tintedCanvas,
                 0,
                 0,
                 width * resolution,

--- a/packages/canvas/canvas-sprite/src/Sprite.js
+++ b/packages/canvas/canvas-sprite/src/Sprite.js
@@ -9,14 +9,6 @@ import { Sprite } from '@pixi/sprite';
 Sprite.prototype._tintedCanvas = null;
 
 /**
- * Cached tint value so we can tell when the tint is changed.
- * @memberof PIXI.Sprite#
- * @member {number} _cachedTint
- * @protected
- */
-Sprite.prototype._cachedTint = 0xFFFFFF;
-
-/**
 * Renders the object using the Canvas renderer
 *
 * @private

--- a/packages/sprite-animated/src/AnimatedSprite.js
+++ b/packages/sprite-animated/src/AnimatedSprite.js
@@ -296,7 +296,7 @@ export default class AnimatedSprite extends Sprite
         this._texture = this._textures[this.currentFrame];
         this._textureID = -1;
         this._textureTrimmedID = -1;
-        this.cachedTint = 0xFFFFFF;
+        this._cachedTint = 0xFFFFFF;
         this.uvs = this._texture._uvs.uvsFloat32;
 
         if (this.updateAnchor)

--- a/packages/sprite-tiling/src/TilingSprite.js
+++ b/packages/sprite-tiling/src/TilingSprite.js
@@ -137,7 +137,7 @@ export default class TilingSprite extends Sprite
         {
             this.uvMatrix.texture = this._texture;
         }
-        this.cachedTint = 0xFFFFFF;
+        this._cachedTint = 0xFFFFFF;
     }
 
     /**

--- a/packages/sprite/src/Sprite.js
+++ b/packages/sprite/src/Sprite.js
@@ -114,13 +114,14 @@ export default class Sprite extends Container
         this.shader = null;
 
         /**
-         * An internal cached value of the tint.
+         * Cached tint value so we can tell when the tint is changed.
+         * Value is used for 2d CanvasRenderer.
          *
-         * @private
+         * @protected
          * @member {number}
          * @default 0xFFFFFF
          */
-        this.cachedTint = 0xFFFFFF;
+        this._cachedTint = 0xFFFFFF;
 
         this.uvs = null;
 
@@ -188,7 +189,7 @@ export default class Sprite extends Container
     {
         this._textureID = -1;
         this._textureTrimmedID = -1;
-        this.cachedTint = 0xFFFFFF;
+        this._cachedTint = 0xFFFFFF;
 
         this.uvs = this._texture._uvs.uvsFloat32;
         // so if _width is 0 then width was not set..
@@ -622,7 +623,7 @@ export default class Sprite extends Container
         }
 
         this._texture = value || Texture.EMPTY;
-        this.cachedTint = 0xFFFFFF;
+        this._cachedTint = 0xFFFFFF;
 
         this._textureID = -1;
         this._textureTrimmedID = -1;


### PR DESCRIPTION
Fix #5731 

Broken: https://www.pixiplayground.com/#/edit/Cb6stLyzhuLCOEiaYcsZa
Fixed: https://www.pixiplayground.com/#/edit/K19jO7gbgvvsPrdvQiPJu

Broken: https://www.pixiplayground.com/#/edit/07nXx54J53DrMMKg6PO5Q
Fixed: https://www.pixiplayground.com/#/edit/mOaEKjbqZ3kgY09fpbSDz

+1 example, checks TilingSprite:
https://www.pixiplayground.com/#/edit/Tn4p3ZaUggOs0hsO7P4kV