### PR TITLE
Fixes Graphics holes with CanvasRenderer

### DIFF
--- a/packages/canvas/canvas-graphics/src/CanvasGraphicsRenderer.js
+++ b/packages/canvas/canvas-graphics/src/CanvasGraphicsRenderer.js
@@ -82,6 +82,8 @@ export default class CanvasGraphicsRenderer
                 const holes = data.holes;
                 let outerArea;
                 let innerArea;
+                let px;
+                let py;
 
                 context.moveTo(points[0], points[1]);
 
@@ -98,19 +100,30 @@ export default class CanvasGraphicsRenderer
                 if (holes.length > 0)
                 {
                     outerArea = 0;
-                    for (let j = 0; j < points.length; j += 2)
+                    px = points[0];
+                    py = points[1];
+                    for (let j = 2; j + 2 < points.length; j += 2)
                     {
-                        outerArea += (points[j] * points[j + 3]) - (points[j + 1] * points[j + 2]);
+                        outerArea += ((points[j] - px) * (points[j + 3] - py))
+                            - ((points[j + 2] - px) * (points[j + 1] - py));
                     }
 
                     for (let k = 0; k < holes.length; k++)
                     {
-                        points = holes[k].points;
+                        points = holes[k].shape.points;
+
+                        if (!points)
+                        {
+                            continue;
+                        }
 
                         innerArea = 0;
-                        for (let j = 0; j < points.length; j += 2)
+                        px = points[0];
+                        py = points[1];
+                        for (let j = 2; j + 2 < points.length; j += 2)
                         {
-                            innerArea += (points[j] * points[j + 3]) - (points[j + 1] * points[j + 2]);
+                            innerArea += ((points[j] - px) * (points[j + 3] - py))
+                                - ((points[j + 2] - px) * (points[j + 1] - py));
                         }
 
                         if (innerArea * outerArea < 0)


### PR DESCRIPTION
Fix #5727

Its partial fix that works only for polygon that has polygon holes. `drawRect` and other things wont work with it.

Bug: https://www.pixiplayground.com/#/edit/4GVTR9VA2uBmxe74PB2~z
Fixed: https://www.pixiplayground.com/#/edit/VJga6DVoy9jekGt1e~NzF
