### PR TITLE
BlendMode alpha fix.

### DIFF
--- a/packages/core/src/state/utils/mapWebGLBlendModesToPixi.js
+++ b/packages/core/src/state/utils/mapWebGLBlendModesToPixi.js
@@ -15,7 +15,7 @@ export default function mapWebGLBlendModesToPixi(gl, array = [])
     // TODO - premultiply alpha would be different.
     // add a boolean for that!
     array[BLEND_MODES.NORMAL] = [gl.ONE, gl.ONE_MINUS_SRC_ALPHA];
-    array[BLEND_MODES.ADD] = [gl.ONE, gl.DST_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA];
+    array[BLEND_MODES.ADD] = [gl.ONE, gl.ONE];
     array[BLEND_MODES.MULTIPLY] = [gl.DST_COLOR, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA];
     array[BLEND_MODES.SCREEN] = [gl.ONE, gl.ONE_MINUS_SRC_COLOR, gl.ONE, gl.ONE_MINUS_SRC_ALPHA];
     array[BLEND_MODES.OVERLAY] = [gl.ONE, gl.ONE_MINUS_SRC_ALPHA];
@@ -35,7 +35,7 @@ export default function mapWebGLBlendModesToPixi(gl, array = [])
 
     // not-premultiplied blend modes
     array[BLEND_MODES.NORMAL_NPM] = [gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA];
-    array[BLEND_MODES.ADD_NPM] = [gl.SRC_ALPHA, gl.DST_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA];
+    array[BLEND_MODES.ADD_NPM] = [gl.ONE, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE];
     array[BLEND_MODES.SCREEN_NPM] = [gl.SRC_ALPHA, gl.ONE_MINUS_SRC_COLOR, gl.ONE, gl.ONE_MINUS_SRC_ALPHA];
 
     // composite operations

--- a/packages/core/src/state/utils/mapWebGLBlendModesToPixi.js
+++ b/packages/core/src/state/utils/mapWebGLBlendModesToPixi.js
@@ -35,7 +35,7 @@ export default function mapWebGLBlendModesToPixi(gl, array = [])
 
     // not-premultiplied blend modes
     array[BLEND_MODES.NORMAL_NPM] = [gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA];
-    array[BLEND_MODES.ADD_NPM] = [gl.ONE, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE];
+    array[BLEND_MODES.ADD_NPM] = [gl.SRC_ALPHA, gl.ONE, gl.ONE, gl.ONE];
     array[BLEND_MODES.SCREEN_NPM] = [gl.SRC_ALPHA, gl.ONE_MINUS_SRC_COLOR, gl.ONE, gl.ONE_MINUS_SRC_ALPHA];
 
     // composite operations


### PR DESCRIPTION
Broken: https://www.pixiplayground.com/#/edit/wh4NJRXJqWCcI87N8lB03
Fixed: https://www.pixiplayground.com/#/edit/2LB0thwrX8EQM5iE7SXN~

Output in Flash runtime: 
![image](https://user-images.githubusercontent.com/695831/58567256-b81af800-823a-11e9-9add-a343bf39ab00.png)


This is not the breaking change: in most of cases ADD was applied on opaque backdrop, and when people use it on transparent background they see the difference:

#5677 
#5673 
#5446

This is the final answer on BlendMode ADD problem.

Sometimes when I look many hours on the same line, when I know there's a bug but I dont see it. I knew about that effect and thanks to several people I deduced that something is wrong with my memory and sight.

Call it brain blind zone. Call it memory hash collision. Such things happen.

After blackboxing and making more tests with Adobe Flash, I finally found that brain glitch.

I do not know how the heck `gl.DST_ALPHA` appeared in one of coefficients. maybe it was before my time in pixijs. Somehow, at some point of time I changed `ADD` in my private fork to correct one `[gl.ONE, gl.ONE]`, but I forgot to push it into vanilla pixijs! 

That's why I thought that pixijs vanilla ADD is correct, I even answered to multiple people that having completely transparent geometry add over half-transparent background actually changes the color. I recommended to use custom blendMode with `[gl.ONE, gl.ONE]` as workaround, completely forgetting that its actually the correct one from my private fork!

Related PR: #5562

I thank @hsienwei, @SergiyTopalov , @distinctdan and others who drew my attention to the problem.