### PR TITLE
Update Sprite.pluginName documentation

### DIFF
--- a/packages/sprite/src/Sprite.js
+++ b/packages/sprite/src/Sprite.js
@@ -161,7 +161,7 @@ export default class Sprite extends Container
          * Allows to customize the rendering process without overriding '_render' & '_renderCanvas' methods.
          *
          * @member {string}
-         * @default 'sprite'
+         * @default 'batch'
          */
         this.pluginName = 'batch';
 


### PR DESCRIPTION
Currently the documentation for Sprite.pluginName does not match the code. This is a small update that sorts out the issue. Related to #5761