### PR TITLE
Do not throw error when calling Sprite.destroy() more than once

### DIFF
--- a/packages/sprite/src/Sprite.js
+++ b/packages/sprite/src/Sprite.js
@@ -463,20 +463,23 @@ export default class Sprite extends Container
     {
         super.destroy(options);
 
-        this._texture.off('update', this._onTextureUpdate, this);
-
-        this._anchor = null;
-
-        const destroyTexture = typeof options === 'boolean' ? options : options && options.texture;
-
-        if (destroyTexture)
+        if (this._texture)
         {
-            const destroyBaseTexture = typeof options === 'boolean' ? options : options && options.baseTexture;
+            this._texture.off('update', this._onTextureUpdate, this);
 
-            this._texture.destroy(!!destroyBaseTexture);
+            const destroyTexture = typeof options === 'boolean' ? options : options && options.texture;
+
+            if (destroyTexture)
+            {
+                const destroyBaseTexture = typeof options === 'boolean' ? options : options && options.baseTexture;
+
+                this._texture.destroy(!!destroyBaseTexture);
+            }
+
+            this._texture = null;
         }
 
-        this._texture = null;
+        this._anchor = null;
         this.shader = null;
     }
 


### PR DESCRIPTION
##### Description of change
This update makes Sprite.destroy() perform like Container.destroy() or any other DisplayObject.destroy(). Before this update an error was thrown as `_texture` does not exist. This update simply checks for where the `_texture` exists.

Here's a test: 
https://www.pixiplayground.com/#/edit/tfnFfI01kNpXKVTuPH1c5