### PR TITLE
Fixes issue with docs/types with BatchPluginFactory

### DIFF
--- a/packages/core/src/batch/BatchPluginFactory.js
+++ b/packages/core/src/batch/BatchPluginFactory.js
@@ -6,33 +6,32 @@ import defaultVertex from './texture.vert';
 import defaultFragment from './texture.frag';
 
 /**
- * Used to create new, custom BatchRenderer plugins for the Renderer.
- * @example
- * const fragment = `
- * varying vec2 vTextureCoord;
- * varying vec4 vColor;
- * varying float vTextureId;
- * uniform sampler2D uSamplers[%count%];
- *
- * void main(void){
- *     vec4 color;
- *     %forloop%
- *     gl_FragColor = vColor * vec4(color.a - color.rgb, color.a);
- * }
- * `;
- * const InvertBatchRenderer = PIXI.BatchPluginFactory.create({ fragment });
- * PIXI.Renderer.registerPlugin('invert', InvertBatchRenderer);
- * const sprite = new PIXI.Sprite();
- * sprite.pluginName = 'invert';
- *
  * @class
  * @memberof PIXI
+ * @hideconstructor
  */
-export class BatchPluginFactory
+export default class BatchPluginFactory
 {
     /**
      * Create a new BatchRenderer plugin for Renderer. this convenience can provide an easy way
      * to extend BatchRenderer with all the necessary pieces.
+     * @example
+     * const fragment = `
+     * varying vec2 vTextureCoord;
+     * varying vec4 vColor;
+     * varying float vTextureId;
+     * uniform sampler2D uSamplers[%count%];
+     *
+     * void main(void){
+     *     vec4 color;
+     *     %forloop%
+     *     gl_FragColor = vColor * vec4(color.a - color.rgb, color.a);
+     * }
+     * `;
+     * const InvertBatchRenderer = PIXI.BatchPluginFactory.create({ fragment });
+     * PIXI.Renderer.registerPlugin('invert', InvertBatchRenderer);
+     * const sprite = new PIXI.Sprite();
+     * sprite.pluginName = 'invert';
      *
      * @static
      * @param {object} [options]

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -22,7 +22,7 @@ export { default as BaseRenderTexture } from './renderTexture/BaseRenderTexture'
 export { default as TextureUvs } from './textures/TextureUvs';
 export { default as State } from './state/State';
 export { default as ObjectRenderer } from './batch/ObjectRenderer';
-export * from './batch/BatchPluginFactory';
+export { default as BatchPluginFactory, BatchRenderer } from './batch/BatchPluginFactory';
 export { default as BatchShaderGenerator } from './batch/BatchShaderGenerator';
 export { default as BatchGeometry } from './batch/BatchGeometry';
 export { default as BatchDrawCall } from './batch/BatchDrawCall';


### PR DESCRIPTION
Resolves docs/types issue with new BatchPluginFactory. Somehow this was missed.

Also, adds `@hideconstructor` on BatchPluginFactory for future use once the `@pixi/jsdoc-template` supports this.

**Broken:** http://pixijs.download/dev/docs/PIXI.exports.BatchPluginFactory.html
**Fixed:** http://pixijs.download/fix-batch-factory-docs/docs/PIXI.BatchPluginFactory.html

**Future Work:**
Documentation doesn't work for non-default exports unless you explicitly name the class, or else the class shows up as `exports.MyClass`. JSDoc needs an upgrade and we need a better workaround for ES6 non-default exports. JSDoc is not getting updated much these days, so not sure our best solution here.
