### PR TITLE
SVG infers width, height from viewBox

### DIFF
--- a/packages/core/src/textures/resources/SVGResource.js
+++ b/packages/core/src/textures/resources/SVGResource.js
@@ -154,13 +154,25 @@ export default class SVGResource extends BaseImageResource
      */
     static getSize(svgString)
     {
-        const sizeMatch = SVGResource.SVG_SIZE.exec(svgString);
         const size = {};
+        const sizeMatch = SVGResource.SVG_SIZE.exec(svgString);
 
         if (sizeMatch)
         {
             size[sizeMatch[1]] = Math.round(parseFloat(sizeMatch[3]));
             size[sizeMatch[5]] = Math.round(parseFloat(sizeMatch[7]));
+
+            return size;
+        }
+
+        const viewBoxMatch = SVGResource.SVG_VIEWBOX.exec(svgString);
+
+        if (viewBoxMatch)
+        {
+            size.width = Math.round(parseFloat(viewBoxMatch[3]));
+            size.height = Math.round(parseFloat(viewBoxMatch[4]));
+
+            return size;
         }
 
         return size;
@@ -204,3 +216,13 @@ export default class SVGResource extends BaseImageResource
  * @example &lt;svg width="100" height="100"&gt;&lt;/svg&gt;
  */
 SVGResource.SVG_SIZE = /<svg[^>]*(?:\s(width|height)=('|")(\d*(?:\.\d+)?)(?:px)?('|"))[^>]*(?:\s(width|height)=('|")(\d*(?:\.\d+)?)(?:px)?('|"))[^>]*>/i; // eslint-disable-line max-len
+
+/**
+ * RegExp for SVG viewBox.
+ *
+ * @static
+ * @constant {RegExp|string} SVG_SIZE
+ * @memberof PIXI.resources.SVGResource
+ * @example &lt;svg viewBox"0 0 100 100"&gt;&lt;/svg&gt;
+ */
+SVGResource.SVG_VIEWBOX = /<svg[^>]*viewBox=(?:'|")(\d*(?:\.\d+)?(?:\s|,))(\d*(?:\.\d+)?(?:\s|,))(\d*(?:\.\d+)?(?:\s|,))(\d*(?:\.\d+)?)(?:'|")[^>]*>/i; // eslint-disable-line max-len

--- a/packages/core/test/SVGResource.js
+++ b/packages/core/test/SVGResource.js
@@ -95,6 +95,18 @@ describe('PIXI.resources.SVGResource', function ()
                 .to.equal(32);
         });
 
+        it('should return a size object with width and height inferred from viewBox in an SVG string', function ()
+        {
+            const svgSize = SVGResource.getSize('<svg viewBox="0 0 64 32"></svg>');
+
+            expect(svgSize)
+                .to.be.an('object');
+            expect(svgSize.width)
+                .to.equal(64);
+            expect(svgSize.height)
+                .to.equal(32);
+        });
+
         it('should return a size object from an SVG string with inverted quotes', function ()
         {
             const svgSize = SVGResource.getSize("<svg height='32' width='64'></svg>"); // eslint-disable-line quotes

--- a/packages/core/test/SVGResource.js
+++ b/packages/core/test/SVGResource.js
@@ -27,7 +27,7 @@ describe('PIXI.resources.SVGResource', function ()
             });
         });
 
-        it('should create resource from SVG URL', function (done)
+        it('should create resource from SVG URL (heart.svg)', function (done)
         {
             const resource = new SVGResource(
                 path.join(this.resources, 'heart.svg'),
@@ -38,6 +38,22 @@ describe('PIXI.resources.SVGResource', function ()
             {
                 expect(resource.width).to.equal(100);
                 expect(resource.height).to.equal(100);
+
+                done();
+            });
+        });
+
+        it('should create resource from SVG URL (ai_export.svg)', function (done)
+        {
+            const resource = new SVGResource(
+                path.join(this.resources, 'ai_export.svg'),
+                { autoLoad: false }
+            );
+
+            resource.load().then(function ()
+            {
+                expect(resource.width).to.equal(18);
+                expect(resource.height).to.equal(18);
 
                 done();
             });

--- a/packages/core/test/resources/ai_export.svg
+++ b/packages/core/test/resources/ai_export.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 20.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="pixijs_ai_export_test-layer"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 18 18"
+	 style="enable-background:new 0 0 18 18;" xml:space="preserve">
+<style type="text/css">
+	.st0{opacity:0.25;}
+	.st1{fill:none;}
+</style>
+<g id="pixijs_ai_export_test">
+	<g>
+		<polygon points="1,7.3 1,9.8 9,17.8 17,9.8 17,7.3 9,15.3 		"/>
+		<polygon points="9,8.3 1,0.3 1,2.8 9,10.8 17,2.8 17,0.3 		"/>
+	</g>
+	<g class="st0">
+		<rect x="1" y="0" class="st1" width="16" height="18"/>
+	</g>
+</g>
+<rect y="0" class="st1" width="18" height="18"/>
+</svg>


### PR DESCRIPTION
##### Description of change
In an SVG element, the `width` and `height` attributes default to `auto`. PixiJS cannot handle this (see #5754). This PR extends the PixiJS's SVG parsing to infer these from the `viewBox` attribute, if present. This allows PixiJS to load a wider variety of SVG resources. In particular, some found in the wild created via export from Adobe Illustrator.

##### Pre-Merge Checklist
- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)