### PR TITLE
Feature/set state rename

### DIFF
--- a/bundles/pixi.js/src/useDeprecated.js
+++ b/bundles/pixi.js/src/useDeprecated.js
@@ -774,6 +774,18 @@ export default function useDeprecated()
         return this.copyTo(p);
     };
 
+    /**
+     * @method PIXI.systems.StateSystem#setState
+     * @deprecated since 5.1.0
+     * @see PIXI.systems.StateSystem#set
+     */
+    PIXI.systems.StateSystem.prototype.setState = function setState(s)
+    {
+        deprecation('v5.1.0', 'StateSystem.setState has been renamed to StateSystem.set');
+
+        return this.set(s);
+    };
+
     Object.assign(PIXI.systems.FilterSystem.prototype, {
         /**
          * @method PIXI.FilterManager#getRenderTarget

--- a/packages/core/src/batch/BatchRenderer.js
+++ b/packages/core/src/batch/BatchRenderer.js
@@ -467,7 +467,7 @@ export default class BatchRenderer extends ObjectRenderer
      */
     start()
     {
-        this.renderer.state.set(this.state);
+        this.renderer.state.setState(this.state);
 
         this.renderer.shader.bind(this.shader);
 

--- a/packages/core/src/batch/BatchRenderer.js
+++ b/packages/core/src/batch/BatchRenderer.js
@@ -467,7 +467,7 @@ export default class BatchRenderer extends ObjectRenderer
      */
     start()
     {
-        this.renderer.state.setState(this.state);
+        this.renderer.state.set(this.state);
 
         this.renderer.shader.bind(this.shader);
 

--- a/packages/core/src/filters/FilterSystem.js
+++ b/packages/core/src/filters/FilterSystem.js
@@ -357,7 +357,7 @@ export default class FilterSystem extends System
         // because it does at the moment cos of global uniforms.
         // they need to get resynced
 
-        renderer.state.set(filter.state);
+        renderer.state.setState(filter.state);
         renderer.shader.bind(filter);
 
         if (filter.legacy)

--- a/packages/core/src/filters/FilterSystem.js
+++ b/packages/core/src/filters/FilterSystem.js
@@ -357,7 +357,7 @@ export default class FilterSystem extends System
         // because it does at the moment cos of global uniforms.
         // they need to get resynced
 
-        renderer.state.setState(filter.state);
+        renderer.state.set(filter.state);
         renderer.shader.bind(filter);
 
         if (filter.legacy)

--- a/packages/core/src/state/StateSystem.js
+++ b/packages/core/src/state/StateSystem.js
@@ -90,6 +90,11 @@ export default class StateSystem extends System
         this.defaultState = new State();
         this.defaultState.blend = true;
         this.defaultState.depth = true;
+
+        /**
+         * alias for set
+         */
+        this.setState = this.set;
     }
 
     contextChange(gl)
@@ -98,7 +103,7 @@ export default class StateSystem extends System
 
         this.blendModes = mapWebGLBlendModesToPixi(gl);
 
-        this.setState(this.defaultState);
+        this.set(this.defaultState);
 
         this.reset();
     }
@@ -108,7 +113,7 @@ export default class StateSystem extends System
      *
      * @param {*} state - The state to set.
      */
-    setState(state)
+    set(state)
     {
         state = state || this.defaultState;
 

--- a/packages/core/src/state/StateSystem.js
+++ b/packages/core/src/state/StateSystem.js
@@ -90,11 +90,6 @@ export default class StateSystem extends System
         this.defaultState = new State();
         this.defaultState.blend = true;
         this.defaultState.depth = true;
-
-        /**
-         * alias for set
-         */
-        this.setState = this.set;
     }
 
     contextChange(gl)

--- a/packages/core/src/state/StateSystem.js
+++ b/packages/core/src/state/StateSystem.js
@@ -90,11 +90,6 @@ export default class StateSystem extends System
         this.defaultState = new State();
         this.defaultState.blend = true;
         this.defaultState.depth = true;
-
-        /**
-         * alias for set
-         */
-        this.setState = this.set;
     }
 
     contextChange(gl)
@@ -103,7 +98,7 @@ export default class StateSystem extends System
 
         this.blendModes = mapWebGLBlendModesToPixi(gl);
 
-        this.set(this.defaultState);
+        this.setState(this.defaultState);
 
         this.reset();
     }
@@ -113,7 +108,7 @@ export default class StateSystem extends System
      *
      * @param {*} state - The state to set.
      */
-    set(state)
+    setState(state)
     {
         state = state || this.defaultState;
 

--- a/packages/graphics/src/Graphics.js
+++ b/packages/graphics/src/Graphics.js
@@ -938,7 +938,7 @@ export default class Graphics extends Container
             renderer.geometry.bind(geometry, this.shader);
 
             // set state..
-            renderer.state.setState(this.state);
+            renderer.state.set(this.state);
 
             // then render the rest of them...
             for (let i = 0; i < geometry.drawCalls.length; i++)

--- a/packages/graphics/src/Graphics.js
+++ b/packages/graphics/src/Graphics.js
@@ -938,7 +938,7 @@ export default class Graphics extends Container
             renderer.geometry.bind(geometry, this.shader);
 
             // set state..
-            renderer.state.set(this.state);
+            renderer.state.setState(this.state);
 
             // then render the rest of them...
             for (let i = 0; i < geometry.drawCalls.length; i++)

--- a/packages/mesh/src/Mesh.js
+++ b/packages/mesh/src/Mesh.js
@@ -292,7 +292,7 @@ export default class Mesh extends Container
         renderer.shader.bind(shader);
 
         // set state..
-        renderer.state.set(this.state);
+        renderer.state.setState(this.state);
 
         // bind the geometry...
         renderer.geometry.bind(this.geometry, shader);

--- a/packages/mesh/src/Mesh.js
+++ b/packages/mesh/src/Mesh.js
@@ -292,7 +292,7 @@ export default class Mesh extends Container
         renderer.shader.bind(shader);
 
         // set state..
-        renderer.state.setState(this.state);
+        renderer.state.set(this.state);
 
         // bind the geometry...
         renderer.geometry.bind(this.geometry, shader);


### PR DESCRIPTION
Small tweak, but feel set looks better and feels better to write:

`renderer.state.set(myState);`

vs

`renderer.state.setState(myState);`

small tweak!

