### PR TITLE
Graphics clear fill and line style settings

### DIFF
--- a/packages/graphics/src/Graphics.js
+++ b/packages/graphics/src/Graphics.js
@@ -775,11 +775,12 @@ export default class Graphics extends Container
     clear()
     {
         this.geometry.clear();
+        this._lineStyle.reset();
+        this._fillStyle.reset();
 
         this._matrix = null;
         this._holeMode = false;
         this.currentPath = null;
-        this._spriteRect = null;
 
         return this;
     }


### PR DESCRIPTION
Subj.

```js
/**
 * Clears the graphics that were drawn to this Graphics object, and resets fill and line style settings.
 *
 * @return {PIXI.Graphics} This Graphics object. Good for chaining method calls
 */
clear()
```

> and resets fill and line style settings

ok.

![image](https://user-images.githubusercontent.com/695831/59761816-7102ae80-929e-11e9-95e0-3631035b948e.png)

Here's what is wrong: https://www.pixiplayground.com/#/edit/mFP~j1ZtEiVQXu95WT4Hb