### PR TITLE
Use OffscreenCanvas for measureText if available

### DIFF
--- a/packages/text/src/TextMetrics.js
+++ b/packages/text/src/TextMetrics.js
@@ -699,7 +699,22 @@ export default class TextMetrics
  * @private
  */
 
-const canvas = document.createElement('canvas');
+const canvas = (() =>
+{
+    try
+    {
+        // OffscreenCanvas2D measureText can be up to 40% faster.
+        const c = new OffscreenCanvas(0, 0);
+
+        c.getContext('2d');
+
+        return c;
+    }
+    catch (ex)
+    {
+        return document.createElement('canvas');
+    }
+})();
 
 canvas.width = canvas.height = 10;
 


### PR DESCRIPTION
##### Description of change
OffscreenCanvas setFont + measureText is 15-40% faster than the Canvas element version, when available. This detects if OffscreenCanvas 2D exists, and if so, uses it instead of canvas. There should be no visible behavior change.

##### Pre-Merge Checklist
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
