### PR TITLE
Adds a setting that allows disabling the 'failIfMajorPerformanceCaveat' flag used in the 'isWebGLSupported' function

### DIFF
--- a/packages/utils/src/browser/isWebGLSupported.js
+++ b/packages/utils/src/browser/isWebGLSupported.js
@@ -1,3 +1,5 @@
+import { settings } from '../settings';
+
 let supported;
 
 /**
@@ -13,7 +15,10 @@ export function isWebGLSupported()
     {
         supported = (function supported()
         {
-            const contextOptions = { stencil: true, failIfMajorPerformanceCaveat: true };
+            const contextOptions = {
+                stencil: true,
+                failIfMajorPerformanceCaveat: settings.FAIL_IF_MAJOR_PERFORMANCE_CAVEAT,
+            };
 
             try
             {

--- a/packages/utils/src/settings.js
+++ b/packages/utils/src/settings.js
@@ -18,7 +18,7 @@ settings.RETINA_PREFIX = /@([0-9\.]+)x/;
  * However, it can be useful to disable under certain scenarios, such as headless unit tests.
  *
  * @static
- * @name WEBGL_CONTEXT_OPTIONS
+ * @name FAIL_IF_MAJOR_PERFORMANCE_CAVEAT
  * @memberof PIXI.settings
  * @type {boolean}
  * @default true

--- a/packages/utils/src/settings.js
+++ b/packages/utils/src/settings.js
@@ -12,4 +12,17 @@ import { settings } from '@pixi/settings';
  */
 settings.RETINA_PREFIX = /@([0-9\.]+)x/;
 
+/**
+ * Should the `failIfMajorPerformanceCaveat` flag be enabled as a context option used in the `isWebGLSupported` function.
+ * For most scenarios this should be left as true, as otherwise the user may have a poor experience.
+ * However, it can be useful to disable under certain scenarios, such as headless unit tests.
+ *
+ * @static
+ * @name WEBGL_CONTEXT_OPTIONS
+ * @memberof PIXI.settings
+ * @type {boolean}
+ * @default true
+ */
+settings.FAIL_IF_MAJOR_PERFORMANCE_CAVEAT = true;
+
 export { settings };


### PR DESCRIPTION
https://github.com/pixijs/pixi.js/issues/5774
https://github.com/pixijs/pixi.js/issues/5778