### PR TITLE
OffscreenCanvas types fix

### DIFF
--- a/packages/core/src/textures/resources/CanvasResource.js
+++ b/packages/core/src/textures/resources/CanvasResource.js
@@ -1,6 +1,10 @@
 import BaseImageResource from './BaseImageResource';
 
 /**
+ * @interface OffscreenCanvas
+ */
+
+/**
  * Resource type for HTMLCanvasElement.
  * @class
  * @extends PIXI.resources.BaseImageResource


### PR DESCRIPTION
Older typescript version doesn't have offscreenCanvas in it. Lets do the same as in `BufferResource` and `SharedArrayBuffer`, declare an empty interface!

I've tested it on old and new ts.