### PR TITLE
Fix for the SVGResource#valid issue (#5816)

### DIFF
--- a/packages/core/src/textures/resources/SVGResource.js
+++ b/packages/core/src/textures/resources/SVGResource.js
@@ -17,12 +17,9 @@ export default class SVGResource extends BaseImageResource
     {
         options = options || {};
 
-        const canvas = document.createElement('canvas');
-
-        canvas.width = 0;
-        canvas.height = 0;
-
-        super(canvas);
+        super(document.createElement('canvas'));
+        this._width = 0;
+        this._height = 0;
 
         /**
          * Base64 encoded SVG element or URL for SVG file

--- a/packages/core/src/textures/resources/SVGResource.js
+++ b/packages/core/src/textures/resources/SVGResource.js
@@ -16,8 +16,9 @@ export default class SVGResource extends BaseImageResource
     constructor(source, options)
     {
         options = options || {};
-
-        super(document.createElement('canvas'));
+        const canvas = document.createElement('canvas');
+        canvas.width = canvas.height = 0;
+        super(canvas);
 
         /**
          * Base64 encoded SVG element or URL for SVG file

--- a/packages/core/src/textures/resources/SVGResource.js
+++ b/packages/core/src/textures/resources/SVGResource.js
@@ -16,8 +16,12 @@ export default class SVGResource extends BaseImageResource
     constructor(source, options)
     {
         options = options || {};
+
         const canvas = document.createElement('canvas');
-        canvas.width = canvas.height = 0;
+
+        canvas.width = 0;
+        canvas.height = 0;
+
         super(canvas);
 
         /**

--- a/packages/core/test/SVGResource.js
+++ b/packages/core/test/SVGResource.js
@@ -18,8 +18,10 @@ describe('PIXI.resources.SVGResource', function ()
             const buffer = fs.readFileSync(url, 'utf8');
             const resource = new SVGResource(buffer, { autoLoad: false });
 
+            expect(resource.valid).to.equal(false);
             resource.load().then(function ()
             {
+                expect(resource.valid).to.equal(true);
                 expect(resource.width).to.equal(100);
                 expect(resource.height).to.equal(100);
 
@@ -34,8 +36,10 @@ describe('PIXI.resources.SVGResource', function ()
                 { autoLoad: false }
             );
 
+            expect(resource.valid).to.equal(false);
             resource.load().then(function ()
             {
+                expect(resource.valid).to.equal(true);
                 expect(resource.width).to.equal(100);
                 expect(resource.height).to.equal(100);
 
@@ -49,8 +53,10 @@ describe('PIXI.resources.SVGResource', function ()
             const buffer = fs.readFileSync(url, 'utf8');
             const resource = new SVGResource(buffer, { autoLoad: false });
 
+            expect(resource.valid).to.equal(false);
             resource.load().then(function ()
             {
+                expect(resource.valid).to.equal(true);
                 expect(resource.width).to.equal(100);
                 expect(resource.height).to.equal(100);
 


### PR DESCRIPTION
##### Description of change

This PR is for fixing the issue #5816. As described at the issue, a canvas created by `document.createElement('canvas')` may have non-zero width and height. Thus, the method `SVGResource#valid` may return true even when loading is in process. This PR changes the `SVGResource` to set the width / height of a created canvas to zero.

##### Pre-Merge Checklist
- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
