### PR TITLE
Fix for the empty graphics batchability issue (#5817)

### DIFF
--- a/packages/graphics/src/GraphicsGeometry.js
+++ b/packages/graphics/src/GraphicsGeometry.js
@@ -403,7 +403,12 @@ export default class GraphicsGeometry extends BatchGeometry
     updateBatches()
     {
         if (this.dirty === this.cacheDirty) return;
-        if (this.graphicsData.length === 0) return;
+        if (this.graphicsData.length === 0)
+        {
+            this.batchable = true;
+
+            return;
+        }
 
         if (this.dirty !== this.cacheDirty)
         {

--- a/packages/graphics/test/index.js
+++ b/packages/graphics/test/index.js
@@ -391,4 +391,16 @@ describe('PIXI.Graphics', function ()
         GRAPHICS_CURVES.adaptive = defMode;
         GRAPHICS_CURVES.maxLength = defMaxLen;
     });
+
+    describe('geometry', function ()
+    {
+        it('should be batchable if graphicsData is empty', function ()
+        {
+            const graphics = new Graphics();
+            const geometry = graphics.geometry;
+
+            geometry.updateBatches();
+            expect(geometry.batchable).to.be.true;
+        });
+    });
 });


### PR DESCRIPTION
##### Description of change

This PR is for fixing the #5817.  If a `PIXI.Graphics` instance has no graphics data (i.e., `graphics.geometry.graphicsData.length` is zero), `BatchRenderer` may treat it as if it is not batchable. This is because `PIXI.GraphicsGeometry#updateBatches()` leaves the property `#batchable` as it is when `#graphicsData.length` is zero. This PR fixes the method `#updateBatches()` to update the property `#batchable` when `#graphicsData.length` is zero.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
