### PR TITLE
Make DisplayObject#mask nullable

### DIFF
--- a/packages/display/src/DisplayObject.js
+++ b/packages/display/src/DisplayObject.js
@@ -152,7 +152,7 @@ export default class DisplayObject extends EventEmitter
         /**
          * The original, cached mask of the object.
          *
-         * @member {PIXI.Graphics|PIXI.Sprite}
+         * @member {PIXI.Graphics|PIXI.Sprite|null}
          * @protected
          */
         this._mask = null;
@@ -680,7 +680,7 @@ export default class DisplayObject extends EventEmitter
      * sprite.mask = graphics;
      * @todo At the moment, PIXI.CanvasRenderer doesn't support PIXI.Sprite as mask.
      *
-     * @member {PIXI.Graphics|PIXI.Sprite}
+     * @member {PIXI.Graphics|PIXI.Sprite|null}
      */
     get mask()
     {


### PR DESCRIPTION
##### Description of change

In Pixi.js v5.0.4, the `DisplayObject#mask` is declared as `PIXI.Graphics | PIXI.Sprite`. However, to remove a mask from a display object, need to set a mask to null (as far as I know). This PR makes the `DisplayObject#mask` nullable.

https://github.com/pixijs/pixi.js/blob/c4968736f2c6e928097ef7e903e14e86e6f1de01/packages/display/src/DisplayObject.js#L682-L688

I tried the following variations of the type declaration. 
None of them works for me. The `tsd-jsdoc` may not support the question mark?

 - ?(PIXI.Graphics | PIXI.Sprite),
 - ?PIXI.Graphics | ?PIXI.Sprite, and
 - (?PIXI.Graphics) | (?PIXI.Sprite).

##### Pre-Merge Checklist

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
