### PR TITLE
Prevented System from attaching itself to the Renderer's contextChang…

### DIFF
--- a/packages/core/src/Renderer.js
+++ b/packages/core/src/Renderer.js
@@ -85,7 +85,7 @@ export default class Renderer extends AbstractRenderer
          * The type of this renderer as a standardized const
          *
          * @member {number}
-         * @see PIXI.RENDERER_TYPE
+         * PIXI.RENDERER_TYPE
          */
         this.type = RENDERER_TYPE.WEBGL;
 
@@ -98,7 +98,7 @@ export default class Renderer extends AbstractRenderer
         /**
          * Internal signal instances of **runner**, these
          * are assigned to each system created.
-         * @see PIXI.Runner
+         * PIXI.Runner
          * @name PIXI.Renderer#runners
          * @private
          * @type {object}
@@ -258,6 +258,26 @@ export default class Renderer extends AbstractRenderer
 
     /**
      * Add a new system to the renderer.
+     *
+     * The features of renderer are provided by individual systems
+     * that can be accessed using their name via `renderer.name`.
+     *
+     * | Name          | Class                    |
+     * |---------------|--------------------------|
+     * | mask          | PIXI.MaskSystem          |
+     * | context       | PIXI.ContextSystem       |
+     * | state         | PIXI.StateSystem         |
+     * | shader        | PIXI.ShaderSystem        |
+     * | texture       | PIXI.TextureSystem       |
+     * | geometry      | PIXI.GeometrySystem      |
+     * | framebuffer   | PIXI.FramebufferSystem   |
+     * | stencil       | PIXI.StencilSystem       |
+     * | projection    | PIXI.ProjectionSystem    |
+     * | textureGC     | PIXI.TextureGCSystem     |
+     * | filter        | PIXI.FilterSystem        |
+     * | renderTexture | PIXI.RenderTextureSystem |
+     * | batch         | PIXI.BatchSystem         |
+     *
      * @param {Function} ClassRef - Class reference
      * @param {string} [name] - Property name for system, if not specified
      *        will use a static `name` property on the class itself. This

--- a/packages/core/src/Renderer.js
+++ b/packages/core/src/Renderer.js
@@ -440,6 +440,11 @@ export default class Renderer extends AbstractRenderer
     {
         this.runners.destroy.run();
 
+        for (const r in this.runners)
+        {
+            r.destroy();
+        }
+
         // call base destroy
         super.destroy(removeView);
 

--- a/packages/core/src/Renderer.js
+++ b/packages/core/src/Renderer.js
@@ -85,7 +85,7 @@ export default class Renderer extends AbstractRenderer
          * The type of this renderer as a standardized const
          *
          * @member {number}
-         * PIXI.RENDERER_TYPE
+         * @see PIXI.RENDERER_TYPE
          */
         this.type = RENDERER_TYPE.WEBGL;
 
@@ -98,7 +98,7 @@ export default class Renderer extends AbstractRenderer
         /**
          * Internal signal instances of **runner**, these
          * are assigned to each system created.
-         * PIXI.Runner
+         * @see PIXI.Runner
          * @name PIXI.Renderer#runners
          * @private
          * @type {object}

--- a/packages/core/src/System.js
+++ b/packages/core/src/System.js
@@ -18,8 +18,6 @@ export default class System
          * @member {PIXI.Renderer}
          */
         this.renderer = renderer;
-
-        this.renderer.runners.contextChange.add(this);
     }
 
     /**

--- a/packages/core/src/batch/BatchPluginFactory.js
+++ b/packages/core/src/batch/BatchPluginFactory.js
@@ -59,6 +59,8 @@ export default class BatchPluginFactory
                 this.shaderGenerator = new BatchShaderGenerator(vertex, fragment);
                 this.geometryClass = geometryClass;
                 this.vertexSize = vertexSize;
+
+                renderer.runners.contextChange.add(this);
             }
         };
     }

--- a/packages/core/src/geometry/GeometrySystem.js
+++ b/packages/core/src/geometry/GeometrySystem.js
@@ -6,7 +6,7 @@ import { settings } from '../settings';
 const byteSizeMap = { 5126: 4, 5123: 2, 5121: 1 };
 
 /**
- * System plugin to the renderer to manage geometry.
+ * Renderer system that manages geometry.
  *
  * @class
  * @extends PIXI.System
@@ -148,6 +148,9 @@ export default class GeometrySystem extends System
 
     /**
      * Binds geometry so that is can be drawn. Creating a Vao if required
+     *
+     * Binds attributes and indicies to the WebGL context and buffers
+     * them. A VAO may be used if available.
      *
      * @param {PIXI.Geometry} geometry instance of geometry to bind
      * @param {PIXI.Shader} [shader] instance of shader to use vao for

--- a/packages/math/src/GroupD8.js
+++ b/packages/math/src/GroupD8.js
@@ -1,46 +1,87 @@
-// Your friendly neighbour https://en.wikipedia.org/wiki/Dihedral_group of order 16
+// Your friendly neighbour https://en.wikipedia.org/wiki/Dihedral_group
+//
+// This file implements the dihedral group of order 16, also called
+// of degree 8. That's why its called GroupD8.
+
 import Matrix from './Matrix';
 
+/**
+ * Maps each `PIXI.GD8Symmetry` to the direction of
+ * the X-component of the new U-axis.
+ */
 const ux = [1, 1, 0, -1, -1, -1, 0, 1, 1, 1, 0, -1, -1, -1, 0, 1];
+
+/**
+ * Maps each `PIXI.GD8Symmetry` rotation to the direction of
+ * the Y-component of the new U-axis.
+ */
 const uy = [0, 1, 1, 1, 0, -1, -1, -1, 0, 1, 1, 1, 0, -1, -1, -1];
+
+/**
+ * Maps each `PIXI.GD8Symmetry` rotation to the direction of
+ * the X-component of the new V-axis.
+ */
 const vx = [0, -1, -1, -1, 0, 1, 1, 1, 0, 1, 1, 1, 0, -1, -1, -1];
+
+/**
+ * Maps each `PIXI.GD8Symmetry` rotation to the direction of
+ * the Y-component of the new V-axis.
+ */
 const vy = [1, 1, 0, -1, -1, -1, 0, 1, -1, -1, 0, 1, 1, 1, 0, -1];
-const tempMatrices = [];
 
-const mul = [];
+/**
+ * [Cayley Table]{@link https://en.wikipedia.org/wiki/Cayley_table}
+ * for the composition of each rotation in the dihederal group D8.
+ *
+ * It is a 2D array as follows:
+ * |    | E  | SE | S  | SW | W  | NW | N  | NE |
+ * |----|----|----|----|----|----|----|----|----|
+ * | E  | E  | SE | S  | SW | W  | NW | N  | NE |
+ * | SE | SE | S  | SW | W  | NW | N  | NE | E  |
+ * | S  | S  | SW | W  | NW | N  | NE | E  | SE |
+ * | SW | SW | W  | NW | N  | NE | E  | SE | S  |
+ * | W  | W  | NW | N  | NE | E  | SE | S  | SW |
+ * | NW | NW | N  | NE | E  | SE | S  | SW | W  |
+ * | N  | N  | NE | E  | SE | S  | SW | W  | NW |
+ * | NE | NE | E  | SE | S  | SW | W  | NW | N  |
+ */
+const rotationCayley = [];
 
-function signum(x)
-{
-    if (x < 0)
-    {
-        return -1;
-    }
-    if (x > 0)
-    {
-        return 1;
-    }
+/**
+ * Matrices for each `GD8Symmetry` rotation.
+ */
+const rotationMatrices = [];
 
-    return 0;
-}
+/*
+ * Alias for {@code Math.sign}.
+ */
+const signum = Math.sign;
 
+/*
+ * Initializes `rotationCayley` and `rotationMatrices`. It is called
+ * only once below.
+ */
 function init()
 {
     for (let i = 0; i < 16; i++)
     {
         const row = [];
 
-        mul.push(row);
+        rotationCayley.push(row);
 
         for (let j = 0; j < 16; j++)
         {
+            /* Multiplies rotation matrices i and j. */
             const _ux = signum((ux[i] * ux[j]) + (vx[i] * uy[j]));
             const _uy = signum((uy[i] * ux[j]) + (vy[i] * uy[j]));
             const _vx = signum((ux[i] * vx[j]) + (vx[i] * vy[j]));
             const _vy = signum((uy[i] * vx[j]) + (vy[i] * vy[j]));
 
+            /* Finds rotation matrix matching the product and pushes it. */
             for (let k = 0; k < 16; k++)
             {
-                if (ux[k] === _ux && uy[k] === _uy && vx[k] === _vx && vy[k] === _vy)
+                if (ux[k] === _ux && uy[k] === _uy
+                      && vx[k] === _vx && vy[k] === _vy)
                 {
                     row.push(k);
                     break;
@@ -54,78 +95,246 @@ function init()
         const mat = new Matrix();
 
         mat.set(ux[i], uy[i], vx[i], vy[i], 0, 0);
-        tempMatrices.push(mat);
+        rotationMatrices.push(mat);
     }
 }
 
 init();
 
 /**
- * Implements Dihedral Group D_8, see [group D4]{@link http://mathworld.wolfram.com/DihedralGroupD4.html},
- * D8 is the same but with diagonals. Used for texture rotations.
+ * @memberof PIXI
+ * @typedef {number} GD8Symmetry
+ * @see PIXI.GroupD8
+ */
+
+/**
+ * Implements the dihedral group D8, which is similar to
+ * [group D4]{@link http://mathworld.wolfram.com/DihedralGroupD4.html};
+ * D8 is the same but with diagonals, and it is used for texture
+ * rotations.
  *
- * Vector xX(i), xY(i) is U-axis of sprite with rotation i
- * Vector yY(i), yY(i) is V-axis of sprite with rotation i
- * Rotations: 0 grad (0), 90 grad (2), 180 grad (4), 270 grad (6)
- * Mirrors: vertical (8), main diagonal (10), horizontal (12), reverse diagonal (14)
- * This is the small part of gameofbombs.com portal system. It works.
+ * The directions the U- and V- axes after rotation
+ * of an angle of `a: GD8Constant` are the vectors `(uX(a), uY(a))`
+ * and `(vX(a), vY(a))`. These aren't necessarily unit vectors.
  *
+ * **Origin:**<br>
+ *  This is the small part of gameofbombs.com portal system. It works.
+ *
+ * @see PIXI.GroupD8.E
+ * @see PIXI.GroupD8.SE
+ * @see PIXI.GroupD8.S
+ * @see PIXI.GroupD8.SW
+ * @see PIXI.GroupD8.W
+ * @see PIXI.GroupD8.NW
+ * @see PIXI.GroupD8.N
+ * @see PIXI.GroupD8.NE
  * @author Ivan @ivanpopelyshev
  * @class
  * @memberof PIXI
  */
 const GroupD8 = {
+    /**
+     * | Rotation | Direction |
+     * |----------|-----------|
+     * | 0°       | East      |
+     *
+     * @constant {PIXI.GD8Symmetry}
+     */
     E: 0,
-    SE: 1,
-    S: 2,
-    SW: 3,
-    W: 4,
-    NW: 5,
-    N: 6,
-    NE: 7,
-    MIRROR_VERTICAL: 8,
-    MIRROR_HORIZONTAL: 12,
-    uX: (ind) => ux[ind],
-    uY: (ind) => uy[ind],
-    vX: (ind) => vx[ind],
-    vY: (ind) => vy[ind],
-    inv: (rotation) =>
-    {
-        if (rotation & 8)
-        {
-            return rotation & 15;
-        }
-
-        return (-rotation) & 7;
-    },
-    add: (rotationSecond, rotationFirst) => mul[rotationSecond][rotationFirst],
-    sub: (rotationSecond, rotationFirst) => mul[rotationSecond][GroupD8.inv(rotationFirst)],
 
     /**
-     * Adds 180 degrees to rotation. Commutative operation.
+     * | Rotation | Direction |
+     * |----------|-----------|
+     * | 45°↻     | Southeast |
+     *
+     * @constant {PIXI.GD8Symmetry}
+     */
+    SE: 1,
+
+    /**
+     * | Rotation | Direction |
+     * |----------|-----------|
+     * | 90°↻     | South     |
+     *
+     * @constant {PIXI.GD8Symmetry}
+     */
+    S: 2,
+
+    /**
+     * | Rotation | Direction |
+     * |----------|-----------|
+     * | 135°↻    | Southwest |
+     *
+     * @constant {PIXI.GD8Symmetry}
+     */
+    SW: 3,
+
+    /**
+     * | Rotation | Direction |
+     * |----------|-----------|
+     * | 180°     | West      |
+     *
+     * @constant {PIXI.GD8Symmetry}
+     */
+    W: 4,
+
+    /**
+     * | Rotation    | Direction    |
+     * |-------------|--------------|
+     * | -135°/225°↻ | Northwest    |
+     *
+     * @constant {PIXI.GD8Symmetry}
+     */
+    NW: 5,
+
+    /**
+     * | Rotation    | Direction    |
+     * |-------------|--------------|
+     * | -90°/270°↻  | North        |
+     *
+     * @constant {PIXI.GD8Symmetry}
+     */
+    N: 6,
+
+    /**
+     * | Rotation    | Direction    |
+     * |-------------|--------------|
+     * | -45°/315°↻  | Northeast    |
+     *
+     * @constant {PIXI.GD8Symmetry}
+     */
+    NE: 7,
+
+    /**
+     * Reflection about Y-axis.
+     *
+     * @constant {PIXI.GD8Symmetry}
+     */
+    MIRROR_VERTICAL: 8,
+
+    /**
+     * Reflection about the main diagonal.
+     *
+     * @constant {PIXI.GD8Symmetry}
+     */
+    MAIN_DIAGONAL: 10,
+
+    /**
+     * Reflection about X-axis.
+     *
+     * @constant {PIXI.GD8Symmetry}
+     */
+    MIRROR_HORIZONTAL: 12,
+
+    /**
+     * Reflection about reverse diagonal.
+     *
+     * @constant {PIXI.GD8Symmetry}
+     */
+    REVERSE_DIAGONAL: 14,
+
+    /**
+     * @memberof PIXI.GroupD8
+     * @param {PIXI.GD8Symmetry} ind - sprite rotation angle.
+     * @return {PIXI.GD8Symmetry} The X-component of the U-axis
+     *    after rotating the axes.
+     */
+    uX: (ind) => ux[ind],
+
+    /**
+     * @memberof PIXI.GroupD8
+     * @param {PIXI.GD8Symmetry} ind - sprite rotation angle.
+     * @return {PIXI.GD8Symmetry} The Y-component of the U-axis
+     *    after rotating the axes.
+     */
+    uY: (ind) => uy[ind],
+
+    /**
+     * @memberof PIXI.GroupD8
+     * @param {PIXI.GD8Symmetry} ind - sprite rotation angle.
+     * @return {PIXI.GD8Symmetry} The X-component of the V-axis
+     *    after rotating the axes.
+     */
+    vX: (ind) => vx[ind],
+
+    /**
+     * @memberof PIXI.GroupD8
+     * @param {PIXI.GD8Symmetry} ind - sprite rotation angle.
+     * @return {PIXI.GD8Symmetry} The Y-component of the V-axis
+     *    after rotating the axes.
+     */
+    vY: (ind) => vy[ind],
+
+    /**
+     * @memberof PIXI.GroupD8
+     * @param {PIXI.GD8Symmetry} rotation - symmetry whose opposite
+     *   is needed. Only rotations have opposite symmetries while
+     *   reflections don't.
+     * @return {PIXI.GD8Symmetry} The opposite symmetry of `rotation`
+     */
+    inv: (rotation) =>
+    {
+        if (rotation & 8)// true only if 8 or 12
+        {
+            return rotation & 15;// or rotation % 16
+        }
+
+        return (-rotation) & 7;// or (8 - rotation) % 8
+    },
+
+    /**
+     * Composes the two D8 operations.
+     *
+     * @memberof PIXI.GroupD8
+     * @param {PIXI.GD8Symmetry} second - second operation
+     * @param {PIXI.GD8Symmetry} first - first operation
+     * @return {PIXI.GD8Symmetry} Composed operation
+     */
+    add: (rotationSecond, rotationFirst) => (
+        rotationCayley[rotationSecond][rotationFirst]
+    ),
+
+    /**
+     * Reverse of `add`.
+     *
+     * @memberof PIXI.GroupD8
+     * @param {PIXI.GD8Symmetry} second - second operation
+     * @param {PIXI.GD8Symmetry} first - first operation
+     * @return {PIXI.GD8Symmetry} Result
+     */
+    sub: (rotationSecond, rotationFirst) => (
+        rotationCayley[rotationSecond][GroupD8.inv(rotationFirst)]
+    ),
+
+    /**
+     * Adds 180 degrees to rotation, which is a commutative
+     * operation.
      *
      * @memberof PIXI.GroupD8
      * @param {number} rotation - The number to rotate.
-     * @returns {number} rotated number
+     * @returns {number} Rotated number
      */
     rotate180: (rotation) => rotation ^ 4,
 
     /**
-     * Direction of main vector can be horizontal, vertical or diagonal.
-     * Some objects work with vertical directions different.
+     * Checks if the rotation angle is vertical, i.e. south
+     * or north. It doesn't work for reflections.
      *
      * @memberof PIXI.GroupD8
-     * @param {number} rotation - The number to check.
+     * @param {PIXI.GD8Symmetry} rotation - The number to check.
      * @returns {boolean} Whether or not the direction is vertical
      */
-    isVertical: (rotation) => (rotation & 3) === 2,
+    isVertical: (rotation) => (rotation & 3) === 2, // rotation % 4 === 2
 
     /**
-     * @memberof PIXI.GroupD8
-     * @param {number} dx - TODO
-     * @param {number} dy - TODO
+     * Approximates the vector `V(dx,dy)` into one of the
+     * eight directions provided by `GroupD8`.
      *
-     * @return {number} TODO
+     * @memberof PIXI.GroupD8
+     * @param {number} dx - X-component of the vector
+     * @param {number} dy - Y-component of the vector
+     * @return {PIXI.GD8Symmetry} Approximation of the vector into
+     *  one of the eight symmetries.
      */
     byDirection: (dx, dy) =>
     {
@@ -169,14 +378,14 @@ const GroupD8 = {
      *
      * @memberof PIXI.GroupD8
      * @param {PIXI.Matrix} matrix - sprite world matrix
-     * @param {number} rotation - The rotation factor to use.
+     * @param {PIXI.GroupD8Symmetry} rotation - The rotation factor to use.
      * @param {number} tx - sprite anchoring
      * @param {number} ty - sprite anchoring
      */
     matrixAppendRotationInv: (matrix, rotation, tx = 0, ty = 0) =>
     {
         // Packer used "rotation", we use "inv(rotation)"
-        const mat = tempMatrices[GroupD8.inv(rotation)];
+        const mat = rotationMatrices[GroupD8.inv(rotation)];
 
         mat.tx = tx;
         mat.ty = ty;


### PR DESCRIPTION
This fixes #5825 - however, there was a side effect which I've fixed too.

PixiJS's `BatchPlugin`, which is also called `BatchRenderer` in its default export, was being treated as a `System`. This was because its inheritance chain is like this:
1. `BatchPlugin`
2. `BatchRenderer` (used as `BaseBatchRender` which references the `BatchRender.js` file)
3. `ObjectRenderer`
4. `System`

Since the `System` constructor added itself to the `contextChange` signal, there was no problem before. I removed that line; hence, `BatchPlugin` wasn't able to add itself to the `contextChange` signal. This broke the tests in `Graphics#_render: property program cannot be read from null (line 909)`. I've added the line that makes `BatchPlugin` attach to the `contextChange` signal.

So far, the tests are passing. However, if someone treated a plugin as a system somewhere else too and assumed that the plugin would attach to `contextChange` automatically, then that will become a bug.