### PR TITLE
Add JSDoc comments on the TextureUvs properties

### DIFF
--- a/packages/core/src/textures/TextureUvs.js
+++ b/packages/core/src/textures/TextureUvs.js
@@ -11,16 +11,60 @@ export default class TextureUvs
 {
     constructor()
     {
+        /**
+         * The position of the top-left corner on the x axis.
+         *
+         * @member {number}
+         */
         this.x0 = 0;
+
+        /**
+         * The position of the top-left corner on the y axis.
+         *
+         * @member {number}
+         */
         this.y0 = 0;
 
+        /**
+         * The position of the top-right corner on the x axis.
+         *
+         * @member {number}
+         */
         this.x1 = 1;
+
+        /**
+         * The position of the top-right corner on the y axis.
+         *
+         * @member {number}
+         */
         this.y1 = 0;
 
+        /**
+         * The position of the bottom-right corner on the x axis.
+         *
+         * @member {number}
+         */
         this.x2 = 1;
+
+        /**
+         * The position of the bottom-right corner on the y axis.
+         *
+         * @member {number}
+         */
         this.y2 = 1;
 
+        /**
+         * The position of the bottom-left corner on the x axis.
+         *
+         * @member {number}
+         */
         this.x3 = 0;
+
+        /**
+         * The position of the bottom-left corner on the y axis.
+         *
+         * @member {number}
+         */
         this.y3 = 1;
 
         this.uvsFloat32 = new Float32Array(8);


### PR DESCRIPTION
##### Description of change

The `PIXI.TextureUvs` properties such as `x0` are missing in the type declaration file. I thought this might be intentional. If so, I'm sorry for bothering you :(. However, they were in the PixiJS v4 type declaration file. So I thought this might be not. This PR adds JSDoc comments on the `TextureUvs` properties.

I omit the property `TextureUvs#uvsFloat32` on purpose. 
It looks too internal to me. 

##### Pre-Merge Checklist

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
