### PR TITLE
Fixes the prepare system in v5

### DIFF
--- a/bundles/pixi.js/src/useDeprecated.js
+++ b/bundles/pixi.js/src/useDeprecated.js
@@ -1068,6 +1068,20 @@ export default function useDeprecated()
     });
 
     /**
+     * @deprecated since 5.0.0
+     * @member {PIXI.systems.TextureSystem} PIXI.Renderer#textureManager
+     * @see PIXI.Renderer#texture
+     */
+    Object.defineProperty(PIXI.Renderer.prototype, 'textureManager', {
+        get()
+        {
+            deprecation(v5, 'PIXI.Renderer.textureManager property is deprecated, use texture');
+
+            return this.texture;
+        },
+    });
+
+    /**
      * @namespace PIXI.utils.mixins
      * @deprecated since 5.0.0
      */

--- a/packages/core/src/textures/BaseTexture.js
+++ b/packages/core/src/textures/BaseTexture.js
@@ -35,6 +35,7 @@ const defaultBufferOptions = {
  * @param {boolean} [options.premultiplyAlpha=true] - Pre multiply the image alpha
  * @param {number} [options.width=0] - Width of the texture
  * @param {number} [options.height=0] - Height of the texture
+ * @param {number} [options.resolution] - Resolution of the base texture
  * @param {object} [options.resourceOptions] - Optional resource options,
  *        see {@link PIXI.resources.autoDetectResource autoDetectResource}
  */

--- a/packages/core/src/textures/TextureGCSystem.js
+++ b/packages/core/src/textures/TextureGCSystem.js
@@ -41,7 +41,7 @@ export default class TextureGCSystem extends System
         this.maxIdle = settings.GC_MAX_IDLE;
 
         /**
-         * Maximum number of itesm to check
+         * Maximum number of item to check
          * @member {number}
          * @see PIXI.settings.GC_MAX_CHECK_COUNT
          */

--- a/packages/core/src/textures/TextureSystem.js
+++ b/packages/core/src/textures/TextureSystem.js
@@ -269,6 +269,12 @@ export default class TextureSystem extends System
     updateTexture(texture)
     {
         const glTexture = texture._glTextures[this.CONTEXT_UID];
+
+        if (!glTexture)
+        {
+            return;
+        }
+
         const renderer = this.renderer;
 
         this.initTextureType(texture, glTexture);

--- a/packages/prepare/src/Prepare.js
+++ b/packages/prepare/src/Prepare.js
@@ -45,7 +45,7 @@ function uploadBaseTextures(renderer, item)
         // reuploads the texture without need for preparing it again
         if (!item._glTextures[renderer.CONTEXT_UID])
         {
-            renderer.textureManager.updateTexture(item);
+            renderer.texture.updateTexture(item);
         }
 
         return true;


### PR DESCRIPTION
There were 2 errors here; the first is in Prepare.js, the property on the renderer was renamed in v5 from textureManager to texture. (added a deprecation for this)
Second, the TextureSystem had an assumption in updateTexture that there would be a glTexture, which could end up throwing an error
