### PR TITLE
Fix the DisplayObject#cacheAsBitmap issue #5784

### DIFF
--- a/packages/mixin-cache-as-bitmap/src/index.js
+++ b/packages/mixin-cache-as-bitmap/src/index.js
@@ -184,7 +184,9 @@ DisplayObject.prototype._initCachedDisplayObject = function _initCachedDisplayOb
 
     // for now we cache the current renderTarget that the WebGL renderer is currently using.
     // this could be more elegant..
-    const cachedRenderTarget = renderer._activeRenderTarget;
+    const cachedRenderTarget = renderer.renderTexture.current;
+    const cachedProjectionTransform = renderer.projection.transform;
+
     // We also store the filter stack - I will definitely look to change how this works a little later down the line.
     // const stack = renderer.filterManager.filterStack;
 
@@ -211,8 +213,9 @@ DisplayObject.prototype._initCachedDisplayObject = function _initCachedDisplayOb
     this.render = this._cacheData.originalRender;
 
     renderer.render(this, renderTexture, true, m, true);
-    // now restore the state be setting the new properties
 
+    // now restore the state be setting the new properties
+    renderer.projection.transform = cachedProjectionTransform;
     renderer.renderTexture.bind(cachedRenderTarget);
 
     // renderer.filterManager.filterStack = stack;


### PR DESCRIPTION
##### Description of change

This PR is to fix #5784. There are two problems in `DisplayObject#_initCachedDisplayObject`.

1) The first one is `renderer._activeRenderTarget` does not hold a current rendering target.

https://github.com/pixijs/pixi.js/blob/4d71fa06ea787d81651fc3e624610ccfc3c3f457/packages/mixin-cache-as-bitmap/src/index.js#L185-L189

I replaced it with `const cachedRenderTarget = renderer.renderTexture.current;`.

2) The second one is `renderer.projection.transform` is not restored after the line 213.
I changed the method so that the projection transform is restored.

https://github.com/pixijs/pixi.js/blob/4d71fa06ea787d81651fc3e624610ccfc3c3f457/packages/mixin-cache-as-bitmap/src/index.js#L210-L216

Working example is [https://www.pixiplayground.com/#/edit/hk1gjmUM84Nl72GncOii~](https://www.pixiplayground.com/#/edit/hk1gjmUM84Nl72GncOii~).

*Please note I could not find the way of writing tests of features like this :( *

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
