### PR TITLE
Prevented System from attaching itself to the Renderer's contextChange signal

### DIFF
--- a/packages/core/src/Renderer.js
+++ b/packages/core/src/Renderer.js
@@ -420,6 +420,11 @@ export default class Renderer extends AbstractRenderer
     {
         this.runners.destroy.run();
 
+        for (const r in this.runners)
+        {
+            this.runners[r].destroy();
+        }
+
         // call base destroy
         super.destroy(removeView);
 

--- a/packages/core/src/System.js
+++ b/packages/core/src/System.js
@@ -18,18 +18,6 @@ export default class System
          * @member {PIXI.Renderer}
          */
         this.renderer = renderer;
-
-        this.renderer.runners.contextChange.add(this);
-    }
-
-    /**
-     * Generic method called when there is a WebGL context change.
-     *
-     * @param {WebGLRenderingContext} gl new webgl context
-     */
-    contextChange(gl) // eslint-disable-line no-unused-vars
-    {
-        // do some codes init!
     }
 
     /**
@@ -37,7 +25,6 @@ export default class System
      */
     destroy()
     {
-        this.renderer.runners.contextChange.remove(this);
         this.renderer = null;
     }
 }

--- a/packages/core/src/batch/BatchPluginFactory.js
+++ b/packages/core/src/batch/BatchPluginFactory.js
@@ -59,6 +59,8 @@ export default class BatchPluginFactory
                 this.shaderGenerator = new BatchShaderGenerator(vertex, fragment);
                 this.geometryClass = geometryClass;
                 this.vertexSize = vertexSize;
+
+                renderer.runners.contextChange.add(this);
             }
         };
     }


### PR DESCRIPTION
I've fixed #5825 and a the side effect on `BatchPlugin`. This was discussed in a failed PR https://github.com/pixijs/pixi.js/pull/5826, which was corrupted due to another change being recorded in the same branch.