### PR TITLE
Polished BatchRenderer

### DIFF
--- a/packages/core/src/batch/BatchPluginFactory.js
+++ b/packages/core/src/batch/BatchPluginFactory.js
@@ -59,8 +59,6 @@ export default class BatchPluginFactory
                 this.shaderGenerator = new BatchShaderGenerator(vertex, fragment);
                 this.geometryClass = geometryClass;
                 this.vertexSize = vertexSize;
-
-                renderer.runners.contextChange.add(this);
             }
         };
     }

--- a/packages/graphics/src/Graphics.js
+++ b/packages/graphics/src/Graphics.js
@@ -906,7 +906,7 @@ export default class Graphics extends Container
                     };
 
                     // we can bbase default shader of the batch renderers program
-                    const program =  renderer.plugins.batch.shader.program;
+                    const program =  renderer.plugins.batch._shader.program;
 
                     defaultShader = new Shader(program, uniforms);
                 }


### PR DESCRIPTION
(PLEASE JUST READ THE NEW `BatchRenderer` CLASS, since the changes reordered a lot
of things and you might not be able to locate the additions/deletions pairs.

I have edited the BatchRenderer class. The following major changes were
made:

1. Changed old `vertexCount` to `_flushId`. This is because the name
itself was misleading. It signified the number of flushes in the
current frame.

2. Renamed `vaos` and `vaosMax` to `_packedGeometries` and
`_packedGeometryPoolSize`. They _were not_ VAOs in the sense
that they binded all the buffers automatically to the WebGL
context. Instead, they were just reusable `BatchGeometry` objects.

3. Renamed `groups` to `_drawCalls`. That is what they are, and it
makes more sense, especially after documenting it.

4. Renamed all private variables by adding a _ prefix.

5. Added documentation to all private/public properties and methods.

6. Fixed destroy(). It was nullifying non-existent variables. They
were probably from when this class was being built/tested. I've fixed
it so that it nullifies the correct resources.

7. contextChange signal is now hooked in `BatchRenderer` rather than
the `BatchPluginFactory#create`. This makes sense since the former
is the one implementing the `contextChange` signal.

8. SIDE EFFECT: Graphics used the `shader` property of `BatchRenderer`,
and since that was deemed a private properties, it broke. It fixed that
by making Graphics use `_shader`.

9. I reordered the way in which properties are initialized in the
constructor. The most important/public ones are on the top. They are
ordered in a way that makes a new-comer sense.

10. Reordered methods. The first methods are related to rendering and
are lifecycle-type methods: contextChange, render, flush, and destroy. Then
the start and stop methods. Then the private methods getAttributeBuffer,
getIndexBuffer, and packInterleavedGeometry.

11. Renamed packGeometry to packInterleavedGeometry; this is because
the method doesn't take any geometry to put into. Rather it takes
the interleaved buffers.

12. Documented literally anything else.

<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
