### PR TITLE
 'resource-loader' import and version fixes

### DIFF
--- a/packages/loaders/package.json
+++ b/packages/loaders/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@pixi/core": "^5.0.3",
     "@pixi/utils": "^5.0.3",
-    "resource-loader": "^2.2.4"
+    "resource-loader": "2.2.4"
   },
   "devDependencies": {
     "floss": "^2.2.0"

--- a/packages/loaders/src/Loader.js
+++ b/packages/loaders/src/Loader.js
@@ -1,4 +1,4 @@
-import ResourceLoader from 'resource-loader';
+import { Loader as ResourceLoader } from 'resource-loader';
 import { EventEmitter } from '@pixi/utils';
 import { blobMiddlewareFactory } from 'resource-loader/lib/middlewares/parsing/blob';
 import TextureLoader from './TextureLoader';


### PR DESCRIPTION
##### Description of change
Usage of 'resource-loader' deafult export in `packages/loaders/src/Loader.js` replaced with named one
It happens because of actual version of 'resource-loader' is 2.3.0 where default export was removed

Also I replaced version of 'resource-loader' in package.json with strict "2.2.4" because of backwards comptibility needed instead of risky refactoring of blobMiddlewareFactory calls removed in newer version

##### Pre-Merge Checklist
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
