### PR TITLE
Adds new ImageBitmapResource

### DIFF
--- a/packages/core/src/textures/resources/CanvasResource.js
+++ b/packages/core/src/textures/resources/CanvasResource.js
@@ -18,7 +18,7 @@ export default class CanvasResource extends BaseImageResource
      *
      * @static
      * @param {HTMLCanvasElement|OffscreenCanvas} source - The source object
-     * @return {boolean} `true` if <canvas>
+     * @return {boolean} `true` if source is HTMLCanvasElement or OffscreenCanvas
      */
     static test(source)
     {

--- a/packages/core/src/textures/resources/ImageBitmapResource.js
+++ b/packages/core/src/textures/resources/ImageBitmapResource.js
@@ -1,0 +1,23 @@
+import BaseImageResource from './BaseImageResource';
+
+/**
+ * Resource type for ImageBitmap.
+ * @class
+ * @extends PIXI.resources.BaseImageResource
+ * @memberof PIXI.resources
+ * @param {ImageBitmap} source - Image element to use
+ */
+export default class ImageBitmapResource extends BaseImageResource
+{
+    /**
+     * Used to auto-detect the type of resource.
+     *
+     * @static
+     * @param {ImageBitmap} source - The source object
+     * @return {boolean} `true` if source is an ImageBitmap
+     */
+    static test(source)
+    {
+        return !!window.createImageBitmap && source instanceof ImageBitmap;
+    }
+}

--- a/packages/core/src/textures/resources/index.js
+++ b/packages/core/src/textures/resources/index.js
@@ -6,6 +6,7 @@ import CubeResource from './CubeResource';
 import ImageResource from './ImageResource';
 import SVGResource from './SVGResource';
 import VideoResource from './VideoResource';
+import ImageBitmapResource from './ImageBitmapResource';
 
 /**
  * Collection of base resource types supported by PixiJS.
@@ -23,6 +24,7 @@ export { default as BaseImageResource } from './BaseImageResource';
 
 INSTALLED.push(
     ImageResource,
+    ImageBitmapResource,
     CanvasResource,
     VideoResource,
     SVGResource,
@@ -39,5 +41,6 @@ export {
     CanvasResource,
     CubeResource,
     ImageResource,
+    ImageBitmapResource,
     SVGResource,
     VideoResource };

--- a/packages/core/test/ImageBitmapResource.js
+++ b/packages/core/test/ImageBitmapResource.js
@@ -1,0 +1,70 @@
+const { resources } = require('../');
+const { ImageBitmapResource } = resources;
+
+describe('PIXI.resources.ImageBitmapResource', function ()
+{
+    it('should create new dimension-less resource', async function ()
+    {
+        const canvas = document.createElement('canvas');
+
+        const bitmap = await createImageBitmap(canvas);
+        const resource = new ImageBitmapResource(bitmap);
+
+        expect(resource.width).to.equal(canvas.width);
+        expect(resource.height).to.equal(canvas.height);
+        expect(resource.valid).to.be.true;
+
+        resource.destroy();
+    });
+
+    it('should create new valid resource', async function ()
+    {
+        const canvas = document.createElement('canvas');
+
+        canvas.width = 100;
+        canvas.height = 200;
+
+        const bitmap = await createImageBitmap(canvas);
+        const resource = new ImageBitmapResource(bitmap);
+
+        expect(resource.width).to.equal(100);
+        expect(resource.height).to.equal(200);
+        expect(resource.valid).to.be.true;
+
+        resource.destroy();
+    });
+
+    it('should fire resize event on bind', async function ()
+    {
+        const canvas = document.createElement('canvas');
+        const bitmap = await createImageBitmap(canvas);
+        const resource = new ImageBitmapResource(bitmap);
+        const baseTexture = { setRealSize: sinon.stub() };
+
+        resource.bind(baseTexture);
+
+        expect(baseTexture.setRealSize.calledOnce).to.be.true;
+
+        resource.unbind(baseTexture);
+        resource.destroy();
+    });
+
+    it('should fire manual update event', async function ()
+    {
+        const canvas = document.createElement('canvas');
+        const bitmap = await createImageBitmap(canvas);
+        const resource = new ImageBitmapResource(bitmap);
+        const baseTexture = { update: sinon.stub() };
+
+        resource.bind(baseTexture);
+
+        expect(baseTexture.update.called).to.be.false;
+
+        resource.update();
+
+        expect(baseTexture.update.calledOnce).to.be.true;
+
+        resource.unbind(baseTexture);
+        resource.destroy();
+    });
+});

--- a/packages/core/test/autoDetectResource.js
+++ b/packages/core/test/autoDetectResource.js
@@ -17,7 +17,7 @@ describe('PIXI.resources.autoDetectResource', function ()
     it('should have installed resources', function ()
     {
         expect(INSTALLED).to.be.an.array;
-        expect(INSTALLED.length).to.equal(7);
+        expect(INSTALLED.length).to.equal(8);
     });
 
     it('should auto-detect canvas element', function ()

--- a/packages/core/test/index.js
+++ b/packages/core/test/index.js
@@ -2,6 +2,7 @@ require('./BaseTexture');
 require('./Texture');
 require('./Renderer');
 require('./CanvasResource');
+require('./ImageBitmapResource');
 require('./ImageResource');
 require('./SVGResource');
 require('./VideoResource');


### PR DESCRIPTION
### Description of change

This is a follow-up to #5783 

Basically adds a new resource type for ImageBitmap. Instead of overcomplicating ImageResource, a simple new resource types adds the ability for developers to create their own ImageBitmaps.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
