### PR TITLE
Migrate to new s3 bucket & CDN provider

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,45 @@ deploy:
   - provider: s3
     access_key_id: $S3_ACCESS_KEY_ID
     secret_access_key: $S3_SECRET_ACCESS_KEY
+    bucket: "pixijs.download"
+    skip_cleanup: true
+    region: us-east-2
+    cache_control: "max-age=60"
+    local_dir: dist
+    upload-dir: "pixi.js/$TRAVIS_BRANCH"
+    on:
+        all_branches: true
+        condition: -z $TRAVIS_TAG
+  # Deploy config for tagged releases
+  - provider: s3
+    access_key_id: $S3_ACCESS_KEY_ID
+    secret_access_key: $S3_SECRET_ACCESS_KEY
+    bucket: "pixijs.download"
+    skip_cleanup: true
+    region: us-east-2
+    cache_control: "max-age=2592000"
+    local_dir: dist
+    upload-dir: "pixi.js/$TRAVIS_BRANCH"
+    on:
+        all_branches: true
+        condition: $TRAVIS_TAG
+  # Deploy config for latest release
+  - provider: s3
+    access_key_id: $S3_ACCESS_KEY_ID
+    secret_access_key: $S3_SECRET_ACCESS_KEY
+    bucket: "pixijs.download"
+    skip_cleanup: true
+    region: us-east-2
+    cache_control: "max-age=1209600"
+    local_dir: dist
+    upload-dir: "pixi.js/release"
+    on:
+        all_branches: true
+        condition: $TRAVIS_TAG
+  # REMOVE AFTER CLOUDFLARE UPDATE - Deploy config for non-tag branches
+  - provider: s3
+    access_key_id: $S3_ACCESS_KEY_ID
+    secret_access_key: $S3_SECRET_ACCESS_KEY
     bucket: "pixi.js"
     skip_cleanup: true
     acl: public_read
@@ -45,7 +84,7 @@ deploy:
     on:
         all_branches: true
         condition: -z $TRAVIS_TAG
-  # Deploy config for tagged releases
+  # REMOVE AFTER CLOUDFLARE UPDATE - Deploy config for tagged releases
   - provider: s3
     access_key_id: $S3_ACCESS_KEY_ID
     secret_access_key: $S3_SECRET_ACCESS_KEY
@@ -59,7 +98,7 @@ deploy:
     on:
         all_branches: true
         condition: $TRAVIS_TAG
-  # Deploy config for latest release
+  # REMOVE AFTER CLOUDFLARE UPDATE - Deploy config for latest release
   - provider: s3
     access_key_id: $S3_ACCESS_KEY_ID
     secret_access_key: $S3_SECRET_ACCESS_KEY


### PR DESCRIPTION
**Hold**: Don't merge this yet. Need ~~additional testing, and~~ to discuss my proposed strategy below. I'll apply this to other repos once we agree on how to move forward.

For those who don't know @finscn has been asking for a long time for us to use a CDN that is China-friendly. CloudFlare is China friendly, but there are some restrictions with how we will have to setup our S3 bucket data to migrate off of AWS CloudFront and onto CloudFlare. For some discussion see [this issue](https://github.com/pixijs/examples/issues/67).

My current idea is:

- Merge a change similar to this for each of our repos we deploy.
    * Each which deploy to the old repo-specific bucket, but also to a new bucket for `pixijs.download` which has a folder for each repo. More details below.
- Once merged, copy all the old values for each from the old bucket into the new one.
- Bring down our CloudFront implementation and move our DNS over to CloudFlare
    * This will be the downtime which will last as long as it takes me to complete the CloudFlare setup and for DNS to propagate.
- After we have confirmed the CloudFlare distribution is working:
    1. Merge a change to each repo to stop deploying to the old buckets
    2. Delete our CloudFront setup from AWS
    3. Delete the old buckets from AWS

Details on the new single-bucket setup:

This single bucket strategy will make it much easier to scale and manage permissions. Currently adding a new project involves writing the travis scripts, adding a new bucket, and adding a CloudFront proxy. With this setup no S3/CloudFlare changes would be needed, all you need to do is write the travis config.

However, it does mean the cannonical url for some buckets will be `pixijs.download/<repo>` rather than `<repo>.pixijs.download`. I think I have have CNAME rules to make this not be a breaking change for most urls. The only URL that would be broken is the main `pixi.js` repo one, because it used no subdomain and no path.

An alternative to maintain backwards compatibility would be to have the new canonical url be `files.pixijs.download/<repo>` (or any subdomain) and have the root redirect to the new path. 