### PR TITLE
Fix BatchRenderer and GroupD8 types

### DIFF
--- a/packages/core/src/batch/BatchRenderer.js
+++ b/packages/core/src/batch/BatchRenderer.js
@@ -613,7 +613,7 @@ export default class BatchRenderer extends ObjectRenderer
      * present.
      *
      * @param {PIXI.Sprite} element - element being rendered
-     * @param {FLoat32Array} float32View - float32-view of the attribute buffer
+     * @param {Float32Array} float32View - float32-view of the attribute buffer
      * @param {Uint32Array} uint32View - uint32-view of the attribute buffer
      * @param {Uint16Array} indexBuffer - index buffer
      * @param {number} aIndex - number of floats already in the attribute buffer

--- a/packages/math/src/GroupD8.js
+++ b/packages/math/src/GroupD8.js
@@ -375,7 +375,7 @@ const GroupD8 = {
      *
      * @memberof PIXI.GroupD8
      * @param {PIXI.Matrix} matrix - sprite world matrix
-     * @param {PIXI.GroupD8Symmetry} rotation - The rotation factor to use.
+     * @param {PIXI.GD8Symmetry} rotation - The rotation factor to use.
      * @param {number} tx - sprite anchoring
      * @param {number} ty - sprite anchoring
      */


### PR DESCRIPTION
Fixed typo in BatchRenderer JSDoc which breaks the TypeScript definitions (capital L in FLoat).