### PR TITLE
Batch renderer types

### DIFF
--- a/packages/core/src/batch/BatchPluginFactory.js
+++ b/packages/core/src/batch/BatchPluginFactory.js
@@ -39,7 +39,7 @@ export default class BatchPluginFactory
      * @param {string} [options.fragment=PIXI.BatchPluginFactory.defaultFragmentTemplate] - Fragment shader template
      * @param {number} [options.vertexSize=6] - Vertex size
      * @param {object} [options.geometryClass=PIXI.BatchGeometry]
-     * @return {PIXI.BatchRenderer} New batch renderer plugin.
+     * @return {*} New batch renderer plugin
      */
     static create(options)
     {

--- a/packages/core/src/batch/BatchRenderer.js
+++ b/packages/core/src/batch/BatchRenderer.js
@@ -45,7 +45,7 @@ export default class BatchRenderer extends ObjectRenderer
          * custom shader generator.
          *
          * @member {PIXI.BatchShaderGenerator}
-         * @readonly
+         * @protected
          */
         this.shaderGenerator = null;
 
@@ -55,7 +55,7 @@ export default class BatchRenderer extends ObjectRenderer
          *
          * @member {object}
          * @default PIXI.BatchGeometry
-         * @readonly
+         * @protected
          */
         this.geometryClass = null;
 
@@ -134,7 +134,7 @@ export default class BatchRenderer extends ObjectRenderer
          * number of textures being batched together.
          *
          * @member {PIXI.Shader}
-         * @private
+         * @protected
          */
         this._shader = null;
 


### PR DESCRIPTION
Can't build [pixi-projection](https://github.com/pixijs/pixi-projection/) without it.

Those fields have to be overriden in constructor, cant do that in case of read-only. 

Protected `_shader` is needed for extra renderer hacks.

Factory doesn't return BatchRenderer, it returns class of BatchRenderer.