### PR TITLE
Fixes base texture prepare (#5856)

### DIFF
--- a/packages/prepare/src/Prepare.js
+++ b/packages/prepare/src/Prepare.js
@@ -45,7 +45,7 @@ function uploadBaseTextures(renderer, item)
         // reuploads the texture without need for preparing it again
         if (!item._glTextures[renderer.CONTEXT_UID])
         {
-            renderer.texture.updateTexture(item);
+            renderer.texture.bind(item);
         }
 
         return true;


### PR DESCRIPTION
`updateTexture` was changed in v5 which caused the prepare to do nothing. Callng `bind` here will actually create the texture.