### PR TITLE
ViewableBuffer: Uint32View and Float32View dont need getters

### DIFF
--- a/packages/core/src/geometry/ViewableBuffer.js
+++ b/packages/core/src/geometry/ViewableBuffer.js
@@ -134,8 +134,8 @@ export default class ViewableBuffer
         this._int16View = null;
         this._uint16View = null;
         this._int32View = null;
-        this._uint32View = null;
-        this._float32View = null;
+        this.uint32View = null;
+        this.float32View = null;
     }
 
     static sizeOf(type)

--- a/packages/core/src/geometry/ViewableBuffer.js
+++ b/packages/core/src/geometry/ViewableBuffer.js
@@ -27,7 +27,6 @@ export default class ViewableBuffer
          */
         this.uint32View = new Uint32Array(this.rawBinaryData);
 
-
         /**
          * View on the raw binary data as a `Float32Array`.
          *

--- a/packages/core/src/geometry/ViewableBuffer.js
+++ b/packages/core/src/geometry/ViewableBuffer.js
@@ -19,6 +19,21 @@ export default class ViewableBuffer
          * @member {ArrayBuffer}
          */
         this.rawBinaryData = new ArrayBuffer(size);
+
+        /**
+         * View on the raw binary data as a `Uint32Array`.
+         *
+         * @member {Uint32Array}
+         */
+        this.uint32View = new Uint32Array(this.rawBinaryData);
+
+
+        /**
+         * View on the raw binary data as a `Float32Array`.
+         *
+         * @member {Float32Array}
+         */
+        this.float32View = new Float32Array(this.rawBinaryData);
     }
 
     /**
@@ -94,36 +109,6 @@ export default class ViewableBuffer
         }
 
         return this._int32View;
-    }
-
-    /**
-     * View on the raw binary data as a `Uint32Array`.
-     *
-     * @member {Float32Array}
-     */
-    get uint32View()
-    {
-        if (!this._uint32View)
-        {
-            this._uint32View = new Uint32Array(this.rawBinaryData);
-        }
-
-        return this._uint32View;
-    }
-
-    /**
-     * View on the raw binary data as a `Float32Array`.
-     *
-     * @member {Float32Array}
-     */
-    get float32View()
-    {
-        if (!this._float32View)
-        {
-            this._float32View = new Float32Array(this.rawBinaryData);
-        }
-
-        return this._float32View;
     }
 
     /**


### PR DESCRIPTION
Subj. I just dont know cases that dont use one or both of them.

Pushing colors or something else in uint8 or int8 can happen but its rare.

Also Uint32 had wrong jsdoc type.