### PR TITLE
Fixed parent not defined when calling updateTransform on a container with no parent

### DIFF
--- a/packages/canvas/canvas-renderer/src/CanvasRenderer.js
+++ b/packages/canvas/canvas-renderer/src/CanvasRenderer.js
@@ -200,7 +200,8 @@ export default class CanvasRenderer extends AbstractRenderer
 
             displayObject.parent = this._tempDisplayObjectParent;
 
-            displayObject.updateTransform();
+            // Use the internal version that doesn't check for the existence of a parent
+            displayObject._updateTransform();
             displayObject.parent = cacheParent;
             // displayObject.hitArea = //TODO add a temp hit area
         }

--- a/packages/core/src/batch/BatchRenderer.js
+++ b/packages/core/src/batch/BatchRenderer.js
@@ -425,7 +425,7 @@ export default class BatchRenderer extends ObjectRenderer
                 packedGeometries[this._flushId] = new (this.geometryClass)();
             }
 
-            packedGeometries[this._flushId]._buffer.update(attributeBuffer.vertices, 0);
+            packedGeometries[this._flushId]._buffer.update(attributeBuffer.rawBinaryData, 0);
             packedGeometries[this._flushId]._indexBuffer.update(indexBuffer, 0);
 
             this.renderer.geometry.bind(packedGeometries[this._flushId]);
@@ -435,7 +435,7 @@ export default class BatchRenderer extends ObjectRenderer
         else
         {
             // lets use the faster option, always use buffer number 0
-            packedGeometries[this._flushId]._buffer.update(attributeBuffer.vertices, 0);
+            packedGeometries[this._flushId]._buffer.update(attributeBuffer.rawBinaryData, 0);
             packedGeometries[this._flushId]._indexBuffer.update(indexBuffer, 0);
 
             this.renderer.geometry.updateBuffers();

--- a/packages/display/src/Container.js
+++ b/packages/display/src/Container.js
@@ -417,6 +417,10 @@ export default class Container extends DisplayObject
         {
             this.transform.updateTransform(this.parent.transform);
         }
+        else
+        {
+            this.transform.updateLocalTransform();
+        }
 
         // TODO: check render flags, how to process stuff here
         this.worldAlpha = this.alpha * (this.parent ? this.parent.worldAlpha : 1);

--- a/packages/display/src/Container.js
+++ b/packages/display/src/Container.js
@@ -402,9 +402,11 @@ export default class Container extends DisplayObject
     }
 
     /**
-     * Updates the transform on all children of this container for rendering
+     * Updates the transform on all children of this container for rendering. Used internally.
+     *
+     * @override
      */
-    updateTransform()
+    _updateTransform()
     {
         if (this.sortableChildren && this.sortDirty)
         {
@@ -413,17 +415,10 @@ export default class Container extends DisplayObject
 
         this._boundsID++;
 
-        if (this.parent)
-        {
-            this.transform.updateTransform(this.parent.transform);
-        }
-        else
-        {
-            this.transform.updateLocalTransform();
-        }
+        this.transform.updateTransform(this.parent.transform);
 
         // TODO: check render flags, how to process stuff here
-        this.worldAlpha = this.alpha * (this.parent ? this.parent.worldAlpha : 1);
+        this.worldAlpha = this.alpha * this.parent.worldAlpha;
 
         for (let i = 0, j = this.children.length; i < j; ++i)
         {
@@ -431,7 +426,7 @@ export default class Container extends DisplayObject
 
             if (child.visible)
             {
-                child.updateTransform();
+                child._updateTransform();
             }
         }
     }

--- a/packages/display/src/Container.js
+++ b/packages/display/src/Container.js
@@ -419,7 +419,7 @@ export default class Container extends DisplayObject
         }
 
         // TODO: check render flags, how to process stuff here
-        this.worldAlpha = this.alpha * this.parent.worldAlpha;
+        this.worldAlpha = this.alpha * (this.parent ? this.parent.worldAlpha : 1);
 
         for (let i = 0, j = this.children.length; i < j; ++i)
         {

--- a/packages/display/src/Container.js
+++ b/packages/display/src/Container.js
@@ -413,7 +413,10 @@ export default class Container extends DisplayObject
 
         this._boundsID++;
 
-        this.transform.updateTransform(this.parent.transform);
+        if (this.parent)
+        {
+            this.transform.updateTransform(this.parent.transform);
+        }
 
         // TODO: check render flags, how to process stuff here
         this.worldAlpha = this.alpha * this.parent.worldAlpha;

--- a/packages/display/src/DisplayObject.js
+++ b/packages/display/src/DisplayObject.js
@@ -207,6 +207,24 @@ export default class DisplayObject extends EventEmitter
      */
     updateTransform()
     {
+        if (!this.parent)
+        {
+            // Add an empty parent container to avoid checking for its existence before performing transform updates
+            this.parent = this._tempDisplayObjectParent;
+            this._updateTransform();
+            this.parent = null;
+        }
+        else
+        {
+            this._updateTransform();
+        }
+    }
+
+    /**
+     * Updates the object transform for rendering. Will crash if there is no parent element. Used internally.
+     */
+    _updateTransform()
+    {
         this.transform.updateTransform(this.parent.transform);
         // multiply the alphas..
         this.worldAlpha = this.alpha * this.parent.worldAlpha;
@@ -247,13 +265,13 @@ export default class DisplayObject extends EventEmitter
             if (!this.parent)
             {
                 this.parent = this._tempDisplayObjectParent;
-                this.updateTransform();
+                this._updateTransform();
                 this.parent = null;
             }
             else
             {
                 this._recursivePostUpdateTransform();
-                this.updateTransform();
+                this._updateTransform();
             }
         }
 

--- a/packages/display/test/Container.js
+++ b/packages/display/test/Container.js
@@ -510,13 +510,16 @@ describe('PIXI.Container', function ()
         {
             const container = new Container();
             const child = new Container();
-            const canvasSpy = sinon.spy(child, 'updateTransform');
+            const containerSpy = sinon.spy(child, 'updateTransform');
+            // The transform has no parent so it should call updateLocalTransform
+            const transformSpy = sinon.spy(container.transform, 'updateLocalTransform');
 
             container.addChild(child);
 
             container.updateTransform();
 
-            expect(canvasSpy).to.have.been.called;
+            expect(containerSpy).to.have.been.called;
+            expect(transformSpy).to.have.been.called;
         });
     });
 

--- a/packages/display/test/Container.js
+++ b/packages/display/test/Container.js
@@ -505,6 +505,19 @@ describe('PIXI.Container', function ()
 
             expect(canvasSpy).to.not.have.been.called;
         });
+
+        it('should succeed when called on a top level container', function ()
+        {
+            const container = new Container();
+            const child = new Container();
+            const canvasSpy = sinon.spy(child, 'updateTransform');
+
+            container.addChild(child);
+
+            container.updateTransform();
+
+            expect(canvasSpy).to.have.been.called;
+        });
     });
 
     describe('render', function ()

--- a/packages/display/test/Container.js
+++ b/packages/display/test/Container.js
@@ -510,16 +510,13 @@ describe('PIXI.Container', function ()
         {
             const container = new Container();
             const child = new Container();
-            const containerSpy = sinon.spy(child, 'updateTransform');
-            // The transform has no parent so it should call updateLocalTransform
-            const transformSpy = sinon.spy(container.transform, 'updateLocalTransform');
+            const containerSpy = sinon.spy(child, '_updateTransform');
 
             container.addChild(child);
 
             container.updateTransform();
 
             expect(containerSpy).to.have.been.called;
-            expect(transformSpy).to.have.been.called;
         });
     });
 

--- a/packages/particles/src/ParticleContainer.js
+++ b/packages/particles/src/ParticleContainer.js
@@ -176,18 +176,6 @@ export default class ParticleContainer extends Container
     }
 
     /**
-     * Updates the object transform for rendering
-     *
-     * @private
-     */
-    updateTransform()
-    {
-        // TODO don't need to!
-        this.displayObjectUpdateTransform();
-        //  PIXI.Container.prototype.updateTransform.call( this );
-    }
-
-    /**
      * The tint applied to the container. This is a hex value.
      * A value of 0xFFFFFF will remove any tint effect.
      ** IMPORTANT: This is a WebGL only feature and will be ignored by the canvas renderer.

--- a/packages/text-bitmap/src/BitmapText.js
+++ b/packages/text-bitmap/src/BitmapText.js
@@ -329,9 +329,9 @@ export default class BitmapText extends Container
     /**
      * Updates the transform of this object
      *
-     * @private
+     * @override
      */
-    updateTransform()
+    _updateTransform()
     {
         this.validate();
         this.containerUpdateTransform();


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
I added checks for a missing parent to Container.updateTransform to prevent reference errors when calling it on a container with no parent. It can currently be worked around by wrapping the top level container you want to call updateTransform on in another container, but that should probably not be necessary and the documentation makes no mention of requiring a parent.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Tests and/or benchmarks are included
- [X] Lint process passed (`npm run lint`)
- [X] Tests passed (`npm run test`)
