### PR TITLE
Moved _renderCanvas call from text package into new canvas-text package

### DIFF
--- a/bundles/pixi.js-legacy/package.json
+++ b/bundles/pixi.js-legacy/package.json
@@ -40,6 +40,7 @@
     "@pixi/canvas-renderer": "^5.0.4",
     "@pixi/canvas-sprite": "^5.0.4",
     "@pixi/canvas-sprite-tiling": "^5.0.4",
+    "@pixi/canvas-text": "^5.0.4",
     "pixi.js": "^5.0.4"
   }
 }

--- a/bundles/pixi.js-legacy/src/index.js
+++ b/bundles/pixi.js-legacy/src/index.js
@@ -8,6 +8,7 @@ import * as canvasPrepare from '@pixi/canvas-prepare';
 import '@pixi/canvas-sprite-tiling';
 import '@pixi/canvas-particles';
 import '@pixi/canvas-display';
+import '@pixi/canvas-text';
 
 CanvasRenderer.registerPlugin('accessibility', accessibility.AccessibilityManager);
 CanvasRenderer.registerPlugin('extract', canvasExtract.CanvasExtract);

--- a/packages/canvas/canvas-text/LICENSE
+++ b/packages/canvas/canvas-text/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2013-2018 Mathew Groves, Chad Engler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/canvas/canvas-text/README.md
+++ b/packages/canvas/canvas-text/README.md
@@ -1,0 +1,13 @@
+# @pixi/canvas-text
+
+## Installation
+
+```bash
+npm install @pixi/canvas-text
+```
+
+## Usage
+
+```js
+import '@pixi/canvas-text';
+```

--- a/packages/canvas/canvas-text/package.json
+++ b/packages/canvas/canvas-text/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@pixi/canvas-text",
+  "version": "5.0.4",
+  "main": "lib/canvas-text.js",
+  "module": "lib/canvas-text.es.js",
+  "bundle": "dist/canvas-text.js",
+  "bundleNoExports": false,
+  "description": "Canvas mixin for the text package",
+  "author": "Dave Moore",
+  "homepage": "http://pixijs.com/",
+  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pixijs/pixi.js.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "lib",
+    "dist"
+  ],
+  "dependencies": {
+	  "@pixi/sprite": "^5.0.4",
+    "@pixi/text": "^5.0.4"
+  }
+}

--- a/packages/canvas/canvas-text/package.json
+++ b/packages/canvas/canvas-text/package.json
@@ -4,7 +4,7 @@
   "main": "lib/canvas-text.js",
   "module": "lib/canvas-text.es.js",
   "bundle": "dist/canvas-text.js",
-  "bundleNoExports": false,
+  "bundleNoExports": true,
   "description": "Canvas mixin for the text package",
   "author": "Dave Moore",
   "homepage": "http://pixijs.com/",
@@ -22,7 +22,7 @@
     "dist"
   ],
   "dependencies": {
-	  "@pixi/sprite": "^5.0.4",
+    "@pixi/sprite": "^5.0.4",
     "@pixi/text": "^5.0.4"
   }
 }

--- a/packages/canvas/canvas-text/src/Text.js
+++ b/packages/canvas/canvas-text/src/Text.js
@@ -9,7 +9,7 @@ import { Sprite } from '@pixi/sprite';
  * @private
  * @param {PIXI.CanvasRenderer} renderer - The renderer
  */
-Text.prototype._renderCanvas = function _renderCanvas(renderer) // eslint-disable-line no-unused-vars
+Text.prototype._renderCanvas = function _renderCanvas(renderer)
 {
     if (this._autoResolution && this._resolution !== renderer.resolution)
     {

--- a/packages/canvas/canvas-text/src/Text.js
+++ b/packages/canvas/canvas-text/src/Text.js
@@ -1,0 +1,23 @@
+import { Text } from '@pixi/text';
+import { Sprite } from '@pixi/sprite';
+
+/**
+ * Renders the object using the Canvas renderer
+ *
+ * @method _renderCanvas
+ * @memberof PIXI.Text#
+ * @private
+ * @param {PIXI.CanvasRenderer} renderer - The renderer
+ */
+Text.prototype._renderCanvas = function _renderCanvas(renderer) // eslint-disable-line no-unused-vars
+{
+    if (this._autoResolution && this._resolution !== renderer.resolution)
+    {
+        this._resolution = renderer.resolution;
+        this.dirty = true;
+    }
+
+    this.updateText(true);
+
+    Sprite.prototype._renderCanvas.call(this, renderer);
+};

--- a/packages/canvas/canvas-text/src/index.js
+++ b/packages/canvas/canvas-text/src/index.js
@@ -1,0 +1,1 @@
+import './Text';

--- a/packages/text/src/Text.js
+++ b/packages/text/src/Text.js
@@ -330,9 +330,10 @@ export default class Text extends Sprite
     /**
      * Renders the object using the WebGL renderer
      *
+     * @private
      * @param {PIXI.Renderer} renderer - The renderer
      */
-    render(renderer)
+    _render(renderer)
     {
         if (this._autoResolution && this._resolution !== renderer.resolution)
         {
@@ -342,26 +343,7 @@ export default class Text extends Sprite
 
         this.updateText(true);
 
-        super.render(renderer);
-    }
-
-    /**
-     * Renders the object using the Canvas renderer
-     *
-     * @private
-     * @param {PIXI.CanvasRenderer} renderer - The renderer
-     */
-    _renderCanvas(renderer)
-    {
-        if (this._autoResolution && this._resolution !== renderer.resolution)
-        {
-            this._resolution = renderer.resolution;
-            this.dirty = true;
-        }
-
-        this.updateText(true);
-
-        super._renderCanvas(renderer);
+        super._render(renderer);
     }
 
     /**

--- a/packages/text/test/Text.js
+++ b/packages/text/test/Text.js
@@ -6,6 +6,7 @@ const { CanvasRenderer } = require('@pixi/canvas-renderer');
 const { CanvasSpriteRenderer } = require('@pixi/canvas-sprite');
 
 require('@pixi/canvas-display');
+require('@pixi/canvas-text');
 
 skipHello();
 

--- a/packages/text/test/Text.js
+++ b/packages/text/test/Text.js
@@ -6,7 +6,6 @@ const { CanvasRenderer } = require('@pixi/canvas-renderer');
 const { CanvasSpriteRenderer } = require('@pixi/canvas-sprite');
 
 require('@pixi/canvas-display');
-require('@pixi/canvas-text');
 
 skipHello();
 

--- a/tools/integration-tests/package.json
+++ b/tools/integration-tests/package.json
@@ -9,6 +9,7 @@
     "@pixi/canvas-mesh": "^5.0.4",
     "@pixi/canvas-renderer": "^5.0.4",
     "@pixi/canvas-sprite": "^5.0.4",
+    "@pixi/canvas-text": "^5.0.4",
     "@pixi/core": "^5.0.4",
     "@pixi/display": "^5.0.4",
     "@pixi/graphics": "^5.0.4",

--- a/tools/integration-tests/test/display/getLocalBounds.js
+++ b/tools/integration-tests/test/display/getLocalBounds.js
@@ -10,6 +10,7 @@ const { SimplePlane } = require('@pixi/mesh-extras');
 const { CanvasMeshRenderer } = require('@pixi/canvas-mesh');
 
 require('@pixi/canvas-display');
+require('@pixi/canvas-text');
 
 CanvasRenderer.registerPlugin('sprite', CanvasSpriteRenderer);
 CanvasRenderer.registerPlugin('graphics', CanvasGraphicsRenderer);


### PR DESCRIPTION
It's only required for legacy builds, not normal WebGL only builds

Also renamed render to _render, as internally in other areas of the code, when overriding a render method it is always the underscored version

##### Pre-Merge Checklist
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
