### PR TITLE
Set parentID to -1 rather than worldID for when flagging parent transform as dirty

### DIFF
--- a/packages/canvas/canvas-renderer/src/CanvasRenderer.js
+++ b/packages/canvas/canvas-renderer/src/CanvasRenderer.js
@@ -191,7 +191,7 @@ export default class CanvasRenderer extends AbstractRenderer
                 transform.copyTo(tempWt);
 
                 // lets not forget to flag the parent transform as dirty...
-                this._tempDisplayObjectParent.transform._worldID = -1;
+                this._tempDisplayObjectParent.transform._parentID = -1;
             }
             else
             {


### PR DESCRIPTION
Was recommended in a comment for a previous PR, and I've seen no negative side efffects
https://github.com/pixijs/pixi.js/pull/5030#issuecomment-441299080

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
