### PR TITLE
Uses super instead of prototype.call

### DIFF
--- a/packages/core/src/Renderer.js
+++ b/packages/core/src/Renderer.js
@@ -384,7 +384,7 @@ export default class Renderer extends AbstractRenderer
      */
     resize(screenWidth, screenHeight)
     {
-        super.resize(this, screenWidth, screenHeight);
+        super.resize(screenWidth, screenHeight);
 
         this.runners.resize.run(screenWidth, screenHeight);
     }

--- a/packages/core/src/Renderer.js
+++ b/packages/core/src/Renderer.js
@@ -384,7 +384,7 @@ export default class Renderer extends AbstractRenderer
      */
     resize(screenWidth, screenHeight)
     {
-        AbstractRenderer.prototype.resize.call(this, screenWidth, screenHeight);
+        super.resize(this, screenWidth, screenHeight);
 
         this.runners.resize.run(screenWidth, screenHeight);
     }


### PR DESCRIPTION
Fixes #5892

Still works as expected:
https://pixiplayground.com/#/edit/_mWHW7~9s4k6QZDuOOlQ5
