### PR TITLE
minor mistakes related to framebuffer

### DIFF
--- a/packages/core/src/framebuffer/FramebufferSystem.js
+++ b/packages/core/src/framebuffer/FramebufferSystem.js
@@ -421,7 +421,7 @@ export default class FramebufferSystem extends System
 
         this.managedFramebuffers = [];
 
-        for (let i = 0; i < list.count; i++)
+        for (let i = 0; i < list.length; i++)
         {
             this.disposeFramebuffer(list[i], contextLost);
         }

--- a/packages/core/src/renderTexture/BaseRenderTexture.js
+++ b/packages/core/src/renderTexture/BaseRenderTexture.js
@@ -142,7 +142,5 @@ export default class BaseRenderTexture extends BaseTexture
         super.destroy(true);
 
         this.framebuffer = null;
-
-        this.renderer = null;
     }
 }


### PR DESCRIPTION
`count` didnt actually affect much , we just had some old links inside Framebuffer in case of context loss. 
`renderer` is not field of RenderTexture for a long time.