### PR TITLE
Moving to OpenCollective

### DIFF
--- a/bundles/pixi.js/scripts/support-pixi.js
+++ b/bundles/pixi.js/scripts/support-pixi.js
@@ -5,5 +5,5 @@ const white = '\u001b[22m\u001b[39m';
 const boldCyan = '\u001b[96m\u001b[1m';
 const reset = '\u001b[0m';
 
-console.log(`${green}Have some ❤️  for PixiJS? You can support the project via Patreon:`);
-console.log(`${white}> ${boldCyan}https://www.patreon.com/user?u=2384552\n${reset}`);
+console.log(`${green}Have some ❤️  for PixiJS? You can support the project via OpenCollective:`);
+console.log(`${white}> ${boldCyan}https://opencollective.com/pixijs/contribute\n${reset}`);


### PR DESCRIPTION
We have decided to move to the [OpenCollective](https://opencollective.com/pixijs) platform for sponsorship. We have already added the **Sponsor** button to the project.

Primarily, @GoodBoyDigital and I feel like this is a better vehicle for driving community engagement. This change will also make it easier for us to compensate the community for things such as bug/feature bounties, allows for more transparency with regard to expenses, and we hope push PixiJS toward our long-term goal of financial independence.

In addition, OpenCollective is home to tools like Babel and Webpack which are heavily used by the PixiJS developer community. We feel like we'd be in good company with this move.

This PR simply replaces the **pixi.js** postinstall message with an OpenCollective link.