### PR TITLE
Pre-5.1.0 types fixes

### DIFF
--- a/packages/core/src/batch/AbstractBatchRenderer.js
+++ b/packages/core/src/batch/AbstractBatchRenderer.js
@@ -72,7 +72,7 @@ export default class AbstractBatchRenderer extends ObjectRenderer
          * | aColor          | 1 |
          * | aTextureId      | 1 |
          *
-         * @member {number} vertexSize
+         * @member {number}
          * @readonly
          */
         this.vertexSize = null;

--- a/packages/core/src/renderTexture/RenderTexturePool.js
+++ b/packages/core/src/renderTexture/RenderTexturePool.js
@@ -25,7 +25,8 @@ export default class RenderTexturePool
          *
          * Automatically sets to true after `setScreenSize`
          *
-         * @member {boolean} [enableFullScreen=false]
+         * @member {boolean}
+         * @default false
          */
         this.enableFullScreen = false;
 
@@ -132,7 +133,7 @@ export default class RenderTexturePool
     /**
      * Clears the pool
      *
-     * @member {boolean} [destroyTextures=true] destroy all stored textures
+     * @param {boolean} [destroyTextures=true] destroy all stored textures
      */
     clear(destroyTextures)
     {


### PR DESCRIPTION
subj.
Also, `vertexSize` should be protected like `geometryClass`, need that for the only ts plugin that uses new API.
