### PR TITLE
Fix Cannot read property 'disposeGeometry' of undefined (#5929)

### DIFF
--- a/packages/runner/src/Runner.js
+++ b/packages/runner/src/Runner.js
@@ -62,8 +62,9 @@ export default class Runner
         }
 
         const { name, items } = this;
+        let i = items.length;
 
-        for (let i = 0, len = items.length; i < len; i++)
+        while (i--)
         {
             items[i][name](a0, a1, a2, a3, a4, a5, a6, a7);
         }


### PR DESCRIPTION
##### Description of change
Loop through runner items backwards, in case one of the items removes itself from the array.

https://www.pixiplayground.com/#/edit/yjTOm9m7zJN0XMYWMVTCv

##### Pre-Merge Checklist

- [x] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)

##### Note
Just realizing that I unfortunately cannot run `npm run test` due to a [separate issue](https://github.com/pixijs/pixi.js/issues/5931) which happens from a clean install on my machine with the latest master.