### PR TITLE
Fix TextMetrics OffscreenCanvas context null

### DIFF
--- a/packages/text/src/TextMetrics.js
+++ b/packages/text/src/TextMetrics.js
@@ -705,11 +705,7 @@ const canvas = (() =>
     {
         // OffscreenCanvas2D measureText can be up to 40% faster.
         const c = new OffscreenCanvas(0, 0);
-
-        if (c.getContext('2d')===null)
-            throw('context null');
-
-        return c;
+        return c.getContext('2d') ? c : document.createElement('canvas');
     }
     catch (ex)
     {

--- a/packages/text/src/TextMetrics.js
+++ b/packages/text/src/TextMetrics.js
@@ -706,7 +706,8 @@ const canvas = (() =>
         // OffscreenCanvas2D measureText can be up to 40% faster.
         const c = new OffscreenCanvas(0, 0);
 
-        c.getContext('2d');
+        if (c.getContext('2d')===null)
+            throw('context null');
 
         return c;
     }


### PR DESCRIPTION
Found a bug in iOS12.3.0 webview that stops PIXI.Text from working, note it does not affect iOS safari browser. Traced it down to TextMetrics.js getContext('2d') of OffscreenCanvas returning null.