### PR TITLE
Adds generic types to container child methods

### DIFF
--- a/types/assemble.js
+++ b/types/assemble.js
@@ -47,6 +47,18 @@ if (bundle === 'pixi.js') {
         .replace(/PIXI\.prepare\.CanvasPrepare \| (PIXI\.Renderer)/g, '$1');
 }
 
+// tsd-jsdoc doesn't currently support indexed generics (TChildren[0])
+buffer = buffer.replace(
+    /(addChild|removeChild)\(\.\.\.child: PIXI.DisplayObject\[\]\): PIXI\.DisplayObject;/g,
+    '$1<TChildren extends PIXI.DisplayObject[]>(...child: TChildren): TChildren[0];'
+);
+
+// tsd-jsdoc supports this case using the @template tag, but using said tag breaks documentation generation
+buffer = buffer.replace(
+    /addChildAt\(child: PIXI\.DisplayObject, index: number\): PIXI\.DisplayObject;/g,
+    'addChildAt<T extends PIXI.DisplayObject>(child: T, index: number): T;'
+);
+
 // EventEmitter3 and resource-loader are external dependencies, we'll
 // inject these into the find output
 const eventTypes = fs.readFileSync(path.join(__dirname, 'events.d.ts'), 'utf8');


### PR DESCRIPTION
##### Description of change
Adds generic types to Container.addChild, Container.removeChild and Container.addChildAt, allowing for the proper subclass of PIXI.DisplayObject to be returned.

fixes #5927.

##### Pre-Merge Checklist
- [x] Documentation is changed or added
