### PR TITLE
fix bug where OffscreenCanvas.getContext is null

### DIFF
--- a/packages/text/src/TextMetrics.js
+++ b/packages/text/src/TextMetrics.js
@@ -705,10 +705,7 @@ const canvas = (() =>
     {
         // OffscreenCanvas2D measureText can be up to 40% faster.
         const c = new OffscreenCanvas(0, 0);
-
-        c.getContext('2d');
-
-        return c;
+        return c.getContext('2d') ? c : document.createElement('canvas');
     }
     catch (ex)
     {

--- a/packages/text/src/TextMetrics.js
+++ b/packages/text/src/TextMetrics.js
@@ -705,6 +705,7 @@ const canvas = (() =>
     {
         // OffscreenCanvas2D measureText can be up to 40% faster.
         const c = new OffscreenCanvas(0, 0);
+
         return c.getContext('2d') ? c : document.createElement('canvas');
     }
     catch (ex)


### PR DESCRIPTION
Re submission of fix to bug where an iOS webview OffscreenCanvas would return a context of null. 
