### PR TITLE
Allows the user to decide where drop shadows are applied to text

### DIFF
--- a/packages/text/src/Text.js
+++ b/packages/text/src/Text.js
@@ -4,7 +4,7 @@ import { Texture } from '@pixi/core';
 import { settings } from '@pixi/settings';
 import { Rectangle } from '@pixi/math';
 import { sign, trimCanvas, hex2rgb, string2hex } from '@pixi/utils';
-import { TEXT_GRADIENT } from './const';
+import { TEXT_DROPSHADOWLOCATION, TEXT_GRADIENT } from './const';
 import TextStyle from './TextStyle';
 import TextMetrics from './TextMetrics';
 
@@ -170,24 +170,6 @@ export default class Text extends Sprite
         let linePositionX;
         let linePositionY;
 
-        if (style.dropShadow)
-        {
-            const dropShadowColor = style.dropShadowColor;
-            const rgb = hex2rgb(typeof dropShadowColor === 'number' ? dropShadowColor : string2hex(dropShadowColor));
-
-            context.shadowColor = `rgba(${rgb[0] * 255},${rgb[1] * 255},${rgb[2] * 255},${style.dropShadowAlpha})`;
-            context.shadowBlur = style.dropShadowBlur;
-            context.shadowOffsetX = Math.cos(style.dropShadowAngle) * style.dropShadowDistance;
-            context.shadowOffsetY = Math.sin(style.dropShadowAngle) * style.dropShadowDistance;
-        }
-        else
-        {
-            context.shadowColor = 0;
-            context.shadowBlur = 0;
-            context.shadowOffsetX = 0;
-            context.shadowOffsetY = 0;
-        }
-
         // set canvas text styles
         context.fillStyle = this._generateFillStyle(style, lines);
 
@@ -208,6 +190,8 @@ export default class Text extends Sprite
 
             if (style.stroke && style.strokeThickness)
             {
+                this._applyDropShadow(true);
+
                 this.drawLetterSpacing(
                     lines[i],
                     linePositionX + style.padding,
@@ -218,6 +202,8 @@ export default class Text extends Sprite
 
             if (style.fill)
             {
+                this._applyDropShadow();
+
                 this.drawLetterSpacing(
                     lines[i],
                     linePositionX + style.padding,
@@ -485,6 +471,40 @@ export default class Text extends Sprite
         }
 
         return gradient;
+    }
+
+    /**
+     * Apply drop shadow settings to the canvas
+     *
+     * @param {boolean} [isStroke=false] - Is this creating drop shadows for the outside stroke of the
+     *  text? If not, it's for the inside fill
+     * @private
+     */
+    _applyDropShadow(isStroke = false)
+    {
+        const style = this._style;
+        const context = this.context;
+        const DSL = TEXT_DROPSHADOWLOCATION;
+
+        const correctDSL = isStroke ? style.dropShadowLocation === DSL.STROKE : style.dropShadowLocation === DSL.FILL;
+
+        if (style.dropShadow && (style.dropShadowLocation === DSL.BOTH || correctDSL))
+        {
+            const dropShadowColor = style.dropShadowColor;
+            const rgb = hex2rgb(typeof dropShadowColor === 'number' ? dropShadowColor : string2hex(dropShadowColor));
+
+            context.shadowColor = `rgba(${rgb[0] * 255},${rgb[1] * 255},${rgb[2] * 255},${style.dropShadowAlpha})`;
+            context.shadowBlur = style.dropShadowBlur;
+            context.shadowOffsetX = Math.cos(style.dropShadowAngle) * style.dropShadowDistance;
+            context.shadowOffsetY = Math.sin(style.dropShadowAngle) * style.dropShadowDistance;
+        }
+        else
+        {
+            context.shadowColor = 0;
+            context.shadowBlur = 0;
+            context.shadowOffsetX = 0;
+            context.shadowOffsetY = 0;
+        }
     }
 
     /**

--- a/packages/text/src/TextStyle.js
+++ b/packages/text/src/TextStyle.js
@@ -1,7 +1,7 @@
 // disabling eslint for now, going to rewrite this in v5
 /* eslint-disable */
 
-import { TEXT_GRADIENT } from './const';
+import { TEXT_DROPSHADOWLOCATION, TEXT_GRADIENT } from './const';
 import { hex2string } from '@pixi/utils';
 
 const defaultStyle = {
@@ -13,6 +13,7 @@ const defaultStyle = {
     dropShadowBlur: 0,
     dropShadowColor: 'black',
     dropShadowDistance: 5,
+    dropShadowLocation: TEXT_DROPSHADOWLOCATION.FILL,
     fill: 'black',
     fillGradientType: TEXT_GRADIENT.LINEAR_VERTICAL,
     fillGradientStops: [],
@@ -21,6 +22,7 @@ const defaultStyle = {
     fontStyle: 'normal',
     fontVariant: 'normal',
     fontWeight: 'normal',
+    leading: 0,
     letterSpacing: 0,
     lineHeight: 0,
     lineJoin: 'miter',
@@ -33,7 +35,6 @@ const defaultStyle = {
     whiteSpace: 'pre',
     wordWrap: false,
     wordWrapWidth: 100,
-    leading: 0,
 };
 
 const genericFontFamilies = [
@@ -69,6 +70,8 @@ export default class TextStyle
      * @param {number} [style.dropShadowBlur=0] - Set a shadow blur radius
      * @param {string|number} [style.dropShadowColor='black'] - A fill style to be used on the dropshadow e.g 'red', '#00FF00'
      * @param {number} [style.dropShadowDistance=5] - Set a distance of the drop shadow
+     * @param {number} [style.dropShadowLocation=PIXI.TEXT_DROPSHADOWLOCATION.FILL] - Decides where the drop shadow is applied.
+     *  You can drop shadow just the 'fill', just the 'stroke', or apply it to 'both'. See {@link PIXI.TEXT_DROPSHADOWLOCATION}
      * @param {string|string[]|number|number[]|CanvasGradient|CanvasPattern} [style.fill='black'] - A canvas
      *  fillstyle that will be used on the text e.g 'red', '#00FF00'. Can be an array to create a gradient
      *  eg ['#000000','#FFFFFF']
@@ -278,6 +281,26 @@ export default class TextStyle
         if (this._dropShadowDistance !== dropShadowDistance)
         {
             this._dropShadowDistance = dropShadowDistance;
+            this.styleID++;
+        }
+    }
+
+    /**
+     * Decides where the drop shadow is applied.
+     * You can drop shadow just the 'fill', just the 'stroke', or apply it to 'both'.
+     * See {@link PIXI.TEXT_DROPSHADOWLOCATION}
+     *
+     * @member {number}
+     */
+    get dropShadowLocation()
+    {
+        return this._dropShadowLocation;
+    }
+    set dropShadowLocation(dropShadowLocation) // eslint-disable-line require-jsdoc
+    {
+        if (this._dropShadowLocation !== dropShadowLocation)
+        {
+            this._dropShadowLocation = dropShadowLocation;
             this.styleID++;
         }
     }

--- a/packages/text/src/const.js
+++ b/packages/text/src/const.js
@@ -1,5 +1,23 @@
 /**
- * Constants that define the type of gradient on text.
+ * Constants that define the location of the drop shadow that can be applied to text.
+ *
+ * @static
+ * @constant
+ * @name TEXT_DROPSHADOWLOCATION
+ * @memberof PIXI
+ * @type {object}
+ * @property {number} FILL Only add a drop shadow to the 'fill'
+ * @property {number} STROKE Only add a drop shadow to the 'stroke'
+ * @property {number} BOTH Add a drop shadow to both the 'fill' and the 'stroke'
+ */
+export const TEXT_DROPSHADOWLOCATION = {
+    FILL: 0,
+    STROKE: 1,
+    BOTH: 2,
+};
+
+/**
+ * Constants that define the type of gradient that can be applied to text.
  *
  * @static
  * @constant


### PR DESCRIPTION
##### Description of change
Since porting over games from v4 to v5, an issue was noticed where drop shadows were looking different to how they did in v4 (due to my PR https://github.com/pixijs/pixi.js/pull/5375) Namely, for v4, drop shadows occurred only on the 'fill', but for v5 they occur on both the fill and the stroke.

I went around the houses on how to solve this, and I've finalised on letting the user decide what they want. With a new text style property, they can decide whether they want the drop shadow to only occur on the 'fill' (default behaviour, which matches v4), or if they want it to only occur on the stroke (new for v5), or they want it to occur on both (accidental buggy behaviour which v5 does now).

Sorry about introducing the bug in the first place :/

##### Pre-Merge Checklist
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
