### PR TITLE
Fixing batch breaking by empty filter array.

### DIFF
--- a/packages/display/src/Container.js
+++ b/packages/display/src/Container.js
@@ -494,7 +494,7 @@ export default class Container extends DisplayObject
         }
 
         // do a quick check to see if this element has a mask or a filter.
-        if (this._mask || this.filters)
+        if (this._mask || (this.filters && this.filters.length))
         {
             this.renderAdvanced(renderer);
         }


### PR DESCRIPTION
Empty filter array in Container breaks batched render.

Bug replay:
https://www.pixiplayground.com/#/edit/pRUcpdTxAEml0qiV83HUI

Remove line 37 and bunny will nbe rendered.


<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
