### PR TITLE
Fixes text shadows for v5, take 2

### DIFF
--- a/packages/text/src/Text.js
+++ b/packages/text/src/Text.js
@@ -170,59 +170,79 @@ export default class Text extends Sprite
         let linePositionX;
         let linePositionY;
 
-        if (style.dropShadow)
-        {
-            const dropShadowColor = style.dropShadowColor;
-            const rgb = hex2rgb(typeof dropShadowColor === 'number' ? dropShadowColor : string2hex(dropShadowColor));
-
-            context.shadowColor = `rgba(${rgb[0] * 255},${rgb[1] * 255},${rgb[2] * 255},${style.dropShadowAlpha})`;
-            context.shadowBlur = style.dropShadowBlur;
-            context.shadowOffsetX = Math.cos(style.dropShadowAngle) * style.dropShadowDistance;
-            context.shadowOffsetY = Math.sin(style.dropShadowAngle) * style.dropShadowDistance;
-        }
-        else
-        {
-            context.shadowColor = 0;
-            context.shadowBlur = 0;
-            context.shadowOffsetX = 0;
-            context.shadowOffsetY = 0;
-        }
-
         // set canvas text styles
         context.fillStyle = this._generateFillStyle(style, lines);
 
-        // draw lines line by line
-        for (let i = 0; i < lines.length; i++)
+        // require 2 passes if a shadow; the first to draw the drop shadow, the second to draw the text
+        const passesCount = style.dropShadow ? 2 : 1;
+
+        // For v4, we drew text at the colours of the drop shadow underneath the normal text. This gave the correct zIndex,
+        // but features such as alpha and shadowblur did not look right at all, since we were using actual text as a shadow.
+        //
+        // For v5.0.0, we moved over to just use the canvas API for drop shadows, which made them look much nicer and more
+        // visually please, but now because the stroke is drawn and then the fill, drop shadows would appear on both the fill
+        // and the stroke; and fill drop shadows would appear over the top of the stroke.
+        //
+        // For v5.1.1, the new route is to revert to v4 style of drawing text first to get the drop shadows underneath normal
+        // text, but instead drawing text in the correct location, we'll draw it off screen (-paddingY), and then adjust the
+        // drop shadow so only that appears on screen (+paddingY). Now we'll have the correct draw order of the shadow
+        // beneath the text, whilst also having the proper text shadow styling.
+        for (let i = 0; i < passesCount; ++i)
         {
-            linePositionX = style.strokeThickness / 2;
-            linePositionY = ((style.strokeThickness / 2) + (i * lineHeight)) + fontProperties.ascent;
+            const isShadowPass = style.dropShadow && i === 0;
+            const dropShadowOffset = isShadowPass ? height : 0;
 
-            if (style.align === 'right')
+            if (isShadowPass)
             {
-                linePositionX += maxLineWidth - lineWidths[i];
+                const dropShadowColor = style.dropShadowColor;
+                const rgb = hex2rgb(typeof dropShadowColor === 'number' ? dropShadowColor : string2hex(dropShadowColor));
+
+                context.shadowColor = `rgba(${rgb[0] * 255},${rgb[1] * 255},${rgb[2] * 255},${style.dropShadowAlpha})`;
+                context.shadowBlur = style.dropShadowBlur;
+                context.shadowOffsetX = Math.cos(style.dropShadowAngle) * style.dropShadowDistance;
+                context.shadowOffsetY = (Math.sin(style.dropShadowAngle) * style.dropShadowDistance) + dropShadowOffset;
             }
-            else if (style.align === 'center')
+            else
             {
-                linePositionX += (maxLineWidth - lineWidths[i]) / 2;
+                context.shadowColor = 0;
+                context.shadowBlur = 0;
+                context.shadowOffsetX = 0;
+                context.shadowOffsetY = 0;
             }
 
-            if (style.stroke && style.strokeThickness)
+            // draw lines line by line
+            for (let i = 0; i < lines.length; i++)
             {
-                this.drawLetterSpacing(
-                    lines[i],
-                    linePositionX + style.padding,
-                    linePositionY + style.padding,
-                    true
-                );
-            }
+                linePositionX = style.strokeThickness / 2;
+                linePositionY = ((style.strokeThickness / 2) + (i * lineHeight)) + fontProperties.ascent;
 
-            if (style.fill)
-            {
-                this.drawLetterSpacing(
-                    lines[i],
-                    linePositionX + style.padding,
-                    linePositionY + style.padding
-                );
+                if (style.align === 'right')
+                {
+                    linePositionX += maxLineWidth - lineWidths[i];
+                }
+                else if (style.align === 'center')
+                {
+                    linePositionX += (maxLineWidth - lineWidths[i]) / 2;
+                }
+
+                if (style.stroke && style.strokeThickness)
+                {
+                    this.drawLetterSpacing(
+                        lines[i],
+                        linePositionX + style.padding,
+                        linePositionY + style.padding - dropShadowOffset,
+                        true
+                    );
+                }
+
+                if (style.fill)
+                {
+                    this.drawLetterSpacing(
+                        lines[i],
+                        linePositionX + style.padding,
+                        linePositionY + style.padding - dropShadowOffset
+                    );
+                }
             }
         }
 

--- a/packages/text/src/Text.js
+++ b/packages/text/src/Text.js
@@ -186,7 +186,7 @@ export default class Text extends Sprite
         for (let i = 0; i < passesCount; ++i)
         {
             const isShadowPass = style.dropShadow && i === 0;
-            const dsOffsetText = isShadowPass ? height : 0;
+            const dsOffsetText = isShadowPass ? height * 2 : 0; // we only want the drop shadow, so put text way off-screen
             const dsOffsetShadow = dsOffsetText * this.resolution;
 
             if (isShadowPass)

--- a/packages/text/src/Text.js
+++ b/packages/text/src/Text.js
@@ -190,7 +190,8 @@ export default class Text extends Sprite
         for (let i = 0; i < passesCount; ++i)
         {
             const isShadowPass = style.dropShadow && i === 0;
-            const dropShadowOffset = isShadowPass ? height : 0;
+            const dsOffsetText = isShadowPass ? height : 0;
+            const dsOffsetShadow = dsOffsetText * this.resolution;
 
             if (isShadowPass)
             {
@@ -200,7 +201,7 @@ export default class Text extends Sprite
                 context.shadowColor = `rgba(${rgb[0] * 255},${rgb[1] * 255},${rgb[2] * 255},${style.dropShadowAlpha})`;
                 context.shadowBlur = style.dropShadowBlur;
                 context.shadowOffsetX = Math.cos(style.dropShadowAngle) * style.dropShadowDistance;
-                context.shadowOffsetY = (Math.sin(style.dropShadowAngle) * style.dropShadowDistance) + dropShadowOffset;
+                context.shadowOffsetY = (Math.sin(style.dropShadowAngle) * style.dropShadowDistance) + dsOffsetShadow;
             }
             else
             {
@@ -230,7 +231,7 @@ export default class Text extends Sprite
                     this.drawLetterSpacing(
                         lines[i],
                         linePositionX + style.padding,
-                        linePositionY + style.padding - dropShadowOffset,
+                        linePositionY + style.padding - dsOffsetText,
                         true
                     );
                 }
@@ -240,7 +241,7 @@ export default class Text extends Sprite
                     this.drawLetterSpacing(
                         lines[i],
                         linePositionX + style.padding,
-                        linePositionY + style.padding - dropShadowOffset
+                        linePositionY + style.padding - dsOffsetText
                     );
                 }
             }

--- a/packages/text/src/Text.js
+++ b/packages/text/src/Text.js
@@ -161,7 +161,6 @@ export default class Text extends Sprite
         context.clearRect(0, 0, this.canvas.width, this.canvas.height);
 
         context.font = this._font;
-        context.strokeStyle = style.stroke;
         context.lineWidth = style.strokeThickness;
         context.textBaseline = style.textBaseline;
         context.lineJoin = style.lineJoin;
@@ -169,9 +168,6 @@ export default class Text extends Sprite
 
         let linePositionX;
         let linePositionY;
-
-        // set canvas text styles
-        context.fillStyle = this._generateFillStyle(style, lines);
 
         // require 2 passes if a shadow; the first to draw the drop shadow, the second to draw the text
         const passesCount = style.dropShadow ? 2 : 1;
@@ -195,6 +191,12 @@ export default class Text extends Sprite
 
             if (isShadowPass)
             {
+                // On Safari, text with gradient and drop shadows together do not position correctly
+                // if the scale of the canvas is not 1: https://bugs.webkit.org/show_bug.cgi?id=197689
+                // Therefore we'll set the styles to be a plain black whilst generating this drop shadow
+                context.fillStyle = 'black';
+                context.strokeStyle = 'black';
+
                 const dropShadowColor = style.dropShadowColor;
                 const rgb = hex2rgb(typeof dropShadowColor === 'number' ? dropShadowColor : string2hex(dropShadowColor));
 
@@ -205,6 +207,10 @@ export default class Text extends Sprite
             }
             else
             {
+                // set canvas text styles
+                context.fillStyle = this._generateFillStyle(style, lines);
+                context.strokeStyle = style.stroke;
+
                 context.shadowColor = 0;
                 context.shadowBlur = 0;
                 context.shadowOffsetX = 0;


### PR DESCRIPTION
Alternative to https://github.com/pixijs/pixi.js/pull/5943

Goes back to v4 style of separate draw calls to make sure all of the drop shadow is underneath all of the text; but this time rather than using the first drawn text as the actual drop shadows, it draws this text off screen, whilst positioning the drop shadow to appear on screen. So we get the drawing order that v4 has with the good native canvas drop shadow looks of v5.

It doesn't solve 'double drop shadow with low alpha overlapping', but I think that'd require using a second canvas, which is out of scope for this PR

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
