### PR TITLE
Fix the DisplayObject type declaration

### DIFF
--- a/types/events.d.ts
+++ b/types/events.d.ts
@@ -101,11 +101,23 @@ declare namespace PIXI {
 
     export interface DisplayObject {
         on(event: interaction.InteractionEventTypes, fn: (event: interaction.InteractionEvent) => void, context?: any): this;
+        //tslint:disable-next-line:ban-types forbidden-types
+        on(event: string | symbol, fn: Function, context?: any): this;
         once(event: interaction.InteractionEventTypes, fn: (event: interaction.InteractionEvent) => void, context?: any): this;
+        //tslint:disable-next-line:ban-types forbidden-types
+        once(event: string | symbol, fn: Function, context?: any): this;
         removeListener(event: interaction.InteractionEventTypes, fn?: (event: interaction.InteractionEvent) => void, context?: any): this;
+        //tslint:disable-next-line:ban-types forbidden-types
+        removeListener(event: string | symbol, fn?: Function, context?: any): this;
         removeAllListeners(event?: interaction.InteractionEventTypes): this;
+        //tslint:disable-next-line:ban-types forbidden-types
+        removeAllListeners(event?: string | symbol): this;
         off(event: interaction.InteractionEventTypes, fn?: (event: interaction.InteractionEvent) => void, context?: any): this;
+        //tslint:disable-next-line:ban-types forbidden-types
+        off(event: string | symbol, fn?: Function, context?: any): this;
         addListener(event: interaction.InteractionEventTypes, fn: (event: interaction.InteractionEvent) => void, context?: any): this;
+        //tslint:disable-next-line:ban-types forbidden-types
+        addListener(event: string | symbol, fn: Function, context?: any): this;
     }
 
     export interface Container {

--- a/types/events.d.ts
+++ b/types/events.d.ts
@@ -110,7 +110,6 @@ declare namespace PIXI {
         //tslint:disable-next-line:ban-types forbidden-types
         removeListener(event: string | symbol, fn?: Function, context?: any): this;
         removeAllListeners(event?: interaction.InteractionEventTypes): this;
-        //tslint:disable-next-line:ban-types forbidden-types
         removeAllListeners(event?: string | symbol): this;
         off(event: interaction.InteractionEventTypes, fn?: (event: interaction.InteractionEvent) => void, context?: any): this;
         //tslint:disable-next-line:ban-types forbidden-types


### PR DESCRIPTION
##### Description of change

The `DisplayObject` is declared as follows:

https://github.com/pixijs/pixi.js/blob/fc70bdd66c19b2d52e42f3653fe43e313cb19566/types/events.d.ts#L102-L109

This declaration overrides the methods inherited from the `EventEmitter`. Because overridden methods do not accept the `string | symbol` as a `event`, `displayObject.on( "foo", ... )` leads to a compilation error as shown in the following typescript playground. This PR is to fix this.

https://www.typescriptlang.org/play/index.html#code/MYGwhgzhAECiBuBTAdgF1gWwJatYgTtAN4BQ050A9sgBTSJJoBc0Eq+WyA5tAD6sBPDACNKIaAEoW8SlgAmxAL4llJUJBgARLBAAO4AQHlhAK0TBU9AB55kcmAhTpsuAkpIlOefADMwwRGhtPQNjMwtiMgoAemjoADlYWE1oABUACVgE2AANVOgAGQBJRLTDaAAlWABlQwKANSyMrIBhQwBZAAUigoBBVKLDeLgKisMKqPJYqlp6RlQWNg5uPkERMUlpWTkAbmhJmboGJxYAIl1ZNAI5SgB3ZFPN6Bl5HZUPYGo2aDkdfTAjKZzAsgn9QkCIgBeYiHCRKaCKN6-EIAsLAgB01Dopx8lEojwke2mbS6PX6g2GsFG4yAA

##### Pre-Merge Checklist

- [x] Lint process passed (`npm run lint`)
