### PR TITLE
The RenderTexturePool should create renderTextures at resolution of 1

### DIFF
--- a/packages/core/src/filters/FilterSystem.js
+++ b/packages/core/src/filters/FilterSystem.js
@@ -107,7 +107,7 @@ export default class FilterSystem extends System
          * stores a bunch of PO2 textures used for filtering
          * @member {Object}
          */
-        this.texturePool = new RenderTexturePool({ resolution: 1 });
+        this.texturePool = new RenderTexturePool();
 
         this.texturePool.setScreenSize(renderer.view);
 

--- a/packages/core/src/filters/FilterSystem.js
+++ b/packages/core/src/filters/FilterSystem.js
@@ -107,7 +107,7 @@ export default class FilterSystem extends System
          * stores a bunch of PO2 textures used for filtering
          * @member {Object}
          */
-        this.texturePool = new RenderTexturePool();
+        this.texturePool = new RenderTexturePool({ resolution: 1 });
 
         this.texturePool.setScreenSize(renderer.view);
 

--- a/packages/core/src/renderTexture/RenderTexturePool.js
+++ b/packages/core/src/renderTexture/RenderTexturePool.js
@@ -15,6 +15,8 @@ export default class RenderTexturePool
 {
     /**
      * @param {object} [textureOptions] - options that will be passed to BaseRenderTexture constructor
+     * @param {PIXI.SCALE_MODES} [textureOptions.scaleMode] - See {@link PIXI.SCALE_MODES} for possible values.
+     * @param {number} [textureOptions.resolution=1] - The resolution / device pixel ratio of the texture being generated.
      */
     constructor(textureOptions)
     {

--- a/packages/core/src/renderTexture/RenderTexturePool.js
+++ b/packages/core/src/renderTexture/RenderTexturePool.js
@@ -16,7 +16,6 @@ export default class RenderTexturePool
     /**
      * @param {object} [textureOptions] - options that will be passed to BaseRenderTexture constructor
      * @param {PIXI.SCALE_MODES} [textureOptions.scaleMode] - See {@link PIXI.SCALE_MODES} for possible values.
-     * @param {number} [textureOptions.resolution=1] - The resolution / device pixel ratio of the texture being generated.
      */
     constructor(textureOptions)
     {

--- a/packages/core/src/renderTexture/RenderTexturePool.js
+++ b/packages/core/src/renderTexture/RenderTexturePool.js
@@ -48,6 +48,7 @@ export default class RenderTexturePool
         const baseRenderTexture = new BaseRenderTexture(Object.assign({
             width: realWidth,
             height: realHeight,
+            resolution: 1,
         }, this.textureOptions));
 
         return new RenderTexture(baseRenderTexture);


### PR DESCRIPTION
Since internally it has already scaled the requested render texture size within getOptimalTexture
https://github.com/pixijs/pixi.js/issues/5954

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)