### PR TITLE
Support mid-emit removal of Runner items

### DIFF
--- a/packages/runner/src/Runner.js
+++ b/packages/runner/src/Runner.js
@@ -48,6 +48,7 @@ export default class Runner
     {
         this.items = [];
         this._name = name;
+        this._aliasCount = 0;
     }
 
     /**
@@ -63,12 +64,28 @@ export default class Runner
 
         const { name, items } = this;
 
+        this._aliasCount++;
+
         for (let i = 0, len = items.length; i < len; i++)
         {
             items[i][name](a0, a1, a2, a3, a4, a5, a6, a7);
         }
 
+        if (items === this.items)
+        {
+            this._aliasCount--;
+        }
+
         return this;
+    }
+
+    ensureNonAliasedItems()
+    {
+        if (this._aliasCount > 0 && this.items.length > 1)
+        {
+            this._aliasCount = 0;
+            this.items = this.items.slice(0);
+        }
     }
 
     /**
@@ -92,6 +109,7 @@ export default class Runner
     {
         if (item[this._name])
         {
+            this.ensureNonAliasedItems();
             this.remove(item);
             this.items.push(item);
         }
@@ -109,6 +127,7 @@ export default class Runner
 
         if (index !== -1)
         {
+            this.ensureNonAliasedItems();
             this.items.splice(index, 1);
         }
 
@@ -129,6 +148,7 @@ export default class Runner
      */
     removeAll()
     {
+        this.ensureNonAliasedItems();
         this.items.length = 0;
 
         return this;

--- a/packages/runner/test/index.js
+++ b/packages/runner/test/index.js
@@ -128,4 +128,32 @@ describe('PIXI.Runner', function ()
         complete.add(obj).add(obj);
         expect(complete.items.length).to.equal(1);
     });
+
+    it('should not not bug out is items are removed items whilst mid run', function ()
+    {
+        const complete = new Runner('complete');
+
+        const objs = [];
+        let tick = 0;
+
+        for (let i = 0; i < 10; i++)
+        {
+            // eslint-disable-next-line no-loop-func
+            const obj = { complete()
+            {
+                tick++;
+                complete.remove(obj);
+            } };
+
+            obj.id = i;
+            objs.push(obj);
+
+            complete.add(obj);
+        }
+
+        complete.run();
+
+        expect(complete.items.length).to.equal(0);
+        expect(tick).to.equal(10);
+    });
 });


### PR DESCRIPTION
Same as #5972 , but it handles many other cases, I'll prepare more tests.

This is not "I can code better" statement.

The approach was taken from mozilla shumway https://github.com/mozilla/shumway/blob/master/src/flash/events/EventDispatcher.ts#L66

I modified it a bit, we don't even spawn new array in case we had only one listener.
