### PR TITLE
Restore stencil params after mask stack swap

### DIFF
--- a/packages/core/src/mask/StencilSystem.js
+++ b/packages/core/src/mask/StencilSystem.js
@@ -31,8 +31,10 @@ export default class StencilSystem extends System
     setMaskStack(stencilMaskStack)
     {
         const gl = this.renderer.gl;
+        const curStackLen = this.stencilMaskStack.length;
 
-        if (stencilMaskStack.length !== this.stencilMaskStack.length)
+        this.stencilMaskStack = stencilMaskStack;
+        if (stencilMaskStack.length !== curStackLen)
         {
             if (stencilMaskStack.length === 0)
             {
@@ -44,8 +46,6 @@ export default class StencilSystem extends System
                 this._useCurrent();
             }
         }
-
-        this.stencilMaskStack = stencilMaskStack;
     }
 
     /**

--- a/packages/core/src/mask/StencilSystem.js
+++ b/packages/core/src/mask/StencilSystem.js
@@ -41,6 +41,7 @@ export default class StencilSystem extends System
             else
             {
                 gl.enable(gl.STENCIL_TEST);
+                this._useCurrent();
             }
         }
 

--- a/types/assemble.js
+++ b/types/assemble.js
@@ -47,6 +47,18 @@ if (bundle === 'pixi.js') {
         .replace(/PIXI\.prepare\.CanvasPrepare \| (PIXI\.Renderer)/g, '$1');
 }
 
+// tsd-jsdoc doesn't currently support indexed generics (TChildren[0])
+buffer = buffer.replace(
+    /(addChild|removeChild)\(\.\.\.child: PIXI.DisplayObject\[\]\): PIXI\.DisplayObject;/g,
+    '$1<TChildren extends PIXI.DisplayObject[]>(...child: TChildren): TChildren[0];'
+);
+
+// tsd-jsdoc supports this case using the @template tag, but using said tag breaks documentation generation
+buffer = buffer.replace(
+    /addChildAt\(child: PIXI\.DisplayObject, index: number\): PIXI\.DisplayObject;/g,
+    'addChildAt<T extends PIXI.DisplayObject>(child: T, index: number): T;'
+);
+
 // EventEmitter3 and resource-loader are external dependencies, we'll
 // inject these into the find output
 const eventTypes = fs.readFileSync(path.join(__dirname, 'events.d.ts'), 'utf8');


### PR DESCRIPTION
Fixes #5974

Broken: https://www.pixiplayground.com/#/edit/PmNR2aqebJB2i56E5IiBz
Fixed: https://www.pixiplayground.com/#/edit/t09LhS3_ttR6R7przuBOi