### PR TITLE
fixed `containsPoint` failing

### DIFF
--- a/packages/graphics/src/GraphicsGeometry.js
+++ b/packages/graphics/src/GraphicsGeometry.js
@@ -380,6 +380,10 @@ export default class GraphicsGeometry extends BatchGeometry
             // only deal with fills..
             if (data.shape)
             {
+                if(data.matrix) {
+                    point = data.matrix.applyInverse(point);
+                }
+                
                 if (data.shape.contains(point.x, point.y))
                 {
                     if (data.holes)

--- a/packages/graphics/src/GraphicsGeometry.js
+++ b/packages/graphics/src/GraphicsGeometry.js
@@ -380,7 +380,8 @@ export default class GraphicsGeometry extends BatchGeometry
             // only deal with fills..
             if (data.shape)
             {
-                if(data.matrix) {
+                if(data.matrix)
+                {
                     point = data.matrix.applyInverse(point);
                 }
                 

--- a/packages/graphics/src/GraphicsGeometry.js
+++ b/packages/graphics/src/GraphicsGeometry.js
@@ -1,4 +1,4 @@
-import { SHAPES } from '@pixi/math';
+import { SHAPES, Point } from '@pixi/math';
 import { Bounds } from '@pixi/display';
 import { BatchGeometry, BatchDrawCall, BaseTexture } from '@pixi/core';
 import { DRAW_MODES, WRAP_MODES } from '@pixi/constants';
@@ -13,6 +13,7 @@ import { premultiplyTint } from '@pixi/utils';
 
 const BATCH_POOL = [];
 const DRAW_CALL_POOL = [];
+const tmpPoint = new Point();
 
 /**
  * Map of fill commands for each shape type.
@@ -371,6 +372,7 @@ export default class GraphicsGeometry extends BatchGeometry
         for (let i = 0; i < graphicsData.length; ++i)
         {
             const data = graphicsData[i];
+            tmpPoint.copyFrom(point);
 
             if (!data.fillStyle.visible)
             {
@@ -382,10 +384,10 @@ export default class GraphicsGeometry extends BatchGeometry
             {
                 if(data.matrix)
                 {
-                    point = data.matrix.applyInverse(point);
+                    data.matrix.applyInverse(point, tmpPoint);
                 }
-                
-                if (data.shape.contains(point.x, point.y))
+
+                if (data.shape.contains(tmpPoint.x, tmpPoint.y))
                 {
                     if (data.holes)
                     {
@@ -393,7 +395,7 @@ export default class GraphicsGeometry extends BatchGeometry
                         {
                             const hole = data.holes[i];
 
-                            if (hole.shape.contains(point.x, point.y))
+                            if (hole.shape.contains(tmpPoint.x, tmpPoint.y))
                             {
                                 return false;
                             }

--- a/packages/graphics/src/GraphicsGeometry.js
+++ b/packages/graphics/src/GraphicsGeometry.js
@@ -372,7 +372,6 @@ export default class GraphicsGeometry extends BatchGeometry
         for (let i = 0; i < graphicsData.length; ++i)
         {
             const data = graphicsData[i];
-            tmpPoint.copyFrom(point);
 
             if (!data.fillStyle.visible)
             {
@@ -382,9 +381,13 @@ export default class GraphicsGeometry extends BatchGeometry
             // only deal with fills..
             if (data.shape)
             {
-                if(data.matrix)
+                if (data.matrix)
                 {
                     data.matrix.applyInverse(point, tmpPoint);
+                }
+                else 
+                {
+                    tmpPoint.copyFrom(point);
                 }
 
                 if (data.shape.contains(tmpPoint.x, tmpPoint.y))

--- a/packages/graphics/src/GraphicsGeometry.js
+++ b/packages/graphics/src/GraphicsGeometry.js
@@ -385,7 +385,7 @@ export default class GraphicsGeometry extends BatchGeometry
                 {
                     data.matrix.applyInverse(point, tmpPoint);
                 }
-                else 
+                else
                 {
                     tmpPoint.copyFrom(point);
                 }


### PR DESCRIPTION
Fixed failed result of containsPoint when GraphicsData#matrix is setted.

<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

GraphicsData support setting specific matrix for points transformation, but containsPoint wasn't consider it.

Before:
https://www.pixiplayground.com/#/edit/iMS~MESj6tf1KHMhiRO~Q
After:
https://www.pixiplayground.com/#/edit/DGKjCWH7ayLAU7FW6NnJl

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
