### PR TITLE
Graphics close points epsilon

### DIFF
--- a/packages/graphics/src/Graphics.js
+++ b/packages/graphics/src/Graphics.js
@@ -534,6 +534,7 @@ export default class Graphics extends Container
 
         const startX = cx + (Math.cos(startAngle) * radius);
         const startY = cy + (Math.sin(startAngle) * radius);
+        const eps = this.geometry.closePointEps;
 
         // If the currentPath exists, take its points. Otherwise call `moveTo` to start a path.
         let points = this.currentPath ? this.currentPath.points : null;
@@ -546,7 +547,7 @@ export default class Graphics extends Container
             const xDiff = Math.abs(points[points.length - 2] - startX);
             const yDiff = Math.abs(points[points.length - 1] - startY);
 
-            if (xDiff < 0.001 && yDiff < 0.001)
+            if (xDiff < eps && yDiff < eps)
             {
                 // If the point is very close, we don't add it, since this would lead to artifacts
                 // during tessellation due to floating point imprecision.

--- a/packages/graphics/src/GraphicsGeometry.js
+++ b/packages/graphics/src/GraphicsGeometry.js
@@ -197,6 +197,14 @@ export default class GraphicsGeometry extends BatchGeometry
         this.indicesUint16 = null;
 
         this.uvsFloat32 = null;
+
+        /**
+         * Minimal distance between points that are considered different.
+         * Affects line tesselation.
+         *
+         * @member {number}
+         */
+        this.closePointEps = 1e-4;
     }
 
     /**

--- a/packages/graphics/src/utils/buildLine.js
+++ b/packages/graphics/src/utils/buildLine.js
@@ -36,6 +36,7 @@ function buildLine(graphicsData, graphicsGeometry)
 {
     const shape = graphicsData.shape;
     let points = graphicsData.points || shape.points.slice();
+    const eps = graphicsGeometry.closePointEps;
 
     if (points.length === 0)
     {
@@ -57,7 +58,8 @@ function buildLine(graphicsData, graphicsGeometry)
     const firstPoint = new Point(points[0], points[1]);
     const lastPoint = new Point(points[points.length - 2], points[points.length - 1]);
     const closedShape = shape.type !== SHAPES.POLY || shape.closeStroke;
-    const closedPath = firstPoint.x === lastPoint.x && firstPoint.y === lastPoint.y;
+    const closedPath = Math.abs(firstPoint.x - lastPoint.x) < eps
+        && Math.abs(firstPoint.y - lastPoint.y) < eps;
 
     // if the first point is the last point - gonna have issues :)
     if (closedShape)


### PR DESCRIPTION
Thanks to @eXponenta , one more obvious fix in Graphics.

Unfortunately, we are introducing new constant in GraphicsGeometry API , and without default settings (we can do it in next version).

Source: https://commons.m.wikimedia.org/wiki/File:Ghostscript_Tiger.svg

Broken: https://www.pixiplayground.com/#/edit/hA0cEqMaLra2qlieotC0F , look at the right - curve is not actually closed, and its real case from some SVG.
Fixed: https://www.pixiplayground.com/#/edit/GTnupAh_2mr6pMhvIUUfn

Why are those points different? Because `arc` in SVG cant be converted to our arc clearly, and while calculating coefficients for our arc rounding error can happen.

Alternative solution: provide a round resolution to graphicsGeometry tesselator. Make everything close to 0.001 or so.

@GoodBoyDigital are we ready to introduce an epsilon now for 5.1.1 or should we do it later? My point is - we already how strange constant inside the `arc` code.