### PR TITLE
Fix the FireFox cached image issue (#5968)

### DIFF
--- a/packages/core/src/textures/resources/ImageResource.js
+++ b/packages/core/src/textures/resources/ImageResource.js
@@ -33,6 +33,16 @@ export default class ImageResource extends BaseImageResource
 
         super(source);
 
+        // FireFox 68, and possibly other versions, seems like setting the HTMLImageElement#width and #height
+        // to non-zero values before its loading completes if images are in a cache.
+        // Because of this, need to set the `_width` and the `_height` to zero to avoid uploading incomplete images.
+        // Please refer to the issue #5968 (https://github.com/pixijs/pixi.js/issues/5968).
+        if (!source.complete && !!this._width && !!this._height)
+        {
+            this._width = 0;
+            this._height = 0;
+        }
+
         /**
          * URL of the image source
          * @member {string}


### PR DESCRIPTION
##### Description of change

This is to fix #5968. 

FireFox 68, and possibly other versions, seems like setting the `HTMLImageElement#width` and `#height`  to non-zero values before its loading completes (namely, `HTMLImageElement#complete === false`) if images are in a cache. Because of this, need to set the `_width` and the `_height` to zero to avoid uploading incomplete images.

Please refer to the following working example:
[https://www.pixiplayground.com/#/edit/XX8a7e2XBMBpDMc0gLzz_](https://www.pixiplayground.com/#/edit/XX8a7e2XBMBpDMc0gLzz_)

##### Pre-Merge Checklist
- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
