### PR TITLE
Fixed issue where Application.destroy ignored stageOptions

### DIFF
--- a/packages/app/src/Application.js
+++ b/packages/app/src/Application.js
@@ -129,7 +129,7 @@ export default class Application
      * @param {boolean} [stageOptions.baseTexture=false] - Only used for child Sprites if stageOptions.children is set
      *  to true. Should it destroy the base texture of the child sprite
      */
-    destroy(removeView)
+    destroy(removeView, stageOptions)
     {
         // Destroy plugins in the opposite order
         // which they were constructed
@@ -141,7 +141,7 @@ export default class Application
             plugin.destroy.call(this);
         });
 
-        this.stage.destroy();
+        this.stage.destroy(stageOptions);
         this.stage = null;
 
         this.renderer.destroy(removeView);

--- a/packages/app/test/index.js
+++ b/packages/app/test/index.js
@@ -1,6 +1,6 @@
 const { Application } = require('../');
 const { autoDetectRenderer } = require('@pixi/canvas-renderer');
-const { Container } = require('@pixi/display');
+const { Container, DisplayObject } = require('@pixi/display');
 const { skipHello } = require('@pixi/utils');
 
 skipHello();
@@ -54,6 +54,30 @@ describe('PIXI.Application', function ()
         expect(document.body.contains(view)).to.be.true;
         app.destroy(true);
         expect(document.body.contains(view)).to.be.false;
+    });
+
+    it('should not destroy children by default', function ()
+    {
+        const app = new Application();
+        const stage = app.stage;
+        const child = new DisplayObject();
+
+        stage.addChild(child);
+
+        app.destroy(true);
+        expect(child.transform).to.not.be.null;
+    });
+
+    it('should allow children destroy', function ()
+    {
+        const app = new Application();
+        const stage = app.stage;
+        const child = new DisplayObject();
+
+        stage.addChild(child);
+
+        app.destroy(true, true);
+        expect(child.transform).to.be.null;
     });
 
     describe('resizeTo', function ()


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
Fixed `stageOptions` not being propagated to `stage.destroy()`

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
