### PR TITLE
workaround for the issue that videos not working issue on Chrome v76

### DIFF
--- a/packages/core/src/textures/resources/VideoResource.js
+++ b/packages/core/src/textures/resources/VideoResource.js
@@ -24,6 +24,8 @@ export default class VideoResource extends BaseImageResource
         {
             const videoElement = document.createElement('video');
 
+            // workaround for https://github.com/pixijs/pixi.js/issues/5996
+            videoElement.setAttribute('preload', 'auto');
             videoElement.setAttribute('webkit-playsinline', '');
             videoElement.setAttribute('playsinline', '');
 


### PR DESCRIPTION
Ref: #5996
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)

just set `preload` with some value (`'auto'`) when it be created.

I don't know the reason, but it just works.

And those also work::
```
preload='' // equal to `preload='auto'`
// or
preload='none'
```

