### PR TITLE
Fixes the error event for BaseTexture resources

### DIFF
--- a/packages/core/src/textures/BaseTexture.js
+++ b/packages/core/src/textures/BaseTexture.js
@@ -257,6 +257,7 @@ export default class BaseTexture extends EventEmitter
          * @protected
          * @event PIXI.BaseTexture#error
          * @param {PIXI.BaseTexture} baseTexture - Resource errored.
+         * @param {ErrorEvent} event - Load error event.
          */
 
         /**
@@ -265,14 +266,6 @@ export default class BaseTexture extends EventEmitter
          * @protected
          * @event PIXI.BaseTexture#loaded
          * @param {PIXI.BaseTexture} baseTexture - Resource loaded.
-         */
-
-        /**
-         * Fired when BaseTexture is destroyed.
-         *
-         * @protected
-         * @event PIXI.BaseTexture#error
-         * @param {PIXI.BaseTexture} baseTexture - Resource errored.
          */
 
         /**
@@ -470,6 +463,16 @@ export default class BaseTexture extends EventEmitter
             this.dirtyStyleId++;
             this.emit('update', this);
         }
+    }
+
+    /**
+     * Handle errors with resources.
+     * @private
+     * @param {ErrorEvent} event - Error event emitted.
+     */
+    onError(event)
+    {
+        this.emit('error', this, event);
     }
 
     /**

--- a/packages/core/src/textures/resources/ImageResource.js
+++ b/packages/core/src/textures/resources/ImageResource.js
@@ -152,6 +152,7 @@ export default class ImageResource extends BaseImageResource
             else
             {
                 source.onload = completed;
+                source.onerror = (event) => this.onError.run(event);
             }
         });
 
@@ -261,6 +262,9 @@ export default class ImageResource extends BaseImageResource
      */
     dispose()
     {
+        this.source.onload = null;
+        this.source.onerror = null;
+
         super.dispose();
 
         if (this.bitmap)

--- a/packages/core/src/textures/resources/Resource.js
+++ b/packages/core/src/textures/resources/Resource.js
@@ -63,6 +63,14 @@ export default class Resource
          * @private
          */
         this.onUpdate = new Runner('update');
+
+        /**
+         * Handle internal errors, such as loading errors
+         *
+         * @member {Runner}
+         * @private
+         */
+        this.onError = new Runner('onError', 2);
     }
 
     /**
@@ -74,6 +82,7 @@ export default class Resource
     {
         this.onResize.add(baseTexture);
         this.onUpdate.add(baseTexture);
+        this.onError.add(baseTexture);
 
         // Call a resize immediate if we already
         // have the width and height of the resource
@@ -92,6 +101,7 @@ export default class Resource
     {
         this.onResize.remove(baseTexture);
         this.onUpdate.remove(baseTexture);
+        this.onError.remove(baseTexture);
     }
 
     /**
@@ -206,12 +216,14 @@ export default class Resource
     {
         if (!this.destroyed)
         {
+            this.destroyed = true;
+            this.dispose();
+            this.onError.removeAll();
+            this.onError = null;
             this.onResize.removeAll();
             this.onResize = null;
             this.onUpdate.removeAll();
             this.onUpdate = null;
-            this.destroyed = true;
-            this.dispose();
         }
     }
 }

--- a/packages/core/src/textures/resources/Resource.js
+++ b/packages/core/src/textures/resources/Resource.js
@@ -70,7 +70,7 @@ export default class Resource
          * @member {Runner}
          * @private
          */
-        this.onError = new Runner('onError', 2);
+        this.onError = new Runner('onError', 1);
     }
 
     /**

--- a/packages/core/src/textures/resources/SVGResource.js
+++ b/packages/core/src/textures/resources/SVGResource.js
@@ -123,6 +123,12 @@ export default class SVGResource extends BaseImageResource
         BaseImageResource.crossOrigin(tempImage, this.svg, this._crossorigin);
         tempImage.src = this.svg;
 
+        tempImage.onerror = (event) =>
+        {
+            tempImage.onerror = null;
+            this.onError.run(event);
+        };
+
         tempImage.onload = () =>
         {
             const svgWidth = tempImage.width;

--- a/packages/core/src/textures/resources/VideoResource.js
+++ b/packages/core/src/textures/resources/VideoResource.js
@@ -93,6 +93,7 @@ export default class VideoResource extends BaseImageResource
 
         // Bind for listeners
         this._onCanPlay = this._onCanPlay.bind(this);
+        this._onError = this._onError.bind(this);
 
         if (options.autoLoad !== false)
         {
@@ -149,6 +150,7 @@ export default class VideoResource extends BaseImageResource
         {
             source.addEventListener('canplay', this._onCanPlay);
             source.addEventListener('canplaythrough', this._onCanPlay);
+            source.addEventListener('error', this._onError, true);
         }
         else
         {
@@ -170,6 +172,17 @@ export default class VideoResource extends BaseImageResource
         });
 
         return this._load;
+    }
+
+    /**
+     * Handle video error events.
+     *
+     * @private
+     */
+    _onError()
+    {
+        this.source.removeEventListener('error', this._onError, true);
+        this.onError.run(event);
     }
 
     /**
@@ -276,6 +289,7 @@ export default class VideoResource extends BaseImageResource
 
         if (this.source)
         {
+            this.source.removeEventListener('error', this._onError, true);
             this.source.pause();
             this.source.src = '';
             this.source.load();

--- a/packages/core/test/BaseTexture.js
+++ b/packages/core/test/BaseTexture.js
@@ -1,6 +1,6 @@
 const { BaseTextureCache, TextureCache } = require('@pixi/utils');
 const { BaseTexture, Texture, RenderTexture, resources } = require('../');
-const { ImageResource } = resources;
+const { ImageResource, SVGResource, VideoResource } = resources;
 
 const URL = 'foo.png';
 const NAME = 'foo';
@@ -35,6 +35,57 @@ describe('BaseTexture', function ()
         });
     });
     */
+
+    it('should handle invalid image URL for textures', function (done)
+    {
+        cleanCache();
+
+        const invalidFile = 'missing-image.png';
+        const baseTexture = BaseTexture.from(invalidFile);
+
+        baseTexture.once('error', function (baseTexture, event)
+        {
+            expect(baseTexture.resource).to.be.instanceof(ImageResource);
+            expect(baseTexture.resource.url).contains(invalidFile);
+            expect(event.type).to.equal('error');
+            baseTexture.destroy();
+            done();
+        });
+    });
+
+    it('should handle invalid svg URL for textures', function (done)
+    {
+        cleanCache();
+
+        const invalidFile = 'missing-image.svg';
+        const baseTexture = BaseTexture.from(invalidFile);
+
+        baseTexture.once('error', function (baseTexture, event)
+        {
+            expect(baseTexture.resource).to.be.instanceof(SVGResource);
+            expect(baseTexture.resource.svg).contains(invalidFile);
+            expect(event.type).to.equal('error');
+            baseTexture.destroy();
+            done();
+        });
+    });
+
+    it('should handle invalid video URL for textures', function (done)
+    {
+        cleanCache();
+
+        const invalidFile = 'missing-image.mp4';
+        const baseTexture = BaseTexture.from(invalidFile);
+
+        baseTexture.once('error', function (baseTexture, event)
+        {
+            expect(baseTexture.resource).to.be.instanceof(VideoResource);
+            expect(baseTexture.resource.source.firstChild.src).contains(invalidFile);
+            expect(event.type).to.equal('error');
+            baseTexture.destroy();
+            done();
+        });
+    });
 
     it('should remove Canvas BaseTexture from cache on destroy', function ()
     {


### PR DESCRIPTION
##### Description of change

Fixes #5900

This change handle error events for Video, SVG and Image resources that can load their own contents via HTML element tags.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
