### PR TITLE
InteractionManager: fix event.stopPropagation()

### DIFF
--- a/packages/interaction/src/InteractionEvent.js
+++ b/packages/interaction/src/InteractionEvent.js
@@ -9,11 +9,32 @@ export default class InteractionEvent
     constructor()
     {
         /**
-         * Whether this event will continue propagating in the tree
+         * Whether this event will continue propagating in the tree.
+         *
+         * Remaining events for the {@link stopsPropagatingAt} object
+         * will still be dispatched.
          *
          * @member {boolean}
          */
         this.stopped = false;
+
+        /**
+         * At which object this event stops propagating.
+         *
+         * @private
+         * @member {PIXI.DisplayObject}
+         */
+        this.stopsPropagatingAt = null;
+
+        /**
+         * Whether we already reached the element we want to
+         * stop propagating at. This is important for delayed events,
+         * where we start over deeper in the tree again.
+         *
+         * @private
+         * @member {boolean}
+         */
+        this.stopPropagationHint = false;
 
         /**
          * The object which caused this event to be dispatched.
@@ -52,6 +73,8 @@ export default class InteractionEvent
     stopPropagation()
     {
         this.stopped = true;
+        this.stopPropagationHint = true;
+        this.stopsPropagatingAt = this.currentTarget;
     }
 
     /**
@@ -60,6 +83,8 @@ export default class InteractionEvent
     reset()
     {
         this.stopped = false;
+        this.stopsPropagatingAt = null;
+        this.stopPropagationHint = false;
         this.currentTarget = null;
         this.target = null;
     }

--- a/packages/interaction/src/InteractionEvent.js
+++ b/packages/interaction/src/InteractionEvent.js
@@ -21,7 +21,7 @@ export default class InteractionEvent
         /**
          * At which object this event stops propagating.
          *
-         * @readonly
+         * @private
          * @member {PIXI.DisplayObject}
          */
         this.stopsPropagatingAt = null;

--- a/packages/interaction/src/InteractionEvent.js
+++ b/packages/interaction/src/InteractionEvent.js
@@ -21,7 +21,7 @@ export default class InteractionEvent
         /**
          * At which object this event stops propagating.
          *
-         * @private
+         * @readonly
          * @member {PIXI.DisplayObject}
          */
         this.stopsPropagatingAt = null;

--- a/packages/interaction/src/InteractionManager.js
+++ b/packages/interaction/src/InteractionManager.js
@@ -1172,7 +1172,7 @@ export default class InteractionManager extends EventEmitter
                 const { displayObject, eventString, eventData } = delayedEvents[i];
 
                 // When we reach the object we wanted to stop propagating at,
-                // reset the propagation hint.
+                // set the propagation hint.
                 if (eventData.stopsPropagatingAt === displayObject)
                 {
                     eventData.stopPropagationHint = true;

--- a/packages/interaction/src/InteractionManager.js
+++ b/packages/interaction/src/InteractionManager.js
@@ -939,7 +939,9 @@ export default class InteractionManager extends EventEmitter
      */
     dispatchEvent(displayObject, eventString, eventData)
     {
-        if (!eventData.stopped)
+        // Even the event was stopped, at least dispatch any remaining events
+        // for the same display object.
+        if (!eventData.stopPropagationHint || displayObject === eventData.stopsPropagatingAt)
         {
             eventData.currentTarget = displayObject;
             eventData.type = eventString;
@@ -1158,15 +1160,25 @@ export default class InteractionManager extends EventEmitter
 
         if (delayedEvents.length && !skipDelayed)
         {
+            // Reset the propagation hint, because we start deeper in the tree again.
+            interactionEvent.stopPropagationHint = false;
+
             const delayedLen = delayedEvents.length;
 
             this.delayedEvents = [];
 
             for (let i = 0; i < delayedLen; i++)
             {
-                const delayed = delayedEvents[i];
+                const { displayObject, eventString, eventData } = delayedEvents[i];
 
-                this.dispatchEvent(delayed.displayObject, delayed.eventString, delayed.eventData);
+                // When we reach the object we wanted to stop propagating at,
+                // reset the propagation hint.
+                if (eventData.stopsPropagatingAt === displayObject)
+                {
+                    eventData.stopPropagationHint = true;
+                }
+
+                this.dispatchEvent(displayObject, eventString, eventData);
             }
         }
 

--- a/packages/interaction/src/InteractionManager.js
+++ b/packages/interaction/src/InteractionManager.js
@@ -939,7 +939,7 @@ export default class InteractionManager extends EventEmitter
      */
     dispatchEvent(displayObject, eventString, eventData)
     {
-        // Even the event was stopped, at least dispatch any remaining events
+        // Even if the event was stopped, at least dispatch any remaining events
         // for the same display object.
         if (!eventData.stopPropagationHint || displayObject === eventData.stopsPropagatingAt)
         {

--- a/packages/interaction/test/InteractionManager.js
+++ b/packages/interaction/test/InteractionManager.js
@@ -184,6 +184,113 @@ describe('PIXI.interaction.InteractionManager', function ()
         });
     });
 
+    describe('event propagation', function ()
+    {
+        it('should stop event propagation', function ()
+        {
+            const stage = new Container();
+            const parent = new Container();
+            const graphics = new Graphics();
+
+            const pointer = this.pointer = new MockPointer(stage);
+
+            const mouseDownChild = sinon.spy((evt) => evt.stopPropagation());
+            const mouseDownParent = sinon.spy();
+
+            stage.addChild(parent);
+            parent.addChild(graphics);
+
+            graphics.beginFill(0xFFFFFF);
+            graphics.drawRect(0, 0, 50, 50);
+            graphics.interactive = true;
+            parent.interactive = true;
+
+            graphics.on('mousedown', mouseDownChild);
+
+            parent.on('mousedown', mouseDownParent);
+
+            pointer.mousedown(10, 10);
+
+            expect(mouseDownChild).to.have.been.called;
+            expect(mouseDownParent).to.not.have.been.called;
+        });
+
+        it('should not stop events on the same object from happening', function ()
+        {
+            const stage = new Container();
+            const parent = new Container();
+            const graphics = new Graphics();
+
+            const pointer = this.pointer = new MockPointer(stage);
+
+            // Neither of these should stop the other from firing
+            const mouseMoveChild = sinon.spy((evt) => evt.stopPropagation());
+            const mouseOverChild = sinon.spy((evt) => evt.stopPropagation());
+
+            const mouseMoveParent = sinon.spy();
+            const mouseOverParent = sinon.spy();
+
+            stage.addChild(parent);
+            parent.addChild(graphics);
+
+            graphics.beginFill(0xFFFFFF);
+            graphics.drawRect(0, 0, 50, 50);
+            graphics.interactive = true;
+            parent.interactive = true;
+
+            graphics.on('mousemove', mouseMoveChild);
+            graphics.on('mouseover', mouseOverChild);
+
+            parent.on('mousemove', mouseMoveParent);
+            parent.on('mouseover', mouseOverParent);
+
+            pointer.mousemove(10, 10);
+
+            expect(mouseOverChild).to.have.been.called;
+            expect(mouseMoveChild).to.have.been.called;
+
+            expect(mouseOverParent).to.not.have.been.called;
+            expect(mouseMoveParent).to.not.have.been.called;
+        });
+
+        it('should not stop events on children of an object from happening', function ()
+        {
+            const stage = new Container();
+            const parent = new Container();
+            const graphics = new Graphics();
+
+            const pointer = this.pointer = new MockPointer(stage);
+
+            const mouseMoveChild = sinon.spy();
+            const mouseMoveParent = sinon.spy((evt) => evt.stopPropagation());
+
+            const mouseOverChild = sinon.spy();
+            const mouseOverParent = sinon.spy();
+
+            stage.addChild(parent);
+            parent.addChild(graphics);
+
+            graphics.beginFill(0xFFFFFF);
+            graphics.drawRect(0, 0, 50, 50);
+            graphics.interactive = true;
+            parent.interactive = true;
+
+            graphics.on('mousemove', mouseMoveChild);
+            graphics.on('mouseover', mouseOverChild);
+
+            parent.on('mousemove', mouseMoveParent);
+            parent.on('mouseover', mouseOverParent);
+
+            pointer.mousemove(10, 10);
+
+            expect(mouseMoveChild).to.have.been.called;
+            expect(mouseOverChild).to.have.been.called;
+
+            expect(mouseMoveParent).to.have.been.called;
+            expect(mouseOverParent).to.have.been.called;
+        });
+    });
+
     describe('touch vs pointer', function ()
     {
         it('should call touchstart and pointerdown when touch event and pointer supported', function ()


### PR DESCRIPTION
This fixes ``event.stopPropagation()`` - which didn't ever really just stop propagation, but rather
stopped events dead in their tracks.

Basically when you called ``stopPropagation`` there would be no further events emitted for the same action. So if you did it in, say, a ``mouseup`` event, you wouldn't even get a ``click`` event. Bummer.

This becomes really apparent with the recent [mouseover/pointerover](https://github.com/pixijs/pixi.js/pull/5989) changes, because if you now call ``stopPropagation`` in a ``mousemove`` event, you wouldn't ever see any ``mouseover`` event (which *would* be dispatched after).

Previously there were no tests for event propagation, so I added three of those.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
