### PR TITLE
Replace filters getter with filters member

### DIFF
--- a/packages/display/src/Container.js
+++ b/packages/display/src/Container.js
@@ -494,7 +494,7 @@ export class Container extends DisplayObject
         }
 
         // do a quick check to see if this element has a mask or a filter.
-        if (this._mask || (this.filters && this.filters.length))
+        if (this._mask || (this._filters && this._filters.length))
         {
             this.renderAdvanced(renderer);
         }
@@ -520,7 +520,7 @@ export class Container extends DisplayObject
     {
         renderer.batch.flush();
 
-        const filters = this.filters;
+        const filters = this._filters;
         const mask = this._mask;
 
         // push filter first as we need to ensure the stencil buffer is correct for any masking


### PR DESCRIPTION
### Description of change

This is a small change recommended by @finscn. Probably a good idea because `render` will use the property directly instead of hitting the getter function.
