### PR TITLE
Fix sprite's uvs updating

### DIFF
--- a/packages/sprite/src/Sprite.js
+++ b/packages/sprite/src/Sprite.js
@@ -232,6 +232,7 @@ export default class Sprite extends Container
             return;
         }
 
+        // update texture UV here, because base texture can be changed without calling `_onTextureUpdate`
         if (this._textureID !== texture._updateID)
         {
             this.uvs = this._texture._uvs.uvsFloat32;

--- a/packages/sprite/src/Sprite.js
+++ b/packages/sprite/src/Sprite.js
@@ -197,7 +197,6 @@ export default class Sprite extends Container
         this._textureTrimmedID = -1;
         this._cachedTint = 0xFFFFFF;
 
-        this.uvs = this._texture._uvs.uvsFloat32;
         // so if _width is 0 then width was not set..
         if (this._width)
         {
@@ -231,6 +230,11 @@ export default class Sprite extends Container
         if (this._transformID === this.transform._worldID && this._textureID === texture._updateID)
         {
             return;
+        }
+
+        if (this._textureID !== texture._updateID)
+        {
+            this.uvs = this._texture._uvs.uvsFloat32;
         }
 
         this._transformID = this.transform._worldID;


### PR DESCRIPTION
##### Description of change
<!-- Provide a description of the change below this comment. -->
Bug:
https://www.pixiplayground.com/#/edit/nygKQ4JiT675hWX35JN8k

Resume:
When `baseTexure` or `frame` was be reassigned, uvs not changes on sprites with this base texture.

Case 1:
It corrupts sprite when basetextures is valid  but dimensions isn't equals.

Case 2:
Renderer throws 'undefined' exception about uvs when you chage from Texture.EMPTY (`valid = false`) to `valid = true` texture;

Fixed:
https://www.pixiplayground.com/#/edit/gcxJ1nKj2GUp5H~AptY37

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
