### PR TITLE
Revert "Replace filters getter with filters member (#6058)"

### DIFF
--- a/packages/display/src/Container.js
+++ b/packages/display/src/Container.js
@@ -494,7 +494,7 @@ export class Container extends DisplayObject
         }
 
         // do a quick check to see if this element has a mask or a filter.
-        if (this._mask || (this._filters && this._filters.length))
+        if (this._mask || (this.filters && this.filters.length))
         {
             this.renderAdvanced(renderer);
         }
@@ -520,7 +520,7 @@ export class Container extends DisplayObject
     {
         renderer.batch.flush();
 
-        const filters = this._filters;
+        const filters = this.filters;
         const mask = this._mask;
 
         // push filter first as we need to ensure the stencil buffer is correct for any masking


### PR DESCRIPTION
This reverts commit 646990a3846a581f9d8eeeba17df807c72638562.

This change was wrong, (my bad) we no longer use getter/setters for filters.

See https://github.com/pixijs/pixi-filters/issues/220