### PR TITLE
Force texImage2D upload for videos

### DIFF
--- a/packages/core/src/textures/resources/BaseImageResource.js
+++ b/packages/core/src/textures/resources/BaseImageResource.js
@@ -25,6 +25,15 @@ export class BaseImageResource extends Resource
          * @readonly
          */
         this.source = source;
+
+        /**
+         * If set to `true`, will force `texImage2D` over `texSubImage2D` for uploading.
+         * Certain types of media (e.g. video) using `texImage2D` is more performant.
+         * @member {boolean}
+         * @default false
+         * @private
+         */
+        this.noSubImage = false;
     }
 
     /**
@@ -64,7 +73,10 @@ export class BaseImageResource extends Resource
 
         gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, baseTexture.premultiplyAlpha);
 
-        if (baseTexture.target === gl.TEXTURE_2D && glTexture.width === width && glTexture.height === height)
+        if (!this.noSubImage
+            && baseTexture.target === gl.TEXTURE_2D
+            && glTexture.width === width
+            && glTexture.height === height)
         {
             gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, baseTexture.format, baseTexture.type, source);
         }

--- a/packages/core/src/textures/resources/VideoResource.js
+++ b/packages/core/src/textures/resources/VideoResource.js
@@ -62,6 +62,7 @@ export class VideoResource extends BaseImageResource
 
         super(source);
 
+        this.noSubImage = true;
         this._autoUpdate = true;
         this._isAutoUpdating = false;
         this._updateFPS = options.updateFPS || 0;


### PR DESCRIPTION
Addresses #4089 

This defaults `texImage2D` uploading instead of `texSubImage2D` for VideoResource objects.

See for more information and performance measurements: http://codeflow.org/issues/slow_video_to_texture/

**Build:**
http://pixijs.download/fix-video-performance/pixi.min.js

**Example:**
https://pixiplayground.com/#/edit/jpeAPzXpQFY336WzsTKqn (PR)
https://pixiplayground.com/#/edit/9vDVREwmsMLTMNoCgW2VI (5.1.3)

**Measurements (Chrome 76)**
I did a small benchmark in Chrome to see the performance. At least in Chrome, `texImage2D` is  faster (although on my laptop I didn't _perceive_ much of a different, would probably show up more on mobile/slower devices).

| Branch | Duration | Render Time (lower is better) |
|---|---|---|
| 5.1.3 | 5000ms | 387ms `texSubImage2D` |
| fix-video-performance | 5000ms | 55ms `texImage2D` |