### PR TITLE
Fix kerning rendering with letterSpacing (v4.x)

### DIFF
--- a/src/core/text/Text.js
+++ b/src/core/text/Text.js
@@ -290,6 +290,8 @@ export default class Text extends Sprite
         let currentPosition = x;
         let index = 0;
         let current = '';
+        let previousWidth = this.context.measureText(text).width;
+        let currentWidth = 0;
 
         while (index < text.length)
         {
@@ -302,7 +304,9 @@ export default class Text extends Sprite
             {
                 this.context.fillText(current, currentPosition, y);
             }
-            currentPosition += this.context.measureText(current).width + letterSpacing;
+            currentWidth = this.context.measureText(text.substring(index)).width;
+            currentPosition += previousWidth - currentWidth + letterSpacing;
+            previousWidth = currentWidth;
         }
     }
 


### PR DESCRIPTION
##### Description of change
Addresses issue of incorrect kerning for PIXI.Text when `letterSpacing` is a value other than `0`, as described in issue [#4635](https://github.com/pixijs/pixi.js/issues/4635).

##### Pre-Merge Checklist
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)


### Example:
```new PIXI.Text('YouTube', {align: 'center', fontSize: 72, fontFamily: 'Times', letterSpacing:1});```
##### With this change:
![with_change](https://user-images.githubusercontent.com/1676115/64879693-83358400-d624-11e9-8c0e-a7dda097d225.png)
##### Current behavior in v4.8.8:
![without_change](https://user-images.githubusercontent.com/1676115/64879694-83358400-d624-11e9-8cd4-ec833b970225.png)