### PR TITLE
Fix kerning rendering with letterSpacing (v5.x)

### DIFF
--- a/packages/text/src/Text.js
+++ b/packages/text/src/Text.js
@@ -295,6 +295,8 @@ export class Text extends Sprite
         // https://medium.com/@giltayar/iterating-over-emoji-characters-the-es6-way-f06e4589516
         // https://github.com/orling/grapheme-splitter
         const stringArray = Array.from ? Array.from(text) : text.split('');
+        let previousWidth = this.context.measureText(text).width;
+        let currentWidth = 0;
 
         for (let i = 0; i < stringArray.length; ++i)
         {
@@ -308,7 +310,9 @@ export class Text extends Sprite
             {
                 this.context.fillText(currentChar, currentPosition, y);
             }
-            currentPosition += this.context.measureText(currentChar).width + letterSpacing;
+            currentWidth = this.context.measureText(text.substring(i + 1)).width;
+            currentPosition += previousWidth - currentWidth + letterSpacing;
+            previousWidth = currentWidth;
         }
     }
 


### PR DESCRIPTION
Same as https://github.com/pixijs/pixi.js/pull/6090 but targeted at v5.x - I have not separately tested the v5 change, so it would be good to confirm correct visual behavior in renderer.

##### Description of change
Addresses issue of incorrect kerning for PIXI.Text when `letterSpacing` is a value other than `0`, as described in issue [#4635](https://github.com/pixijs/pixi.js/issues/4635).

##### Pre-Merge Checklist
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)


### Example:
```new PIXI.Text('YouTube', {align: 'center', fontSize: 72, fontFamily: 'Times', letterSpacing:1});```
##### With this change:
![with_change](https://user-images.githubusercontent.com/1676115/64879693-83358400-d624-11e9-8c0e-a7dda097d225.png)
##### Current behavior:
![without_change](https://user-images.githubusercontent.com/1676115/64879694-83358400-d624-11e9-8cd4-ec833b970225.png)