### PR TITLE
Optional renderTexture stencil

### DIFF
--- a/packages/core/src/framebuffer/FramebufferSystem.js
+++ b/packages/core/src/framebuffer/FramebufferSystem.js
@@ -371,7 +371,6 @@ export default class FramebufferSystem extends System
             { // you can't have both, so one should take priority if enabled
                 gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.RENDERBUFFER, fbo.stencil);
             }
-            // fbo.enableStencil();
         }
     }
 
@@ -425,6 +424,44 @@ export default class FramebufferSystem extends System
         {
             this.disposeFramebuffer(list[i], contextLost);
         }
+    }
+
+    /**
+     * Forcing creation of stencil buffer for current framebuffer, if it wasn't done before.
+     * Used by MaskSystem, when its time to use stencil mask for Graphics element.
+     *
+     * Its an alternative for public lazy `framebuffer.enableStencil`, in case we need stencil without rebind.
+     *
+     * @private
+     */
+    forceStencil()
+    {
+        const framebuffer = this.current;
+
+        if (!framebuffer)
+        {
+            return;
+        }
+
+        const fbo = framebuffer.glFramebuffers[this.CONTEXT_UID];
+
+        if (!fbo || fbo.stencil)
+        {
+            return;
+        }
+        framebuffer.enableStencil();
+
+        const w = framebuffer.width;
+        const h = framebuffer.height;
+        const gl = this.gl;
+        const stencil = gl.createRenderbuffer();
+
+        gl.bindRenderbuffer(gl.RENDERBUFFER, stencil);
+        gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_STENCIL, w, h);
+
+        fbo.stencil = stencil;
+        gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.STENCIL_ATTACHMENT, gl.RENDERBUFFER, stencil);
+        gl.bindFramebuffer(gl.FRAMEBUFFER, fbo.framebuffer);
     }
 
     /**

--- a/packages/core/src/mask/StencilSystem.js
+++ b/packages/core/src/mask/StencilSystem.js
@@ -60,6 +60,8 @@ export default class StencilSystem extends System
 
         if (prevMaskCount === 0)
         {
+            // force use stencil texture in current framebuffer
+            this.renderer.framebuffer.forceStencil();
             gl.enable(gl.STENCIL_TEST);
         }
 

--- a/packages/core/src/renderTexture/BaseRenderTexture.js
+++ b/packages/core/src/renderTexture/BaseRenderTexture.js
@@ -86,8 +86,7 @@ export default class BaseRenderTexture extends BaseTexture
         this.clearColor = [0, 0, 0, 0];
 
         this.framebuffer = new Framebuffer(this.width * this.resolution, this.height * this.resolution)
-            .addColorTexture(0, this)
-            .enableStencil();
+            .addColorTexture(0, this);
 
         // TODO - could this be added the systems?
 


### PR DESCRIPTION
That's for 5.1.4

First part of renderTexture stencil optimization: reduce the memory of renderTexture in case there are no masks. Comparing to v4 that was a downgrade.

Next PR's will add temporary pow2 renderbuffers for filters, and add a setting to allow run pixi in stencil-less webgl.

Open chrome or canary, single page, press SHIFT+ESC, look in GPU process memory

1000 renderTextures of size 256x256. 

In windows stencil+depth is 32bit, and STENCIL8 cant help, it always creates both. +33% tax on potential mipmaps for colorbuffer.

That's 350kb colorbuffer per one renderTexture +256kb stencil/depth. 

That means 350MB vs 600MB if we use stencil for every texture.

My measurements:

Empty playground, 140M total.
![image](https://user-images.githubusercontent.com/695831/64953683-1b817200-d88c-11e9-8218-de009c9222db.png)

Stencil, 800M GPU total in chrome canary: https://www.pixiplayground.com/#/edit/8vkPJSK3IBCisZYdc6YC1
![image](https://user-images.githubusercontent.com/695831/64953608-e2e19880-d88b-11e9-8b11-bfabe5af056b.png)

This branch, no stencil, 550M 
https://www.pixiplayground.com/#/edit/3Bxzpc~OW18PHxsJ3wxcc
![image](https://user-images.githubusercontent.com/695831/64953620-ec6b0080-d88b-11e9-93e6-1c3ae5aabb03.png)

I dont know where else 60M goes, but I think we can ignore that.

Proof that `forceStencil()` code works, filter on `app.stage` : https://www.pixiplayground.com/#/edit/aN_YFvmR5W6UmSl6Han6X
