### PR TITLE
Critical fix stencil webgl1

### DIFF
--- a/packages/core/src/framebuffer/FramebufferSystem.js
+++ b/packages/core/src/framebuffer/FramebufferSystem.js
@@ -460,8 +460,7 @@ export default class FramebufferSystem extends System
         gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_STENCIL, w, h);
 
         fbo.stencil = stencil;
-        gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.STENCIL_ATTACHMENT, gl.RENDERBUFFER, stencil);
-        gl.bindFramebuffer(gl.FRAMEBUFFER, fbo.framebuffer);
+        gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.RENDERBUFFER, stencil);
     }
 
     /**


### PR DESCRIPTION
As in last critical, THANK YOU @Metatron92

#6099 , my bad

Problem appears only in webgl1.

DEPTH_STENCIL/STENCIL_ATTACHMENT, Bad: https://www.pixiplayground.com/#/edit/smrqNrd3Vgv7v5GeRdf12

DEPTH_STENCIL/DEPTH_STENCIL_ATTACHMENT , Good: https://www.pixiplayground.com/#/edit/RQ6S5kkMpjtUzPzoZ7rXK

STENCIL_INDEX8/STENCIL_ATTACHMENT, Also good, but eats the same memory in windows anyway: https://www.pixiplayground.com/#/edit/RQ6S5kkMpjtUzPzoZ7rXK

Also that rebind is useless.

How to check that branch works: comment this line in a good example, its bound to our branch so it'll work.

```js
PIXI.systems.FramebufferSystem.prototype.forceStencil = forceStencil;
```