### PR TITLE
Fix: unsubscribe from old Sprite texture

### DIFF
--- a/packages/sprite/src/Sprite.js
+++ b/packages/sprite/src/Sprite.js
@@ -640,6 +640,11 @@ export class Sprite extends Container
             return;
         }
 
+        if (this._texture)
+        {
+            this._texture.off('update', this._onTextureUpdate, this);
+        }
+
         this._texture = value || Texture.EMPTY;
         this._cachedTint = 0xFFFFFF;
 

--- a/packages/sprite/test/Sprite.js
+++ b/packages/sprite/test/Sprite.js
@@ -128,6 +128,29 @@ describe('PIXI.Sprite', function ()
         });
     });
 
+    describe('texture', function ()
+    {
+        it('should unsubscribe from old texture', function ()
+        {
+            const texture = new Texture(new BaseTexture());
+            const texture2 = new Texture(new BaseTexture());
+
+            const sprite = new Sprite(texture);
+
+            expect(texture._eventsCount).to.equal(1);
+            expect(texture2._eventsCount).to.equal(0);
+
+            sprite.texture = texture2;
+
+            expect(texture._eventsCount).to.equal(0);
+            expect(texture2._eventsCount).to.equal(1);
+
+            sprite.destroy();
+            texture.destroy(true);
+            texture2.destroy(true);
+        });
+    });
+
     describe('destroy', function ()
     {
         it('should destroy while BaseTexture is loading', function ()


### PR DESCRIPTION
##### Description of change

Unsubscribe from old texture in Sprite once the new one set.

##### Pre-Merge Checklist

- [X] Tests and/or benchmarks are included
- [X] Lint process passed (`npm run lint`)
- [X] Tests passed (`npm run test`)
