### PR TITLE
Fix test context

### DIFF
--- a/packages/core/src/shader/utils/getTestContext.js
+++ b/packages/core/src/shader/utils/getTestContext.js
@@ -13,7 +13,7 @@ let context = unknownContext;
  */
 export function getTestContext()
 {
-    if (context === unknownContext || context.isContextLost())
+    if (context === unknownContext || (context && context.isContextLost()))
     {
         const canvas = document.createElement('canvas');
 

--- a/packages/core/src/shader/utils/getTestContext.js
+++ b/packages/core/src/shader/utils/getTestContext.js
@@ -9,7 +9,7 @@ let context = unknownContext;
  *
  * @static
  * @private
- * @returns {webGL-context} a gl context to test with
+ * @returns {WebGLRenderingContext} a gl context to test with
  */
 export function getTestContext()
 {


### PR DESCRIPTION
I found a problem with #6116  , however I have no test for it. One of our possible returns is `null`, means there's no webgl on computer. In that case, asking second time for a test context will lead to nullpointer.