### PR TITLE
make IPoint an interface and not union

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -254,7 +254,8 @@
           "extends": ["plugin:@typescript-eslint/recommended"],
           "rules": {
             "@typescript-eslint/semi": 1,
-            "@typescript-eslint/no-explicit-any": 0
+            "@typescript-eslint/no-explicit-any": 0,
+            "@typescript-eslint/interface-name-prefix": 0
           }
         }
     ]

--- a/packages/math/src/IPoint.ts
+++ b/packages/math/src/IPoint.ts
@@ -1,0 +1,63 @@
+export interface IPoint
+{
+    x: number;
+    y: number;
+    copyFrom(p: IPoint): this;
+    copyTo(p: IPoint): IPoint;
+    equals(p: IPoint): boolean;
+    set(x?: number, y?: number): void;
+}
+/**
+ * Common interface for points. Both Point and ObservablePoint implement it
+ * @memberof PIXI
+ * @interface IPoint
+ */
+
+/**
+ * X coord
+ * @memberof PIXI.IPoint#
+ * @member {number} x
+ */
+
+/**
+ * Y coord
+ * @memberof PIXI.IPoint#
+ * @member {number} y
+ */
+
+/**
+ * Sets the point to a new x and y position.
+ * If y is omitted, both x and y will be set to x.
+ *
+ * @method set
+ * @memberof PIXI.IPoint#
+ * @param {number} [x=0] - position of the point on the x axis
+ * @param {number} [y=0] - position of the point on the y axis
+ */
+
+/**
+ * Copies x and y from the given point
+ * @method copyFrom
+ * @memberof PIXI.IPoint#
+ * @param {PIXI.IPoint} p - The point to copy from
+ * @returns {this} Returns itself.
+ */
+
+/**
+ * Copies x and y into the given point
+ * @method copyTo
+ * @memberof PIXI.IPoint#
+ * @param {PIXI.IPoint} p - The point to copy.
+ * @returns {PIXI.IPoint} Given point with values updated
+ */
+
+/**
+ * Returns true if the given point is equal to this point
+ *
+ * @method equals
+ * @memberof PIXI.IPoint#
+ * @param {PIXI.IPoint} p - The point to check
+ * @returns {boolean} Whether the given point equal to this point
+ */
+
+

--- a/packages/math/src/IPoint.ts
+++ b/packages/math/src/IPoint.ts
@@ -3,7 +3,7 @@ export interface IPoint
     x: number;
     y: number;
     copyFrom(p: IPoint): this;
-    copyTo(p: IPoint): IPoint;
+    copyTo<T extends IPoint>(p: T): T;
     equals(p: IPoint): boolean;
     set(x?: number, y?: number): void;
 }

--- a/packages/math/src/IPoint.ts
+++ b/packages/math/src/IPoint.ts
@@ -32,7 +32,7 @@ export interface IPoint
  * @method set
  * @memberof PIXI.IPoint#
  * @param {number} [x=0] - position of the point on the x axis
- * @param {number} [y=0] - position of the point on the y axis
+ * @param {number} [y=x] - position of the point on the y axis
  */
 
 /**
@@ -59,5 +59,4 @@ export interface IPoint
  * @param {PIXI.IPoint} p - The point to check
  * @returns {boolean} Whether the given point equal to this point
  */
-
 

--- a/packages/math/src/Matrix.ts
+++ b/packages/math/src/Matrix.ts
@@ -1,3 +1,4 @@
+import { IPoint } from './IPoint';
 import { Point } from './Point';
 import { PI_2 } from './const';
 import { Transform } from './Transform';
@@ -170,7 +171,7 @@ export class Matrix
      * @param {PIXI.Point} [newPos] - The point that the new position is assigned to (allowed to be same as input)
      * @return {PIXI.Point} The new point, transformed through this matrix
      */
-    apply(pos: Point, newPos?: Point): Point
+    apply(pos: IPoint, newPos?: Point): Point
     {
         newPos = newPos || new Point();
 
@@ -191,7 +192,7 @@ export class Matrix
      * @param {PIXI.Point} [newPos] - The point that the new position is assigned to (allowed to be same as input)
      * @return {PIXI.Point} The new point, inverse-transformed through this matrix
      */
-    applyInverse(pos: Point, newPos?: Point): Point
+    applyInverse(pos: IPoint, newPos?: Point): Point
     {
         newPos = newPos || new Point();
 

--- a/packages/math/src/ObservablePoint.ts
+++ b/packages/math/src/ObservablePoint.ts
@@ -52,7 +52,7 @@ export class ObservablePoint implements IPoint
      * If y is omitted, both x and y will be set to x.
      *
      * @param {number} [x=0] - position of the point on the x axis
-     * @param {number} [y=0] - position of the point on the y axis
+     * @param {number} [y=x] - position of the point on the y axis
      */
     set(x = 0, y = x): void
     {

--- a/packages/math/src/ObservablePoint.ts
+++ b/packages/math/src/ObservablePoint.ts
@@ -1,4 +1,4 @@
-import { Point } from './Point';
+import { IPoint } from './Point';
 
 /**
  * The Point object represents a location in a two-dimensional coordinate system, where x represents
@@ -8,8 +8,9 @@ import { Point } from './Point';
  *
  * @class
  * @memberof PIXI
+ * @implements IPoint
  */
-export class ObservablePoint
+export class ObservablePoint implements IPoint
 {
     public cb: () => any;
     public scope: any;
@@ -143,10 +144,3 @@ export class ObservablePoint
         }
     }
 }
-
-/**
- * A number, or a string containing a number.
- * @memberof PIXI
- * @typedef {(PIXI.Point|PIXI.ObservablePoint)} IPoint
- */
-export type IPoint = Point|ObservablePoint;

--- a/packages/math/src/ObservablePoint.ts
+++ b/packages/math/src/ObservablePoint.ts
@@ -88,7 +88,7 @@ export class ObservablePoint implements IPoint
      * @param {PIXI.IPoint} p - The point to copy.
      * @returns {PIXI.IPoint} Given point with values updated
      */
-    copyTo(p: IPoint): IPoint
+    copyTo<T extends IPoint>(p: T): T
     {
         p.set(this._x, this._y);
 

--- a/packages/math/src/ObservablePoint.ts
+++ b/packages/math/src/ObservablePoint.ts
@@ -1,4 +1,4 @@
-import { IPoint } from './Point';
+import { IPoint } from './IPoint';
 
 /**
  * The Point object represents a location in a two-dimensional coordinate system, where x represents
@@ -68,7 +68,7 @@ export class ObservablePoint implements IPoint
      * Copies x and y from the given point
      *
      * @param {PIXI.IPoint} p - The point to copy from.
-     * @returns {PIXI.IPoint} Returns itself.
+     * @returns {this} Returns itself.
      */
     copyFrom(p: IPoint): this
     {

--- a/packages/math/src/Point.ts
+++ b/packages/math/src/Point.ts
@@ -61,7 +61,7 @@ export class Point implements IPoint
      * @param {PIXI.IPoint} p - The point to copy.
      * @returns {PIXI.IPoint} Given point with values updated
      */
-    copyTo(p: IPoint): IPoint
+    copyTo<T extends IPoint>(p: T): T
     {
         p.set(this.x, this.y);
 

--- a/packages/math/src/Point.ts
+++ b/packages/math/src/Point.ts
@@ -1,4 +1,19 @@
-import { IPoint } from './ObservablePoint';
+/**
+ * Common interface for points. Both Point and ObservablePoint implement it
+ * @memberof PIXI
+ * @interface IPoint
+ * @property {number} x - x coord
+ * @property {number} y - y coord
+ */
+export interface IPoint
+{
+    x: number;
+    y: number;
+    copyFrom(p: IPoint): this;
+    copyTo(p: IPoint): IPoint;
+    equals(p: IPoint): boolean;
+    set(x?: number, y?: number): void;
+}
 
 /**
  * The Point object represents a location in a two-dimensional coordinate system, where x represents
@@ -6,8 +21,9 @@ import { IPoint } from './ObservablePoint';
  *
  * @class
  * @memberof PIXI
+ * @implements IPoint
  */
-export class Point
+export class Point implements IPoint
 {
     public x: number;
     public y: number;

--- a/packages/math/src/Point.ts
+++ b/packages/math/src/Point.ts
@@ -1,10 +1,3 @@
-/**
- * Common interface for points. Both Point and ObservablePoint implement it
- * @memberof PIXI
- * @interface IPoint
- * @property {number} x - x coord
- * @property {number} y - y coord
- */
 export interface IPoint
 {
     x: number;
@@ -14,6 +7,13 @@ export interface IPoint
     equals(p: IPoint): boolean;
     set(x?: number, y?: number): void;
 }
+/**
+ * Common interface for points. Both Point and ObservablePoint implement it
+ * @memberof PIXI
+ * @interface IPoint
+ * @property {number} x - x coord
+ * @property {number} y - y coord
+ */
 
 /**
  * The Point object represents a location in a two-dimensional coordinate system, where x represents

--- a/packages/math/src/Point.ts
+++ b/packages/math/src/Point.ts
@@ -1,19 +1,4 @@
-export interface IPoint
-{
-    x: number;
-    y: number;
-    copyFrom(p: IPoint): this;
-    copyTo(p: IPoint): IPoint;
-    equals(p: IPoint): boolean;
-    set(x?: number, y?: number): void;
-}
-/**
- * Common interface for points. Both Point and ObservablePoint implement it
- * @memberof PIXI
- * @interface IPoint
- * @property {number} x - x coord
- * @property {number} y - y coord
- */
+import { IPoint } from './IPoint';
 
 /**
  * The Point object represents a location in a two-dimensional coordinate system, where x represents
@@ -61,7 +46,7 @@ export class Point implements IPoint
      * Copies x and y from the given point
      *
      * @param {PIXI.IPoint} p - The point to copy from
-     * @returns {PIXI.IPoint} Returns itself.
+     * @returns {this} Returns itself.
      */
     copyFrom(p: IPoint): this
     {

--- a/packages/math/src/Point.ts
+++ b/packages/math/src/Point.ts
@@ -84,7 +84,7 @@ export class Point implements IPoint
      * If y is omitted, both x and y will be set to x.
      *
      * @param {number} [x=0] - position of the point on the x axis
-     * @param {number} [y=0] - position of the point on the y axis
+     * @param {number} [y=x] - position of the point on the y axis
      */
     set(x = 0, y = x): void
     {

--- a/packages/math/src/groupD8.ts
+++ b/packages/math/src/groupD8.ts
@@ -82,12 +82,12 @@ function init(): void
 
 init();
 
+type GD8Symmetry = number;
 /**
  * @memberof PIXI
  * @typedef {number} GD8Symmetry
  * @see PIXI.groupD8
  */
-type GD8Symmetry = number;
 
 /**
  * Implements the dihedral group D8, which is similar to

--- a/packages/math/src/groupD8.ts
+++ b/packages/math/src/groupD8.ts
@@ -82,12 +82,12 @@ function init(): void
 
 init();
 
-type GD8Symmetry = number;
 /**
  * @memberof PIXI
  * @typedef {number} GD8Symmetry
  * @see PIXI.groupD8
  */
+type GD8Symmetry = number;
 
 /**
  * Implements the dihedral group D8, which is similar to

--- a/packages/math/src/index.ts
+++ b/packages/math/src/index.ts
@@ -3,6 +3,7 @@
  *
  * @lends PIXI
  */
+export * from './IPoint';
 export * from './Point';
 export * from './ObservablePoint';
 export * from './Matrix';


### PR DESCRIPTION
Follow-up for #6141 

After mentioned PR, `IPoint` disappeared from `pixi.js.d.ts` , completely. Type `npm run types` and see the result in `bundles/pixi.js/pixi.js.d.ts`.

I don't understand what is going on, but at least I can start moving this thing from union to normal interface, in case some classes in `pixi-projection` (Point3d) will to implement it.

`IPoint` is still missing in output, but now we have one more problem!

```js
interface ObservablePoint extends IPoint {
}
class ObservablePoint implements IPoint {
}
```

I know that it should work, but how exactly this thing is generating?

Our current typings are filled with copies of methods and classes that we dont need, we didnt have all those problems in manual v4. Please help me fix at least that one.

I also specified `"@typescript-eslint/interface-name-prefix": 0` because some of our interface dont have "I" in them, for example `SharedArrayBuffer` that exists only in case someone uses es5 ts lib and not es6.

UPD: thanks @Zyie , all fixed.