### PR TITLE
Fixes types for groupD8 and GraphicsGeometry

### DIFF
--- a/packages/graphics/src/GraphicsGeometry.js
+++ b/packages/graphics/src/GraphicsGeometry.js
@@ -527,7 +527,7 @@ export class GraphicsGeometry extends BatchGeometry
      * Affinity check
      *
      * @param {PIXI.FillStyle | PIXI.LineStyle} styleA
-     * @param {PIXI.FillStyle | PIXI.LineSTyle} styleB
+     * @param {PIXI.FillStyle | PIXI.LineStyle} styleB
      */
     _compareStyles(styleA, styleB)
     {

--- a/packages/math/src/groupD8.ts
+++ b/packages/math/src/groupD8.ts
@@ -82,12 +82,12 @@ function init(): void
 
 init();
 
+type GD8Symmetry = number;
 /**
  * @memberof PIXI
  * @typedef {number} GD8Symmetry
  * @see PIXI.groupD8
  */
-type GD8Symmetry = number;
 
 /**
  * Implements the dihedral group D8, which is similar to


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
With the #6141 pr the jsdoc type for `GD8Symmetry` was being removed. Placing the doc comment below the initialisation fixes this issue.

Also found that `GraphicsGeometry` had a typo in one of its types.
##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] Documentation is changed or added
