### PR TITLE
Ignore useDeprecated file from typings

### DIFF
--- a/packages/interaction/src/TreeSearch.js
+++ b/packages/interaction/src/TreeSearch.js
@@ -172,12 +172,11 @@ export class TreeSearch
     }
 
     /**
-     * @private
-     *
      * This function is provides a neat way of crawling through the scene graph and running a
      * specified function on all interactive objects it finds. It will also take care of hit
      * testing the interactive objects and passes the hit across in the function.
      *
+     * @private
      * @param {PIXI.interaction.InteractionEvent} interactionEvent - event containing the point that
      *  is tested for collision
      * @param {PIXI.Container|PIXI.Sprite|PIXI.TilingSprite} displayObject - the displayObject

--- a/types/jsdoc-legacy.conf.json
+++ b/types/jsdoc-legacy.conf.json
@@ -3,7 +3,7 @@
         "include": [
             "dist/compiled"
         ],
-        "excludePattern": "(node_modules|lib|test|deprecated)"
+        "excludePattern": "(node_modules|lib|test|useDeprecated)"
     },
     "plugins": [
         "@pixi/jsdoc-template/plugins/es6-fix"

--- a/types/jsdoc.conf.json
+++ b/types/jsdoc.conf.json
@@ -3,7 +3,7 @@
         "include": [
             "dist/compiled"
         ],
-        "excludePattern": "(node_modules|lib|test|deprecated|canvas)"
+        "excludePattern": "(node_modules|lib|test|useDeprecated|canvas)"
     },
     "plugins": [
         "@pixi/jsdoc-template/plugins/es6-fix"


### PR DESCRIPTION
Fixes #6161

The intention always was explicitly to ignore the typings for deprecated APIs. But our pattern was old.

* **Broken:** http://pixijs.download/dev/types/pixi.js.d.ts
* **Fixed:** http://pixijs.download/fix-deprecated-typings/types/pixi.js.d.ts