### PR TITLE
Remove extra gl-flush and GC checks

### DIFF
--- a/packages/core/src/context/ContextSystem.js
+++ b/packages/core/src/context/ContextSystem.js
@@ -229,7 +229,10 @@ export class ContextSystem extends System
      */
     postrender()
     {
-        this.gl.flush();
+        if (this.renderer.renderingToScreen)
+        {
+            this.gl.flush();
+        }
     }
 
     /**

--- a/packages/core/src/textures/TextureGCSystem.js
+++ b/packages/core/src/textures/TextureGCSystem.js
@@ -61,6 +61,11 @@ export class TextureGCSystem extends System
      */
     postrender()
     {
+        if (!this.renderer.renderingToScreen)
+        {
+            return;
+        }
+
         this.count++;
 
         if (this.mode === GC_MODES.MANUAL)


### PR DESCRIPTION
I think we have to call `gl.flush()` for certain mobile devices after our frame, but we dont have to do it for each renderTexture call.

Also GC ticker rate was increased if user draws renderTextures.