### PR TITLE
Allow wrap for webgl2 without mipmap

### DIFF
--- a/packages/core/src/textures/TextureSystem.js
+++ b/packages/core/src/textures/TextureSystem.js
@@ -372,11 +372,18 @@ export class TextureSystem extends System
         if ((texture.mipmap === MIPMAP_MODES.POW2 || this.webGLVersion !== 2) && !texture.isPowerOfTwo)
         {
             glTexture.mipmap = 0;
-            glTexture.wrapMode = WRAP_MODES.CLAMP;
         }
         else
         {
             glTexture.mipmap = texture.mipmap >= 1;
+        }
+
+        if (this.webGLVersion !== 2 && !texture.isPowerOfTwo)
+        {
+            glTexture.wrapMode = WRAP_MODES.CLAMP;
+        }
+        else
+        {
             glTexture.wrapMode = texture.wrapMode;
         }
 

--- a/packages/core/test/TextureSystem.js
+++ b/packages/core/test/TextureSystem.js
@@ -1,0 +1,55 @@
+const { WRAP_MODES } = require('@pixi/constants');
+const { Renderer, BaseTexture } = require('../');
+
+describe('PIXI.systems.TextureSystem', function ()
+{
+    function createTempTexture()
+    {
+        const canvas = document.createElement('canvas');
+
+        canvas.width = 10;
+        canvas.height = 10;
+
+        return BaseTexture.from(canvas);
+    }
+
+    before(function ()
+    {
+        this.renderer = new Renderer();
+        this.renderer.mask.enableScissor = true;
+    });
+
+    after(function ()
+    {
+        this.renderer.destroy();
+        this.renderer = null;
+    });
+
+    it('should allow glTexture wrapMode=REPEAT for non-pow2 in webgl2', function ()
+    {
+        const baseTex = createTempTexture();
+
+        baseTex.wrapMode = WRAP_MODES.REPEAT;
+        this.renderer.texture.webGLVersion = 2;
+        this.renderer.texture.bind(baseTex);
+
+        const glTex = baseTex._glTextures[this.renderer.CONTEXT_UID];
+
+        expect(glTex).to.be.notnull;
+        expect(glTex.wrapMode).to.equal(WRAP_MODES.REPEAT);
+    });
+
+    it('should not allow glTexture wrapMode=REPEAT for non-pow2 in webgl1', function ()
+    {
+        const baseTex = createTempTexture();
+
+        baseTex.wrapMode = WRAP_MODES.REPEAT;
+        this.renderer.texture.webGLVersion = 1;
+        this.renderer.texture.bind(baseTex);
+
+        const glTex = baseTex._glTextures[this.renderer.CONTEXT_UID];
+
+        expect(glTex).to.be.notnull;
+        expect(glTex.wrapMode).to.equal(WRAP_MODES.CLAMP);
+    });
+});

--- a/packages/core/test/index.js
+++ b/packages/core/test/index.js
@@ -2,6 +2,7 @@ require('./BaseTexture');
 require('./Texture');
 require('./Renderer');
 require('./MaskSystem');
+require('./TextureSystem');
 require('./BatchRenderer');
 require('./Geometry');
 require('./CanvasResource');


### PR DESCRIPTION
subj.

We have special logic for mipmaps, so they work the same in webgl1 and webgl2 by default, but if user wants he can enable mips for non-pow texture in webgl.

For REPEAT wrapMode its different : we have workarounds in tilingSprite and i'll add one for Graphics,