### PR TITLE
Fix deprecation on BaseTexture in NineSlicePlane

### DIFF
--- a/packages/canvas/canvas-mesh/src/NineSlicePlane.js
+++ b/packages/canvas/canvas-mesh/src/NineSlicePlane.js
@@ -54,7 +54,7 @@ NineSlicePlane.prototype._renderCanvas = function _renderCanvas(renderer)
         }
     }
 
-    const textureSource = !isTinted ? texture.baseTexture.source : this._tintedCanvas;
+    const textureSource = !isTinted ? texture.baseTexture.resource.source : this._tintedCanvas;
 
     if (!this._canvasUvs)
     {


### PR DESCRIPTION
Fixes #6204 

**Broken (v5.1.5):** https://jsfiddle.net/bigtimebuddy/2zbtowq7/1/
**Fixed (this branch):** https://jsfiddle.net/bigtimebuddy/bg85rLs3/1/

(open console to see the deprecation warning on v5.1.5)