### PR TITLE
Add NineSlicePlane canvas test

### DIFF
--- a/packages/canvas/canvas-mesh/package.json
+++ b/packages/canvas/canvas-mesh/package.json
@@ -29,5 +29,9 @@
     "@pixi/mesh": "^5.1.5",
     "@pixi/mesh-extras": "^5.1.5",
     "@pixi/settings": "^5.1.3"
+  },
+  "devDependencies": {
+    "@pixi/core": "^5.1.5",
+    "@pixi/sprite": "^5.1.3"
   }
 }

--- a/packages/canvas/canvas-mesh/src/NineSlicePlane.js
+++ b/packages/canvas/canvas-mesh/src/NineSlicePlane.js
@@ -54,7 +54,7 @@ NineSlicePlane.prototype._renderCanvas = function _renderCanvas(renderer)
         }
     }
 
-    const textureSource = !isTinted ? texture.baseTexture.resource.source : this._tintedCanvas;
+    const textureSource = !isTinted ? texture.baseTexture.getDrawableSource() : this._tintedCanvas;
 
     if (!this._canvasUvs)
     {

--- a/packages/canvas/canvas-mesh/test/.eslintrc.json
+++ b/packages/canvas/canvas-mesh/test/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+    "globals": {
+        "expect": false,
+        "assert": false,
+        "sinon": false,
+        "PIXI": false
+    },
+    "rules": {
+        "func-names": 0,
+        "no-unused-expressions": 0
+    }
+}

--- a/packages/canvas/canvas-mesh/test/NineSlicePlane.js
+++ b/packages/canvas/canvas-mesh/test/NineSlicePlane.js
@@ -26,7 +26,6 @@ describe('PIXI.NineSlicePlane', function ()
 
         const nineSlicePlane = new NineSlicePlane(rt, 1, 1, 1, 1);
 
-        renderer.render(nineSlicePlane);
         expect(() => { renderer.render(nineSlicePlane); }).to.not.throw();
     });
 });

--- a/packages/canvas/canvas-mesh/test/NineSlicePlane.js
+++ b/packages/canvas/canvas-mesh/test/NineSlicePlane.js
@@ -1,0 +1,32 @@
+const { Texture, RenderTexture } = require('@pixi/core');
+const { Sprite } = require('@pixi/sprite');
+const { CanvasRenderer } = require('@pixi/canvas-renderer');
+const { NineSlicePlane } = require('@pixi/mesh-extras');
+
+describe('PIXI.NineSlicePlane', function ()
+{
+    before(function ()
+    {
+        this.renderer = new CanvasRenderer();
+    });
+
+    after(function ()
+    {
+        this.renderer.destroy();
+        this.renderer = null;
+    });
+
+    it('should be renderable with renderTexture in canvas', function ()
+    {
+        const rt = RenderTexture.create({ width: 10, height: 10 });
+        const spr = new Sprite(Texture.WHITE);
+        const renderer = new CanvasRenderer({ width: 12, height: 12 });
+
+        renderer.render(spr, rt);
+
+        const nineSlicePlane = new NineSlicePlane(rt, 1, 1, 1, 1);
+
+        renderer.render(nineSlicePlane);
+        expect(() => { renderer.render(nineSlicePlane); }).to.not.throw();
+    });
+});

--- a/packages/canvas/canvas-mesh/test/index.js
+++ b/packages/canvas/canvas-mesh/test/index.js
@@ -1,0 +1,1 @@
+require('./NineSlicePlane');


### PR DESCRIPTION
Follow-up for #6205 

This is not a bugfix, this is just extra test for last PR. 

We have special method `getDrawableSource` in case we want to get canvas drawable from baseTexture, lets use it. It worked in @bigtimebuddy because CanvasRenderer creates actual resource for RenderTexture, and I honestly didnt remember about that.

I think that in future, we'll change `getDrawableSource` code, so its better if we cover it with extra test.