### PR TITLE
Fix `DisplayObject.destroy` should call listener `removed`

### DIFF
--- a/packages/display/src/DisplayObject.js
+++ b/packages/display/src/DisplayObject.js
@@ -454,11 +454,11 @@ export class DisplayObject extends EventEmitter
      */
     destroy()
     {
-        this.removeAllListeners();
         if (this.parent)
         {
             this.parent.removeChild(this);
         }
+        this.removeAllListeners();
         this.transform = null;
 
         this.parent = null;

--- a/packages/display/test/DisplayObject.js
+++ b/packages/display/test/DisplayObject.js
@@ -108,4 +108,22 @@ describe('PIXI.DisplayObject', function ()
             expect(object.angle).to.be.equal(180);
         });
     });
+
+    describe('destroy', function ()
+    {
+        it('should trigger removed listeners', function ()
+        {
+            const child = new DisplayObject();
+            const container = new Container();
+
+            container.addChild(child);
+
+            let removedListenerWasCalled = false;
+
+            child.on('removed', () => { removedListenerWasCalled = true; });
+            child.destroy();
+
+            expect(removedListenerWasCalled).to.be.true;
+        });
+    });
 });


### PR DESCRIPTION
##### Description of change
Fix #5808  

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
