### PR TITLE
Publishes exact versions when version bumping

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "postdist": "copyfiles -f bundles/*/dist/* dist && copyfiles -f \"packages/**/dist/*\" dist/packages",
     "prerelease": "npm run clean:build && npm test",
     "postversion": "npm run build:prod",
-    "release": "lerna publish",
+    "release": "lerna publish --exact",
     "compile:docs": "tsc -p tsconfig.docs.json"
   },
   "pre-commit": [


### PR DESCRIPTION
Fixes #6208 #5998 

These issues are caused because of the default fuzzy dependency versions used throughout the project. By pinning the dependencies with Lerna whenever we bump, it will reduce our complexity in the wild.

There could be side-effect issues with users having multiple version of the same package, but that's a little more manageable then the current situation which requires users resolve all sub-packages of pixi explicitly.

Context about `--exact` https://github.com/lerna/lerna/tree/master/commands/version#--exact