### PR TITLE
Add typings to `this` parameter of callback functions

### DIFF
--- a/packages/math/src/ObservablePoint.ts
+++ b/packages/math/src/ObservablePoint.ts
@@ -10,9 +10,9 @@ import { IPoint } from './IPoint';
  * @memberof PIXI
  * @implements IPoint
  */
-export class ObservablePoint implements IPoint
+export class ObservablePoint<T = any> implements IPoint
 {
-    public cb: () => any;
+    public cb: (this: T) => any;
     public scope: any;
     protected _x: number;
     protected _y: number;
@@ -23,7 +23,7 @@ export class ObservablePoint implements IPoint
      * @param {number} [x=0] - position of the point on the x axis
      * @param {number} [y=0] - position of the point on the y axis
      */
-    constructor(cb: () => any, scope: any, x = 0, y = 0)
+    constructor(cb: (this: T) => any, scope: T, x = 0, y = 0)
     {
         this._x = x;
         this._y = y;

--- a/packages/ticker/src/Ticker.ts
+++ b/packages/ticker/src/Ticker.ts
@@ -2,7 +2,7 @@ import { settings } from './settings';
 import { UPDATE_PRIORITY } from './const';
 import { TickerListener } from './TickerListener';
 
-export type TickerCallback<T> = (this: T, dt: number) => void;
+export type TickerCallback<T> = (this: T, dt: number) => any;
 
 /**
  * A Ticker class that runs an update loop that other objects listen to.

--- a/packages/ticker/src/Ticker.ts
+++ b/packages/ticker/src/Ticker.ts
@@ -2,6 +2,8 @@ import { settings } from './settings';
 import { UPDATE_PRIORITY } from './const';
 import { TickerListener } from './TickerListener';
 
+export type TickerCallback<T> = (this: T, dt: number) => void;
+
 /**
  * A Ticker class that runs an update loop that other objects listen to.
  *
@@ -257,7 +259,7 @@ export class Ticker
      * @param {number} [priority=PIXI.UPDATE_PRIORITY.NORMAL] - The priority for emitting
      * @returns {PIXI.Ticker} This instance of a ticker
      */
-    add(fn: (dt?: number) => any, context: any, priority = UPDATE_PRIORITY.NORMAL): this
+    add<T = any>(fn: TickerCallback<T>, context: T, priority = UPDATE_PRIORITY.NORMAL): this
     {
         return this._addListener(new TickerListener(fn, context, priority));
     }
@@ -270,7 +272,7 @@ export class Ticker
      * @param {number} [priority=PIXI.UPDATE_PRIORITY.NORMAL] - The priority for emitting
      * @returns {PIXI.Ticker} This instance of a ticker
      */
-    addOnce(fn: (dt?: number) => any, context: any, priority = UPDATE_PRIORITY.NORMAL): this
+    addOnce<T = any>(fn: TickerCallback<T>, context: T, priority = UPDATE_PRIORITY.NORMAL): this
     {
         return this._addListener(new TickerListener(fn, context, priority, true));
     }
@@ -329,7 +331,7 @@ export class Ticker
      * @param {*} [context] - The listener context to be removed
      * @returns {PIXI.Ticker} This instance of a ticker
      */
-    remove(fn: (dt?: number) => any, context: any): this
+    remove<T = any>(fn: TickerCallback<T>, context: T): this
     {
         let listener = this._head.next;
 

--- a/packages/ticker/src/TickerListener.ts
+++ b/packages/ticker/src/TickerListener.ts
@@ -1,3 +1,5 @@
+import { TickerCallback } from './Ticker';
+
 /**
  * Internal class for handling the priority sorting of ticker handlers.
  *
@@ -5,14 +7,14 @@
  * @class
  * @memberof PIXI
  */
-export class TickerListener
+export class TickerListener<T = any>
 {
     public priority: number;
     public next: TickerListener;
     public previous: TickerListener;
 
-    private fn: (dt?: number) => any;
-    private context: any;
+    private fn: TickerCallback<T>;
+    private context: T;
     private once: boolean;
     private _destroyed: boolean;
 
@@ -24,7 +26,7 @@ export class TickerListener
      * @param {number} [priority=0] - The priority for emitting
      * @param {boolean} [once=false] - If the handler should fire once
      */
-    constructor(fn: (dt?: number) => any, context: any = null, priority = 0, once = false)
+    constructor(fn: TickerCallback<T>, context: T = null, priority = 0, once = false)
     {
         /**
          * The handler function to execute.
@@ -83,7 +85,7 @@ export class TickerListener
      * @param {any} [context] - The listener context
      * @return {boolean} `true` if the listener match the arguments
      */
-    match(fn: (dt?: number) => any, context: any = null): boolean
+    match(fn: TickerCallback<T>, context: any = null): boolean
     {
         return this.fn === fn && this.context === context;
     }
@@ -104,7 +106,7 @@ export class TickerListener
             }
             else
             {
-                this.fn(deltaTime);
+                (this as TickerListener<any>).fn(deltaTime);
             }
         }
 


### PR DESCRIPTION
##### Description of change
I've updated Ticker, TickerListener and ObservablePoint 's callback properties to have a stricter `this`
 parameter. This provides additional IntelliSense and error catching capabilities in some situations such as:
```ts
ticker.add(function(dt) {

    //Type of this is {index: number}
    this

}, {index: 5});
```
##### Pre-Merge Checklist
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
