### PR TITLE
Fix graphics fillStyle instead of lineStyle

### DIFF
--- a/packages/graphics/src/utils/BatchPart.js
+++ b/packages/graphics/src/utils/BatchPart.js
@@ -1,6 +1,7 @@
 /**
- * A structure to hold interim batch objects.
- *
+ * A structure to hold interim batch objects for Graphics.
+ * @class
+ * @memberof PIXI.graphicsUtils
  */
 export class BatchPart
 {

--- a/packages/graphics/src/utils/index.js
+++ b/packages/graphics/src/utils/index.js
@@ -30,6 +30,7 @@ import { SHAPES } from '@pixi/math';
 /**
  * Map of fill commands for each shape type.
  *
+ * @namespace PIXI.graphicsUtils
  * @member {Object}
  */
 export const FILL_COMMANDS = {
@@ -43,6 +44,7 @@ export const FILL_COMMANDS = {
 /**
  * Batch pool, stores unused batches for preventing allocations.
  *
+ * @namespace PIXI.graphicsUtils
  * @type {Array<BatchPart>}
  */
 export const BATCH_POOL = [];
@@ -50,6 +52,7 @@ export const BATCH_POOL = [];
 /**
  * Draw call pool, stores unused draw calls for preventing allocations.
  *
+ * @namespace PIXI.graphicsUtils
  * @type {Array<PIXI.BatchDrawCall>}
  */
 export const DRAW_CALL_POOL = [];

--- a/packages/graphics/src/utils/index.js
+++ b/packages/graphics/src/utils/index.js
@@ -30,7 +30,7 @@ import { SHAPES } from '@pixi/math';
 /**
  * Map of fill commands for each shape type.
  *
- * @namespace PIXI.graphicsUtils
+ * @memberof PIXI.graphicsUtils
  * @member {Object}
  */
 export const FILL_COMMANDS = {
@@ -44,15 +44,15 @@ export const FILL_COMMANDS = {
 /**
  * Batch pool, stores unused batches for preventing allocations.
  *
- * @namespace PIXI.graphicsUtils
- * @type {Array<BatchPart>}
+ * @memberof PIXI.graphicsUtils
+ * @type {Array<PIXI.graphicsUtils.BatchPart>}
  */
 export const BATCH_POOL = [];
 
 /**
  * Draw call pool, stores unused draw calls for preventing allocations.
  *
- * @namespace PIXI.graphicsUtils
+ * @memberof PIXI.graphicsUtils
  * @type {Array<PIXI.BatchDrawCall>}
  */
 export const DRAW_CALL_POOL = [];

--- a/packages/graphics/test/index.js
+++ b/packages/graphics/test/index.js
@@ -829,5 +829,26 @@ describe('PIXI.Graphics', function ()
             geometry.updateBatches();
             expect(geometry.batches).to.have.lengthOf(1);
         });
+
+        it('should not use fill if triangulation does nothing', function ()
+        {
+            const graphics = new Graphics();
+
+            graphics
+                .lineStyle(2, 0x00ff00)
+                .beginFill(0xff0000)
+                .drawRect(0, 0, 100, 100)
+                .moveTo(200, 0)
+                .lineTo(250, 200);
+
+            const geometry = graphics.geometry;
+
+            geometry.updateBatches();
+            expect(geometry.batches).to.have.lengthOf(2);
+            expect(geometry.batches[0].style.color).to.equals(0xff0000);
+            expect(geometry.batches[0].size).to.equal(6);
+            expect(geometry.batches[1].style.color).to.equals(0x00ff00);
+            expect(geometry.batches[1].size).to.equal(30);
+        });
     });
 });


### PR DESCRIPTION
Another bug again, found by @eXponenta 

Bugged: https://www.pixiplayground.com/#/edit/QF2RXuO21iDTwvxGntVBr
Fixed: https://www.pixiplayground.com/#/edit/yhKcbj73S9RHy1ajD0tdX

I've added test on it. With our previous tests everything should be fine, but I'll make a pass on pixijs examples anyway.

Also it fixes our typings.