### PR TITLE
Added SimpleRope deprecation

### DIFF
--- a/bundles/pixi.js/src/useDeprecated.js
+++ b/bundles/pixi.js/src/useDeprecated.js
@@ -1069,6 +1069,28 @@ export function useDeprecated()
         },
     });
 
+    /**
+     * @deprecated since 5.0.0
+     * @member {PIXI.Point[]} PIXI.SimpleRope#points
+     * @see PIXI.Mesh#geometry
+     */
+    Object.defineProperty(PIXI.SimpleRope.prototype, 'points', {
+        get()
+        {
+            deprecation(v5, 'PIXI.SimpleRope.points property is deprecated, '
+                + 'use PIXI.SimpleRope.geometry.points');
+
+            return this.geometry.points;
+        },
+        set(value)
+        {
+            deprecation(v5, 'PIXI.SimpleRope.points property is deprecated, '
+                + 'use PIXI.SimpleRope.geometry.points');
+
+            this.geometry.points = value;
+        },
+    });
+
     // Use these to deprecate all the Sprite from* methods
     function spriteFrom(name, source, crossorigin, scaleMode)
     {


### PR DESCRIPTION
##### Description of change
Added a deprecation to PIXI.SimpleRope (which was PIXI.mesh.Rope) that I came across upgrading games from v4 to v5.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
