### PR TITLE
Fixes roundPixels calculation differences between v4 and v5

### DIFF
--- a/packages/mesh/src/Mesh.js
+++ b/packages/mesh/src/Mesh.js
@@ -370,9 +370,11 @@ export class Mesh extends Container
 
         if (this._roundPixels)
         {
-            for (let i = 0; i < vertexData.length; i++)
+            const resolution = settings.RESOLUTION;
+
+            for (let i = 0; i < vertexData.length; ++i)
             {
-                vertexData[i] = Math.round(vertexData[i]);
+                vertexData[i] = Math.round((vertexData[i] * resolution | 0) / resolution);
             }
         }
 

--- a/packages/sprite/src/Sprite.js
+++ b/packages/sprite/src/Sprite.js
@@ -304,9 +304,11 @@ export class Sprite extends Container
 
         if (this._roundPixels)
         {
-            for (let i = 0; i < 8; i++)
+            const resolution = settings.RESOLUTION;
+
+            for (let i = 0; i < vertexData.length; ++i)
             {
-                vertexData[i] = Math.round(vertexData[i]);
+                vertexData[i] = Math.round((vertexData[i] * resolution | 0) / resolution);
             }
         }
     }


### PR DESCRIPTION
##### Description of change
Fixes issue descripted in https://github.com/pixijs/pixi.js/issues/6232 with roundPixels implementation difference between v4 and v5 for resolutions less than 1.

##### Pre-Merge Checklist
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
