### PR TITLE
BlendMode NONE fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1606,7 +1606,7 @@
 				},
 				"readable-stream": {
 					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"requires": {
@@ -1621,7 +1621,7 @@
 				},
 				"string_decoder": {
 					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"requires": {
@@ -3102,7 +3102,7 @@
 				},
 				"yargs": {
 					"version": "11.1.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+					"resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
 					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 					"dev": true,
 					"requires": {
@@ -4244,7 +4244,7 @@
 				},
 				"readable-stream": {
 					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"requires": {
@@ -4259,7 +4259,7 @@
 				},
 				"string_decoder": {
 					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1606,7 +1606,7 @@
 				},
 				"readable-stream": {
 					"version": "2.3.6",
-					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"requires": {
@@ -1621,7 +1621,7 @@
 				},
 				"string_decoder": {
 					"version": "1.1.1",
-					"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"requires": {
@@ -3102,7 +3102,7 @@
 				},
 				"yargs": {
 					"version": "11.1.0",
-					"resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
 					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 					"dev": true,
 					"requires": {
@@ -4244,7 +4244,7 @@
 				},
 				"readable-stream": {
 					"version": "2.3.6",
-					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"requires": {
@@ -4259,7 +4259,7 @@
 				},
 				"string_decoder": {
 					"version": "1.1.1",
-					"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"requires": {

--- a/packages/core/src/batch/AbstractBatchRenderer.js
+++ b/packages/core/src/batch/AbstractBatchRenderer.js
@@ -534,7 +534,8 @@ export class AbstractBatchRenderer extends ObjectRenderer
                 this.bindAndClearTexArray(texArray);
             }
 
-            stateSystem.setBlendMode(blend);
+            this.state.blendMode = blend;
+            stateSystem.set(this.state);
             gl.drawElements(type, size, gl.UNSIGNED_SHORT, start * 2);
         }
     }

--- a/packages/core/test/BatchRenderer.js
+++ b/packages/core/test/BatchRenderer.js
@@ -155,8 +155,8 @@ describe('PIXI.BatchRenderer', function ()
             batchRenderer.MAX_TEXTURES = 2;
             batchRenderer.start();
 
-            const glEnable = sinon.spy(gl.enable);
-            const glDisable = sinon.spy(gl.disable);
+            const glEnable = sinon.spy(gl, 'enable');
+            const glDisable = sinon.spy(gl, 'disable');
 
             elements.forEach((element) => batchRenderer.render(element));
             batchRenderer.flush();

--- a/packages/core/test/BatchRenderer.js
+++ b/packages/core/test/BatchRenderer.js
@@ -138,8 +138,8 @@ describe('PIXI.BatchRenderer', function ()
     it('should ask StateSystem to call gl.disable(gl.BLEND) if sprite has BLEND_MODES.NONE', function ()
     {
         const renderer = new Renderer(1, 1);
-        const { gl } = renderer;
         const batchRenderer = new BatchRenderer(renderer);
+        const { gl } = renderer;
 
         const elements = [
             { uvs, vertexData, indices, _tintRGB: tint1, worldAlpha: 1.0, _texture: new Texture(tex1),

--- a/packages/particles/src/ParticleRenderer.js
+++ b/packages/particles/src/ParticleRenderer.js
@@ -1,5 +1,5 @@
 import { TYPES } from '@pixi/constants';
-import { ObjectRenderer, Shader } from '@pixi/core';
+import { ObjectRenderer, Shader, State } from '@pixi/core';
 import { correctBlendMode, premultiplyRgba, premultiplyTint } from '@pixi/utils';
 import { Matrix } from '@pixi/math';
 import { ParticleBuffer } from './ParticleBuffer';
@@ -90,6 +90,14 @@ export class ParticleRenderer extends ObjectRenderer
         ];
 
         this.shader = Shader.from(vertex, fragment, {});
+
+        /**
+         * The WebGL state in which this renderer will work.
+         *
+         * @member {PIXI.State}
+         * @readonly
+         */
+        this.state = State.for2d();
     }
 
     /**
@@ -124,7 +132,8 @@ export class ParticleRenderer extends ObjectRenderer
         const baseTexture = children[0]._texture.baseTexture;
 
         // if the uvs have not updated then no point rendering just yet!
-        this.renderer.state.setBlendMode(correctBlendMode(container.blendMode, baseTexture.alphaMode));
+        this.state.blendMode = correctBlendMode(container.blendMode, baseTexture.alphaMode);
+        renderer.state.set(this.state);
 
         const gl = renderer.gl;
 

--- a/packages/sprite-tiling/src/TilingSpriteRenderer.js
+++ b/packages/sprite-tiling/src/TilingSpriteRenderer.js
@@ -1,4 +1,4 @@
-import { ObjectRenderer, Shader, QuadUv } from '@pixi/core';
+import { ObjectRenderer, Shader, State, QuadUv } from '@pixi/core';
 import { WRAP_MODES } from '@pixi/constants';
 import { Matrix } from '@pixi/math';
 import { premultiplyTintToRgba, correctBlendMode } from '@pixi/utils';
@@ -34,6 +34,14 @@ export class TilingSpriteRenderer extends ObjectRenderer
         this.simpleShader = Shader.from(vertex, fragmentSimple, uniforms);
 
         this.quad = new QuadUv();
+
+        /**
+         * The WebGL state in which this renderer will work.
+         *
+         * @member {PIXI.State}
+         * @readonly
+         */
+        this.state = State.for2d();
     }
 
     /**
@@ -130,7 +138,8 @@ export class TilingSpriteRenderer extends ObjectRenderer
         renderer.shader.bind(shader);
         renderer.geometry.bind(quad);// , renderer.shader.getGLShader());
 
-        renderer.state.setBlendMode(correctBlendMode(ts.blendMode, baseTex.alphaMode));
+        this.state.blendMode = correctBlendMode(ts.blendMode, baseTex.alphaMode);
+        renderer.state.set(this.state);
         renderer.geometry.draw(this.renderer.gl.TRIANGLES, 6, 0);
     }
 }


### PR DESCRIPTION
The way we handled blendModes in BatchRenderer is wrong, it doesn't call`gl.disable(gl.BLEND)`

Broken: https://www.pixiplayground.com/#/edit/862Ww3O7ZhoAxzQW15ZjV

Fixed: https://www.pixiplayground.com/#/edit/OSKK2hg7EugpvQ2VTR40h