### PR TITLE
Refactored some of TextMetrics tests so that they pass on Windows

### DIFF
--- a/packages/text/test/TextMetrics.js
+++ b/packages/text/test/TextMetrics.js
@@ -1,5 +1,10 @@
 const { TextMetrics, TextStyle } = require('../');
 
+/**
+ * Fonts render slightly differently between platforms so tests that depend on a specific
+ * widths or breaking of words may not be cross-platform
+ */
+
 /* eslint-disable no-multi-str */
 const longText = 'Sed ut perspiciatis unde omnis iste natus error sit voluptatem \
 accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo \
@@ -56,7 +61,8 @@ describe('PIXI.TextMetrics', function ()
     {
         it('width should not be greater than wordWrapWidth with longText', function ()
         {
-            const style = Object.assign({}, defaultStyle, { breakWords: false });
+            // On Windows 'exercitationem' renders to about 217px, bigger wrap width required for this test to be valid on every platform
+            const style = Object.assign({}, defaultStyle, { wordWrapWidth: 220, breakWords: false });
 
             const metrics = TextMetrics.measureText(longText, new TextStyle(style));
 
@@ -64,6 +70,7 @@ describe('PIXI.TextMetrics', function ()
 
             metrics.lines.forEach((line) =>
             {
+                expect(line).to.not.contain('  ', 'should not have multiple spaces in a row');
                 expect(line[0]).to.not.equal(' ', 'should not have space at the start');
                 expect(line[line - 1]).to.not.equal(' ', 'should not have space at the end');
             });
@@ -230,17 +237,32 @@ describe('PIXI.TextMetrics', function ()
 
             expect(metrics.width).to.be.above(style.wordWrapWidth);
 
+            metrics.lines.forEach((line) =>
+            {
+                expect(line).to.not.contain('  ', 'should not have multiple spaces in a row');
+                expect(line[0]).to.not.equal(' ', 'all lines should not have space at the start');
+                expect(line[line - 1]).to.not.equal(' ', 'no lines should have a space at the end');
+            });
+        });
+
+        it('text is wrapped in a platform-specific way', function ()
+        {
+            if (process.platform === 'win32')
+            {
+                this.skip();
+
+                return;
+            }
+
+            const style = Object.assign({}, defaultStyle, { breakWords: false, whiteSpace: 'normal' });
+
+            const metrics = TextMetrics.measureText(spaceNewLineText, new TextStyle(style));
+
             expect(metrics.lines[0][0]).to.equal('S', '1st line should not start with a space');
             expect(metrics.lines[4][0]).to.equal('m', '5th line should not start with 3 spaces (1)');
             expect(metrics.lines[4][1]).to.equal('o', '5th line should not start with 3 spaces (2)');
             expect(metrics.lines[4][2]).to.equal('r', '5th line should not start with 3 spaces (3)');
             expect(metrics.lines[17][0]).to.equal('a', '17th line should not have wrapped');
-
-            metrics.lines.forEach((line) =>
-            {
-                expect(line[0]).to.not.equal(' ', 'all lines should not have space at the start');
-                expect(line[line - 1]).to.not.equal(' ', 'no lines should have a space at the end');
-            });
         });
     });
 
@@ -278,17 +300,32 @@ describe('PIXI.TextMetrics', function ()
 
             expect(metrics.width).to.be.below(style.wordWrapWidth);
 
+            metrics.lines.forEach((line) =>
+            {
+                expect(line).to.not.contain('  ', 'should not have multiple spaces in a row');
+                expect(line[0]).to.not.equal(' ', 'all lines should not have space at the start');
+                expect(line[line - 1]).to.not.equal(' ', 'no lines should have a space at the end');
+            });
+        });
+
+        it('text is wrapped in a platform-specific way', function ()
+        {
+            if (process.platform === 'win32')
+            {
+                this.skip();
+
+                return;
+            }
+
+            const style = Object.assign({}, defaultStyle, { breakWords: true, whiteSpace: 'normal' });
+
+            const metrics = TextMetrics.measureText(spaceNewLineText, new TextStyle(style));
+
             expect(metrics.lines[0][0]).to.equal('S', '1st line should not start with a space');
             expect(metrics.lines[4][0]).to.equal('m', '5th line should not start with 3 spaces (1)');
             expect(metrics.lines[4][1]).to.equal('o', '5th line should not start with 3 spaces (2)');
             expect(metrics.lines[4][2]).to.equal('r', '5th line should not start with 3 spaces (3)');
             expect(metrics.lines[17][0]).to.equal('a', '17th line should not have wrapped');
-
-            metrics.lines.forEach((line) =>
-            {
-                expect(line[0]).to.not.equal(' ', 'all lines should not have space at the start');
-                expect(line[line - 1]).to.not.equal(' ', 'no lines should have a space at the end');
-            });
         });
     });
 


### PR DESCRIPTION
##### Description of change
Refactored some of `TextMetric` tests so that they pass on Windows.

 * I've allowed myself to leave a comment at the top of `TextMetric` class about the fact that the text may render (and measure) differently on different platforms.
 * One failing test required changing the expected width, because `exercitationem` renders to about 217px making it impossible to fit in the requested 200px. This shouldn't invalidate the test on different platforms, because `breakWords` was set to `false` either way, so on other platforms it just rendered to a smaller dimension already. Also the test's goal is to check if the width is not exceeded by stacking >1 word in the line, not by a word too long.
 * Two other tests I refactored to be 2 tests each, one part being stuff that works the same across all platforms (trimming whitespace) the other part being stuff that depends on how things are rendered (checking exactly how things break).

##### Pre-Merge Checklist
- [X] Lint process passed (`npm run lint`)
- [X] Tests passed (`npm run test`)

Referenced issue: #6247 