### PR TITLE
Fixed BitmapFontLoader tests failing on Windows

### DIFF
--- a/packages/text-bitmap/src/BitmapFontLoader.js
+++ b/packages/text-bitmap/src/BitmapFontLoader.js
@@ -39,6 +39,7 @@ export class BitmapFontLoader
     static dirname(url)
     {
         const dir = url
+            .replace(/\\/g, '/') // convert windows notation to UNIX notation, URL-safe because it's a forbidden character
             .replace(/\/$/, '') // replace trailing slash
             .replace(/\/[^\/]*$/, ''); // remove everything after the last
 

--- a/packages/text-bitmap/test/BitmapFontLoader.js
+++ b/packages/text-bitmap/test/BitmapFontLoader.js
@@ -402,8 +402,8 @@ describe('PIXI.BitmapFontLoader', function ()
         loader.add(path.join(this.resources, 'split_font2.fnt'));
         loader.load(() =>
         {
-            const page0 = path.join(this.resources, 'split_font_ab.png');
-            const page1 = path.join(this.resources, 'split_font_cd.png');
+            const page0 = path.join(this.resources, 'split_font_ab.png').replace(/\\/g, '/');
+            const page1 = path.join(this.resources, 'split_font_cd.png').replace(/\\/g, '/');
 
             expect(loader.resources[page0].metadata.pageFile).to.equal('split_font_ab.png');
             expect(loader.resources[page1].metadata.pageFile).to.equal('split_font_cd.png');


### PR DESCRIPTION
##### Description of change
Fixed the two tests that failed on windows in BitmapFontLoader. I think the code itself is self-explanatory so I don't really have much more to say. I am confident the change in `dirname` method should be safe because backslashes are not allowed in a URL, so shouldn't ever break any existing code, and even though they're allowed in unix's filenames afaik no one ever does it.

##### Pre-Merge Checklist

- [X] Lint process passed (`npm run lint`)
- [X] Tests passed (`npm run test`)

Referenced issue: #6247