### PR TITLE
TextMetrics.wordWrap() customization of splitting method

### DIFF
--- a/packages/text/src/TextMetrics.js
+++ b/packages/text/src/TextMetrics.js
@@ -575,7 +575,6 @@ export class TextMetrics
      * // Correctly splits emojis, eg "🤪🤪" will result in two element array, each with one emoji.
      * TextMetrics.wordWrapSplit = (token) => [...token];
      *
-     * @private
      * @param  {string}  token The token to split
      * @return {string[]} The characters of the token
      */
@@ -735,15 +734,6 @@ const canvas = (() =>
 })();
 
 canvas.width = canvas.height = 10;
-
-/**
- * Configuration for TextMetrics
- * @type {{wordWrapTokenSplit: (function(*): (Array|string[]))}} A function that splits a token in `wordWrap` method into
- * separate characters when token is longer than the allowed width
- */
-TextMetrics.configuration = {
-    wordWrapTokenSplit: (token) => token.split(''),
-};
 
 /**
  * Cached canvas element for measuring text

--- a/packages/text/src/TextMetrics.js
+++ b/packages/text/src/TextMetrics.js
@@ -250,7 +250,7 @@ export class TextMetrics
                 if (TextMetrics.canBreakWords(token, style.breakWords))
                 {
                     // break word into characters
-                    const characters = TextMetrics.configuration.wordWrapTokenSplit(token);
+                    const characters = TextMetrics.wordWrapSplit(token);
 
                     // loop the characters
                     for (let j = 0; j < characters.length; j++)
@@ -562,6 +562,26 @@ export class TextMetrics
     static canBreakChars(char, nextChar, token, index, breakWords) // eslint-disable-line no-unused-vars
     {
         return true;
+    }
+
+    /**
+     * Overridable helper method used internally by TextMetrics, exposed to allow customizing the class's behavior.
+     *
+     * It is called when a token (usually a word) has to be split into separate pieces
+     * in order to determine the point to break a word.
+     * It must return an array of characters.
+     *
+     * @example
+     * // Correctly splits emojis, eg "🤪🤪" will result in two element array, each with one emoji.
+     * TextMetrics.wordWrapSplit = (token) => [...token];
+     *
+     * @private
+     * @param  {string}  token The token to split
+     * @return {string[]} The characters of the token
+     */
+    static wordWrapSplit(token)
+    {
+        return token.split('');
     }
 
     /**

--- a/packages/text/src/TextMetrics.js
+++ b/packages/text/src/TextMetrics.js
@@ -250,7 +250,7 @@ export class TextMetrics
                 if (TextMetrics.canBreakWords(token, style.breakWords))
                 {
                     // break word into characters
-                    const characters = token.split('');
+                    const characters = TextMetrics.configuration.wordWrapTokenSplit(token);
 
                     // loop the characters
                     for (let j = 0; j < characters.length; j++)
@@ -715,6 +715,15 @@ const canvas = (() =>
 })();
 
 canvas.width = canvas.height = 10;
+
+/**
+ * Configuration for TextMetrics
+ * @type {{wordWrapTokenSplit: (function(*): (Array|string[]))}} A function that splits a token in `wordWrap` method into
+ * separate characters when token is longer than the allowed width
+ */
+TextMetrics.configuration = {
+    wordWrapTokenSplit: (token) => token.split(''),
+};
 
 /**
  * Cached canvas element for measuring text

--- a/packages/text/src/TextMetrics.js
+++ b/packages/text/src/TextMetrics.js
@@ -529,12 +529,12 @@ export class TextMetrics
     }
 
     /**
-     * This method exists to be easily overridden
+     * Overridable helper method used internally by TextMetrics, exposed to allow customizing the class's behavior.
+     *
      * It allows one to customise which words should break
      * Examples are if the token is CJK or numbers.
      * It must return a boolean.
      *
-     * @private
      * @param  {string}  token       The token
      * @param  {boolean}  breakWords  The style attr break words
      * @return {boolean} whether to break word or not
@@ -545,13 +545,13 @@ export class TextMetrics
     }
 
     /**
-     * This method exists to be easily overridden
+     * Overridable helper method used internally by TextMetrics, exposed to allow customizing the class's behavior.
+     *
      * It allows one to determine whether a pair of characters
      * should be broken by newlines
      * For example certain characters in CJK langs or numbers.
      * It must return a boolean.
      *
-     * @private
      * @param  {string}  char      The character
      * @param  {string}  nextChar  The next character
      * @param  {string}  token     The token/word the characters are from

--- a/packages/text/test/TextMetrics.js
+++ b/packages/text/test/TextMetrics.js
@@ -220,6 +220,34 @@ describe('PIXI.TextMetrics', function ()
         });
     });
 
+    describe('wordWrap misc', function ()
+    {
+        const originalSplit = TextMetrics.configuration.wordWrapTokenSplit;
+
+        afterEach(function ()
+        {
+            TextMetrics.configuration.wordWrapTokenSplit = originalSplit;
+        });
+
+        it('should use configuration callback to split a token', () =>
+        {
+            let wasSplitCalled = false;
+
+            TextMetrics.configuration.wordWrapTokenSplit = (token) =>
+            {
+                wasSplitCalled = true;
+                expect(token).to.equal('testword1234567890abcd!');
+
+                return ['s', 'p', 'l', 'i', 't'];
+            };
+
+            const brokenText = TextMetrics.wordWrap('testword1234567890abcd!', new TextStyle(defaultStyle));
+
+            expect(wasSplitCalled).to.equal(true);
+            expect(brokenText).to.equal('split');
+        });
+    });
+
     describe('whiteSpace `normal` without breakWords', function ()
     {
         it('multiple spaces should be collapsed to 1 and but not newlines', function ()

--- a/packages/text/test/TextMetrics.js
+++ b/packages/text/test/TextMetrics.js
@@ -222,18 +222,18 @@ describe('PIXI.TextMetrics', function ()
 
     describe('wordWrap misc', function ()
     {
-        const originalSplit = TextMetrics.configuration.wordWrapTokenSplit;
+        const originalSplit = TextMetrics.wordWrapSplit;
 
         afterEach(function ()
         {
-            TextMetrics.configuration.wordWrapTokenSplit = originalSplit;
+            TextMetrics.wordWrapSplit = originalSplit;
         });
 
         it('should use configuration callback to split a token', () =>
         {
             let wasSplitCalled = false;
 
-            TextMetrics.configuration.wordWrapTokenSplit = (token) =>
+            TextMetrics.wordWrapSplit = (token) =>
             {
                 wasSplitCalled = true;
                 expect(token).to.equal('testword1234567890abcd!');


### PR DESCRIPTION
##### Description of change
As requested in #6201, made it so that the method used to split a token into characters in `TextMetrics.wordWrap()` can be customized.

##### Pre-Merge Checklist
- [X] Lint process passed (`npm run lint`)
- [X] Tests passed (`npm run test`)
