### PR TITLE
Canvas mask supports container with graphics

### DIFF
--- a/packages/canvas/canvas-renderer/package.json
+++ b/packages/canvas/canvas-renderer/package.json
@@ -31,6 +31,8 @@
     "@pixi/utils": "^5.2.0"
   },
   "devDependencies": {
-    "@pixi/display": "^5.2.0"
+    "@pixi/display": "^5.2.0",
+    "@pixi/sprite": "^5.2.0",
+    "@pixi/graphics": "^5.2.0"
   }
 }

--- a/packages/canvas/canvas-renderer/src/utils/CanvasMaskManager.js
+++ b/packages/canvas/canvas-renderer/src/utils/CanvasMaskManager.js
@@ -30,27 +30,12 @@ export class CanvasMaskManager
 
         renderer.context.save();
 
-        const cacheAlpha = maskObject.alpha;
-        const transform = maskObject.transform.worldTransform;
-        const resolution = renderer.resolution;
-
-        renderer.context.setTransform(
-            transform.a * resolution,
-            transform.b * resolution,
-            transform.c * resolution,
-            transform.d * resolution,
-            transform.tx * resolution,
-            transform.ty * resolution
-        );
-
         // TODO support sprite alpha masks??
         // lots of effort required. If demand is great enough..
         if (this.recursiveFindShapes(maskObject))
         {
             renderer.context.clip();
         }
-
-        maskData.worldAlpha = cacheAlpha;
     }
 
     /**
@@ -66,6 +51,19 @@ export class CanvasMaskManager
         if (container.geometry && container.geometry.graphicsData)
         {
             found = true;
+
+            const transform = container.transform.worldTransform;
+            const resolution = this.renderer.resolution;
+
+            this.renderer.context.setTransform(
+                transform.a * resolution,
+                transform.b * resolution,
+                transform.c * resolution,
+                transform.d * resolution,
+                transform.tx * resolution,
+                transform.ty * resolution
+            );
+
             this.renderGraphicsShape(container);
         }
 

--- a/packages/canvas/canvas-renderer/src/utils/CanvasMaskManager.js
+++ b/packages/canvas/canvas-renderer/src/utils/CanvasMaskManager.js
@@ -45,13 +45,44 @@ export class CanvasMaskManager
 
         // TODO support sprite alpha masks??
         // lots of effort required. If demand is great enough..
-        if (!maskObject._texture)
+        if (this.recursiveFindShapes(maskObject))
         {
-            this.renderGraphicsShape(maskObject);
             renderer.context.clip();
         }
 
         maskData.worldAlpha = cacheAlpha;
+    }
+
+    /**
+     * Renders all PIXI.Graphics shapes in a subtree.
+     *
+     * @param {PIXI.Container} container - container to scan.
+     * @returns {boolean} whether graphics was found
+     */
+    recursiveFindShapes(container)
+    {
+        let found = false;
+
+        if (container.geometry && container.geometry.graphicsData)
+        {
+            found = true;
+            this.renderGraphicsShape(container);
+        }
+
+        const { children } = container;
+
+        if (children)
+        {
+            for (let i = 0; i < children.length; i++)
+            {
+                if (this.recursiveFindShapes(children[i]))
+                {
+                    found = true;
+                }
+            }
+        }
+
+        return found;
     }
 
     /**
@@ -61,6 +92,8 @@ export class CanvasMaskManager
      */
     renderGraphicsShape(graphics)
     {
+        graphics.finishPoly();
+
         const context = this.renderer.context;
         const graphicsData = graphics.geometry.graphicsData;
         const len = graphicsData.length;

--- a/packages/canvas/canvas-renderer/test/CanvasMaskManager.js
+++ b/packages/canvas/canvas-renderer/test/CanvasMaskManager.js
@@ -1,0 +1,38 @@
+const { Container } = require('@pixi/display');
+const { Graphics } = require('@pixi/graphics');
+const { Sprite } = require('@pixi/sprite');
+const { CanvasRenderer } = require('../');
+
+describe('PIXI.CanvasMaskManager', function ()
+{
+    it('should work on all graphics masks inside container', function ()
+    {
+        const renderer = new CanvasRenderer(1, 1);
+        const shapeSpy = sinon.spy(renderer.maskManager, 'renderGraphicsShape');
+        const contextPath = sinon.spy(renderer.context, 'closePath');
+        const cont = new Container();
+
+        cont.mask = new Sprite();
+        expect(() => { renderer.render(cont); }).to.not.throw();
+        expect(shapeSpy).to.not.called;
+
+        const graphics1 = new Graphics();
+        const graphics2 = new Graphics();
+
+        graphics1.beginFill(0xffffff, 1.0);
+        graphics1.drawRect(0, 0, 100, 100);
+        graphics2.beginFill(0xffffff, 1.0);
+        graphics2.drawRect(150, 150, 100, 100);
+
+        cont.mask = new Container();
+        cont.mask.addChild(graphics1, graphics2);
+
+        expect(() => { renderer.render(cont); }).to.not.throw();
+        expect(shapeSpy).to.calledTwice;
+        expect(contextPath).to.calledTwice;
+        cont.mask = graphics1;
+        expect(() => { renderer.render(cont); }).to.not.throw();
+        expect(shapeSpy).to.calledThrice;
+        expect(contextPath).to.calledThrice;
+    });
+});

--- a/packages/canvas/canvas-renderer/test/CanvasMaskManager.js
+++ b/packages/canvas/canvas-renderer/test/CanvasMaskManager.js
@@ -26,13 +26,41 @@ describe('PIXI.CanvasMaskManager', function ()
 
         cont.mask = new Container();
         cont.mask.addChild(graphics1, graphics2);
+        cont.addChild(cont.mask);
 
         expect(() => { renderer.render(cont); }).to.not.throw();
         expect(shapeSpy).to.calledTwice;
         expect(contextPath).to.calledTwice;
+        cont.mask.removeChildren();
         cont.mask = graphics1;
         expect(() => { renderer.render(cont); }).to.not.throw();
         expect(shapeSpy).to.calledThrice;
         expect(contextPath).to.calledThrice;
+    });
+
+    it('should set correct transform for graphics', function ()
+    {
+        const renderer = new CanvasRenderer(1, 1);
+        const transformSpy = sinon.spy(renderer.context, 'setTransform');
+        const cont = new Container();
+        const graphics1 = new Graphics();
+        const graphics2 = new Graphics();
+
+        graphics1.beginFill(0xffffff, 1.0);
+        graphics1.drawRect(0, 0, 100, 100);
+        graphics2.beginFill(0xffffff, 1.0);
+        graphics2.drawRect(0, 0, 100, 100);
+
+        graphics1.scale.set(2.0);
+        graphics2.scale.set(3.0);
+
+        cont.mask = new Container();
+        cont.mask.addChild(graphics1, graphics2);
+        cont.addChild(cont.mask);
+
+        expect(() => { renderer.render(cont); }).to.not.throw();
+        expect(transformSpy).to.calledThrice;
+        expect(transformSpy.args[1][0]).to.equal(2.0);
+        expect(transformSpy.args[2][0]).to.equal(3.0);
     });
 });

--- a/packages/canvas/canvas-renderer/test/index.js
+++ b/packages/canvas/canvas-renderer/test/index.js
@@ -1,1 +1,2 @@
 require('./CanvasRenderer');
+require('./CanvasMaskManager');

--- a/packages/display/src/DisplayObject.js
+++ b/packages/display/src/DisplayObject.js
@@ -688,7 +688,7 @@ export class DisplayObject extends EventEmitter
      * sprite.mask = graphics;
      * @todo At the moment, PIXI.CanvasRenderer doesn't support PIXI.Sprite as mask.
      *
-     * @member {PIXI.Graphics|PIXI.Sprite|null}
+     * @member {PIXI.Container|PIXI.MaskData}
      */
     get mask()
     {


### PR DESCRIPTION
Currently assigning container as a mask causes an Exception in CanvasRenderer.

Lets fix that, add a feature, and cover with pair of tests.

Demo: https://www.pixiplayground.com/#/edit/IO~sST9K~QxzhBh9b4b3u
Two rects in two graphics instead of one.

To be fixed in next PR: Even-odd fail. https://www.pixiplayground.com/#/edit/DsFS6hI4dG0tFGrdBSbxW
