### PR TITLE
bump ismobilejs version to 1.0.3

### DIFF
--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -24,6 +24,6 @@
     "dist"
   ],
   "dependencies": {
-    "ismobilejs": "^0.5.1"
+    "ismobilejs": "^1.0.3"
   }
 }


### PR DESCRIPTION
##### Description of change
Bump ismobilejs version to 1.0.3
We use the ismobilejs from pixi but found out some issues with detecting newer macOS. bumping the version helped us.

I didn't test impact of this change in any way, just changed the number here at github website. 