### PR TITLE
Corners supposed to be proportionally scaled

### DIFF
--- a/packages/mesh-extras/src/NineSlicePlane.js
+++ b/packages/mesh-extras/src/NineSlicePlane.js
@@ -126,8 +126,7 @@ export class NineSlicePlane extends SimplePlane
     {
         const vertices = this.vertices;
 
-        const h = this._topHeight + this._bottomHeight;
-        const scale = this._height > h ? 1.0 : this._height / h;
+        const scale = this._getMinScale();
 
         vertices[9] = vertices[11] = vertices[13] = vertices[15] = this._topHeight * scale;
         vertices[17] = vertices[19] = vertices[21] = vertices[23] = this._height - (this._bottomHeight * scale);
@@ -142,12 +141,24 @@ export class NineSlicePlane extends SimplePlane
     {
         const vertices = this.vertices;
 
-        const w = this._leftWidth + this._rightWidth;
-        const scale = this._width > w ? 1.0 : this._width / w;
+        const scale = this._getMinScale();
 
         vertices[2] = vertices[10] = vertices[18] = vertices[26] = this._leftWidth * scale;
         vertices[4] = vertices[12] = vertices[20] = vertices[28] = this._width - (this._rightWidth * scale);
         vertices[6] = vertices[14] = vertices[22] = vertices[30] = this._width;
+    }
+
+    _getMinScale()
+    {
+        const w = this._leftWidth + this._rightWidth;
+        const scale_w = this._width > w ? 1.0 : this._width / w;
+        
+        const h = this._topHeight + this._bottomHeight;
+        const scale_h = this._height > h ? 1.0 : this._height / h;
+        
+        const scale = Math.min(scale_w, scale_h);
+        
+        return scale;
     }
 
     /**

--- a/packages/mesh-extras/src/NineSlicePlane.js
+++ b/packages/mesh-extras/src/NineSlicePlane.js
@@ -148,16 +148,22 @@ export class NineSlicePlane extends SimplePlane
         vertices[6] = vertices[14] = vertices[22] = vertices[30] = this._width;
     }
 
+    /**
+     * Returns the smaller of a set of vertical and horizontal scale of nine slice corners.
+     *
+     * @return {number} Smaller number of vertical and horizontal scale.
+     * @private
+     */
     _getMinScale()
     {
         const w = this._leftWidth + this._rightWidth;
-        const scale_w = this._width > w ? 1.0 : this._width / w;
-        
+        const scaleW = this._width > w ? 1.0 : this._width / w;
+
         const h = this._topHeight + this._bottomHeight;
-        const scale_h = this._height > h ? 1.0 : this._height / h;
-        
-        const scale = Math.min(scale_w, scale_h);
-        
+        const scaleH = this._height > h ? 1.0 : this._height / h;
+
+        const scale = Math.min(scaleW, scaleH);
+
         return scale;
     }
 

--- a/packages/mesh-extras/test/NineSlicePlane.js
+++ b/packages/mesh-extras/test/NineSlicePlane.js
@@ -1,0 +1,23 @@
+const { NineSlicePlane } = require('../');
+const { skipHello } = require('@pixi/utils');
+const { Texture } = require('@pixi/core');
+
+skipHello();
+
+describe('PIXI.NineSlicePlane', function ()
+{
+    it('shold return correct scaling for NineSlicePlane corners', function ()
+    {
+        const plane = new NineSlicePlane(Texture.EMPTY, 10, 10, 10, 10);
+
+        plane.width = 100;
+        plane.height = 100;
+        expect(plane._getMinScale()).to.equal(1);
+        plane.width = 10;
+        plane.height = 100;
+        expect(plane._getMinScale()).to.equal(0.5);
+        plane.width = 100;
+        plane.height = 10;
+        expect(plane._getMinScale()).to.equal(0.5);
+    });
+});

--- a/packages/mesh-extras/test/index.js
+++ b/packages/mesh-extras/test/index.js
@@ -1,1 +1,2 @@
 require('./SimplePlane');
+require('./NineSlicePlane');


### PR DESCRIPTION
##### Description of change
If nine slice object on scene is smaller than frame it shouldn't be distorted

https://jsfiddle.net/Heorhiy/ex35ty0m/

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
