### PR TITLE
Fix double onFrameChange events with AnimatedSprite

### DIFF
--- a/packages/core/src/shader/utils/compileProgram.js
+++ b/packages/core/src/shader/utils/compileProgram.js
@@ -32,6 +32,18 @@ export function compileProgram(gl, vertexSrc, fragmentSrc, attributeLocations)
     // if linking fails, then log and cleanup
     if (!gl.getProgramParameter(program, gl.LINK_STATUS))
     {
+        if (!gl.getShaderParameter(glVertShader, gl.COMPILE_STATUS))
+        {
+            console.warn(vertexSrc);
+            console.error(gl.getShaderInfoLog(glVertShader));
+        }
+
+        if (!gl.getShaderParameter(glFragShader, gl.COMPILE_STATUS))
+        {
+            console.warn(fragmentSrc);
+            console.error(gl.getShaderInfoLog(glFragShader));
+        }
+
         console.error('Pixi.js Error: Could not initialize shader.');
         console.error('gl.VALIDATE_STATUS', gl.getProgramParameter(program, gl.VALIDATE_STATUS));
         console.error('gl.getError()', gl.getError());
@@ -66,14 +78,6 @@ function compileShader(gl, type, src)
 
     gl.shaderSource(shader, src);
     gl.compileShader(shader);
-
-    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS))
-    {
-        console.warn(src);
-        console.error(gl.getShaderInfoLog(shader));
-
-        return null;
-    }
 
     return shader;
 }

--- a/packages/sprite-animated/src/AnimatedSprite.js
+++ b/packages/sprite-animated/src/AnimatedSprite.js
@@ -252,7 +252,8 @@ export class AnimatedSprite extends Sprite
 
         if (this._currentTime < 0 && !this.loop)
         {
-            this.gotoAndStop(0);
+            this._currentTime = 0;
+            this.stop();
 
             if (this.onComplete)
             {
@@ -261,7 +262,8 @@ export class AnimatedSprite extends Sprite
         }
         else if (this._currentTime >= this._textures.length && !this.loop)
         {
-            this.gotoAndStop(this._textures.length - 1);
+            this._currentTime = this._textures.length - 1;
+            this.stop();
 
             if (this.onComplete)
             {

--- a/packages/sprite-animated/test/AnimatedSprite.js
+++ b/packages/sprite-animated/test/AnimatedSprite.js
@@ -95,4 +95,214 @@ describe('PIXI.AnimatedSprite', function ()
             this.sprite.playing = true;
         });
     });
+
+    describe('.onComplete()', function ()
+    {
+        before(function ()
+        {
+            this.sprite = new AnimatedSprite([Texture.EMPTY, Texture.EMPTY, Texture.EMPTY]);
+            this.sprite.animationSpeed = 0.5;
+            this.sprite.loop = false;
+        });
+
+        after(function ()
+        {
+            this.sprite.destroy();
+            this.sprite = null;
+        });
+
+        it('should fire onComplete', function (done)
+        {
+            this.timeout((
+                this.sprite.textures.length * 1000 / 60 / this.sprite.animationSpeed)
+                + (1000 / 60 / this.sprite.animationSpeed * 0.9)
+            );
+            this.sprite.onComplete = () =>
+            {
+                this.sprite.onComplete = null;
+                done();
+            };
+            this.sprite.play();
+            expect(this.sprite.playing).to.be.true;
+        });
+    });
+
+    describe('.gotoAndPlay()', function ()
+    {
+        before(function ()
+        {
+            this.sprite = new AnimatedSprite([Texture.EMPTY, Texture.EMPTY, Texture.EMPTY]);
+            this.sprite.animationSpeed = 1;
+            this.sprite.loop = false;
+        });
+
+        after(function ()
+        {
+            this.sprite.destroy();
+            this.sprite = null;
+        });
+
+        it('should fire frame after start frame during one play and fire onComplete', function (done)
+        {
+            const frameIds = [];
+
+            this.sprite.animationSpeed = 1;
+            this.sprite.onComplete = () =>
+            {
+                expect(frameIds).to.deep.equal([1, 2]);
+                expect(this.sprite.playing).to.be.false;
+                this.sprite.onComplete = null;
+                this.sprite.onFrameChange = null;
+                done();
+            };
+            this.sprite.onFrameChange = (frame) =>
+            {
+                frameIds.push(frame);
+            };
+            this.sprite.gotoAndPlay(1);
+            expect(this.sprite.playing).to.be.true;
+        });
+    });
+
+    describe('.gotoAndStop()', function ()
+    {
+        before(function ()
+        {
+            this.sprite = new AnimatedSprite([Texture.EMPTY, Texture.EMPTY, Texture.EMPTY]);
+            this.sprite.animationSpeed = 1;
+            this.sprite.loop = false;
+        });
+
+        after(function ()
+        {
+            this.sprite.destroy();
+            this.sprite = null;
+        });
+
+        beforeEach(function ()
+        {
+            this.sprite.playing = false;
+        });
+
+        it('should fire onFrameChange on target frame', function (done)
+        {
+            const targetFrame = 1;
+
+            this.sprite.animationSpeed = 1;
+            this.sprite.onFrameChange = (frame) =>
+            {
+                expect(frame).to.equal(targetFrame);
+                expect(this.sprite.playing).to.be.false;
+                this.sprite.onComplete = null;
+                this.sprite.onFrameChange = null;
+                done();
+            };
+            this.sprite.gotoAndStop(targetFrame);
+            expect(this.sprite.playing).to.be.false;
+        });
+
+        it('should not fire onFrameChange on target frame if current is already target', function ()
+        {
+            let fired = false;
+            const targetFrame = 1;
+
+            this.sprite.gotoAndStop(targetFrame);
+
+            this.sprite.animationSpeed = 1;
+            this.sprite.onFrameChange = () =>
+            {
+                fired = true;
+            };
+            this.sprite.gotoAndStop(targetFrame);
+            expect(this.sprite.playing).to.be.false;
+            expect(fired).to.be.false;
+        });
+    });
+
+    describe('.onFrameChange()', function ()
+    {
+        before(function ()
+        {
+            this.sprite = new AnimatedSprite([Texture.EMPTY, Texture.EMPTY, Texture.EMPTY]);
+            this.sprite.animationSpeed = 1;
+            this.sprite.loop = false;
+        });
+
+        after(function ()
+        {
+            this.sprite.destroy();
+            this.sprite = null;
+        });
+
+        beforeEach(function ()
+        {
+            this.sprite.playing = false;
+        });
+
+        it('should fire every frame(except current) during one play', function (done)
+        {
+            const frameIds = [];
+
+            this.sprite.gotoAndStop(0);
+            this.sprite.animationSpeed = 1;
+            this.sprite.onComplete = () =>
+            {
+                done();
+                expect(frameIds).to.deep.equal([1, 2]); // from 0 to 2, triggers onFrameChange at 1,2.
+                expect(this.sprite.currentFrame).to.equal(2);
+                this.sprite.onComplete = null;
+                this.sprite.onFrameChange = null;
+            };
+            this.sprite.onFrameChange = (frame) =>
+            {
+                frameIds.push(frame);
+            };
+            this.sprite.play();
+            expect(this.sprite.playing).to.be.true;
+        });
+
+        it('should fire every frame(except current) during one play - reverse', function (done)
+        {
+            const frameIds = [];
+
+            this.sprite.gotoAndStop(2);
+            this.sprite.animationSpeed = -1;
+            this.sprite.onComplete = () =>
+            {
+                done();
+                expect(frameIds).to.deep.equal([1, 0]); // from 2 to 0, triggers onFrameChange at 1,0.
+                expect(this.sprite.currentFrame).to.equal(0);
+                this.sprite.onComplete = null;
+                this.sprite.onFrameChange = null;
+            };
+            this.sprite.onFrameChange = (frame) =>
+            {
+                frameIds.push(frame);
+            };
+            this.sprite.play();
+            expect(this.sprite.playing).to.be.true;
+        });
+
+        it('should fire every frame(except current) during one play - from not start/end', function (done)
+        {
+            const frameIds = [];
+
+            this.sprite.gotoAndStop(1);
+            this.sprite.animationSpeed = -1;
+            this.sprite.onComplete = () =>
+            {
+                done();
+                expect(frameIds).to.deep.equal([0]); // from 1 to 0, triggers onFrameChange at 0.
+                expect(this.sprite.currentFrame).to.equal(0);
+                this.sprite.onComplete = null;
+                this.sprite.onFrameChange = null;
+            };
+            this.sprite.onFrameChange = (frame) =>
+            {
+                frameIds.push(frame);
+            };
+            this.sprite.play();
+            expect(this.sprite.playing).to.be.true;
+        });
+    });
 });

--- a/packages/sprite-animated/test/AnimatedSprite.js
+++ b/packages/sprite-animated/test/AnimatedSprite.js
@@ -247,11 +247,11 @@ describe('PIXI.AnimatedSprite', function ()
             this.sprite.animationSpeed = 1;
             this.sprite.onComplete = () =>
             {
-                done();
                 expect(frameIds).to.deep.equal([1, 2]); // from 0 to 2, triggers onFrameChange at 1,2.
                 expect(this.sprite.currentFrame).to.equal(2);
                 this.sprite.onComplete = null;
                 this.sprite.onFrameChange = null;
+                done();
             };
             this.sprite.onFrameChange = (frame) =>
             {
@@ -269,11 +269,11 @@ describe('PIXI.AnimatedSprite', function ()
             this.sprite.animationSpeed = -1;
             this.sprite.onComplete = () =>
             {
-                done();
                 expect(frameIds).to.deep.equal([1, 0]); // from 2 to 0, triggers onFrameChange at 1,0.
                 expect(this.sprite.currentFrame).to.equal(0);
                 this.sprite.onComplete = null;
                 this.sprite.onFrameChange = null;
+                done();
             };
             this.sprite.onFrameChange = (frame) =>
             {
@@ -291,11 +291,11 @@ describe('PIXI.AnimatedSprite', function ()
             this.sprite.animationSpeed = -1;
             this.sprite.onComplete = () =>
             {
-                done();
                 expect(frameIds).to.deep.equal([0]); // from 1 to 0, triggers onFrameChange at 0.
                 expect(this.sprite.currentFrame).to.equal(0);
                 this.sprite.onComplete = null;
                 this.sprite.onFrameChange = null;
+                done();
             };
             this.sprite.onFrameChange = (frame) =>
             {


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
if it's stoped naturally, then reset frame to the last frame and don't trigger one more onFrameChange
##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
