### PR TITLE
Extra checks for OffscreenCanvas text measure

### DIFF
--- a/packages/text/src/TextMetrics.js
+++ b/packages/text/src/TextMetrics.js
@@ -724,8 +724,16 @@ const canvas = (() =>
     {
         // OffscreenCanvas2D measureText can be up to 40% faster.
         const c = new OffscreenCanvas(0, 0);
+        const context = c.getContext('2d');
 
-        return c.getContext('2d') ? c : document.createElement('canvas');
+        if (context && context.measureText && context === c.getContext('2d'))
+        {
+            return c;
+        }
+        else
+        {
+            return document.createElement('canvas');
+        }
     }
     catch (ex)
     {

--- a/packages/text/src/TextMetrics.js
+++ b/packages/text/src/TextMetrics.js
@@ -726,7 +726,7 @@ const canvas = (() =>
         const c = new OffscreenCanvas(0, 0);
         const context = c.getContext('2d');
 
-        if (context && context.measureText && context === c.getContext('2d'))
+        if (context && context.measureText)
         {
             return c;
         }

--- a/packages/text/src/TextMetrics.js
+++ b/packages/text/src/TextMetrics.js
@@ -730,10 +730,8 @@ const canvas = (() =>
         {
             return c;
         }
-        else
-        {
-            return document.createElement('canvas');
-        }
+
+        return document.createElement('canvas');
     }
     catch (ex)
     {


### PR DESCRIPTION
@Metatron92 reported strange error in his game's "report error" feature: 

```
TypeError: i.measureText is not a function\\n    at Function.ho.measureFont 
```

Its probably another OffscreenCanvas surprise. OffscreenCanvas is used since #5804.

Unfortunately, we don't know which browsers have this issue, I hope @Metatron92 improves his error reporting method.

We really should move this method to another file and make it accessible for users, also make it lazy so user can disable it with `PIXI.settings`. Currently we have to override `_canvas` and `_context` varibles for fast fix.