### PR TITLE
Added support for structs in shader uniforms

### DIFF
--- a/packages/core/src/shader/Program.ts
+++ b/packages/core/src/shader/Program.ts
@@ -200,9 +200,9 @@ export class Program
         for (let i = 0; i < totalUniforms; i++)
         {
             const uniformData = gl.getActiveUniform(program, i);
-            const name = uniformData.name.replace(/\[.*?\]/, '');
+            const name = uniformData.name.replace(/\[.*?\]$/, '');
 
-            const isArray = uniformData.name.match(/\[.*?\]/);
+            const isArray = uniformData.name.match(/\[.*?\]$/);
             const type = mapType(gl, uniformData.type);
 
             /*eslint-disable */

--- a/packages/core/src/shader/utils/generateUniformsSync.ts
+++ b/packages/core/src/shader/utils/generateUniformsSync.ts
@@ -99,7 +99,7 @@ export function generateUniformsSync(group: UniformGroup, uniformData: {[x: stri
             if (group.uniforms[i].group)
             {
                 funcFragments.push(`
-                    renderer.shader.syncUniformGroup(uv.${i}, syncData);
+                    renderer.shader.syncUniformGroup(uv["${i}"], syncData);
                 `);
             }
 
@@ -125,11 +125,11 @@ export function generateUniformsSync(group: UniformGroup, uniformData: {[x: stri
         {
             const templateType = (data.size === 1) ? GLSL_TO_SINGLE_SETTERS_CACHED : GLSL_TO_ARRAY_SETTERS;
 
-            const template =  templateType[data.type].replace('location', `ud.${i}.location`);
+            const template =  templateType[data.type].replace('location', `ud["${i}"].location`);
 
             funcFragments.push(`
-            cv = ud.${i}.value;
-            v = uv.${i};
+            cv = ud["${i}"].value;
+            v = uv["${i}"];
             ${template};`);
         }
     }
@@ -142,3 +142,4 @@ export function generateUniformsSync(group: UniformGroup, uniformData: {[x: stri
      */
     return new Function('ud', 'uv', 'renderer', 'syncData', funcFragments.join('\n')); // eslint-disable-line no-new-func
 }
+

--- a/packages/core/src/shader/utils/uniformParsers.ts
+++ b/packages/core/src/shader/utils/uniformParsers.ts
@@ -26,10 +26,10 @@ export const uniformParsers: IUniformParser[] = [
             data.type === 'float' && data.size === 1,
         code: (name: string): string =>
             `
-            if(uv.${name} !== ud.${name}.value)
+            if(uv["${name}"] !== ud["${name}"].value)
             {
-                ud.${name}.value = uv.${name}
-                gl.uniform1f(ud.${name}.location, uv.${name})
+                ud["${name}"].value = uv["${name}"]
+                gl.uniform1f(ud["${name}"].location, uv["${name}"])
             }
             `,
     },
@@ -40,12 +40,12 @@ export const uniformParsers: IUniformParser[] = [
             (data.type === 'sampler2D' || data.type === 'samplerCube' || data.type === 'sampler2DArray') && data.size === 1 && !data.isArray,
         code: (name: string): string => `t = syncData.textureCount++;
 
-            renderer.texture.bind(uv.${name}, t);
+            renderer.texture.bind(uv["${name}"], t);
 
-            if(ud.${name}.value !== t)
+            if(ud["${name}"].value !== t)
             {
-                ud.${name}.value = t;
-                gl.uniform1i(ud.${name}.location, t);\n; // eslint-disable-line max-len
+                ud["${name}"].value = t;
+                gl.uniform1i(ud["${name}"].location, t);\n; // eslint-disable-line max-len
             }`,
     },
     // uploading pixi matrix object to mat3
@@ -56,7 +56,7 @@ export const uniformParsers: IUniformParser[] = [
 
             // TODO and some smart caching dirty ids here!
             `
-            gl.uniformMatrix3fv(ud.${name}.location, false, uv.${name}.toArray(true));
+            gl.uniformMatrix3fv(ud["${name}"].location, false, uv["${name}"].toArray(true));
             `
         ,
 
@@ -67,14 +67,14 @@ export const uniformParsers: IUniformParser[] = [
             data.type === 'vec2' && data.size === 1 && uniform.x !== undefined,
         code: (name: string): string =>
             `
-                cv = ud.${name}.value;
-                v = uv.${name};
+                cv = ud["${name}"].value;
+                v = uv["${name}"];
 
                 if(cv[0] !== v.x || cv[1] !== v.y)
                 {
                     cv[0] = v.x;
                     cv[1] = v.y;
-                    gl.uniform2f(ud.${name}.location, v.x, v.y);
+                    gl.uniform2f(ud["${name}"].location, v.x, v.y);
                 }`,
     },
     // caching layer for a vec2
@@ -83,14 +83,14 @@ export const uniformParsers: IUniformParser[] = [
             data.type === 'vec2' && data.size === 1,
         code: (name: string): string =>
             `
-                cv = ud.${name}.value;
-                v = uv.${name};
+                cv = ud["${name}"].value;
+                v = uv["${name}"];
 
                 if(cv[0] !== v[0] || cv[1] !== v[1])
                 {
                     cv[0] = v[0];
                     cv[1] = v[1];
-                    gl.uniform2f(ud.${name}.location, v[0], v[1]);
+                    gl.uniform2f(ud["${name}"].location, v[0], v[1]);
                 }
             `,
     },
@@ -101,8 +101,8 @@ export const uniformParsers: IUniformParser[] = [
 
         code: (name: string): string =>
             `
-                cv = ud.${name}.value;
-                v = uv.${name};
+                cv = ud["${name}"].value;
+                v = uv["${name}"];
 
                 if(cv[0] !== v.x || cv[1] !== v.y || cv[2] !== v.width || cv[3] !== v.height)
                 {
@@ -110,7 +110,7 @@ export const uniformParsers: IUniformParser[] = [
                     cv[1] = v.y;
                     cv[2] = v.width;
                     cv[3] = v.height;
-                    gl.uniform4f(ud.${name}.location, v.x, v.y, v.width, v.height)
+                    gl.uniform4f(ud["${name}"].location, v.x, v.y, v.width, v.height)
                 }`,
     },
     // a caching layer for vec4 uploading
@@ -119,8 +119,8 @@ export const uniformParsers: IUniformParser[] = [
             data.type === 'vec4' && data.size === 1,
         code: (name: string): string =>
             `
-                cv = ud.${name}.value;
-                v = uv.${name};
+                cv = ud["${name}"].value;
+                v = uv["${name}"];
 
                 if(cv[0] !== v[0] || cv[1] !== v[1] || cv[2] !== v[2] || cv[3] !== v[3])
                 {
@@ -129,7 +129,8 @@ export const uniformParsers: IUniformParser[] = [
                     cv[2] = v[2];
                     cv[3] = v[3];
 
-                    gl.uniform4f(ud.${name}.location, v[0], v[1], v[2], v[3])
+                    gl.uniform4f(ud["${name}"].location, v[0], v[1], v[2], v[3])
                 }`,
     },
 ];
+

--- a/packages/core/test/Shader.js
+++ b/packages/core/test/Shader.js
@@ -1,0 +1,125 @@
+const { Renderer, Shader, Geometry } = require('../');
+const { skipHello } = require('@pixi/utils');
+
+skipHello();
+
+describe('PIXI.Shader', function ()
+{
+    const vertexSrc = `
+attribute vec2 aVertexPosition;
+
+void main() {
+
+    gl_Position = vec4(aVertexPosition.x, aVertexPosition.y, 0.0, 1.0);
+
+}`;
+
+    before(function ()
+    {
+        this.renderer = new Renderer();
+        this.geometry = new Geometry()
+            .addAttribute('aVertexPosition', [-100, -100, 100, -100, 100, 100], 2);
+    });
+
+    after(function ()
+    {
+        this.renderer.destroy();
+        this.renderer = null;
+    });
+
+    it('should be able to set uniform value', function ()
+    {
+        const fragmentSrc = `
+uniform float uTestFloat;
+
+void main() {
+
+    gl_FragColor = vec4(uTestFloat, uTestFloat, uTestFloat, 1.0);
+ 
+}`;
+
+        const shader = Shader.from(vertexSrc, fragmentSrc);
+
+        shader.uniforms.uTestFloat = 0.88;
+
+        this.renderer.shader.bind(shader);
+        this.renderer.geometry.bind(this.geometry);
+    });
+
+    it('should be able to set uniform arrays', function ()
+    {
+        const fragmentSrc = `
+uniform float uTestFloat[3];
+
+void main() {
+
+    gl_FragColor = vec4(uTestFloat[0], uTestFloat[1], uTestFloat[2], 1.0);
+ 
+}`;
+
+        const shader = Shader.from(vertexSrc, fragmentSrc);
+
+        shader.uniforms.uTestFloat = [1, 2, 3];
+
+        this.renderer.shader.bind(shader);
+        this.renderer.geometry.bind(this.geometry);
+    });
+
+    it('should be able to set uniform structs', function ()
+    {
+        const fragmentSrc = `
+struct Test {
+  float testFloat;
+};
+
+uniform Test uTest;
+
+void main() {
+
+    gl_FragColor = vec4(uTest.testFloat, 0.0, 0.0, 1.0);
+ 
+}`;
+
+        const shader = Shader.from(vertexSrc, fragmentSrc);
+
+        shader.uniforms['uTest.testFloat'] = 1;
+
+        this.renderer.shader.bind(shader);
+        this.renderer.geometry.bind(this.geometry);
+    });
+
+    it('should be able to set uniform struct arrays', function ()
+    {
+        const fragmentSrc = `
+struct Test {
+  float testFloat;
+  vec3 testVec3;
+};
+
+uniform Test uTest[3];
+
+void main() {
+
+    gl_FragColor = vec4(
+        uTest[0].testFloat * uTest[0].testVec3.x, 
+        uTest[1].testFloat * uTest[1].testVec3.y, 
+        uTest[2].testFloat * uTest[2].testVec3.z, 
+        1.0);
+ 
+}`;
+
+        const shader = Shader.from(vertexSrc, fragmentSrc);
+
+        shader.uniforms['uTest[0].testFloat'] = 1.0;
+        shader.uniforms['uTest[0].testVec3'] = [1, 2, 3];
+
+        shader.uniforms['uTest[1].testFloat'] = 2.5;
+        shader.uniforms['uTest[1].testVec3'] = [1, 2, 3];
+
+        shader.uniforms['uTest[2].testFloat'] = 3.3;
+        shader.uniforms['uTest[2].testVec3'] = [1, 2, 3];
+
+        this.renderer.shader.bind(shader);
+        this.renderer.geometry.bind(this.geometry);
+    });
+});

--- a/packages/core/test/index.js
+++ b/packages/core/test/index.js
@@ -6,6 +6,7 @@ require('./TextureSystem');
 require('./FramebufferSystem');
 require('./ShaderSystem');
 require('./FilterSystem');
+require('./Shader');
 require('./BatchRenderer');
 require('./Geometry');
 require('./CanvasResource');


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

With this change we can set structs in shader uniforms the same way we can set it using WebGL directly.

```
shader.uniforms["material.color"] = [1, 1, 1];
shader.uniforms["lights[1].position"] = [0, 1, 0];
```

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x ] Lint process passed (`npm run lint`)
- [x ] Tests passed (`npm run test`)