### PR TITLE
Add empty calculateBounds to DisplayObject, remove Bounds.updateID references

### DIFF
--- a/packages/display/src/Bounds.js
+++ b/packages/display/src/Bounds.js
@@ -56,8 +56,6 @@ export class Bounds
      */
     clear()
     {
-        this.updateID++;
-
         this.minX = Infinity;
         this.minY = Infinity;
         this.maxX = -Infinity;

--- a/packages/display/src/DisplayObject.js
+++ b/packages/display/src/DisplayObject.js
@@ -213,6 +213,8 @@ export class DisplayObject extends EventEmitter
      */
     updateTransform()
     {
+        this._boundsID++;
+
         this.transform.updateTransform(this.parent.transform);
         // multiply the alphas..
         this.worldAlpha = this.alpha * this.parent.worldAlpha;

--- a/packages/display/src/DisplayObject.js
+++ b/packages/display/src/DisplayObject.js
@@ -216,8 +216,16 @@ export class DisplayObject extends EventEmitter
         this.transform.updateTransform(this.parent.transform);
         // multiply the alphas..
         this.worldAlpha = this.alpha * this.parent.worldAlpha;
+    }
 
-        this._bounds.updateID++;
+    /**
+     * Recalculates the bounds of the display object.
+     *
+     * Does nothing by default and can be overwritten in a parent class.
+     */
+    calculateBounds()
+    {
+        // OVERWRITE;
     }
 
     /**


### PR DESCRIPTION

##### Description of change

Since ``DisplayObject`` uses ``DisplayObject.calculateBounds``, it should at least provide an empty implementation to be overwritten in child classes like ``Container``.

Also there was two places in which ``bounds.updateID++`` was used, which is a property that doesn't actually exist on bounds (anymore?). This just causes that property to be created and set to ``NaN`` and it thus was a silent error.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
