### PR TITLE
Includes filter padding in bounds calculation and fix filter padding calculation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+    "root": true,
     "env": {
         "es6": true,
         "browser": true,

--- a/packages/core/src/filters/FilterSystem.js
+++ b/packages/core/src/filters/FilterSystem.js
@@ -180,7 +180,6 @@ export class FilterSystem extends System
         const state = this.statePool.pop() || new FilterState();
 
         let resolution = filters[0].resolution;
-        let padding = filters[0].padding;
         let autoFit = filters[0].autoFit;
         let legacy = filters[0].legacy;
 
@@ -190,8 +189,6 @@ export class FilterSystem extends System
 
             // lets use the lowest resolution..
             resolution = Math.min(resolution, filter.resolution);
-            // and the largest amount of padding!
-            padding = Math.max(padding, filter.padding);
             // only auto fit if all filters are autofit
             autoFit = autoFit || filter.autoFit;
 
@@ -213,7 +210,6 @@ export class FilterSystem extends System
 
         state.sourceFrame.copyFrom(target.filterArea || target.getBounds(true));
 
-        state.sourceFrame.pad(padding);
         if (autoFit)
         {
             state.sourceFrame.fit(this.renderer.renderTexture.sourceFrame);

--- a/packages/display/src/Container.js
+++ b/packages/display/src/Container.js
@@ -463,7 +463,7 @@ export class Container extends DisplayObject
             }
         }
 
-        if (this.filters)
+        if (this.filters && this.filters.length)
         {
             let filterPadding = 0;
 

--- a/packages/display/src/Container.js
+++ b/packages/display/src/Container.js
@@ -411,12 +411,7 @@ export class Container extends DisplayObject
             this.sortChildren();
         }
 
-        this._boundsID++;
-
-        this.transform.updateTransform(this.parent.transform);
-
-        // TODO: check render flags, how to process stuff here
-        this.worldAlpha = this.alpha * this.parent.worldAlpha;
+        super.updateTransform();
 
         for (let i = 0, j = this.children.length; i < j; ++i)
         {
@@ -466,6 +461,18 @@ export class Container extends DisplayObject
             {
                 this._bounds.addBounds(child._bounds);
             }
+        }
+
+        if (this.filters)
+        {
+            let filterPadding = 0;
+
+            for (let i = 0; i < this.filters.length; i++)
+            {
+                filterPadding += this.filters[i].padding;
+            }
+
+            this._bounds.pad(filterPadding);
         }
 
         this._lastBoundsID = this._boundsID;

--- a/packages/display/src/DisplayObject.js
+++ b/packages/display/src/DisplayObject.js
@@ -84,7 +84,7 @@ export class DisplayObject extends EventEmitter
         this.renderable = true;
 
         /**
-         * The display object container that contains this display object.
+         * The display object container that contains this DisplayObject.
          *
          * @member {PIXI.Container}
          * @readonly
@@ -92,7 +92,9 @@ export class DisplayObject extends EventEmitter
         this.parent = null;
 
         /**
-         * The multiplied alpha of the displayObject.
+         * The multiplied alpha of the DisplayObject.
+         *
+         * Updated via updateTransform()
          *
          * @member {number}
          * @readonly
@@ -118,8 +120,10 @@ export class DisplayObject extends EventEmitter
         this._zIndex = 0;
 
         /**
-         * The area the filter is applied to. This is used as more of an optimization
-         * rather than figuring out the dimensions of the displayObject each frame you can set this rectangle.
+         * The area the filters are applied to. This is used as more of an optimization
+         * rather than figuring out the dimensions of the displayObject each frame.
+         *
+         * If you set this you need to add filter padding yourself.
          *
          * Also works as an interaction mask.
          *
@@ -216,6 +220,7 @@ export class DisplayObject extends EventEmitter
         this._boundsID++;
 
         this.transform.updateTransform(this.parent.transform);
+
         // multiply the alphas..
         this.worldAlpha = this.alpha * this.parent.worldAlpha;
     }
@@ -473,7 +478,6 @@ export class DisplayObject extends EventEmitter
 
         this.parent = null;
         this._bounds = null;
-        this._currentBounds = null;
         this._mask = null;
 
         this.filters = null;

--- a/packages/mixin-cache-as-bitmap/src/index.js
+++ b/packages/mixin-cache-as-bitmap/src/index.js
@@ -172,14 +172,6 @@ DisplayObject.prototype._initCachedDisplayObject = function _initCachedDisplayOb
     // TODO pass an object to clone too? saves having to create a new one each time!
     const bounds = this.getLocalBounds().clone();
 
-    // add some padding!
-    if (this.filters)
-    {
-        const padding = this.filters[0].padding;
-
-        bounds.pad(padding);
-    }
-
     bounds.ceil(settings.RESOLUTION);
 
     // for now we cache the current renderTarget that the WebGL renderer is currently using.


### PR DESCRIPTION
##### Description of change

Fixes: https://github.com/pixijs/pixi.js/issues/6303

This makes paddings be added additively to ``Container`` bounds. This means we can get rid
of that calculation in ``FilterSystem`` and ``cacheAsBitmap`` etc.

Calculating bounds additively also fixes issues where an element has multiple filters that each need some padding as well as padding of nested filters.

This is definitely a breaking change because it affects things like ``container.width = w`` that use
bounds in their calculation.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
