### PR TITLE
add option to disable the built-in InteractionManager updater

### DIFF
--- a/packages/interaction/src/InteractionManager.js
+++ b/packages/interaction/src/InteractionManager.js
@@ -730,6 +730,8 @@ export class InteractionManager extends EventEmitter
      */
     setTargetElement(element, resolution = 1)
     {
+        this.removeTicker();
+
         this.removeEvents();
 
         this.interactionDOMElement = element;
@@ -852,8 +854,6 @@ export class InteractionManager extends EventEmitter
         {
             return;
         }
-
-        Ticker.system.remove(this.tickerUpdate, this);
 
         if (window.navigator.msPointerEnabled)
         {

--- a/packages/interaction/src/InteractionManager.js
+++ b/packages/interaction/src/InteractionManager.js
@@ -750,7 +750,7 @@ export class InteractionManager extends EventEmitter
      */
     addTicker()
     {
-        if (this.tickerAdded || !this.interactionDOMElement || !this._useSystemTicker) {
+        if (this.tickerAdded || !this.interactionDOMElement || !this._useSystemTicker)
         {
             return;
         }

--- a/packages/interaction/src/InteractionManager.js
+++ b/packages/interaction/src/InteractionManager.js
@@ -686,11 +686,11 @@ export class InteractionManager extends EventEmitter
 
         if (useSystemTicker)
         {
-            this.addTicker();
+            this.addTickerListener();
         }
         else
         {
-            this.removeTicker();
+            this.removeTickerListener();
         }
     }
 
@@ -730,7 +730,7 @@ export class InteractionManager extends EventEmitter
      */
     setTargetElement(element, resolution = 1)
     {
-        this.removeTicker();
+        this.removeTickerListener();
 
         this.removeEvents();
 
@@ -740,15 +740,15 @@ export class InteractionManager extends EventEmitter
 
         this.addEvents();
 
-        this.addTicker();
+        this.addTickerListener();
     }
 
     /**
-     * Add the ticker
+     * Add the ticker listener
      *
      * @private
      */
-    addTicker()
+    addTickerListener()
     {
         if (this.tickerAdded || !this.interactionDOMElement || !this._useSystemTicker)
         {
@@ -761,11 +761,11 @@ export class InteractionManager extends EventEmitter
     }
 
     /**
-     * Remove the ticker
+     * Remove the ticker listener
      *
      * @private
      */
-    removeTicker()
+    removeTickerListener()
     {
         if (!this.tickerAdded)
         {
@@ -845,12 +845,7 @@ export class InteractionManager extends EventEmitter
      */
     removeEvents()
     {
-        if (!this.eventsAdded)
-        {
-            return;
-        }
-
-        if (!this.interactionDOMElement)
+        if (!this.eventsAdded || !this.interactionDOMElement)
         {
             return;
         }
@@ -1804,7 +1799,7 @@ export class InteractionManager extends EventEmitter
     {
         this.removeEvents();
 
-        this.removeTicker();
+        this.removeTickerListener();
 
         this.removeAllListeners();
 

--- a/packages/interaction/src/InteractionManager.js
+++ b/packages/interaction/src/InteractionManager.js
@@ -40,7 +40,8 @@ export class InteractionManager extends EventEmitter
      * @param {PIXI.CanvasRenderer|PIXI.Renderer} renderer - A reference to the current renderer
      * @param {object} [options] - The options for the manager.
      * @param {boolean} [options.autoPreventDefault=true] - Should the manager automatically prevent default browser actions.
-     * @param {number} [options.interactionFrequency=10] - Frequency increases the interaction events will be checked.
+     * @param {number} [options.interactionFrequency=10] - Maximum requency (ms) at pointer over/out states will be checked.
+     * @param {number} [options.useSystemTicker=true] - Whether to add {@link tickerUpdate} to {@link PIXI.Ticker.system}.
      */
     constructor(renderer, options)
     {
@@ -67,7 +68,7 @@ export class InteractionManager extends EventEmitter
         this.autoPreventDefault = options.autoPreventDefault !== undefined ? options.autoPreventDefault : true;
 
         /**
-         * Frequency in milliseconds that the mousemove, mouseover & mouseout interaction events will be checked.
+         * Maximum requency in milliseconds at which pointer over/out states will be checked by {@link tickerUpdate}.
          *
          * @member {number}
          * @default 10
@@ -138,6 +139,14 @@ export class InteractionManager extends EventEmitter
          * @member {boolean}
          */
         this.eventsAdded = false;
+
+        /**
+         * Has the system ticker been added?
+         *
+         * @protected
+         * @member {boolean}
+         */
+        this.tickerAdded = false;
 
         /**
          * Is the mouse hovering over the renderer?
@@ -656,7 +665,33 @@ export class InteractionManager extends EventEmitter
          * @param {PIXI.interaction.InteractionEvent} event - Interaction event
          */
 
+        this._useSystemTicker = options.useSystemTicker !== undefined ? options.useSystemTicker : true;
+
         this.setTargetElement(this.renderer.view, this.renderer.resolution);
+    }
+
+    /**
+     * Should the InteractionManager automatically add {@link tickerUpdate} to {@link PIXI.Ticker.system}.
+     *
+     * @member {boolean}
+     * @default true
+     */
+    get useSystemTicker()
+    {
+        return this._useSystemTicker;
+    }
+    set useSystemTicker(useSystemTicker)
+    {
+        this._useSystemTicker = useSystemTicker;
+
+        if (useSystemTicker)
+        {
+            this.addTicker();
+        }
+        else
+        {
+            this.removeTicker();
+        }
     }
 
     /**
@@ -702,6 +737,42 @@ export class InteractionManager extends EventEmitter
         this.resolution = resolution;
 
         this.addEvents();
+
+        this.addTicker();
+    }
+
+    /**
+     * Add the ticker
+     *
+     * @private
+     */
+    addTicker()
+    {
+        if (this.tickerAdded || !this.interactionDOMElement || !this._useSystemTicker) {
+        {
+            return;
+        }
+
+        Ticker.system.add(this.tickerUpdate, this, UPDATE_PRIORITY.INTERACTION);
+
+        this.tickerAdded = true;
+    }
+
+    /**
+     * Remove the ticker
+     *
+     * @private
+     */
+    removeTicker()
+    {
+        if (!this.tickerAdded)
+        {
+            return;
+        }
+
+        Ticker.system.remove(this.tickerUpdate, this);
+
+        this.tickerAdded = false;
     }
 
     /**
@@ -711,12 +782,10 @@ export class InteractionManager extends EventEmitter
      */
     addEvents()
     {
-        if (!this.interactionDOMElement)
+        if (this.eventsAdded || !this.interactionDOMElement)
         {
             return;
         }
-
-        Ticker.system.add(this.update, this, UPDATE_PRIORITY.INTERACTION);
 
         if (window.navigator.msPointerEnabled)
         {
@@ -774,12 +843,17 @@ export class InteractionManager extends EventEmitter
      */
     removeEvents()
     {
+        if (!this.eventsAdded)
+        {
+            return;
+        }
+
         if (!this.interactionDOMElement)
         {
             return;
         }
 
-        Ticker.system.remove(this.update, this);
+        Ticker.system.remove(this.tickerUpdate, this);
 
         if (window.navigator.msPointerEnabled)
         {
@@ -823,12 +897,14 @@ export class InteractionManager extends EventEmitter
     }
 
     /**
-     * Updates the state of interactive objects.
+     * Updates the state of interactive objects if at least {@link interactionFrequency}
+     * milliseconds have passed since the last invocation.
+     *
      * Invoked by a throttled ticker update from {@link PIXI.Ticker.system}.
      *
-     * @param {number} deltaTime - time delta since last tick
+     * @param {number} deltaTime - time delta since the last call
      */
-    update(deltaTime)
+    tickerUpdate(deltaTime)
     {
         this._deltaTime += deltaTime;
 
@@ -839,6 +915,14 @@ export class InteractionManager extends EventEmitter
 
         this._deltaTime = 0;
 
+        this.update();
+    }
+
+    /**
+     * Updates the state of interactive objects.
+     */
+    update()
+    {
         if (!this.interactionDOMElement)
         {
             return;
@@ -1719,6 +1803,8 @@ export class InteractionManager extends EventEmitter
     destroy()
     {
         this.removeEvents();
+
+        this.removeTicker();
 
         this.removeAllListeners();
 

--- a/packages/interaction/test/InteractionManager.js
+++ b/packages/interaction/test/InteractionManager.js
@@ -1,5 +1,6 @@
 const MockPointer = require('./MockPointer');
 const { Container } = require('@pixi/display');
+const { Ticker } = require('@pixi/ticker');
 const { Graphics } = require('@pixi/graphics');
 const { Point, Rectangle } = require('@pixi/math');
 const { CanvasRenderer } = require('@pixi/canvas-renderer');
@@ -380,7 +381,7 @@ describe('PIXI.interaction.InteractionManager', function ()
         });
     });
 
-    describe('add/remove events', function ()
+    describe('add/remove events and ticker', function ()
     {
         let stub;
 
@@ -616,6 +617,41 @@ describe('PIXI.interaction.InteractionManager', function ()
             expect(element.removeEventListener).to.have.been.calledWith('touchcancel');
             expect(element.removeEventListener).to.have.been.calledWith('touchend');
             expect(element.removeEventListener).to.have.been.calledWith('touchmove');
+        });
+
+        it('should add and remove Ticker.system listener', function ()
+        {
+            const manager = new InteractionManager(sinon.stub());
+
+            const element = {};
+
+            manager.interactionDOMElement = element;
+
+            const listenerCount = Ticker.system.count;
+
+            manager.addTickerListener();
+
+            expect(Ticker.system.count).to.equal(listenerCount + 1);
+
+            manager.useSystemTicker = false;
+
+            expect(Ticker.system.count).to.equal(listenerCount);
+
+            manager.useSystemTicker = true;
+
+            expect(Ticker.system.count).to.equal(listenerCount + 1);
+
+            manager.removeTickerListener();
+
+            expect(Ticker.system.count).to.equal(listenerCount);
+
+            manager.useSystemTicker = false;
+
+            expect(Ticker.system.count).to.equal(listenerCount);
+
+            manager.addTickerListener();
+
+            expect(Ticker.system.count).to.equal(listenerCount);
         });
     });
 

--- a/packages/ticker/src/Ticker.ts
+++ b/packages/ticker/src/Ticker.ts
@@ -365,6 +365,10 @@ export class Ticker
      */
     get count(): number
     {
+        if (!this._head) {
+            return 0;
+        }
+
         let count = 0;
         let current = this._head;
 

--- a/packages/ticker/src/Ticker.ts
+++ b/packages/ticker/src/Ticker.ts
@@ -365,7 +365,8 @@ export class Ticker
      */
     get count(): number
     {
-        if (!this._head) {
+        if (!this._head)
+        {
             return 0;
         }
 

--- a/packages/ticker/src/Ticker.ts
+++ b/packages/ticker/src/Ticker.ts
@@ -359,6 +359,24 @@ export class Ticker
     }
 
     /**
+     * Counts the number of listeners on this ticker.
+     *
+     * @returns {number} The number of listeners on this ticker
+     */
+    get count(): number
+    {
+        let count = 0;
+        let current = this._head;
+
+        while ((current = current.next))
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+    /**
      * Starts the ticker. If the ticker has listeners
      * a new animation frame is requested at this point.
      */

--- a/packages/ticker/test/Ticker.js
+++ b/packages/ticker/test/Ticker.js
@@ -122,6 +122,33 @@ describe('PIXI.Ticker', function ()
         expect(this.length()).to.equal(length);
     });
 
+    it('should count listeners correctly', function ()
+    {
+        const ticker = new Ticker();
+
+        expect(ticker.count).to.equal(0);
+
+        const listener = sinon.spy();
+
+        ticker.add(listener);
+
+        expect(ticker.count).to.equal(1);
+
+        ticker.add(listener);
+
+        expect(ticker.count).to.equal(2);
+
+        ticker.remove(listener);
+
+        expect(ticker.count).to.equal(0);
+
+        ticker.destroy();
+
+        expect(ticker._head).to.be.null;
+        expect(ticker.started).to.be.false;
+        expect(this.length(ticker)).to.equal(0);
+    });
+
     it('should respect priority order', function ()
     {
         const length = this.length();


### PR DESCRIPTION
##### Description of change

By default ``InteractionManager`` adds ``InteractionManager.update`` to ``Ticker.system``.
Except for now adding ``tickerUpdater`` *instead* this behavior is unchanged.

``tickerUpdate`` now contains the rate limiting check based on ``deltaTime``, then calls ``update`` if it passed.

A configuration option ``InteractionManager.useSystemTicker`` has been added. If it is
set to ``true``, InteractionManager won't automatically use the system ticker.

This partially fixes the problems outlined in https://github.com/pixijs/pixi.js/issues/6307

Basically you can now use your own updating logic like this:

```js
// ...

const renderer = new pixi.Renderer();
renderer.plugins.interaction.useSystemTicker = false;

function renderOneFrame() {
    // update scene
    gameLogic();

    // update transforms once, needs a parent element
    root.updateTransform(); 

    // update hover states
    renderer.plugins.interaction.update(); 

    // the fifth argument prevents updating transforms a second time
    renderer.render(root, null, null, null, true); 
}
```

Thanks to these changes a 3 second performance capture of my application in idle state looks like 
this: 

<img src="https://i.imgur.com/YM3hlz9.png"></img>

Instead of this monstrosity:

<img src="https://i.imgur.com/vmlAzS0.png"></img>

Your battery life will thank you. On my system this saves about 500 wakeups/second in powertop.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
