### PR TITLE
Fixes modules/types not being found by typescript from js packages

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,16 +1,4 @@
 declare module '@pixi/settings';
-declare module '@pixi/constants';
-declare module '@pixi/core' {
-    interface Texture {
-        destroy(): void;
-    }
-
-    interface BaseTexture {
-        destroy(): void;
-    }
-
-    interface Program {}
-}
 
 declare interface IApplicationOptions {
     autoStart?: boolean;

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prerelease": "npm run clean:build && npm test",
     "postversion": "npm run build:prod",
     "release": "lerna publish --exact",
-    "compile:docs": "tsc -p tsconfig.docs.json"
+    "compile:docs": "tsc -p tsconfig.docs.json --skipLibCheck"
   },
   "pre-commit": [
     "lintfix"

--- a/tsconfig.docs.json
+++ b/tsconfig.docs.json
@@ -3,6 +3,22 @@
     "compilerOptions": {
         "target": "es6",
         "outDir": "./dist/compiled",
-        "sourceMap": false
-    }
+        "sourceMap": false,
+        "allowJs": true
+    },
+    "include": [
+        "bundles",
+        "packages",
+        "./global.d.ts"
+    ],
+    "exclude": [
+        "node_modules",
+        "**/dist/**",
+        "**/lib/**",
+        "**/test/**",
+        "**/scripts/**",
+        "**/types/**",
+        "bundles/*/*.d.ts",
+        "rollup.config.js",
+    ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,14 @@
         "noUnusedParameters": true,
         "noImplicitReturns": true,
         "strictNullChecks": false,
-        "esModuleInterop": true
+        "esModuleInterop": true,
+        "moduleResolution": "node",
+        "baseUrl": "./",
+        "paths": {
+            "@pixi/*": ["packages/*/src", "packages/filters/*/src", "packages/canvas/*/src"],
+            "pixi.js": ["bundles/pixi.js/src"],
+            "pixi.js-legacy": ["bundles/pixi.js-legacy/src"]
+        }
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
As discussed here #6261 and in the slack channels there have been issues with getting types and modules being recognised properly.

Before we ran into issues of either a module not being recognised or cannot use namespace as type, depending on the different solutions that have been thrown around.

With this change we no longer need to declare modules inside the `global.d.ts` file (except for settings as this one is weird). We should also get types for packages that are still in javascript.

I've tested this out on my display branch and it fixed all my build issues. 

@EvidentlyCube @ivanpopelyshev  this should help with the core/spritesheet packages as well. 

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x ] Lint process passed (`npm run lint`)
- [x ] Tests passed (`npm run test`)
