### PR TITLE
Fixes docs for DecomposedDataUri

### DIFF
--- a/packages/utils/src/network/decomposeDataUri.ts
+++ b/packages/utils/src/network/decomposeDataUri.ts
@@ -1,30 +1,46 @@
 import { DATA_URI } from '../const';
 
-/**
- * @memberof PIXI.utils
- */
 export interface DecomposedDataUri {
-    /**
-     * @property {string} Media type, eg. `image`
-     */
     mediaType: string;
-    /**
-     * @property {string} subType Sub type, eg. `png`
-     */
     subType: string;
-    /**
-     * @property {string} charset
-     */
     charset: string;
-    /**
-     * @property {string} encoding Data encoding, eg. `base64`
-     */
     encoding: string;
-    /**
-     * @property {string} data The actual data
-     */
     data: string;
 }
+
+/**
+ * @memberof PIXI.utils
+ * @interface DecomposedDataUri
+ */
+
+/**
+ * type, eg. `image`
+ * @memberof PIXI.utils.DecomposedDataUri#
+ * @member {string} mediaType
+ */
+
+/**
+ * Sub type, eg. `png`
+ * @memberof PIXI.utils.DecomposedDataUri#
+ * @member {string} subType
+ */
+
+/**
+ * @memberof PIXI.utils.DecomposedDataUri#
+ * @member {string} charset
+ */
+
+/**
+ * Data encoding, eg. `base64`
+ * @memberof PIXI.utils.DecomposedDataUri#
+ * @member {string} encoding
+ */
+
+/**
+ * The actual data
+ * @memberof PIXI.utils.DecomposedDataUri#
+ * @member {string} data
+ */
 
 /**
  * Split a data URI into components. Returns undefined if


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
This pr fixes the automatically generated types where `DecomposedDataUri` is not exported. This has been an issue before in #6150 where interfaces are stripped out along with there comments.

To document it in a way that it doesn't get removed means defining it below its declaration
##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
