### PR TITLE
A fix to maintain the text gradient when modifying the drop shadow distance.

### DIFF
--- a/packages/text/src/Text.js
+++ b/packages/text/src/Text.js
@@ -437,8 +437,12 @@ export class Text extends Sprite
         let currentIteration;
         let stop;
 
-        const width = Math.ceil(this.canvas.width / this._resolution);
-        const height = Math.ceil(this.canvas.height / this._resolution);
+        // a dropshadow will enlarge the canvas and result in the gradient being
+        // generated with the incorrect dimensions
+        const dropShadowCorrection = (style.dropShadow) ? style.dropShadowDistance : 0;
+
+        const width = Math.ceil(this.canvas.width / this._resolution) - dropShadowCorrection;
+        const height = Math.ceil(this.canvas.height / this._resolution) - dropShadowCorrection;
 
         // make a copy of the style settings, so we can manipulate them later
         const fill = style.fill.slice();


### PR DESCRIPTION
For example, see: https://pixijs.io/examples/#/text/text.js

In the example above, when modifying the dropShadowDistance, try 100, one will observe the gradient distorting across the 3 lines of text.

Animating it will result in a clearer demonstration. For example, add the following:
```
app.ticker.add((delta) => {
  richText.style.dropShadowDistance += 1;
});
```

This is due to the drop shadow's offset increasing the dimensions of the canvas used to render the text and which the gradient's calculations rely on.

The fix corrects the dimensions by removing this offset thus maintaining the desired gradient.

<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
