### PR TITLE
fix(render): make cacheAsBitmap not affect other textures with a filter for 1 frame

### DIFF
--- a/packages/mixin-cache-as-bitmap/src/index.js
+++ b/packages/mixin-cache-as-bitmap/src/index.js
@@ -184,8 +184,8 @@ DisplayObject.prototype._initCachedDisplayObject = function _initCachedDisplayOb
 
     // for now we cache the current renderTarget that the WebGL renderer is currently using.
     // this could be more elegant..
-    const cachedRenderTexture = renderer.renderTexture.current ?
-      renderer.renderTexture.current.clone() : null;
+    const cachedRenderTexture = renderer.renderTexture.current
+        ? renderer.renderTexture.current.clone() : null;
     const cachedSourceFrame = renderer.renderTexture.sourceFrame.clone();
     const cachedProjectionTransform = renderer.projection.transform;
 
@@ -244,16 +244,16 @@ DisplayObject.prototype._initCachedDisplayObject = function _initCachedDisplayOb
 
     this.transform._parentID = -1;
     // restore the transform of the cached sprite to avoid the nasty flicker..
-    // if (!this.parent)
-    // {
-    //     this.parent = renderer._tempDisplayObjectParent;
-    //     this.updateTransform();
-    //     this.parent = null;
-    // }
-    // else
-    // {
-    //     this.updateTransform();
-    // }
+    if (!this.parent)
+    {
+        this.parent = renderer._tempDisplayObjectParent;
+        this.updateTransform();
+        this.parent = null;
+    }
+    else
+    {
+        this.updateTransform();
+    }
 
     // map the hit test..
     this.containsPoint = cachedSprite.containsPoint.bind(cachedSprite);

--- a/packages/mixin-cache-as-bitmap/src/index.js
+++ b/packages/mixin-cache-as-bitmap/src/index.js
@@ -184,8 +184,9 @@ DisplayObject.prototype._initCachedDisplayObject = function _initCachedDisplayOb
 
     // for now we cache the current renderTarget that the WebGL renderer is currently using.
     // this could be more elegant..
-    const cachedRenderTexture = renderer.renderTexture.current;
-    const cachedSourceFrame = renderer.renderTexture.sourceFrame;
+    const cachedRenderTexture = renderer.renderTexture.current ?
+      renderer.renderTexture.current.clone() : null;
+    const cachedSourceFrame = renderer.renderTexture.sourceFrame.clone();
     const cachedProjectionTransform = renderer.projection.transform;
 
     // We also store the filter stack - I will definitely look to change how this works a little later down the line.
@@ -243,16 +244,16 @@ DisplayObject.prototype._initCachedDisplayObject = function _initCachedDisplayOb
 
     this.transform._parentID = -1;
     // restore the transform of the cached sprite to avoid the nasty flicker..
-    if (!this.parent)
-    {
-        this.parent = renderer._tempDisplayObjectParent;
-        this.updateTransform();
-        this.parent = null;
-    }
-    else
-    {
-        this.updateTransform();
-    }
+    // if (!this.parent)
+    // {
+    //     this.parent = renderer._tempDisplayObjectParent;
+    //     this.updateTransform();
+    //     this.parent = null;
+    // }
+    // else
+    // {
+    //     this.updateTransform();
+    // }
 
     // map the hit test..
     this.containsPoint = cachedSprite.containsPoint.bind(cachedSprite);


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change

The issue I was experiencing was that I had a single texture that had a custom filter. Any time I created a new Graphics object and set `cacheAsBitmap` to true, the texture with the custom filter would partially flicker for that frame while the Graphic was being cached. This change fixed the problem for me.

I saw an issue which may be the same as my problem here: https://github.com/pixijs/pixi.js/issues/2831

If you really need me to, I could make a new reproducible test demo. But preferably not, I think this change is quite straightforward.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
