### PR TITLE
Clarify boundsID

### DIFF
--- a/packages/display/src/Bounds.js
+++ b/packages/display/src/Bounds.js
@@ -38,6 +38,15 @@ export class Bounds
         this.maxY = -Infinity;
 
         this.rect = null;
+
+        /**
+         * It is updated to _boundsID of corresponding object to keep bounds in sync with content.
+         * Updated from outside, thus public modifier.
+         *
+         * @member {number}
+         * @public
+         */
+        this.updateID = -1;
     }
 
     /**

--- a/packages/display/src/Container.js
+++ b/packages/display/src/Container.js
@@ -468,7 +468,7 @@ export class Container extends DisplayObject
             }
         }
 
-        this._lastBoundsID = this._boundsID;
+        this._bounds.updateID = this._boundsID;
     }
 
     /**

--- a/packages/display/src/DisplayObject.js
+++ b/packages/display/src/DisplayObject.js
@@ -145,7 +145,6 @@ export class DisplayObject extends EventEmitter
          */
         this._bounds = new Bounds();
         this._boundsID = 0;
-        this._lastBoundsID = -1;
         this._boundsRect = null;
         this._localBoundsRect = null;
 
@@ -273,10 +272,10 @@ export class DisplayObject extends EventEmitter
             }
         }
 
-        if (this._boundsID !== this._lastBoundsID)
+        if (this._bounds.updateID !== this._boundsID)
         {
             this.calculateBounds();
-            this._lastBoundsID = this._boundsID;
+            this._bounds.updateID = this._boundsID;
         }
 
         if (!rect)

--- a/packages/mixin-cache-as-bitmap/src/index.js
+++ b/packages/mixin-cache-as-bitmap/src/index.js
@@ -381,7 +381,7 @@ DisplayObject.prototype._calculateCachedBounds = function _calculateCachedBounds
     this._bounds.clear();
     this._cacheData.sprite.transform._worldID = this.transform._worldID;
     this._cacheData.sprite._calculateBounds();
-    this._lastBoundsID = this._boundsID;
+    this._bounds.updateID = this._boundsID;
 };
 
 /**


### PR DESCRIPTION
It is my fault that #6261 had conflicts, because I made a mistake in review. The problem appeared when we tried to merge #6304  and found that field is still used.

So, lets clear how exactly `_boundsID` is handled:

DisplayObject invalidates its `_boundsID`. The dependent inner object, `_bounds`, tracks its version, and it is being updated in `calculateBounds`. The tracker is stored in `_bounds.updateID`.

No more `lastBoundsID`.

In future, I hope to separate global bounds from local ones and content bounds, thus I store updateID in object that contains the result - we will have multiple objects like that.

Alternatives:

0. Merge this, then merge it with TS convertion
1. I integrate that PR in typescript convertion
2. We disbandle this thing and leave _lastBounds
