### PR TITLE
Typescript display bounds fix

### DIFF
--- a/packages/display/src/Container.ts
+++ b/packages/display/src/Container.ts
@@ -2,7 +2,6 @@ import { MaskData, Renderer } from '@pixi/core';
 import { settings } from '@pixi/settings';
 import { removeItems } from '@pixi/utils';
 import { DisplayObject, IDestroyOptions } from './DisplayObject';
-import { Bounds } from './Bounds';
 
 function sortChildren(a: DisplayObject, b: DisplayObject): number
 {
@@ -465,12 +464,12 @@ export class Container extends DisplayObject
             // TODO: filter+mask, need to mask both somehow
             if (child._mask)
             {
-                const maskObject = (child._mask as MaskData).maskObject || (child._mask as Container);
+                const maskObject = ((child._mask as MaskData).maskObject || child._mask) as Container;
 
                 // TODO: maskObject is getting PIXI.DisplayObject and DisplayObject confused.
                 // Once types are sorted we wont need to do this weird conversion
-                (maskObject as DisplayObject|Container).calculateBounds();
-                this._bounds.addBoundsMask(child._bounds, (maskObject._bounds as Bounds));
+                maskObject.calculateBounds();
+                this._bounds.addBoundsMask(child._bounds, maskObject._bounds);
             }
             else if (child.filterArea)
             {

--- a/packages/display/src/Container.ts
+++ b/packages/display/src/Container.ts
@@ -466,8 +466,6 @@ export class Container extends DisplayObject
             {
                 const maskObject = ((child._mask as MaskData).maskObject || child._mask) as Container;
 
-                // TODO: maskObject is getting PIXI.DisplayObject and DisplayObject confused.
-                // Once types are sorted we wont need to do this weird conversion
                 maskObject.calculateBounds();
                 this._bounds.addBoundsMask(child._bounds, maskObject._bounds);
             }

--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -42,7 +42,6 @@ export abstract class DisplayObject extends EventEmitter
     protected _zIndex: number;
     protected _enabledFilters: Filter[];
     protected _boundsID: number;
-    protected _lastBoundsID: number;
     protected _boundsRect: Rectangle;
     protected _localBoundsRect: Rectangle;
     protected _destroyed: boolean;


### PR DESCRIPTION
I congratulate @Zyie with merge of his big PR, there are not many people that had modified that many lines in PixiJS in one commit, its certainly an achievement!

Now to fixes:
1. `_lastBoundsID` is not needed anymore.
2. my typescript still complaints about certain expression in `Container` I do not understand why, I've tried several versions of TS. Lets make it simple.