### PR TITLE
Fix gaps in circle geometry again

### DIFF
--- a/packages/graphics/src/utils/buildCircle.js
+++ b/packages/graphics/src/utils/buildCircle.js
@@ -49,7 +49,7 @@ export const buildCircle = {
 
         const seg = (Math.PI * 2) / totalSegs;
 
-        for (let i = 0; i < totalSegs - 1; i++)
+        for (let i = 0; i < totalSegs - 0.5; i++)
         {
             points.push(
                 x + (Math.sin(-seg * i) * width),

--- a/packages/graphics/src/utils/buildCircle.js
+++ b/packages/graphics/src/utils/buildCircle.js
@@ -49,7 +49,7 @@ export const buildCircle = {
 
         const seg = (Math.PI * 2) / totalSegs;
 
-        for (let i = 0; i < totalSegs; i++)
+        for (let i = 0; i < totalSegs - 1; i++)
         {
             points.push(
                 x + (Math.sin(-seg * i) * width),


### PR DESCRIPTION
Fix #6327 


Sometimes (with specific radius) `totalSegs` is integer and this case generate extra point same as start point.

Ex:
```
r = 5.3;
Math.floor(30 * Math.sqrt(r)) / 2.3 => 30.00000004
```

Reproduced by:
https://www.pixiplayground.com/#/edit/Iv9DmRYIMeoPAb-TQyBpq
Look in to console. 
Start and 2 end  points are similar.

Line builder fails when more that 2 points one after another is same and generate line segments on [0,0] for them.

Fixed:
https://www.pixiplayground.com/#/edit/OzhTsdVMM0xE-7O1Tcima
##### Description of change
##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
