### PR TITLE
Program name is default to constructor.name rather than "pixi-shader"

### DIFF
--- a/packages/core/src/shader/Program.js
+++ b/packages/core/src/shader/Program.js
@@ -29,7 +29,7 @@ export class Program
      * @param {string} [fragmentSrc] - The source of the fragment shader.
      * @param {string} [name] - Name for shader
      */
-    constructor(vertexSrc, fragmentSrc, name = 'pixi-shader')
+    constructor(vertexSrc, fragmentSrc, name = `${this.constructor.name}`)
     {
         this.id = UID++;
 


### PR DESCRIPTION
Pretty self-descriptive. Related to #6337 
