### PR TITLE
Fix the dist-tag for v4 to be "legacy"

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "lib": "babel src --out-dir lib -s",
     "predocs": "rimraf docs/**",
     "docs": "jsdoc -c scripts/jsdoc.conf.json -R README.md",
-    "publish:patch": "npm version patch && npm publish",
-    "publish:minor": "npm version minor && npm publish",
-    "publish:major": "npm version major && npm publish",
+    "publish:patch": "npm version patch && npm publish --tag legacy",
+    "publish:minor": "npm version minor && npm publish --tag legacy",
+    "publish:major": "npm version major && npm publish --tag legacy",
     "postversion": "npm run clean && npm run build && npm run lib && npm run unit-test",
     "postpublish": "git push && git push --tags"
   },


### PR DESCRIPTION
This is a more permanent fix to #6344 by making sure next time I publish a v4.x version of PixiJS, it'll be under the `legacy` dist-tag on npm instead of `latest`.