### PR TITLE
workaround for firefox/mesa only allowing up to 16 samplers

### DIFF
--- a/packages/core/src/batch/AbstractBatchRenderer.js
+++ b/packages/core/src/batch/AbstractBatchRenderer.js
@@ -6,6 +6,7 @@ import { State } from '../state/State';
 import { ViewableBuffer } from '../geometry/ViewableBuffer';
 
 import { checkMaxIfStatementsInShader } from '../shader/utils/checkMaxIfStatementsInShader';
+import { checkMaxSamplersInShader } from '../shader/utils/checkMaxSamplersInShader';
 
 import { settings } from '@pixi/settings';
 import { premultiplyBlendMode, premultiplyTint, nextPow2, log2 } from '@pixi/utils';
@@ -263,6 +264,10 @@ export class AbstractBatchRenderer extends ObjectRenderer
 
             // step 2: check the maximum number of if statements the shader can have too..
             this.MAX_TEXTURES = checkMaxIfStatementsInShader(
+                this.MAX_TEXTURES, gl);
+
+            // step 3: check maximum number of samplers per shader
+            this.MAX_TEXTURES = checkMaxSamplersInShader(
                 this.MAX_TEXTURES, gl);
         }
 

--- a/packages/core/src/shader/utils/checkMaxSamplersInShader.js
+++ b/packages/core/src/shader/utils/checkMaxSamplersInShader.js
@@ -1,0 +1,20 @@
+export function checkMaxSamplersInShader(maxSamplers, gl)
+{
+    if (maxSamplers === 0)
+    {
+        throw new Error('Invalid value of `0` passed to `checkMaxSamplersInShader`');
+    }
+
+    const debugInfo = gl.getExtension('WEBGL_debug_renderer_info');
+    const renderer = gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL);
+
+    // Mesa drivers may crash with more than 16 samplers and Firefox
+    // will actively refuse to create shaders with more than 16 samplers.
+    if (renderer.slice(0, 4).toUpperCase() === 'MESA')
+    {
+        maxSamplers = Math.min(16, maxSamplers);
+    }
+
+    return maxSamplers;
+}
+


### PR DESCRIPTION


##### Description of change
Fixes

``
Pixi.js Warning: gl.getProgramInfoLog() Programs with more than 16 samplers are disallowed on Mesa drivers to avoid crashing.
``

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
