### PR TITLE
Add eslint rule for explicit accessibility modifiers

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -255,7 +255,8 @@
           "rules": {
             "@typescript-eslint/semi": 1,
             "@typescript-eslint/no-explicit-any": 0,
-            "@typescript-eslint/interface-name-prefix": 0
+            "@typescript-eslint/interface-name-prefix": 0,
+            "@typescript-eslint/explicit-member-accessibility": [1, { "overrides": { "constructors": "no-public", "accessors": "no-public" } }]
           }
         }
     ]

--- a/packages/display/src/Bounds.ts
+++ b/packages/display/src/Bounds.ts
@@ -61,7 +61,7 @@ export class Bounds
      *
      * @return {boolean} True if empty.
      */
-    isEmpty(): boolean
+    public isEmpty(): boolean
     {
         return this.minX > this.maxX || this.minY > this.maxY;
     }
@@ -70,7 +70,7 @@ export class Bounds
      * Clears the bounds and resets.
      *
      */
-    clear(): void
+    public clear(): void
     {
         this.minX = Infinity;
         this.minY = Infinity;
@@ -85,7 +85,7 @@ export class Bounds
      * @param {PIXI.Rectangle} rect - temporary object will be used if AABB is not empty
      * @returns {PIXI.Rectangle} A rectangle of the bounds
      */
-    getRectangle(rect: Rectangle): Rectangle
+    public getRectangle(rect: Rectangle): Rectangle
     {
         if (this.minX > this.maxX || this.minY > this.maxY)
         {
@@ -107,7 +107,7 @@ export class Bounds
      *
      * @param {PIXI.IPoint} point - The point to add.
      */
-    addPoint(point: IPoint): void
+    public addPoint(point: IPoint): void
     {
         this.minX = Math.min(this.minX, point.x);
         this.maxX = Math.max(this.maxX, point.x);
@@ -120,7 +120,7 @@ export class Bounds
      *
      * @param {Float32Array} vertices - The verts to add.
      */
-    addQuad(vertices: Float32Array): void
+    public addQuad(vertices: Float32Array): void
     {
         let minX = this.minX;
         let minY = this.minY;
@@ -171,7 +171,7 @@ export class Bounds
      * @param {number} x1 - right X of frame
      * @param {number} y1 - bottom Y of frame
      */
-    addFrame(transform: Transform, x0: number, y0: number, x1: number, y1: number): void
+    public addFrame(transform: Transform, x0: number, y0: number, x1: number, y1: number): void
     {
         this.addFrameMatrix(transform.worldTransform, x0, y0, x1, y1);
     }
@@ -185,7 +185,7 @@ export class Bounds
      * @param {number} x1 - right X of frame
      * @param {number} y1 - bottom Y of frame
      */
-    addFrameMatrix(matrix: Matrix, x0: number, y0: number, x1: number, y1: number): void
+    public addFrameMatrix(matrix: Matrix, x0: number, y0: number, x1: number, y1: number): void
     {
         const a = matrix.a;
         const b = matrix.b;
@@ -241,7 +241,7 @@ export class Bounds
      * @param {number} beginOffset - begin offset
      * @param {number} endOffset - end offset, excluded
      */
-    addVertexData(vertexData: Float32Array, beginOffset: number, endOffset: number): void
+    public addVertexData(vertexData: Float32Array, beginOffset: number, endOffset: number): void
     {
         let minX = this.minX;
         let minY = this.minY;
@@ -273,7 +273,7 @@ export class Bounds
      * @param {number} beginOffset - begin offset
      * @param {number} endOffset - end offset, excluded
      */
-    addVertices(transform: Transform, vertices: Float32Array, beginOffset: number, endOffset: number): void
+    public addVertices(transform: Transform, vertices: Float32Array, beginOffset: number, endOffset: number): void
     {
         this.addVerticesMatrix(transform.worldTransform, vertices, beginOffset, endOffset);
     }
@@ -288,7 +288,7 @@ export class Bounds
      * @param {number} [padX=0] - x padding
      * @param {number} [padY=0] - y padding
      */
-    addVerticesMatrix(matrix: Matrix, vertices: Float32Array, beginOffset: number,
+    public addVerticesMatrix(matrix: Matrix, vertices: Float32Array, beginOffset: number,
         endOffset: number, padX = 0, padY = padX): void
     {
         const a = matrix.a;
@@ -327,7 +327,7 @@ export class Bounds
      *
      * @param {PIXI.Bounds} bounds - The Bounds to be added
      */
-    addBounds(bounds: Bounds): void
+    public addBounds(bounds: Bounds): void
     {
         const minX = this.minX;
         const minY = this.minY;
@@ -346,7 +346,7 @@ export class Bounds
      * @param {PIXI.Bounds} bounds - The Bounds to be added.
      * @param {PIXI.Bounds} mask - TODO
      */
-    addBoundsMask(bounds: Bounds, mask: Bounds): void
+    public addBoundsMask(bounds: Bounds, mask: Bounds): void
     {
         const _minX = bounds.minX > mask.minX ? bounds.minX : mask.minX;
         const _minY = bounds.minY > mask.minY ? bounds.minY : mask.minY;
@@ -373,7 +373,7 @@ export class Bounds
      * @param {PIXI.Bounds} bounds other bounds
      * @param {PIXI.Matrix} matrix multiplicator
      */
-    addBoundsMatrix(bounds: Bounds, matrix: Matrix): void
+    public addBoundsMatrix(bounds: Bounds, matrix: Matrix): void
     {
         this.addFrameMatrix(matrix, bounds.minX, bounds.minY, bounds.maxX, bounds.maxY);
     }
@@ -384,7 +384,7 @@ export class Bounds
      * @param {PIXI.Bounds} bounds - TODO
      * @param {PIXI.Rectangle} area - TODO
      */
-    addBoundsArea(bounds: Bounds, area: Rectangle): void
+    public addBoundsArea(bounds: Bounds, area: Rectangle): void
     {
         const _minX = bounds.minX > area.x ? bounds.minX : area.x;
         const _minY = bounds.minY > area.y ? bounds.minY : area.y;
@@ -412,7 +412,7 @@ export class Bounds
      * @param {number} [paddingX=0] - The horizontal padding amount.
      * @param {number} [paddingY=0] - The vertical padding amount.
      */
-    pad(paddingX = 0, paddingY = paddingX): void
+    public pad(paddingX = 0, paddingY = paddingX): void
     {
         if (!this.isEmpty())
         {
@@ -433,7 +433,7 @@ export class Bounds
      * @param {number} padX - padding X
      * @param {number} padY - padding Y
      */
-    addFramePad(x0: number, y0: number, x1: number, y1: number, padX: number, padY: number): void
+    public addFramePad(x0: number, y0: number, x1: number, y1: number, padX: number, padY: number): void
     {
         x0 -= padX;
         y0 -= padY;

--- a/packages/display/src/Container.ts
+++ b/packages/display/src/Container.ts
@@ -112,7 +112,7 @@ export class Container extends DisplayObject
      * @param {...PIXI.DisplayObject} children - The DisplayObject(s) to add to the container
      * @return {PIXI.DisplayObject} The first child that was added.
      */
-    addChild<T extends DisplayObject[]>(...children: T): T[0]
+    public addChild<T extends DisplayObject[]>(...children: T): T[0]
     {
         // if there is only one argument we can bypass looping through the them
         if (children.length > 1)
@@ -161,7 +161,7 @@ export class Container extends DisplayObject
      * @param {number} index - The index to place the child in
      * @return {PIXI.DisplayObject} The child that was added.
      */
-    addChildAt<T extends DisplayObject>(child: T, index: number): T
+    public addChildAt<T extends DisplayObject>(child: T, index: number): T
     {
         if (index < 0 || index > this.children.length)
         {
@@ -198,7 +198,7 @@ export class Container extends DisplayObject
      * @param {PIXI.DisplayObject} child - First display object to swap
      * @param {PIXI.DisplayObject} child2 - Second display object to swap
      */
-    swapChildren(child: DisplayObject, child2: DisplayObject): void
+    public swapChildren(child: DisplayObject, child2: DisplayObject): void
     {
         if (child === child2)
         {
@@ -219,7 +219,7 @@ export class Container extends DisplayObject
      * @param {PIXI.DisplayObject} child - The DisplayObject instance to identify
      * @return {number} The index position of the child display object to identify
      */
-    getChildIndex(child: DisplayObject): number
+    public getChildIndex(child: DisplayObject): number
     {
         const index = this.children.indexOf(child);
 
@@ -237,7 +237,7 @@ export class Container extends DisplayObject
      * @param {PIXI.DisplayObject} child - The child DisplayObject instance for which you want to change the index number
      * @param {number} index - The resulting index number for the child display object
      */
-    setChildIndex(child: DisplayObject, index: number): void
+    public setChildIndex(child: DisplayObject, index: number): void
     {
         if (index < 0 || index >= this.children.length)
         {
@@ -258,7 +258,7 @@ export class Container extends DisplayObject
      * @param {number} index - The index to get the child at
      * @return {PIXI.DisplayObject} The child at the given index, if any.
      */
-    getChildAt(index: number): DisplayObject
+    public getChildAt(index: number): DisplayObject
     {
         if (index < 0 || index >= this.children.length)
         {
@@ -274,7 +274,7 @@ export class Container extends DisplayObject
      * @param {...PIXI.DisplayObject} children - The DisplayObject(s) to remove
      * @return {PIXI.DisplayObject} The first child that was removed.
      */
-    removeChild<T extends DisplayObject[]>(...children: T): T[0]
+    public removeChild<T extends DisplayObject[]>(...children: T): T[0]
     {
         // if there is only one argument we can bypass looping through the them
         if (children.length > 1)
@@ -315,7 +315,7 @@ export class Container extends DisplayObject
      * @param {number} index - The index to get the child from
      * @return {PIXI.DisplayObject} The child that was removed.
      */
-    removeChildAt(index: number): DisplayObject
+    public removeChildAt(index: number): DisplayObject
     {
         const child = this.getChildAt(index);
 
@@ -342,7 +342,7 @@ export class Container extends DisplayObject
      * @param {number} [endIndex=this.children.length] - The ending position. Default value is size of the container.
      * @returns {PIXI.DisplayObject[]} List of removed children
      */
-    removeChildren(beginIndex = 0, endIndex = this.children.length): DisplayObject[]
+    public removeChildren(beginIndex = 0, endIndex = this.children.length): DisplayObject[]
     {
         const begin = beginIndex;
         const end = endIndex;
@@ -385,7 +385,7 @@ export class Container extends DisplayObject
     /**
      * Sorts children by zIndex. Previous order is mantained for 2 children with the same zIndex.
      */
-    sortChildren(): void
+    public sortChildren(): void
     {
         let sortRequired = false;
 
@@ -412,7 +412,7 @@ export class Container extends DisplayObject
     /**
      * Updates the transform on all children of this container for rendering
      */
-    updateTransform(): void
+    public updateTransform(): void
     {
         if (this.sortableChildren && this.sortDirty)
         {
@@ -441,7 +441,7 @@ export class Container extends DisplayObject
      * Recalculates the bounds of the container.
      *
      */
-    calculateBounds(): void
+    public calculateBounds(): void
     {
         this._bounds.clear();
 
@@ -495,7 +495,7 @@ export class Container extends DisplayObject
      *
      * @param {PIXI.Renderer} renderer - The renderer
      */
-    render(renderer: Renderer): void
+    public render(renderer: Renderer): void
     {
         // if the object is not visible or the alpha is 0 then no need to render this element
         if (!this.visible || this.worldAlpha <= 0 || !this.renderable)
@@ -609,7 +609,7 @@ export class Container extends DisplayObject
      * @param {boolean} [options.baseTexture=false] - Only used for child Sprites if options.children is set to true
      *  Should it destroy the base texture of the child sprite
      */
-    destroy(options?: IDestroyOptions|boolean): void
+    public destroy(options?: IDestroyOptions|boolean): void
     {
         super.destroy();
 

--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -54,7 +54,7 @@ export abstract class DisplayObject extends EventEmitter
      *
      * @param {object} source The source of properties and methods to mix in.
      */
-    static mixin(source: {[x: string]: any}): void
+    public static mixin(source: {[x: string]: any}): void
     {
         // in ES8/ES2017, this would be really easy:
         // Object.defineProperties(DisplayObject.prototype, Object.getOwnPropertyDescriptors(source));
@@ -296,7 +296,7 @@ export abstract class DisplayObject extends EventEmitter
      *
      * TODO - Optimization pass!
      */
-    updateTransform(): void
+    public updateTransform(): void
     {
         this._boundsID++;
 
@@ -314,7 +314,7 @@ export abstract class DisplayObject extends EventEmitter
      * @param {PIXI.Rectangle} [rect] - Optional rectangle to store the result of the bounds calculation.
      * @return {PIXI.Rectangle} The rectangular bounding area.
      */
-    getBounds(skipUpdate?: boolean, rect?: Rectangle): Rectangle
+    public getBounds(skipUpdate?: boolean, rect?: Rectangle): Rectangle
     {
         if (!skipUpdate)
         {
@@ -356,7 +356,7 @@ export abstract class DisplayObject extends EventEmitter
      * @param {PIXI.Rectangle} [rect] - Optional rectangle to store the result of the bounds calculation.
      * @return {PIXI.Rectangle} The rectangular bounding area.
      */
-    getLocalBounds(rect?: Rectangle): Rectangle
+    public getLocalBounds(rect?: Rectangle): Rectangle
     {
         const transformRef = this.transform;
         const parentRef = this.parent;
@@ -391,7 +391,7 @@ export abstract class DisplayObject extends EventEmitter
      * @param {boolean} [skipUpdate=false] - Should we skip the update transform.
      * @return {PIXI.Point} A point object representing the position of this object.
      */
-    toGlobal(position: IPoint, point?: Point, skipUpdate = false): Point
+    public toGlobal(position: IPoint, point?: Point, skipUpdate = false): Point
     {
         if (!skipUpdate)
         {
@@ -426,7 +426,7 @@ export abstract class DisplayObject extends EventEmitter
      * @param {boolean} [skipUpdate=false] - Should we skip the update transform
      * @return {PIXI.Point} A point object representing the position of this object
      */
-    toLocal(position: IPoint, from: DisplayObject, point?: Point, skipUpdate?: boolean): Point
+    public toLocal(position: IPoint, from: DisplayObject, point?: Point, skipUpdate?: boolean): Point
     {
         if (from)
         {
@@ -462,7 +462,7 @@ export abstract class DisplayObject extends EventEmitter
      * @param {PIXI.Container} container - The Container to add this DisplayObject to.
      * @return {PIXI.Container} The Container that this DisplayObject was added to.
      */
-    setParent(container: Container): Container
+    public setParent(container: Container): Container
     {
         if (!container || !container.addChild)
         {
@@ -488,7 +488,9 @@ export abstract class DisplayObject extends EventEmitter
      * @param {number} [pivotY=0] - The Y pivot value
      * @return {PIXI.DisplayObject} The DisplayObject instance
      */
-    setTransform(x = 0, y = 0, scaleX = 1, scaleY = 1, rotation = 0, skewX = 0, skewY = 0, pivotX = 0, pivotY = 0): this
+    public setTransform(
+        x = 0, y = 0, scaleX = 1, scaleY = 1, rotation = 0, skewX = 0, skewY = 0, pivotX = 0, pivotY = 0
+    ): this
     {
         this.position.x = x;
         this.position.y = y;
@@ -511,7 +513,7 @@ export abstract class DisplayObject extends EventEmitter
      *
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    destroy(_options?: IDestroyOptions|boolean): void
+    public destroy(_options?: IDestroyOptions|boolean): void
     {
         if (this.parent)
         {
@@ -792,8 +794,8 @@ export abstract class DisplayObject extends EventEmitter
 
 class TemporaryDisplayObject extends DisplayObject
 {
-    calculateBounds: () => {} = null;
-    removeChild: (child: DisplayObject) => {} = null;
-    render: (renderer: Renderer) => {} = null;
-    sortDirty: boolean = null;
+    public calculateBounds: () => {} = null;
+    public removeChild: (child: DisplayObject) => {} = null;
+    public render: (renderer: Renderer) => {} = null;
+    public sortDirty: boolean = null;
 }

--- a/packages/math/src/Matrix.ts
+++ b/packages/math/src/Matrix.ts
@@ -85,7 +85,7 @@ export class Matrix
      *
      * @param {number[]} array - The array that the matrix will be populated from.
      */
-    fromArray(array: number[]): void
+    public fromArray(array: number[]): void
     {
         this.a = array[0];
         this.b = array[1];
@@ -107,7 +107,7 @@ export class Matrix
      *
      * @return {PIXI.Matrix} This matrix. Good for chaining method calls.
      */
-    set(a: number, b: number, c: number, d: number, tx: number, ty: number): this
+    public set(a: number, b: number, c: number, d: number, tx: number, ty: number): this
     {
         this.a = a;
         this.b = b;
@@ -126,7 +126,7 @@ export class Matrix
      * @param {Float32Array} [out=new Float32Array(9)] - If provided the array will be assigned to out
      * @return {number[]} the newly created array which contains the matrix
      */
-    toArray(transpose: boolean, out?: Float32Array): Float32Array
+    public toArray(transpose: boolean, out?: Float32Array): Float32Array
     {
         if (!this.array)
         {
@@ -171,7 +171,7 @@ export class Matrix
      * @param {PIXI.Point} [newPos] - The point that the new position is assigned to (allowed to be same as input)
      * @return {PIXI.Point} The new point, transformed through this matrix
      */
-    apply(pos: IPoint, newPos?: Point): Point
+    public apply(pos: IPoint, newPos?: Point): Point
     {
         newPos = newPos || new Point();
 
@@ -192,7 +192,7 @@ export class Matrix
      * @param {PIXI.Point} [newPos] - The point that the new position is assigned to (allowed to be same as input)
      * @return {PIXI.Point} The new point, inverse-transformed through this matrix
      */
-    applyInverse(pos: IPoint, newPos?: Point): Point
+    public applyInverse(pos: IPoint, newPos?: Point): Point
     {
         newPos = newPos || new Point();
 
@@ -214,7 +214,7 @@ export class Matrix
      * @param {number} y How much to translate y by
      * @return {PIXI.Matrix} This matrix. Good for chaining method calls.
      */
-    translate(x: number, y: number): this
+    public translate(x: number, y: number): this
     {
         this.tx += x;
         this.ty += y;
@@ -229,7 +229,7 @@ export class Matrix
      * @param {number} y The amount to scale vertically
      * @return {PIXI.Matrix} This matrix. Good for chaining method calls.
      */
-    scale(x: number, y: number): this
+    public scale(x: number, y: number): this
     {
         this.a *= x;
         this.d *= y;
@@ -247,7 +247,7 @@ export class Matrix
      * @param {number} angle - The angle in radians.
      * @return {PIXI.Matrix} This matrix. Good for chaining method calls.
      */
-    rotate(angle: number): this
+    public rotate(angle: number): this
     {
         const cos = Math.cos(angle);
         const sin = Math.sin(angle);
@@ -272,7 +272,7 @@ export class Matrix
      * @param {PIXI.Matrix} matrix - The matrix to append.
      * @return {PIXI.Matrix} This matrix. Good for chaining method calls.
      */
-    append(matrix: Matrix): this
+    public append(matrix: Matrix): this
     {
         const a1 = this.a;
         const b1 = this.b;
@@ -304,7 +304,7 @@ export class Matrix
      * @param {number} skewY - Skew on the y axis
      * @return {PIXI.Matrix} This matrix. Good for chaining method calls.
      */
-    setTransform(x: number, y: number, pivotX: number, pivotY: number, scaleX: number,
+    public setTransform(x: number, y: number, pivotX: number, pivotY: number, scaleX: number,
         scaleY: number, rotation: number, skewX: number, skewY: number): this
     {
         this.a = Math.cos(rotation + skewY) * scaleX;
@@ -324,7 +324,7 @@ export class Matrix
      * @param {PIXI.Matrix} matrix - The matrix to prepend
      * @return {PIXI.Matrix} This matrix. Good for chaining method calls.
      */
-    prepend(matrix: Matrix): this
+    public prepend(matrix: Matrix): this
     {
         const tx1 = this.tx;
 
@@ -351,7 +351,7 @@ export class Matrix
      * @param {PIXI.Transform} transform - The transform to apply the properties to.
      * @return {PIXI.Transform} The transform with the newly applied properties
      */
-    decompose(transform: Transform): Transform
+    public decompose(transform: Transform): Transform
     {
         // sort out rotation / skew..
         const a = this.a;
@@ -392,7 +392,7 @@ export class Matrix
      *
      * @return {PIXI.Matrix} This matrix. Good for chaining method calls.
      */
-    invert(): this
+    public invert(): this
     {
         const a1 = this.a;
         const b1 = this.b;
@@ -416,7 +416,7 @@ export class Matrix
      *
      * @return {PIXI.Matrix} This matrix. Good for chaining method calls.
      */
-    identity(): this
+    public identity(): this
     {
         this.a = 1;
         this.b = 0;
@@ -433,7 +433,7 @@ export class Matrix
      *
      * @return {PIXI.Matrix} A copy of this matrix. Good for chaining method calls.
      */
-    clone(): Matrix
+    public clone(): Matrix
     {
         const matrix = new Matrix();
 
@@ -453,7 +453,7 @@ export class Matrix
      * @param {PIXI.Matrix} matrix - The matrix to copy to.
      * @return {PIXI.Matrix} The matrix given in parameter with its values updated.
      */
-    copyTo(matrix: Matrix): Matrix
+    public copyTo(matrix: Matrix): Matrix
     {
         matrix.a = this.a;
         matrix.b = this.b;
@@ -471,7 +471,7 @@ export class Matrix
      * @param {PIXI.Matrix} matrix - The matrix to copy from.
      * @return {PIXI.Matrix} this
      */
-    copyFrom(matrix: Matrix): this
+    public copyFrom(matrix: Matrix): this
     {
         this.a = matrix.a;
         this.b = matrix.b;

--- a/packages/math/src/ObservablePoint.ts
+++ b/packages/math/src/ObservablePoint.ts
@@ -42,7 +42,7 @@ export class ObservablePoint<T = any> implements IPoint
      * @param {object} [scope=null] - owner of callback
      * @return {PIXI.ObservablePoint} a copy of the point
      */
-    clone(cb = this.cb, scope = this.scope): ObservablePoint
+    public clone(cb = this.cb, scope = this.scope): ObservablePoint
     {
         return new ObservablePoint(cb, scope, this._x, this._y);
     }
@@ -55,7 +55,7 @@ export class ObservablePoint<T = any> implements IPoint
      * @param {number} [y=x] - position of the point on the y axis
      * @returns {this} Returns itself.
      */
-    set(x = 0, y = x): this
+    public set(x = 0, y = x): this
     {
         if (this._x !== x || this._y !== y)
         {
@@ -73,7 +73,7 @@ export class ObservablePoint<T = any> implements IPoint
      * @param {PIXI.IPoint} p - The point to copy from.
      * @returns {this} Returns itself.
      */
-    copyFrom(p: IPoint): this
+    public copyFrom(p: IPoint): this
     {
         if (this._x !== p.x || this._y !== p.y)
         {
@@ -91,7 +91,7 @@ export class ObservablePoint<T = any> implements IPoint
      * @param {PIXI.IPoint} p - The point to copy.
      * @returns {PIXI.IPoint} Given point with values updated
      */
-    copyTo<T extends IPoint>(p: T): T
+    public copyTo<T extends IPoint>(p: T): T
     {
         p.set(this._x, this._y);
 
@@ -104,7 +104,7 @@ export class ObservablePoint<T = any> implements IPoint
      * @param {PIXI.IPoint} p - The point to check
      * @returns {boolean} Whether the given point equal to this point
      */
-    equals(p: IPoint): boolean
+    public equals(p: IPoint): boolean
     {
         return (p.x === this._x) && (p.y === this._y);
     }

--- a/packages/math/src/Point.ts
+++ b/packages/math/src/Point.ts
@@ -37,7 +37,7 @@ export class Point implements IPoint
      *
      * @return {PIXI.Point} a copy of the point
      */
-    clone(): Point
+    public clone(): Point
     {
         return new Point(this.x, this.y);
     }
@@ -48,7 +48,7 @@ export class Point implements IPoint
      * @param {PIXI.IPoint} p - The point to copy from
      * @returns {this} Returns itself.
      */
-    copyFrom(p: IPoint): this
+    public copyFrom(p: IPoint): this
     {
         this.set(p.x, p.y);
 
@@ -61,7 +61,7 @@ export class Point implements IPoint
      * @param {PIXI.IPoint} p - The point to copy.
      * @returns {PIXI.IPoint} Given point with values updated
      */
-    copyTo<T extends IPoint>(p: T): T
+    public copyTo<T extends IPoint>(p: T): T
     {
         p.set(this.x, this.y);
 
@@ -74,7 +74,7 @@ export class Point implements IPoint
      * @param {PIXI.IPoint} p - The point to check
      * @returns {boolean} Whether the given point equal to this point
      */
-    equals(p: IPoint): boolean
+    public equals(p: IPoint): boolean
     {
         return (p.x === this.x) && (p.y === this.y);
     }
@@ -87,7 +87,7 @@ export class Point implements IPoint
      * @param {number} [y=x] - position of the point on the y axis
      * @returns {this} Returns itself.
      */
-    set(x = 0, y = x): this
+    public set(x = 0, y = x): this
     {
         this.x = x;
         this.y = y;

--- a/packages/math/src/Transform.ts
+++ b/packages/math/src/Transform.ts
@@ -186,7 +186,7 @@ export class Transform
     /**
      * Updates the local transformation matrix.
      */
-    updateLocalTransform(): void
+    public updateLocalTransform(): void
     {
         const lt = this.localTransform;
 
@@ -212,7 +212,7 @@ export class Transform
      *
      * @param {PIXI.Transform} parentTransform - The parent transform
      */
-    updateTransform(parentTransform: Transform): void
+    public updateTransform(parentTransform: Transform): void
     {
         const lt = this.localTransform;
 
@@ -257,7 +257,7 @@ export class Transform
      *
      * @param {PIXI.Matrix} matrix - The matrix to decompose
      */
-    setFromMatrix(matrix: Matrix): void
+    public setFromMatrix(matrix: Matrix): void
     {
         matrix.decompose(this);
         this._localID++;

--- a/packages/math/src/shapes/Circle.ts
+++ b/packages/math/src/shapes/Circle.ts
@@ -55,7 +55,7 @@ export class Circle
      *
      * @return {PIXI.Circle} a copy of the Circle
      */
-    clone(): Circle
+    public clone(): Circle
     {
         return new Circle(this.x, this.y, this.radius);
     }
@@ -67,7 +67,7 @@ export class Circle
      * @param {number} y - The Y coordinate of the point to test
      * @return {boolean} Whether the x/y coordinates are within this Circle
      */
-    contains(x: number, y: number): boolean
+    public contains(x: number, y: number): boolean
     {
         if (this.radius <= 0)
         {
@@ -89,7 +89,7 @@ export class Circle
     *
     * @return {PIXI.Rectangle} the framing rectangle
     */
-    getBounds(): Rectangle
+    public getBounds(): Rectangle
     {
         return new Rectangle(this.x - this.radius, this.y - this.radius, this.radius * 2, this.radius * 2);
     }

--- a/packages/math/src/shapes/Ellipse.ts
+++ b/packages/math/src/shapes/Ellipse.ts
@@ -63,7 +63,7 @@ export class Ellipse
      *
      * @return {PIXI.Ellipse} a copy of the ellipse
      */
-    clone(): Ellipse
+    public clone(): Ellipse
     {
         return new Ellipse(this.x, this.y, this.width, this.height);
     }
@@ -75,7 +75,7 @@ export class Ellipse
      * @param {number} y - The Y coordinate of the point to test
      * @return {boolean} Whether the x/y coords are within this ellipse
      */
-    contains(x: number, y: number): boolean
+    public contains(x: number, y: number): boolean
     {
         if (this.width <= 0 || this.height <= 0)
         {
@@ -97,7 +97,7 @@ export class Ellipse
      *
      * @return {PIXI.Rectangle} the framing rectangle
      */
-    getBounds(): Rectangle
+    public getBounds(): Rectangle
     {
         return new Rectangle(this.x - this.width, this.y - this.height, this.width, this.height);
     }

--- a/packages/math/src/shapes/Polygon.ts
+++ b/packages/math/src/shapes/Polygon.ts
@@ -72,7 +72,7 @@ export class Polygon
      *
      * @return {PIXI.Polygon} a copy of the polygon
      */
-    clone(): Polygon
+    public clone(): Polygon
     {
         const points = this.points.slice();
         const polygon = new Polygon(points);
@@ -89,7 +89,7 @@ export class Polygon
      * @param {number} y - The Y coordinate of the point to test
      * @return {boolean} Whether the x/y coordinates are within this polygon
      */
-    contains(x: number, y: number): boolean
+    public contains(x: number, y: number): boolean
     {
         let inside = false;
 

--- a/packages/math/src/shapes/Rectangle.ts
+++ b/packages/math/src/shapes/Rectangle.ts
@@ -125,7 +125,7 @@ export class Rectangle
      *
      * @return {PIXI.Rectangle} a copy of the rectangle
      */
-    clone(): Rectangle
+    public clone(): Rectangle
     {
         return new Rectangle(this.x, this.y, this.width, this.height);
     }
@@ -136,7 +136,7 @@ export class Rectangle
      * @param {PIXI.Rectangle} rectangle - The rectangle to copy from.
      * @return {PIXI.Rectangle} Returns itself.
      */
-    copyFrom(rectangle: Rectangle): Rectangle
+    public copyFrom(rectangle: Rectangle): Rectangle
     {
         this.x = rectangle.x;
         this.y = rectangle.y;
@@ -152,7 +152,7 @@ export class Rectangle
      * @param {PIXI.Rectangle} rectangle - The rectangle to copy to.
      * @return {PIXI.Rectangle} Returns given parameter.
      */
-    copyTo(rectangle: Rectangle): Rectangle
+    public copyTo(rectangle: Rectangle): Rectangle
     {
         rectangle.x = this.x;
         rectangle.y = this.y;
@@ -169,7 +169,7 @@ export class Rectangle
      * @param {number} y - The Y coordinate of the point to test
      * @return {boolean} Whether the x/y coordinates are within this Rectangle
      */
-    contains(x: number, y: number): boolean
+    public contains(x: number, y: number): boolean
     {
         if (this.width <= 0 || this.height <= 0)
         {
@@ -195,7 +195,7 @@ export class Rectangle
      * @param {number} [paddingY=0] - The vertical padding amount.
      * @return {PIXI.Rectangle} Returns itself.
      */
-    pad(paddingX = 0, paddingY = paddingX): this
+    public pad(paddingX = 0, paddingY = paddingX): this
     {
         this.x -= paddingX;
         this.y -= paddingY;
@@ -212,7 +212,7 @@ export class Rectangle
      * @param {PIXI.Rectangle} rectangle - The rectangle to fit.
      * @return {PIXI.Rectangle} Returns itself.
      */
-    fit(rectangle: Rectangle): this
+    public fit(rectangle: Rectangle): this
     {
         const x1 = Math.max(this.x, rectangle.x);
         const x2 = Math.min(this.x + this.width, rectangle.x + rectangle.width);
@@ -234,7 +234,7 @@ export class Rectangle
      * @param {number} [eps=0.001] precision
      * @return {PIXI.Rectangle} Returns itself.
      */
-    ceil(resolution = 1, eps = 0.001): this
+    public ceil(resolution = 1, eps = 0.001): this
     {
         const x2 = Math.ceil((this.x + this.width - eps) * resolution) / resolution;
         const y2 = Math.ceil((this.y + this.height - eps) * resolution) / resolution;
@@ -254,7 +254,7 @@ export class Rectangle
      * @param {PIXI.Rectangle} rectangle - The rectangle to include.
      * @return {PIXI.Rectangle} Returns itself.
      */
-    enlarge(rectangle: Rectangle): this
+    public enlarge(rectangle: Rectangle): this
     {
         const x1 = Math.min(this.x, rectangle.x);
         const x2 = Math.max(this.x + this.width, rectangle.x + rectangle.width);

--- a/packages/math/src/shapes/RoundedRectangle.ts
+++ b/packages/math/src/shapes/RoundedRectangle.ts
@@ -71,7 +71,7 @@ export class RoundedRectangle
      *
      * @return {PIXI.RoundedRectangle} a copy of the rounded rectangle
      */
-    clone(): RoundedRectangle
+    public clone(): RoundedRectangle
     {
         return new RoundedRectangle(this.x, this.y, this.width, this.height, this.radius);
     }
@@ -83,7 +83,7 @@ export class RoundedRectangle
      * @param {number} y - The Y coordinate of the point to test
      * @return {boolean} Whether the x/y coordinates are within this Rounded Rectangle
      */
-    contains(x: number, y: number): boolean
+    public contains(x: number, y: number): boolean
     {
         if (this.width <= 0 || this.height <= 0)
         {

--- a/packages/runner/src/Runner.ts
+++ b/packages/runner/src/Runner.ts
@@ -184,7 +184,7 @@ export class Runner
      * @member {boolean}
      * @readonly
      */
-    public get empty(): boolean
+    get empty(): boolean
     {
         return this.items.length === 0;
     }
@@ -195,7 +195,7 @@ export class Runner
      * @member {string}
      * @readonly
      */
-    public get name(): string
+    get name(): string
     {
         return this._name;
     }

--- a/packages/ticker/src/Ticker.ts
+++ b/packages/ticker/src/Ticker.ts
@@ -15,8 +15,8 @@ export type TickerCallback<T> = (this: T, dt: number) => any;
  */
 export class Ticker
 {
-    static _shared: Ticker;
-    static _system: Ticker;
+    public static _shared: Ticker;
+    public static _system: Ticker;
 
     public autoStart: boolean;
     public deltaTime: number;
@@ -259,7 +259,7 @@ export class Ticker
      * @param {number} [priority=PIXI.UPDATE_PRIORITY.NORMAL] - The priority for emitting
      * @returns {PIXI.Ticker} This instance of a ticker
      */
-    add<T = any>(fn: TickerCallback<T>, context: T, priority = UPDATE_PRIORITY.NORMAL): this
+    public add<T = any>(fn: TickerCallback<T>, context: T, priority = UPDATE_PRIORITY.NORMAL): this
     {
         return this._addListener(new TickerListener(fn, context, priority));
     }
@@ -272,7 +272,7 @@ export class Ticker
      * @param {number} [priority=PIXI.UPDATE_PRIORITY.NORMAL] - The priority for emitting
      * @returns {PIXI.Ticker} This instance of a ticker
      */
-    addOnce<T = any>(fn: TickerCallback<T>, context: T, priority = UPDATE_PRIORITY.NORMAL): this
+    public addOnce<T = any>(fn: TickerCallback<T>, context: T, priority = UPDATE_PRIORITY.NORMAL): this
     {
         return this._addListener(new TickerListener(fn, context, priority, true));
     }
@@ -331,7 +331,7 @@ export class Ticker
      * @param {*} [context] - The listener context to be removed
      * @returns {PIXI.Ticker} This instance of a ticker
      */
-    remove<T = any>(fn: TickerCallback<T>, context: T): this
+    public remove<T = any>(fn: TickerCallback<T>, context: T): this
     {
         let listener = this._head.next;
 
@@ -385,7 +385,7 @@ export class Ticker
      * Starts the ticker. If the ticker has listeners
      * a new animation frame is requested at this point.
      */
-    start(): void
+    public start(): void
     {
         if (!this.started)
         {
@@ -398,7 +398,7 @@ export class Ticker
      * Stops the ticker. If the ticker has requested
      * an animation frame it is canceled at this point.
      */
-    stop(): void
+    public stop(): void
     {
         if (this.started)
         {
@@ -411,7 +411,7 @@ export class Ticker
      * Destroy the ticker and don't use after this. Calling
      * this method removes all references to internal events.
      */
-    destroy(): void
+    public destroy(): void
     {
         if (!this._protected)
         {
@@ -442,7 +442,7 @@ export class Ticker
      *
      * @param {number} [currentTime=performance.now()] - the current time of execution
      */
-    update(currentTime = performance.now()): void
+    public update(currentTime = performance.now()): void
     {
         let elapsedMS;
 

--- a/packages/ticker/src/TickerListener.ts
+++ b/packages/ticker/src/TickerListener.ts
@@ -85,7 +85,7 @@ export class TickerListener<T = any>
      * @param {any} [context] - The listener context
      * @return {boolean} `true` if the listener match the arguments
      */
-    match(fn: TickerCallback<T>, context: any = null): boolean
+    public match(fn: TickerCallback<T>, context: any = null): boolean
     {
         return this.fn === fn && this.context === context;
     }
@@ -96,7 +96,7 @@ export class TickerListener<T = any>
      * @param {number} deltaTime - time since the last emit.
      * @return {TickerListener} Next ticker
      */
-    emit(deltaTime: number): TickerListener
+    public emit(deltaTime: number): TickerListener
     {
         if (this.fn)
         {
@@ -132,7 +132,7 @@ export class TickerListener<T = any>
      * @private
      * @param {TickerListener} previous - Input node, previous listener
      */
-    connect(previous: TickerListener): void
+    public connect(previous: TickerListener): void
     {
         this.previous = previous;
         if (previous.next)
@@ -150,7 +150,7 @@ export class TickerListener<T = any>
      *        is considered a hard destroy. Soft destroy maintains the next reference.
      * @return {TickerListener} The listener to redirect while emitting or removing.
      */
-    destroy(hard = false): TickerListener
+    public destroy(hard = false): TickerListener
     {
         this._destroyed = true;
         this.fn = null;

--- a/packages/ticker/src/TickerPlugin.ts
+++ b/packages/ticker/src/TickerPlugin.ts
@@ -14,10 +14,10 @@ import { UPDATE_PRIORITY } from './const';
  */
 export class TickerPlugin
 {
-    static start: () => void;
-    static stop: () => void;
-    static _ticker: Ticker;
-    static ticker: Ticker;
+    public static start: () => void;
+    public static stop: () => void;
+    public static _ticker: Ticker;
+    public static ticker: Ticker;
 
     /**
      * Initialize the plugin with scope of application instance
@@ -26,7 +26,7 @@ export class TickerPlugin
      * @private
      * @param {object} [options] - See application options
      */
-    static init(options?: IApplicationOptions): void
+    public static init(options?: IApplicationOptions): void
     {
         // Set default
         options = Object.assign({
@@ -108,7 +108,7 @@ export class TickerPlugin
      * @static
      * @private
      */
-    static destroy(): void
+    public static destroy(): void
     {
         if (this._ticker)
         {

--- a/packages/utils/src/media/CanvasRenderTarget.ts
+++ b/packages/utils/src/media/CanvasRenderTarget.ts
@@ -45,7 +45,7 @@ export class CanvasRenderTarget
      *
      * @private
      */
-    clear(): void
+    public clear(): void
     {
         this.context.setTransform(1, 0, 0, 1, 0, 0);
         this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);
@@ -57,7 +57,7 @@ export class CanvasRenderTarget
      * @param {number} width - the new width of the canvas
      * @param {number} height - the new height of the canvas
      */
-    resize(width: number, height: number): void
+    public resize(width: number, height: number): void
     {
         this.canvas.width = width * this.resolution;
         this.canvas.height = height * this.resolution;
@@ -67,7 +67,7 @@ export class CanvasRenderTarget
      * Destroys this canvas.
      *
      */
-    destroy(): void
+    public destroy(): void
     {
         this.context = null;
         this.canvas = null;


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
As mentioned by @EvidentlyCube in the core pr #6340 we should have an eslint rule to enforce some consistency about how accessibility modifiers are annotated.

Currently this is [rule](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-member-accessibility.md) is configured to force declaring modifiers on methods and properties.

some basic sudo code to explain current rules:
```
public x: string;
private _y: string;

constructor(){}

public test(){}

get y(){}
set y(){}
```

We dont have to use this exact configuration so lets discuss it.
##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] Lint process passed (`npm run lint`)
