### PR TITLE
Add eslint rule to force I prefix for interfaces

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -255,7 +255,7 @@
           "rules": {
             "@typescript-eslint/semi": 1,
             "@typescript-eslint/no-explicit-any": 0,
-            "@typescript-eslint/interface-name-prefix": 0
+            "@typescript-eslint/interface-name-prefix": [1, "always"]
           }
         }
     ]

--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -10,6 +10,7 @@ export interface IDestroyOptions {
     baseTexture?: boolean;
 }
 
+// eslint-disable-next-line @typescript-eslint/interface-name-prefix
 export interface DisplayObject extends InteractiveTarget, EventEmitter {}
 
 /**

--- a/packages/utils/src/media/trimCanvas.ts
+++ b/packages/utils/src/media/trimCanvas.ts
@@ -1,4 +1,4 @@
-interface Inset {
+interface IInset {
     top?: number;
     left?: number;
     right?: number;
@@ -25,7 +25,7 @@ export function trimCanvas(canvas: HTMLCanvasElement): {width: number; height: n
     const pixels = imageData.data;
     const len = pixels.length;
 
-    const bound: Inset = {
+    const bound: IInset = {
         top: null,
         left: null,
         right: null,

--- a/packages/utils/src/network/decomposeDataUri.ts
+++ b/packages/utils/src/network/decomposeDataUri.ts
@@ -1,6 +1,6 @@
 import { DATA_URI } from '../const';
 
-export interface DecomposedDataUri {
+export interface IDecomposedDataUri {
     mediaType: string;
     subType: string;
     charset: string;
@@ -51,7 +51,7 @@ export interface DecomposedDataUri {
  * @param {string} dataUri - the data URI to check
  * @return {PIXI.utils.DecomposedDataUri|undefined} The decomposed data uri or undefined
  */
-export function decomposeDataUri(dataUri: string): DecomposedDataUri
+export function decomposeDataUri(dataUri: string): IDecomposedDataUri
 {
     const dataUriMatch = DATA_URI.exec(dataUri);
 

--- a/packages/utils/src/network/decomposeDataUri.ts
+++ b/packages/utils/src/network/decomposeDataUri.ts
@@ -10,35 +10,35 @@ export interface IDecomposedDataUri {
 
 /**
  * @memberof PIXI.utils
- * @interface DecomposedDataUri
+ * @interface IDecomposedDataUri
  */
 
 /**
  * type, eg. `image`
- * @memberof PIXI.utils.DecomposedDataUri#
+ * @memberof PIXI.utils.IDecomposedDataUri#
  * @member {string} mediaType
  */
 
 /**
  * Sub type, eg. `png`
- * @memberof PIXI.utils.DecomposedDataUri#
+ * @memberof PIXI.utils.IDecomposedDataUri#
  * @member {string} subType
  */
 
 /**
- * @memberof PIXI.utils.DecomposedDataUri#
+ * @memberof PIXI.utils.IDecomposedDataUri#
  * @member {string} charset
  */
 
 /**
  * Data encoding, eg. `base64`
- * @memberof PIXI.utils.DecomposedDataUri#
+ * @memberof PIXI.utils.IDecomposedDataUri#
  * @member {string} encoding
  */
 
 /**
  * The actual data
- * @memberof PIXI.utils.DecomposedDataUri#
+ * @memberof PIXI.utils.IDecomposedDataUri#
  * @member {string} data
  */
 
@@ -49,7 +49,7 @@ export interface IDecomposedDataUri {
  * @memberof PIXI.utils
  * @function decomposeDataUri
  * @param {string} dataUri - the data URI to check
- * @return {PIXI.utils.DecomposedDataUri|undefined} The decomposed data uri or undefined
+ * @return {PIXI.utils.IDecomposedDataUri|undefined} The decomposed data uri or undefined
  */
 export function decomposeDataUri(dataUri: string): IDecomposedDataUri
 {


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->
Another eslint rule to enforce that interfaces start with I.

Throughout our conversion this seems to have become how interfaces are named so we might as well enforce it.

I believe we have to disable this rule in certain circumstances e.g. mixins, but its a pretty minor inconvenience.
##### Description of change
<!-- Provide a description of the change below this comment. -->

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] Lint process passed (`npm run lint`)
