### PR TITLE
Remove EventEmitter mixin from Loader, deprecate methods

### DIFF
--- a/bundles/pixi.js/src/useDeprecated.js
+++ b/bundles/pixi.js/src/useDeprecated.js
@@ -611,6 +611,47 @@ export function useDeprecated()
         return PIXI.loaders.Loader.registerPlugin({ use: middleware() });
     };
 
+    // convenience for converting event name to signal name
+    const eventToSignal = (event) =>
+        `on${event.charAt(0).toUpperCase()}${event.slice(1)}`;
+
+    Object.assign(PIXI.Loader.prototype,
+        {
+            /**
+             * Use the corresponding signal, e.g., event `start`` is signal `onStart`.
+             * @method PIXI.Loader#on
+             * @deprecated since 5.0.0
+             */
+            on(event)
+            {
+                const signal = eventToSignal(event);
+
+                deprecation(v5, `PIXI.Loader#on is completely deprecated, use PIXI.Loader#${signal}.add`);
+            },
+            /**
+             * Use the corresponding signal, e.g., event `start`` is signal `onStart`.
+             * @method PIXI.Loader#once
+             * @deprecated since 5.0.0
+             */
+            once(event)
+            {
+                const signal = eventToSignal(event);
+
+                deprecation(v5, `PIXI.Loader#once is completely deprecated, use PIXI.Loader#${signal}.once`);
+            },
+            /**
+             * Use the corresponding signal, e.g., event `start`` is signal `onStart`.
+             * @method PIXI.Loader#off
+             * @deprecated since 5.0.0
+             */
+            off(event)
+            {
+                const signal = eventToSignal(event);
+
+                deprecation(v5, `PIXI.Loader#off is completely deprecated, use PIXI.Loader#${signal}.detach`);
+            },
+        });
+
     /**
      * @class PIXI.extract.WebGLExtract
      * @deprecated since 5.0.0

--- a/packages/loaders/package.json
+++ b/packages/loaders/package.json
@@ -25,7 +25,9 @@
   ],
   "dependencies": {
     "@pixi/core": "5.2.1",
-    "@pixi/utils": "5.2.1",
     "resource-loader": "^3.0.1"
+  },
+  "devDependencies": {
+    "@pixi/utils": "5.2.1"
   }
 }

--- a/packages/loaders/src/Loader.ts
+++ b/packages/loaders/src/Loader.ts
@@ -1,7 +1,5 @@
 import { Loader as ResourceLoader, middleware, Resource } from 'resource-loader';
-import { EventEmitter } from '@pixi/utils';
 import { TextureLoader } from './TextureLoader';
-import { ILoaderResource } from './LoaderResource';
 
 /**
  * The new loader, extends Resource Loader by Chad Engler: https://github.com/englercj/resource-loader
@@ -72,9 +70,6 @@ export class Loader extends ResourceLoader
     {
         super(baseUrl, concurrency);
 
-        // Mix EE
-        EventEmitter.call(this as any);
-
         for (let i = 0; i < Loader._plugins.length; ++i)
         {
             const plugin = Loader._plugins[i];
@@ -91,16 +86,6 @@ export class Loader extends ResourceLoader
             }
         }
 
-        // TODO remove when resolve mixin problems
-        const ee: EventEmitter = this as any;
-
-        // Compat layer, translate the new v2 signals into old v1 events.
-        this.onStart.add((l: this) => ee.emit('start', l));
-        this.onProgress.add((l: this, r: ILoaderResource) => ee.emit('progress', l, r));
-        this.onError.add((l: this, r: ILoaderResource) => ee.emit('error', l, r));
-        this.onLoad.add((l: this, r: ILoaderResource) => ee.emit('load', l, r));
-        this.onComplete.add((l: this, r: ILoaderResource) => ee.emit('complete', l, r));
-
         /**
          * If this loader cannot be destroyed.
          * @member {boolean}
@@ -116,12 +101,8 @@ export class Loader extends ResourceLoader
      */
     public destroy(): void
     {
-        // TODO remove when resolve mixin problems
-        const ee: EventEmitter = this as any;
-
         if (!this._protected)
         {
-            ee.removeAllListeners();
             this.reset();
         }
     }
@@ -170,9 +151,6 @@ export class Loader extends ResourceLoader
     }
 }
 
-// Copy EE3 prototype (mixin)
-Object.assign(Loader.prototype, EventEmitter.prototype);
-
 // parse any blob into more usable objects (e.g. Image)
 Loader.registerPlugin({ use: middleware.parsing });
 
@@ -205,7 +183,7 @@ export interface ILoaderPlugin {
  * @memberof PIXI.Loader
  * @typedef {function} ISignalCallback
  * @param {function} callback - Callback function
- * @param {object} [contex] - Context
+ * @param {object} [context] - Context
  * @returns {ICallbackID} - CallbackID
  */
 

--- a/types/loader.d.ts
+++ b/types/loader.d.ts
@@ -1,11 +1,16 @@
 declare namespace PIXI {
-    export interface Loader extends utils.EventEmitter {
+    export interface Loader {
         baseUrl: string;
         progress: number;
         loading: boolean;
         defaultQueryString: string;
         resources: IResourceDictionary;
         concurrency: number;
+        onStart: ILoaderSignal;
+        onProgress: ILoaderSignal;
+        onError: ILoaderSignal;
+        onLoad: ILoaderSignal;
+        onComplete: ILoaderSignal;
 
         add(...params: any[]): this;
         //tslint:disable-next-line:ban-types forbidden-types
@@ -22,21 +27,22 @@ declare namespace PIXI {
         load(cb?: (loader: Loader, resources: Partial<Record<string, LoaderResource>>) => void): this;
 
         destroy(): void;
+    }
 
-        // depreciation
+    export type ICallbackID = any;
+    export type ISignalDetach = (id:ICallbackID) => void;
+    //tslint:disable-next-line:ban-types forbidden-types
+    export type ISignalCallback = (callback:Function, context:any) => ICallbackID;
+    export interface ILoaderSignal {
+        add:ISignalCallback;
+        once:ISignalCallback;
+        detach:ISignalCallback;
+    }
 
-        on(event: "complete", fn: (loader: Loader, object: any) => void, context?: any): this;
-        on(event: "error", fn: (error: Error, loader: Loader, resource: LoaderResource) => void, context?: any): this;
-        on(event: "load" | "progress", fn: (loader: Loader, resource: LoaderResource) => void, context?: any): this;
-        on(event: "start", fn: (loader: Loader) => void, context?: any): this;
-
-        once(event: "complete", fn: (loader: Loader, object: any) => void, context?: any): this;
-        once(event: "error", fn: (error: Error, loader: Loader, resource: LoaderResource) => void, context?: any): this;
-        once(event: "load" | "progress", fn: (loader: Loader, resource: LoaderResource) => void, context?: any): this;
-        once(event: "start", fn: (loader: Loader) => void, context?: any): this;
-        //tslint:disable-next-line:ban-types forbidden-types
-        off(event: "complete" | "error" | "load" | "progress" | "start" | string, fn?: Function, context?: any): this;
-
+    export interface ILoaderPlugin {
+        add?(): void;
+        pre?(resource: LoaderResource, next?: (...args: any[]) => void): void;
+        use?(resource: LoaderResource, next?: (...args: any[]) => void): void;
     }
 
     export interface IResourceDictionary {


### PR DESCRIPTION
Follow up to #6385

This removes EventEmitter mixins to Loader officially. They have been removed from docs since v5.0.0 and now are removed from typings and runtime as well. Added a deprecation notice to be a little user-friendly for EE methods.