### PR TITLE
[WIP] Decouple preprocessor from Program

### DIFF
--- a/packages/core/src/batch/BatchShaderGenerator.ts
+++ b/packages/core/src/batch/BatchShaderGenerator.ts
@@ -67,7 +67,7 @@ export class BatchShaderGenerator
             fragmentSrc = fragmentSrc.replace(/%count%/gi, `${maxTextures}`);
             fragmentSrc = fragmentSrc.replace(/%forloop%/gi, this.generateSampleSrc(maxTextures));
 
-            this.programCache[maxTextures] = new Program(this.vertexSrc, fragmentSrc);
+            this.programCache[maxTextures] = new Program({ vertexSrc: this.vertexSrc, fragmentSrc });
         }
 
         const uniforms = {

--- a/packages/core/src/shader/ShaderSystem.ts
+++ b/packages/core/src/shader/ShaderSystem.ts
@@ -224,6 +224,8 @@ export class ShaderSystem extends System
 
         const program = shader.program;
 
+        program.params.template.initProgram(program);
+
         const attribMap: {[key: string]: number} = {};
 
         for (const i in program.attributeData)


### PR DESCRIPTION
Work in progress.

Preprocessors (aka `ProgramTemplate`) are factories Programs.

PixiJS vanilla will have two of them - default injects `precision`, `name`, raw does not modify code.

Program constructor should be protected, and only factory should be able to call it.

BatchShaderGenerator should be preprocessors too.

Theoretically, if we port ThreeJS or any other 3d renderer to PixiJS core, it should have its own ShaderLib as a preprocessor.