### PR TITLE
[WIP] Decouple preprocessor from Program

### DIFF
--- a/packages/core/src/batch/BatchShaderGenerator.ts
+++ b/packages/core/src/batch/BatchShaderGenerator.ts
@@ -1,5 +1,5 @@
 import { Shader } from '../shader/Shader';
-import { Program } from '../shader/Program';
+import { Program, defaultProgramTemplate } from '../shader/Program';
 import { UniformGroup } from '../shader/UniformGroup';
 import { Matrix } from '@pixi/math';
 
@@ -67,7 +67,7 @@ export class BatchShaderGenerator
             fragmentSrc = fragmentSrc.replace(/%count%/gi, `${maxTextures}`);
             fragmentSrc = fragmentSrc.replace(/%forloop%/gi, this.generateSampleSrc(maxTextures));
 
-            this.programCache[maxTextures] = new Program({ vertexSrc: this.vertexSrc, fragmentSrc });
+            this.programCache[maxTextures] = new Program(defaultProgramTemplate, { vertexSrc: this.vertexSrc, fragmentSrc });
         }
 
         const uniforms = {

--- a/packages/core/src/batch/BatchShaderGenerator.ts
+++ b/packages/core/src/batch/BatchShaderGenerator.ts
@@ -67,7 +67,7 @@ export class BatchShaderGenerator
             fragmentSrc = fragmentSrc.replace(/%count%/gi, `${maxTextures}`);
             fragmentSrc = fragmentSrc.replace(/%forloop%/gi, this.generateSampleSrc(maxTextures));
 
-            this.programCache[maxTextures] = new Program(this.vertexSrc, fragmentSrc);
+            this.programCache[maxTextures] = new Program({ vertexSrc: this.vertexSrc, fragmentSrc });
         }
 
         const uniforms = {

--- a/packages/core/src/batch/BatchShaderGenerator.ts
+++ b/packages/core/src/batch/BatchShaderGenerator.ts
@@ -1,5 +1,6 @@
 import { Shader } from '../shader/Shader';
-import { Program, defaultProgramTemplate } from '../shader/Program';
+import { Program } from '../shader/Program';
+import { defaultProgramGenerator } from '../shader/DefaultProgramGenerator';
 import { UniformGroup } from '../shader/UniformGroup';
 import { Matrix } from '@pixi/math';
 
@@ -67,7 +68,8 @@ export class BatchShaderGenerator
             fragmentSrc = fragmentSrc.replace(/%count%/gi, `${maxTextures}`);
             fragmentSrc = fragmentSrc.replace(/%forloop%/gi, this.generateSampleSrc(maxTextures));
 
-            this.programCache[maxTextures] = new Program(defaultProgramTemplate, { vertexSrc: this.vertexSrc, fragmentSrc });
+            this.programCache[maxTextures] = new Program(defaultProgramGenerator,
+                { vertexSrc: this.vertexSrc, fragmentSrc });
         }
 
         const uniforms = {

--- a/packages/core/src/shader/DefaultProgramGenerator.ts
+++ b/packages/core/src/shader/DefaultProgramGenerator.ts
@@ -1,0 +1,223 @@
+import defaultVertex from './defaultProgram.vert';
+import defaultFragment from './defaultProgram.frag';
+import { ProgramCache } from '@pixi/utils';
+import {
+    compileProgram,
+    defaultValue,
+    getMaxFragmentPrecision,
+    getTestContext,
+    mapSize,
+    mapType,
+    setPrecision,
+} from './utils';
+import { settings } from '@pixi/settings';
+import { PRECISION } from '@pixi/constants';
+
+import { Program, IAttributeData, IUniformData, IProgramParameters, IProgramGenerator } from './Program';
+
+const nameCache: { [key: string]: number } = {};
+
+/**
+ * Helper class to create pixi shader programs
+ *
+ * @class
+ * @memberof PIXI
+ * @implements IProgramGenerator
+ */
+export class DefaultProgramGenerator implements IProgramGenerator
+{
+    /**
+     * A short hand function to create a program based of a vertex and fragment shader
+     * this method will also check to see if there is a cached program.
+     *
+     * @param {object} params - parameters for Program creation
+     * @param {string} [params.vertexSrc] - The source of the vertex shader.
+     * @param {string} [params.fragmentSrc] - The source of the fragment shader.
+     * @param {string} [params.name='pixi-shader'] - Name for shader
+     *
+     * @returns {PIXI.Program} an shiny new Pixi shader!
+     */
+    from(params: IProgramParameters): Program
+    {
+        const { vertexSrc, fragmentSrc } = params;
+
+        const key = vertexSrc + fragmentSrc;
+
+        let program = ProgramCache[key];
+
+        if (!program)
+        {
+            ProgramCache[key] = program = new Program(this, params);
+        }
+
+        return program;
+    }
+
+    constructProgram(program: Program): void
+    {
+        const { params } = program;
+
+        params.vertexSrc = params.vertexSrc || defaultVertex;
+        params.fragmentSrc = params.fragmentSrc || defaultFragment;
+        params.name = params.name || 'pixi-shader';
+
+        this.initProgram(program);
+    }
+
+    /**
+     * Uses test context to initialize Program instance: parse attributes and uniforms
+     *
+     * @param {PIXI.Program} program
+     */
+    initProgram(program: Program): void
+    {
+        const { params } = program;
+        let { vertexSrc, fragmentSrc, name } = params;
+
+        if (program.valid)
+        {
+            return;
+        }
+
+        vertexSrc = vertexSrc.trim();
+        fragmentSrc = fragmentSrc.trim();
+
+        if (vertexSrc.substring(0, 8) !== '#version')
+        {
+            name = name.replace(/\s+/g, '-');
+
+            if (nameCache[name])
+            {
+                nameCache[name]++;
+                name += `-${nameCache[name]}`;
+            }
+            else
+            {
+                nameCache[name] = 1;
+            }
+
+            vertexSrc = `#define SHADER_NAME ${name}\n${vertexSrc}`;
+            fragmentSrc = `#define SHADER_NAME ${name}\n${fragmentSrc}`;
+
+            vertexSrc = setPrecision(vertexSrc, settings.PRECISION_VERTEX, PRECISION.HIGH);
+            fragmentSrc = setPrecision(fragmentSrc, settings.PRECISION_FRAGMENT, getMaxFragmentPrecision());
+        }
+
+        // currently this does not extract structs only default types
+        program.vertexSrc = vertexSrc;
+        program.fragmentSrc = fragmentSrc;
+        this.extractData(program);
+        program.valid = true;
+    }
+
+    /**
+     * Extracts the data for a buy creating a small test program
+     * or reading the src directly.
+     * @protected
+     *
+     * @param {PIXI.Program} [program] - The program to analyze
+     * @param {string} [vertexSrc] - The source of the vertex shader.
+     * @param {string} [fragmentSrc] - The source of the fragment shader.
+     */
+    protected extractData(program: Program): void
+    {
+        const gl = getTestContext();
+
+        if (gl)
+        {
+            const { vertexSrc, fragmentSrc } = program;
+            const glProgram = compileProgram(gl, vertexSrc, fragmentSrc);
+
+            program.attributeData = this.getAttributeData(glProgram, gl);
+            program.uniformData = this.getUniformData(glProgram, gl);
+
+            gl.deleteProgram(glProgram);
+        }
+    }
+
+    /**
+     * returns the attribute data from the program
+     * @private
+     *
+     * @param {WebGLProgram} [program] - the WebGL program
+     * @param {WebGLRenderingContext} [gl] - the WebGL context
+     *
+     * @returns {object} the attribute data for this program
+     */
+    protected getAttributeData(program: WebGLProgram, gl: WebGLRenderingContextBase): {[key: string]: IAttributeData}
+    {
+        const attributes: {[key: string]: IAttributeData} = {};
+        const attributesArray: Array<IAttributeData> = [];
+
+        const totalAttributes = gl.getProgramParameter(program, gl.ACTIVE_ATTRIBUTES);
+
+        for (let i = 0; i < totalAttributes; i++)
+        {
+            const attribData = gl.getActiveAttrib(program, i);
+            const type = mapType(gl, attribData.type);
+
+            /*eslint-disable */
+            const data = {
+                type: type,
+                name: attribData.name,
+                size: mapSize(type),
+                location: 0,
+            };
+            /* eslint-enable */
+
+            attributes[attribData.name] = data;
+            attributesArray.push(data);
+        }
+
+        attributesArray.sort((a, b) => (a.name > b.name) ? 1 : -1); // eslint-disable-line no-confusing-arrow
+
+        for (let i = 0; i < attributesArray.length; i++)
+        {
+            attributesArray[i].location = i;
+        }
+
+        return attributes;
+    }
+
+    /**
+     * returns the uniform data from the program
+     * @private
+     *
+     * @param {WebGLProgram} [program] - the webgl program
+     * @param {context} [gl] - the WebGL context
+     *
+     * @returns {object} the uniform data for this program
+     */
+    private getUniformData(program: WebGLProgram, gl: WebGLRenderingContextBase): {[key: string]: IUniformData}
+    {
+        const uniforms: {[key: string]: IUniformData} = {};
+
+        const totalUniforms = gl.getProgramParameter(program, gl.ACTIVE_UNIFORMS);
+
+        // TODO expose this as a prop?
+        // const maskRegex = new RegExp('^(projectionMatrix|uSampler|translationMatrix)$');
+        // const maskRegex = new RegExp('^(projectionMatrix|uSampler|translationMatrix)$');
+
+        for (let i = 0; i < totalUniforms; i++)
+        {
+            const uniformData = gl.getActiveUniform(program, i);
+            const name = uniformData.name.replace(/\[.*?\]/, '');
+
+            const isArray = uniformData.name.match(/\[.*?\]/);
+            const type = mapType(gl, uniformData.type);
+
+            /*eslint-disable */
+            uniforms[name] = {
+                type: type,
+                size: uniformData.size,
+                isArray:isArray,
+                value: defaultValue(type, uniformData.size),
+            };
+            /* eslint-enable */
+        }
+
+        return uniforms;
+    }
+}
+
+export const defaultProgramGenerator = Program.defaultGenerator = new DefaultProgramGenerator();

--- a/packages/core/src/shader/Program.ts
+++ b/packages/core/src/shader/Program.ts
@@ -1,23 +1,11 @@
 // import * as from '../systems/shader/shader';
-import { setPrecision,
-    defaultValue,
-    compileProgram,
-    mapSize,
-    mapType,
-    getTestContext,
-    getMaxFragmentPrecision } from './utils';
-import { ProgramCache } from '@pixi/utils';
 import defaultFragment from './defaultProgram.frag';
 import defaultVertex from './defaultProgram.vert';
-import { settings } from '@pixi/settings';
-import { PRECISION } from '@pixi/constants';
 
 import { GLProgram } from './GLProgram';
+import { DefaultProgramGenerator } from './DefaultProgramGenerator';
 
 let UID = 0;
-
-const nameCache: { [key: string]: number } = {};
-let pixiTemplate: DefaultProgramTemplate;
 
 export interface IAttributeData
 {
@@ -42,7 +30,7 @@ export interface IProgramParameters
     name?: string;
 }
 
-export interface IProgramTemplate
+export interface IProgramGenerator
 {
     constructProgram(program: Program): void;
     initProgram(program: Program): void;
@@ -52,7 +40,7 @@ export interface IProgramTemplate
  * Program template, creates program instances based on source code and parameters
  *
  * @memberof PIXI
- * @typedef {object} IProgramTemplate
+ * @typedef {object} IProgramGenerator
  */
 
 /**
@@ -72,14 +60,14 @@ export class Program
     attributeData: { [key: string]: IAttributeData};
     uniformData: {[key: string]: IUniformData};
     valid: boolean;
-    template: IProgramTemplate;
+    template: IProgramGenerator;
     /**
      * Constructor is not supposed to be called directly, only through program templates (proprocessor)
      *
      * @param {PIXI.ProgramTemplate}
      * @param {object} [params] - Parameters for the program
      */
-    constructor(template: IProgramTemplate, params: IProgramParameters)
+    constructor(template: IProgramGenerator, params: IProgramParameters)
     {
         this.id = UID++;
 
@@ -92,7 +80,7 @@ export class Program
             template = undefined;
         }
 
-        this.template = template || pixiTemplate;
+        this.template = template || Program.defaultGenerator;
 
         this.params = params;
 
@@ -164,212 +152,8 @@ export class Program
      */
     static from(vertexSrc?: string, fragmentSrc?: string, name?: string): Program
     {
-        return pixiTemplate.from({ vertexSrc, fragmentSrc, name });
+        return Program.defaultGenerator.from({ vertexSrc, fragmentSrc, name });
     }
+
+    static defaultGenerator: DefaultProgramGenerator = null;
 }
-
-/**
- * Helper class to create pixi shader programs
- *
- * @class
- * @memberof PIXI
- */
-export class DefaultProgramTemplate implements IProgramTemplate
-{
-    defaultParameters: IProgramParameters =
-    {
-        vertexSrc: defaultVertex,
-        fragmentSrc: defaultFragment,
-        name: 'pixi-shader',
-    };
-
-    /**
-     * A short hand function to create a program based of a vertex and fragment shader
-     * this method will also check to see if there is a cached program.
-     *
-     * @param {object} params - parameters for Program creation
-     * @param {string} [params.vertexSrc] - The source of the vertex shader.
-     * @param {string} [params.fragmentSrc] - The source of the fragment shader.
-     * @param {string} [params.name='pixi-shader'] - Name for shader
-     *
-     * @returns {PIXI.Program} an shiny new Pixi shader!
-     */
-    from(params: IProgramParameters): Program
-    {
-        const { vertexSrc, fragmentSrc } = params;
-
-        const key = vertexSrc + fragmentSrc;
-
-        let program = ProgramCache[key];
-
-        if (!program)
-        {
-            ProgramCache[key] = program = new Program(this, params);
-        }
-
-        return program;
-    }
-
-    constructProgram(program: Program): void
-    {
-        Object.assign(program.params, this.defaultParameters);
-        this.initProgram(program);
-    }
-
-    /**
-     * Uses test context to initialize Program instance: parse attributes and uniforms
-     *
-     * @param {PIXI.Program} program
-     */
-    initProgram(program: Program): void
-    {
-        const { params } = program;
-        let { vertexSrc, fragmentSrc, name } = params;
-
-        if (program.valid)
-        {
-            return;
-        }
-
-        vertexSrc = vertexSrc.trim();
-        fragmentSrc = fragmentSrc.trim();
-
-        if (vertexSrc.substring(0, 8) !== '#version')
-        {
-            name = name.replace(/\s+/g, '-');
-
-            if (nameCache[name])
-            {
-                nameCache[name]++;
-                name += `-${nameCache[name]}`;
-            }
-            else
-            {
-                nameCache[name] = 1;
-            }
-
-            vertexSrc = `#define SHADER_NAME ${name}\n${vertexSrc}`;
-            fragmentSrc = `#define SHADER_NAME ${name}\n${fragmentSrc}`;
-
-            vertexSrc = setPrecision(vertexSrc, settings.PRECISION_VERTEX, PRECISION.HIGH);
-            fragmentSrc = setPrecision(fragmentSrc, settings.PRECISION_FRAGMENT, getMaxFragmentPrecision());
-        }
-
-        // currently this does not extract structs only default types
-        program.vertexSrc = vertexSrc;
-        program.fragmentSrc = fragmentSrc;
-        this.extractData(program);
-        program.valid = true;
-    }
-
-    /**
-     * Extracts the data for a buy creating a small test program
-     * or reading the src directly.
-     * @protected
-     *
-     * @param {PIXI.Program} [program] - The program to analyze
-     * @param {string} [vertexSrc] - The source of the vertex shader.
-     * @param {string} [fragmentSrc] - The source of the fragment shader.
-     */
-    protected extractData(program: Program): void
-    {
-        const gl = getTestContext();
-
-        if (gl)
-        {
-            const { vertexSrc, fragmentSrc } = program;
-            const glProgram = compileProgram(gl, vertexSrc, fragmentSrc);
-
-            program.attributeData = this.getAttributeData(glProgram, gl);
-            program.uniformData = this.getUniformData(glProgram, gl);
-
-            gl.deleteProgram(program);
-        }
-    }
-
-    /**
-     * returns the attribute data from the program
-     * @private
-     *
-     * @param {WebGLProgram} [program] - the WebGL program
-     * @param {WebGLRenderingContext} [gl] - the WebGL context
-     *
-     * @returns {object} the attribute data for this program
-     */
-    protected getAttributeData(program: WebGLProgram, gl: WebGLRenderingContextBase): {[key: string]: IAttributeData}
-    {
-        const attributes: {[key: string]: IAttributeData} = {};
-        const attributesArray: Array<IAttributeData> = [];
-
-        const totalAttributes = gl.getProgramParameter(program, gl.ACTIVE_ATTRIBUTES);
-
-        for (let i = 0; i < totalAttributes; i++)
-        {
-            const attribData = gl.getActiveAttrib(program, i);
-            const type = mapType(gl, attribData.type);
-
-            /*eslint-disable */
-            const data = {
-                type: type,
-                name: attribData.name,
-                size: mapSize(type),
-                location: 0,
-            };
-            /* eslint-enable */
-
-            attributes[attribData.name] = data;
-            attributesArray.push(data);
-        }
-
-        attributesArray.sort((a, b) => (a.name > b.name) ? 1 : -1); // eslint-disable-line no-confusing-arrow
-
-        for (let i = 0; i < attributesArray.length; i++)
-        {
-            attributesArray[i].location = i;
-        }
-
-        return attributes;
-    }
-
-    /**
-     * returns the uniform data from the program
-     * @private
-     *
-     * @param {WebGLProgram} [program] - the webgl program
-     * @param {context} [gl] - the WebGL context
-     *
-     * @returns {object} the uniform data for this program
-     */
-    private getUniformData(program: WebGLProgram, gl: WebGLRenderingContextBase): {[key: string]: IUniformData}
-    {
-        const uniforms: {[key: string]: IUniformData} = {};
-
-        const totalUniforms = gl.getProgramParameter(program, gl.ACTIVE_UNIFORMS);
-
-        // TODO expose this as a prop?
-        // const maskRegex = new RegExp('^(projectionMatrix|uSampler|translationMatrix)$');
-        // const maskRegex = new RegExp('^(projectionMatrix|uSampler|translationMatrix)$');
-
-        for (let i = 0; i < totalUniforms; i++)
-        {
-            const uniformData = gl.getActiveUniform(program, i);
-            const name = uniformData.name.replace(/\[.*?\]/, '');
-
-            const isArray = uniformData.name.match(/\[.*?\]/);
-            const type = mapType(gl, uniformData.type);
-
-            /*eslint-disable */
-            uniforms[name] = {
-                type: type,
-                size: uniformData.size,
-                isArray:isArray,
-                value: defaultValue(type, uniformData.size),
-            };
-            /* eslint-enable */
-        }
-
-        return uniforms;
-    }
-}
-
-export const defaultProgramTemplate = pixiTemplate = new DefaultProgramTemplate();

--- a/packages/core/src/shader/ShaderSystem.ts
+++ b/packages/core/src/shader/ShaderSystem.ts
@@ -224,7 +224,7 @@ export class ShaderSystem extends System
 
         const program = shader.program;
 
-        program.params.template.initProgram(program);
+        program.template.initProgram(program);
 
         const attribMap: {[key: string]: number} = {};
 

--- a/packages/core/src/shader/ShaderSystem.ts
+++ b/packages/core/src/shader/ShaderSystem.ts
@@ -224,6 +224,8 @@ export class ShaderSystem extends System
 
         const program = shader.program;
 
+        program.params.template.initProgram(program);
+
         const attribMap: {[key: string]: number} = {};
 
         for (const i in program.attributeData)


### PR DESCRIPTION
Work in progress.

Preprocessors (aka `ProgramTemplate`) are factories Programs.

PixiJS vanilla will have two of them - default injects `precision`, `name`, raw does not modify code.

Program constructor should be protected, and only factory should be able to call it.

BatchShaderGenerator should be preprocessors too.

Theoretically, if we port ThreeJS or any other 3d renderer to PixiJS core, it should have its own ShaderLib as a preprocessor.