### PR TITLE
Dont show `baseTexture.source` deprecation if texture is not valid

### DIFF
--- a/packages/canvas/canvas-mesh/src/NineSlicePlane.js
+++ b/packages/canvas/canvas-mesh/src/NineSlicePlane.js
@@ -41,6 +41,11 @@ NineSlicePlane.prototype._renderCanvas = function _renderCanvas(renderer)
     const isTinted = this.tint !== 0xFFFFFF;
     const texture = this.texture;
 
+    if (!texture.valid)
+    {
+        return;
+    }
+
     // Work out tinting
     if (isTinted)
     {

--- a/packages/canvas/canvas-particles/src/ParticleContainer.js
+++ b/packages/canvas/canvas-particles/src/ParticleContainer.js
@@ -39,6 +39,11 @@ ParticleContainer.prototype.renderCanvas = function renderCanvas(renderer)
             continue;
         }
 
+        if (!child._texture.valid)
+        {
+            continue;
+        }
+
         const frame = child._texture.frame;
 
         context.globalAlpha = this.worldAlpha * child.alpha;

--- a/packages/canvas/canvas-renderer/src/BaseTexture.js
+++ b/packages/canvas/canvas-renderer/src/BaseTexture.js
@@ -11,5 +11,5 @@ BaseTexture.prototype.getDrawableSource = function getDrawableSource()
 {
     const resource = this.resource;
 
-    return resource ? (resource.bitmap || resource.source) : this.source;
+    return resource ? (resource.bitmap || resource.source) : null;
 };

--- a/packages/canvas/canvas-sprite/src/CanvasSpriteRenderer.js
+++ b/packages/canvas/canvas-sprite/src/CanvasSpriteRenderer.js
@@ -59,7 +59,7 @@ export class CanvasSpriteRenderer
 
         const source = texture.baseTexture.getDrawableSource();
 
-        if (texture.orig.width <= 0 || texture.orig.height <= 0 || !source)
+        if (texture.orig.width <= 0 || texture.orig.height <= 0 || !texture.valid || !source)
         {
             return;
         }


### PR DESCRIPTION
Fix #6401 .

Proof: https://www.pixiplayground.com/#/edit/bDATVV0BjViqlg1suv75b