### PR TITLE
add cube texture again

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export * from './Renderer';
 export * from './AbstractRenderer';
 export * from './framebuffer/Framebuffer';
 export * from './framebuffer/GLFramebuffer';
+export * from './textures/CubeTexture';
 export * from './textures/Texture';
 export * from './textures/BaseTexture';
 export * from './textures/GLTexture';

--- a/packages/core/src/textures/BaseTexture.ts
+++ b/packages/core/src/textures/BaseTexture.ts
@@ -602,7 +602,7 @@ export class BaseTexture extends EventEmitter
      * @param {boolean} [strict] Enforce strict-mode, see {@link PIXI.settings.STRICT_TEXTURE_CACHE}.
      * @returns {PIXI.BaseTexture} The new base texture.
      */
-    static from(source: ImageSource|string, options: IBaseTextureOptions,
+    static from(source: ImageSource|string, options?: IBaseTextureOptions,
         strict = settings.STRICT_TEXTURE_CACHE): BaseTexture
     {
         const isFrame = typeof source === 'string';

--- a/packages/core/src/textures/CubeTexture.ts
+++ b/packages/core/src/textures/CubeTexture.ts
@@ -19,7 +19,7 @@ export class CubeTexture extends BaseTexture
      *        on the options available to each resource.
      * @returns {PIXI.CubeTexture} new cube texture
      */
-    static from(resources: any, options: ICubeResourceOptions): CubeTexture
+    static from(resources: any, options?: ICubeResourceOptions): CubeTexture
     {
         return new CubeTexture(new CubeResource(resources, options));
     }

--- a/packages/core/src/textures/CubeTexture.ts
+++ b/packages/core/src/textures/CubeTexture.ts
@@ -1,0 +1,26 @@
+import { BaseTexture } from './BaseTexture';
+import { CubeResource, ICubeResourceOptions } from './resources/CubeResource';
+
+/**
+ * A Texture that depends on six other resources.
+ *
+ * @class
+ * @extends PIXI.BaseTexture
+ * @memberof PIXI
+ */
+export class CubeTexture extends BaseTexture
+{
+    /**
+     * Generate a new CubeTexture.
+     * @static
+     * @param {string[]|PIXI.resources.Resource[]} resources - Collection of 6 URLs or resources
+     * @param {object} [options] - Optional options passed to the resources being loaded.
+     *        See {@PIXI.resources.autoDetectResource autoDetectResource} for more info
+     *        on the options available to each resource.
+     * @returns {PIXI.CubeTexture} new cube texture
+     */
+    static from(resources: any, options: ICubeResourceOptions): CubeTexture
+    {
+        return new CubeTexture(new CubeResource(resources, options));
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
In #6340 `CubeTexture` was removed as it's `.from` function was not compatible with `BaseTexture`.

@GoodBoyDigital has a use for this class so I'm adding it back in. My solution doesn't solve the underlying issue but at least allows the project to build.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
