### PR TITLE
Application and Renderer resize improvements

### DIFF
--- a/packages/app/src/Application.ts
+++ b/packages/app/src/Application.ts
@@ -13,6 +13,7 @@ export interface IApplicationOptions extends IRendererOptionsAuto {
     sharedTicker?: boolean;
     sharedLoader?: boolean;
     resizeTo?: Window | HTMLElement;
+    resizeThrottle?: number;
 }
 
 /**
@@ -71,6 +72,7 @@ export class Application
      *  The system ticker will always run before both the shared ticker and the app ticker.
      * @param {boolean} [options.sharedLoader=false] - `true` to use PIXI.Loader.shared, `false` to create new Loader.
      * @param {Window|HTMLElement} [options.resizeTo] - Element to automatically resize stage to.
+     * @param {number} [options.resizeThrottle=0] - Throttle time in milliseconds between resizes, if using `resizeTo`.
      */
     constructor(options?: IApplicationOptions)
     {

--- a/packages/app/src/Application.ts
+++ b/packages/app/src/Application.ts
@@ -72,7 +72,7 @@ export class Application
      *  The system ticker will always run before both the shared ticker and the app ticker.
      * @param {boolean} [options.sharedLoader=false] - `true` to use PIXI.Loader.shared, `false` to create new Loader.
      * @param {Window|HTMLElement} [options.resizeTo] - Element to automatically resize stage to.
-     * @param {number} [options.resizeThrottle=0] - Throttle time in milliseconds between resizes, if using `resizeTo`.
+     * @param {number} [options.resizeThrottle=100] - Throttle time in milliseconds between resizes, if using `resizeTo`.
      */
     constructor(options?: IApplicationOptions)
     {

--- a/packages/app/src/Application.ts
+++ b/packages/app/src/Application.ts
@@ -72,7 +72,6 @@ export class Application
      *  The system ticker will always run before both the shared ticker and the app ticker.
      * @param {boolean} [options.sharedLoader=false] - `true` to use PIXI.Loader.shared, `false` to create new Loader.
      * @param {Window|HTMLElement} [options.resizeTo] - Element to automatically resize stage to.
-     * @param {number} [options.resizeThrottle=100] - Throttle time in milliseconds between resizes, if using `resizeTo`.
      */
     constructor(options?: IApplicationOptions)
     {

--- a/packages/app/src/ResizePlugin.ts
+++ b/packages/app/src/ResizePlugin.ts
@@ -25,10 +25,6 @@ export class ResizePlugin
      */
     static init(options?: IApplicationOptions): void
     {
-        // Amount of time for throttling resize
-        const throttle = options.resizeThrottle !== undefined
-            ? options.resizeThrottle : 100;
-
         /**
          * The HTML element or window to automatically resize the
          * renderer's view element to match width and height.
@@ -55,8 +51,9 @@ export class ResizePlugin
             });
 
         /**
-         * Resize to happen after resize throttle timeout, so it's
-         * safe to call this multiple times per frame.
+         * Resize is throttled, so it's
+         * safe to call this multiple times per frame and it'll
+         * only be called once.
          * @method PIXI.Application#queueResize
          */
         this.queueResize = (): void =>
@@ -69,7 +66,7 @@ export class ResizePlugin
             this.cancelResize();
 
             // // Throttle resize events per raf
-            this._resizeId = window.setTimeout(() => this.resize(), throttle);
+            this._resizeId = requestAnimationFrame(() => this.resize());
         };
 
         /**
@@ -81,7 +78,7 @@ export class ResizePlugin
         {
             if (this._resizeId)
             {
-                window.clearTimeout(this._resizeId);
+                cancelAnimationFrame(this._resizeId);
                 this._resizeId = null;
             }
         };

--- a/packages/app/src/ResizePlugin.ts
+++ b/packages/app/src/ResizePlugin.ts
@@ -25,6 +25,9 @@ export class ResizePlugin
      */
     static init(options?: IApplicationOptions): void
     {
+        // Amount of time for throttling resize
+        const throttle = options.resizeThrottle || 0;
+
         /**
          * The HTML element or window to automatically resize the
          * renderer's view element to match width and height.
@@ -51,7 +54,7 @@ export class ResizePlugin
             });
 
         /**
-         * Resize to happen on the next available animation frame, so it's
+         * Resize to happen after resize throttle timeout, so it's
          * safe to call this multiple times per frame.
          * @method PIXI.Application#queueResize
          */
@@ -65,10 +68,7 @@ export class ResizePlugin
             this.cancelResize();
 
             // // Throttle resize events per raf
-            this._resizeId = requestAnimationFrame(() =>
-            {
-                this.resize();
-            });
+            this._resizeId = setTimeout(() => this.resize(), throttle);
         };
 
         /**
@@ -80,7 +80,7 @@ export class ResizePlugin
         {
             if (this._resizeId)
             {
-                cancelAnimationFrame(this._resizeId);
+                clearTimeout(this._resizeId);
                 this._resizeId = null;
             }
         };

--- a/packages/app/src/ResizePlugin.ts
+++ b/packages/app/src/ResizePlugin.ts
@@ -9,13 +9,13 @@ import { IApplicationOptions } from './Application';
  */
 export class ResizePlugin
 {
-    public static _resizeId: number;
-    public static _resizeTo: Window|HTMLElement;
     public static resizeTo: Window|HTMLElement;
     public static resize: () => void;
-    public static queueResize: () => void;
-    public static cancelResize: () => void;
     public static renderer: Renderer|CanvasRenderer;
+    public static queueResize: () => void;
+    private static _resizeId: number;
+    private static _resizeTo: Window|HTMLElement;
+    private static cancelResize: () => void;
 
     /**
      * Initialize the plugin with scope of application instance
@@ -54,7 +54,6 @@ export class ResizePlugin
          * Resize to happen on the next available animation frame, so it's
          * safe to call this multiple times per frame.
          * @method PIXI.Application#queueResize
-         * @private
          */
         this.queueResize = (): void =>
         {

--- a/packages/app/src/ResizePlugin.ts
+++ b/packages/app/src/ResizePlugin.ts
@@ -26,7 +26,8 @@ export class ResizePlugin
     static init(options?: IApplicationOptions): void
     {
         // Amount of time for throttling resize
-        const throttle = options.resizeThrottle || 0;
+        const throttle = options.resizeThrottle !== undefined
+            ? options.resizeThrottle : 100;
 
         /**
          * The HTML element or window to automatically resize the

--- a/packages/app/src/ResizePlugin.ts
+++ b/packages/app/src/ResizePlugin.ts
@@ -26,7 +26,7 @@ export class ResizePlugin
     static init(options?: IApplicationOptions): void
     {
         /**
-         * The HTML element or window to automatically resize the 
+         * The HTML element or window to automatically resize the
          * renderer's view element to match width and height.
          * @type {Window|HTMLElement}
          * @name resizeTo

--- a/packages/app/src/ResizePlugin.ts
+++ b/packages/app/src/ResizePlugin.ts
@@ -68,7 +68,7 @@ export class ResizePlugin
             this.cancelResize();
 
             // // Throttle resize events per raf
-            this._resizeId = setTimeout(() => this.resize(), throttle);
+            this._resizeId = window.setTimeout(() => this.resize(), throttle);
         };
 
         /**
@@ -80,7 +80,7 @@ export class ResizePlugin
         {
             if (this._resizeId)
             {
-                clearTimeout(this._resizeId);
+                window.clearTimeout(this._resizeId);
                 this._resizeId = null;
             }
         };

--- a/packages/app/test/index.js
+++ b/packages/app/test/index.js
@@ -110,6 +110,79 @@ describe('PIXI.Application', function ()
             app.destroy();
         });
 
+        it('should force multiple immediate resizes', function ()
+        {
+            const spy = sinon.spy();
+            const app = new Application({
+                resizeTo: this.div,
+            });
+
+            app.renderer.on('resize', spy);
+
+            app.resize();
+            app.resize();
+
+            expect(spy.calledTwice).to.be.true;
+
+            app.destroy();
+        });
+
+        it('should throttle multipe resizes', function (done)
+        {
+            const spy = sinon.spy();
+            const app = new Application({
+                resizeTo: this.div,
+            });
+
+            app.renderer.on('resize', spy);
+            app.queueResize();
+            app.queueResize();
+
+            requestAnimationFrame(() =>
+            {
+                expect(spy.calledOnce).to.be.true;
+                app.destroy();
+                done();
+            });
+        });
+
+        it('should cancel resize on destroy', function (done)
+        {
+            const spy = sinon.spy();
+            const app = new Application({
+                resizeTo: this.div,
+            });
+
+            app.renderer.on('resize', spy);
+            app.queueResize();
+            app.destroy();
+
+            requestAnimationFrame(() =>
+            {
+                expect(spy.called).to.be.false;
+                done();
+            });
+        });
+
+        it('should resize cancel resize queue', function (done)
+        {
+            const spy = sinon.spy();
+            const app = new Application({
+                resizeTo: this.div,
+            });
+
+            app.renderer.on('resize', spy);
+            app.queueResize();
+            app.resize();
+            app.destroy();
+
+            requestAnimationFrame(() =>
+            {
+                expect(spy.calledOnce).to.be.true;
+                done();
+            });
+        });
+
         it('should resizeTo with resolution', function ()
         {
             const app = new Application({

--- a/packages/app/test/index.js
+++ b/packages/app/test/index.js
@@ -132,6 +132,7 @@ describe('PIXI.Application', function ()
             const spy = sinon.spy();
             const app = new Application({
                 resizeTo: this.div,
+                resizeThrottle: 0,
             });
 
             app.renderer.on('resize', spy);

--- a/packages/app/test/index.js
+++ b/packages/app/test/index.js
@@ -132,7 +132,6 @@ describe('PIXI.Application', function ()
             const spy = sinon.spy();
             const app = new Application({
                 resizeTo: this.div,
-                resizeThrottle: 0,
             });
 
             app.renderer.on('resize', spy);
@@ -145,27 +144,6 @@ describe('PIXI.Application', function ()
                 app.destroy();
                 done();
             }, 50);
-        });
-
-        it('should support throttle time', function (done)
-        {
-            const startTime = performance.now();
-            const app = new Application({
-                resizeTo: this.div,
-                resizeThrottle: 100,
-            });
-
-            app.queueResize();
-            app.renderer.once('resize', () =>
-            {
-                expect(performance.now() - startTime).to.be.at.least(100);
-                // wait for next process to destroy
-                setTimeout(() =>
-                {
-                    app.destroy();
-                    done();
-                });
-            });
         });
 
         it('should cancel resize on destroy', function (done)

--- a/packages/app/test/index.js
+++ b/packages/app/test/index.js
@@ -127,7 +127,7 @@ describe('PIXI.Application', function ()
             app.destroy();
         });
 
-        it('should throttle multipe resizes', function (done)
+        it('should throttle multiple resizes', function (done)
         {
             const spy = sinon.spy();
             const app = new Application({
@@ -138,11 +138,32 @@ describe('PIXI.Application', function ()
             app.queueResize();
             app.queueResize();
 
-            requestAnimationFrame(() =>
+            setTimeout(() =>
             {
                 expect(spy.calledOnce).to.be.true;
                 app.destroy();
                 done();
+            }, 50);
+        });
+
+        it('should support throttle time', function (done)
+        {
+            const startTime = performance.now();
+            const app = new Application({
+                resizeTo: this.div,
+                resizeThrottle: 100,
+            });
+
+            app.queueResize();
+            app.renderer.once('resize', () =>
+            {
+                expect(performance.now() - startTime).to.be.at.least(100);
+                // wait for next process to destroy
+                setTimeout(() =>
+                {
+                    app.destroy();
+                    done();
+                });
             });
         });
 

--- a/packages/core/src/AbstractRenderer.ts
+++ b/packages/core/src/AbstractRenderer.ts
@@ -281,6 +281,15 @@ export abstract class AbstractRenderer extends EventEmitter
             this.view.style.width = `${screenWidth}px`;
             this.view.style.height = `${screenHeight}px`;
         }
+
+        /**
+         * Fired after view has been resized.
+         *
+         * @event PIXI.Renderer#resize
+         * @param {number} screenWidth - The new width of the screen.
+         * @param {number} screenHeight - The new height of the screen.
+         */
+        this.emit('resize', screenWidth, screenHeight);
     }
 
     /**

--- a/packages/core/test/Renderer.js
+++ b/packages/core/test/Renderer.js
@@ -38,6 +38,21 @@ describe('PIXI.Renderer', function ()
         }
     });
 
+    it('should emit resize event', function ()
+    {
+        const renderer = new Renderer(1, 1);
+        const spy = sinon.spy();
+
+        renderer.on('resize', spy);
+        renderer.resize(2, 4);
+
+        expect(spy.calledOnce).to.be.true;
+        expect(spy.firstCall.args[0]).to.equal(2);
+        expect(spy.firstCall.args[1]).to.equal(4);
+
+        renderer.destroy();
+    });
+
     describe('.setObjectRenderer()', function ()
     {
         before(function ()


### PR DESCRIPTION
I've been meaning to tackle this one for awhile, since no one seemed keen on adding the PR for it.

Fixes #6081

### Added

* Introduces `resize` event to the Renderer. Called immediate after view is resized can be used for responsive layouts, or other resizing events.
* Adds throttle resizing on the Application when using `resizeTo`, this will prevent unnecessary extra event calls triggered by the window 'resize'.

### Example

https://jsfiddle.net/bigtimebuddy/u05c1s28/