### PR TITLE
Fix: Floating point imprecision could break vertical text gradient generation

### DIFF
--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -490,6 +490,13 @@ export class Text extends Sprite
             // ['#FF0000', '#00FF00', '#0000FF'] over 2 lines would create stops at 0.125, 0.25, 0.375, 0.625, 0.75, 0.875
             totalIterations = (fill.length + 1) * lines.length;
             currentIteration = 0;
+
+            // There's potential for floating point precision issues at the seams between gradient repeats.
+            // The loop below generates the stops in order, so track the last generated one to prevent
+            // floating point precision from making us go the teeniest bit backwards, resulting in
+            // the first and last colors getting swapped.
+            let lastIterationStop = 0;
+
             for (let i = 0; i < lines.length; i++)
             {
                 currentIteration += 1;
@@ -503,8 +510,13 @@ export class Text extends Sprite
                     {
                         stop = currentIteration / totalIterations;
                     }
-                    gradient.addColorStop(stop, fill[j]);
+
+                    // Prevent color stop generation going backwards from floating point imprecision
+                    const clampedStop = Math.max(lastIterationStop, stop);
+
+                    gradient.addColorStop(clampedStop, fill[j]);
                     currentIteration++;
+                    lastIterationStop = clampedStop;
                 }
             }
         }

--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -512,8 +512,9 @@ export class Text extends Sprite
                     }
 
                     // Prevent color stop generation going backwards from floating point imprecision
-                    const clampedStop = Math.max(lastIterationStop, stop);
+                    let clampedStop = Math.max(lastIterationStop, stop);
 
+                    clampedStop = Math.min(clampedStop, 1); // Cap at 1 as well for safety's sake to avoid a possible throw.
                     gradient.addColorStop(clampedStop, fill[j]);
                     currentIteration++;
                     lastIterationStop = clampedStop;


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
In Chrome, I'd noticed some of my text in a project didn't always have the same gradient on each line. Turns out the seams between tiled gradients could sometimes have floating point imprecision, effectively swapping the start/end gradient colours around and messing a line or two up. This PR caps the gradient to the last value (as color stops are generated in order anyway) to prevent this happening.

[Playground demo (Open in chrome, change bool at start to toggle fix)](https://pixiplayground.com/#/edit/8I-EO0eRlShU4YHvuD6bc)

Happy to backport this for v4 as well if wanted.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- Demo provided.
- Do we have a way of testing visual stuff?
- [x] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
- Can't verify, tests currently failing already.