### PR TITLE
Making "updateText" to be public

### DIFF
--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -135,12 +135,14 @@ export class Text extends Sprite
     }
 
     /**
-     * Renders text and updates it when needed.
+     * Renders text to its canvas, and updates its texture.
+     * By default this is used internally to ensure the texture is correct before rendering,
+     * but it can be used called externally, for example from this class to 'pre-generate' the texture from a piece of text,
+     * and then shared across multiple Sprites.
      *
-     * @private
      * @param {boolean} respectDirty - Whether to abort updating the text if the Text isn't dirty and the function is called.
      */
-    private updateText(respectDirty: boolean): void
+    public updateText(respectDirty: boolean): void
     {
         const style = this._style;
 


### PR DESCRIPTION
We often give advice to use this to force updating of the texture outside of a render cycle; for example, to generate a texture containing a piece of text which is then shared across multiple sprites.

For example
https://github.com/pixijs/pixi.js/issues/5138#issuecomment-425715507
https://github.com/pixijs/pixi.js/issues/5043#issuecomment-408377422
https://www.html5gamedevs.com/topic/42319-pixitext-caching-with-resolution/?do=findComment&comment=239720

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
