### PR TITLE
Fixes usage of NaN

### DIFF
--- a/packages/graphics/src/const.ts
+++ b/packages/graphics/src/const.ts
@@ -29,7 +29,7 @@ export const GRAPHICS_CURVES: IGraphicsCurvesSettings = {
 
     _segmentsCount(length: number, defaultSegments = 20)
     {
-        if (!this.adaptive || !length || Number.isNaN(length))
+        if (!this.adaptive || !length || isNaN(length))
         {
             return defaultSegments;
         }


### PR DESCRIPTION
IE doesn't support the Number.NaN location, so reverting to global NaN
https://github.com/pixijs/pixi.js/issues/6421

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
