### PR TITLE
Hot extract fix

### DIFF
--- a/packages/extract/src/Extract.ts
+++ b/packages/extract/src/Extract.ts
@@ -132,7 +132,7 @@ export class Extract implements IRendererPlugin
         const width = Math.floor((frame.width * resolution) + 1e-4);
         const height = Math.floor((frame.height * resolution) + 1e-4);
 
-        const canvasBuffer = new CanvasRenderTarget(width, height, 1);
+        let canvasBuffer = new CanvasRenderTarget(width, height, 1);
 
         const webglPixels = new Uint8Array(BYTES_PER_PIXEL * width * height);
 
@@ -159,8 +159,15 @@ export class Extract implements IRendererPlugin
         // pulling pixels
         if (flipY)
         {
-            canvasBuffer.context.scale(1, -1);
-            canvasBuffer.context.drawImage(canvasBuffer.canvas, 0, -height);
+            const target = new CanvasRenderTarget(canvasBuffer.width, canvasBuffer.height, 1);
+
+            target.context.scale(1, -1);
+
+            // we can't render to itself because we should be empty before render.
+            target.context.drawImage(canvasBuffer.canvas, 0, -height);
+
+            canvasBuffer.destroy();
+            canvasBuffer = target;
         }
 
         if (generated)


### PR DESCRIPTION
Related to #6424 

Why? Because extract drawn canvas to itself, it is wrong when there is a alpha.

In fix extract creates new CanvasRenderTarget and draw flipped to it.

Before:
https://www.pixiplayground.com/#/edit/pAo7HerhsY5JZTf16ajNq

After:
https://www.pixiplayground.com/#/edit/0vBcRtK80ctpV8pI2bVVn