### PR TITLE
Fix failing on iOS when webgl2 does not exist on global scope

### DIFF
--- a/packages/core/src/context/ContextSystem.ts
+++ b/packages/core/src/context/ContextSystem.ts
@@ -292,7 +292,7 @@ export class ContextSystem extends System
         }
 
         const hasuint32
-            = (gl instanceof WebGL2RenderingContext)
+            = ('WebGL2RenderingContext' in window && gl instanceof window.WebGL2RenderingContext)
             || !!(gl as WebGLRenderingContext).getExtension('OES_element_index_uint');
 
         this.supports.uint32Indices = hasuint32;


### PR DESCRIPTION
Follow up #6417 , #6433 

Includes test to exist `WebGL2RenderingContext` in `window`  before calling `instanceof`, suppresses failing (and downgrade to canvas) on iOS and any devices without WebGL2

Oops:)