### PR TITLE
Canvas2d transform improvement

### DIFF
--- a/packages/canvas/canvas-graphics/src/CanvasGraphicsRenderer.js
+++ b/packages/canvas/canvas-graphics/src/CanvasGraphicsRenderer.js
@@ -73,16 +73,8 @@ export class CanvasGraphicsRenderer
         const context = renderer.context;
         const worldAlpha = graphics.worldAlpha;
         const transform = graphics.transform.worldTransform;
-        const resolution = renderer.resolution;
 
-        context.setTransform(
-            transform.a * resolution,
-            transform.b * resolution,
-            transform.c * resolution,
-            transform.d * resolution,
-            transform.tx * resolution,
-            transform.ty * resolution
-        );
+        renderer.setContextTransform(transform);
 
         // update tint if graphics was dirty
         if (graphics.canvasTintDirty !== graphics.geometry.dirty

--- a/packages/canvas/canvas-mesh/src/CanvasMeshRenderer.js
+++ b/packages/canvas/canvas-mesh/src/CanvasMeshRenderer.js
@@ -25,36 +25,11 @@ export class CanvasMeshRenderer
     render(mesh)
     {
         const renderer = this.renderer;
-        const context = renderer.context;
-
         const transform = mesh.worldTransform;
-        const res = renderer.resolution;
-
-        if (mesh.roundPixels)
-        {
-            context.setTransform(
-                transform.a * res,
-                transform.b * res,
-                transform.c * res,
-                transform.d * res,
-                (transform.tx * res) | 0,
-                (transform.ty * res) | 0
-            );
-        }
-        else
-        {
-            context.setTransform(
-                transform.a * res,
-                transform.b * res,
-                transform.c * res,
-                transform.d * res,
-                transform.tx * res,
-                transform.ty * res
-            );
-        }
 
         renderer.context.globalAlpha = mesh.worldAlpha;
         renderer.setBlendMode(mesh.blendMode);
+        renderer.setContextTransform(transform, mesh.roundPixels);
 
         if (mesh.drawMode !== DRAW_MODES.TRIANGLES)
         {

--- a/packages/canvas/canvas-mesh/src/NineSlicePlane.js
+++ b/packages/canvas/canvas-mesh/src/NineSlicePlane.js
@@ -37,7 +37,6 @@ NineSlicePlane.prototype._renderCanvas = function _renderCanvas(renderer)
 {
     const context = renderer.context;
     const transform = this.worldTransform;
-    const res = renderer.resolution;
     const isTinted = this.tint !== 0xFFFFFF;
     const texture = this.texture;
 
@@ -89,29 +88,7 @@ NineSlicePlane.prototype._renderCanvas = function _renderCanvas(renderer)
 
     context.globalAlpha = this.worldAlpha;
     renderer.setBlendMode(this.blendMode);
-
-    if (this.roundPixels)
-    {
-        context.setTransform(
-            transform.a * res,
-            transform.b * res,
-            transform.c * res,
-            transform.d * res,
-            (transform.tx * res) | 0,
-            (transform.ty * res) | 0
-        );
-    }
-    else
-    {
-        context.setTransform(
-            transform.a * res,
-            transform.b * res,
-            transform.c * res,
-            transform.d * res,
-            transform.tx * res,
-            transform.ty * res
-        );
-    }
+    renderer.setContextTransform(transform, this.roundPixels);
 
     for (let row = 0; row < 3; row++)
     {

--- a/packages/canvas/canvas-particles/src/ParticleContainer.js
+++ b/packages/canvas/canvas-particles/src/ParticleContainer.js
@@ -53,15 +53,7 @@ ParticleContainer.prototype.renderCanvas = function renderCanvas(renderer)
             // this is the fastest  way to optimise! - if rotation is 0 then we can avoid any kind of setTransform call
             if (isRotated)
             {
-                context.setTransform(
-                    transform.a,
-                    transform.b,
-                    transform.c,
-                    transform.d,
-                    transform.tx * renderer.resolution,
-                    transform.ty * renderer.resolution
-                );
-
+                renderer.setContextTransform(transform, false, 1);
                 isRotated = false;
             }
 
@@ -82,28 +74,7 @@ ParticleContainer.prototype.renderCanvas = function renderCanvas(renderer)
 
             const childTransform = child.worldTransform;
 
-            if (this.roundPixels)
-            {
-                context.setTransform(
-                    childTransform.a,
-                    childTransform.b,
-                    childTransform.c,
-                    childTransform.d,
-                    (childTransform.tx * renderer.resolution) | 0,
-                    (childTransform.ty * renderer.resolution) | 0
-                );
-            }
-            else
-            {
-                context.setTransform(
-                    childTransform.a,
-                    childTransform.b,
-                    childTransform.c,
-                    childTransform.d,
-                    childTransform.tx * renderer.resolution,
-                    childTransform.ty * renderer.resolution
-                );
-            }
+            renderer.setContextTransform(childTransform, this.roundPixels, 1);
 
             positionX = ((child.anchor.x) * (-frame.width)) + 0.5;
             positionY = ((child.anchor.y) * (-frame.height)) + 0.5;

--- a/packages/canvas/canvas-renderer/src/CanvasRenderer.js
+++ b/packages/canvas/canvas-renderer/src/CanvasRenderer.js
@@ -141,7 +141,7 @@ export class CanvasRenderer extends AbstractRenderer
      * @param {PIXI.RenderTexture} [renderTexture] - A render texture to be rendered to.
      *  If unset, it will render to the root context.
      * @param {boolean} [clear=false] - Whether to clear the canvas before drawing
-     * @param {PIXI.Matrix} [transform] - A transformation to be applied, supports only translation
+     * @param {PIXI.Matrix} [transform] - A transformation to be applied
      * @param {boolean} [skipUpdateTransform=false] - Whether to skip the update transform
      */
     render(displayObject, renderTexture, clear, transform, skipUpdateTransform)

--- a/packages/canvas/canvas-renderer/src/CanvasRenderer.js
+++ b/packages/canvas/canvas-renderer/src/CanvasRenderer.js
@@ -4,6 +4,9 @@ import { CanvasMaskManager } from './utils/CanvasMaskManager';
 import { mapCanvasBlendModesToPixi } from './utils/mapCanvasBlendModesToPixi';
 import { RENDERER_TYPE, SCALE_MODES, BLEND_MODES } from '@pixi/constants';
 import { settings } from '@pixi/settings';
+import { Matrix } from '@pixi/math';
+
+const tempMatrix = new Matrix();
 
 /**
  * The CanvasRenderer draws the scene and all its content onto a 2d canvas.
@@ -105,6 +108,13 @@ export class CanvasRenderer extends AbstractRenderer
         this._activeBlendMode = null;
         this._outerBlend = false;
 
+        /**
+         * Projection transform, passed in render() stored here
+         * @type {null}
+         * @private
+         */
+        this._projTransform = null;
+
         this.renderingToScreen = false;
 
         sayHello('Canvas');
@@ -131,7 +141,7 @@ export class CanvasRenderer extends AbstractRenderer
      * @param {PIXI.RenderTexture} [renderTexture] - A render texture to be rendered to.
      *  If unset, it will render to the root context.
      * @param {boolean} [clear=false] - Whether to clear the canvas before drawing
-     * @param {PIXI.Matrix} [transform] - A transformation to be applied
+     * @param {PIXI.Matrix} [transform] - A transformation to be applied, supports only translation
      * @param {boolean} [skipUpdateTransform=false] - Whether to skip the update transform
      */
     render(displayObject, renderTexture, clear, transform, skipUpdateTransform)
@@ -173,6 +183,8 @@ export class CanvasRenderer extends AbstractRenderer
 
         const context = this.context;
 
+        this._projTransform = transform || null;
+
         if (!renderTexture)
         {
             this._lastObjectRendered = displayObject;
@@ -182,33 +194,10 @@ export class CanvasRenderer extends AbstractRenderer
         {
             // update the scene graph
             const cacheParent = displayObject.parent;
-            const tempWt = this._tempDisplayObjectParent.transform.worldTransform;
-
-            if (transform)
-            {
-                transform.copyTo(tempWt);
-                // Canvas Renderer doesn't use "context.translate"
-                // nor does it store current translation in projectionSystem
-                // we re-calculate all matrices,
-                // its not like CanvasRenderer can survive more than 1000 elements
-                displayObject.transform._parentID = -1;
-            }
-            else
-            {
-                // in this case matrix cache in displayObject works like expected
-                tempWt.identity();
-            }
 
             displayObject.parent = this._tempDisplayObjectParent;
-
             displayObject.updateTransform();
             displayObject.parent = cacheParent;
-            if (transform)
-            {
-                // Clear the matrix cache one more time,
-                // we dont have our computations to affect standard "transform=null" case
-                displayObject.transform._parentID = -1;
-            }
             // displayObject.hitArea = //TODO add a temp hit area
         }
 
@@ -249,6 +238,52 @@ export class CanvasRenderer extends AbstractRenderer
         this.resolution = rootResolution;
 
         this.emit('postrender');
+    }
+
+    /**
+     * sets matrix of context
+     * called only from render() methods
+     * takes care about resolution
+     * @param {PIXI.Matrix} transform world matrix of current element
+     * @param {boolean} [roundPixels] whether to round (tx,ty) coords
+     * @param {number} [localResolution] If specified, used instead of `renderer.resolution` for local scaling
+     */
+    setContextTransform(transform, roundPixels, localResolution)
+    {
+        let mat = transform;
+        const proj = this._projTransform;
+        const resolution = this.resolution;
+
+        localResolution = localResolution || resolution;
+
+        if (proj)
+        {
+            mat = tempMatrix;
+            mat.prepend(proj);
+        }
+
+        if (roundPixels)
+        {
+            this.context.setTransform(
+                mat.a * localResolution,
+                mat.b * localResolution,
+                mat.c * localResolution,
+                mat.d * localResolution,
+                (mat.tx * resolution) | 0,
+                (mat.ty * resolution) | 0
+            );
+        }
+        else
+        {
+            this.context.setTransform(
+                mat.a * localResolution,
+                mat.b * localResolution,
+                mat.c * localResolution,
+                mat.d * localResolution,
+                mat.tx * resolution,
+                mat.ty * resolution
+            );
+        }
     }
 
     /**

--- a/packages/canvas/canvas-renderer/src/CanvasRenderer.js
+++ b/packages/canvas/canvas-renderer/src/CanvasRenderer.js
@@ -259,6 +259,7 @@ export class CanvasRenderer extends AbstractRenderer
         if (proj)
         {
             mat = tempMatrix;
+            mat.copyFrom(transform);
             mat.prepend(proj);
         }
 

--- a/packages/canvas/canvas-renderer/src/CanvasRenderer.js
+++ b/packages/canvas/canvas-renderer/src/CanvasRenderer.js
@@ -236,6 +236,7 @@ export class CanvasRenderer extends AbstractRenderer
         context.restore();
 
         this.resolution = rootResolution;
+        this._projTransform = null;
 
         this.emit('postrender');
     }

--- a/packages/canvas/canvas-renderer/src/utils/CanvasMaskManager.js
+++ b/packages/canvas/canvas-renderer/src/utils/CanvasMaskManager.js
@@ -40,7 +40,7 @@ export class CanvasMaskManager
         this.recursiveFindShapes(maskObject, foundShapes);
         if (foundShapes.length > 0)
         {
-            const { context, resolution } = renderer;
+            const { context } = renderer;
 
             context.beginPath();
 
@@ -49,14 +49,7 @@ export class CanvasMaskManager
                 const shape = foundShapes[i];
                 const transform = shape.transform.worldTransform;
 
-                this.renderer.context.setTransform(
-                    transform.a * resolution,
-                    transform.b * resolution,
-                    transform.c * resolution,
-                    transform.d * resolution,
-                    transform.tx * resolution,
-                    transform.ty * resolution
-                );
+                this.renderer.setContextTransform(transform);
 
                 this.renderGraphicsShape(shape);
             }

--- a/packages/canvas/canvas-renderer/test/CanvasRenderer.js
+++ b/packages/canvas/canvas-renderer/test/CanvasRenderer.js
@@ -32,19 +32,25 @@ describe('PIXI.CanvasRenderer', function ()
         }
     });
 
-    it('should clear matrix cache in case of translation', function ()
+    it('should update transform in case of temp parent', function ()
     {
         // this test works only for CanvasRenderer, WebGLRenderer behaviour is different
         const renderer = new CanvasRenderer(1, 1);
         const cont = new Container();
+        const par = new Container();
+
+        par.position.set(5, 10);
+        par.addChild(cont);
 
         renderer.render(cont, undefined, undefined, new Matrix().translate(10, 20));
-        expect(cont.worldTransform.tx).to.equal(10);
-        expect(cont.worldTransform.ty).to.equal(20);
+        expect(cont.worldTransform.tx).to.equal(0);
+        expect(cont.worldTransform.ty).to.equal(0);
+
+        renderer.render(par);
+        expect(cont.worldTransform.tx).to.equal(5);
+        expect(cont.worldTransform.ty).to.equal(10);
+
         renderer.render(cont, undefined, undefined, new Matrix().translate(-20, 30));
-        expect(cont.worldTransform.tx).to.equal(-20);
-        expect(cont.worldTransform.ty).to.equal(30);
-        renderer.render(cont);
         expect(cont.worldTransform.tx).to.equal(0);
         expect(cont.worldTransform.ty).to.equal(0);
     });

--- a/packages/canvas/canvas-sprite-tiling/src/TilingSprite.js
+++ b/packages/canvas/canvas-sprite-tiling/src/TilingSprite.js
@@ -21,7 +21,6 @@ TilingSprite.prototype._renderCanvas = function _renderCanvas(renderer)
 
     const context = renderer.context;
     const transform = this.worldTransform;
-    const resolution = renderer.resolution;
     const baseTexture = texture.baseTexture;
     const source = baseTexture.getDrawableSource();
     const baseTextureResolution = baseTexture.resolution;
@@ -54,14 +53,8 @@ TilingSprite.prototype._renderCanvas = function _renderCanvas(renderer)
 
     // set context state..
     context.globalAlpha = this.worldAlpha;
-    context.setTransform(transform.a * resolution,
-        transform.b * resolution,
-        transform.c * resolution,
-        transform.d * resolution,
-        transform.tx * resolution,
-        transform.ty * resolution);
-
     renderer.setBlendMode(this.blendMode);
+    renderer.setContextTransform(transform);
 
     // fill the pattern!
     context.fillStyle = this._canvasPattern;

--- a/packages/canvas/canvas-sprite/src/CanvasSpriteRenderer.js
+++ b/packages/canvas/canvas-sprite/src/CanvasSpriteRenderer.js
@@ -105,31 +105,12 @@ export class CanvasSpriteRenderer
         dx -= width / 2;
         dy -= height / 2;
 
+        renderer.setContextTransform(wt, sprite.roundPixels, 1);
         // Allow for pixel rounding
         if (sprite.roundPixels)
         {
-            renderer.context.setTransform(
-                wt.a,
-                wt.b,
-                wt.c,
-                wt.d,
-                (wt.tx * renderer.resolution) | 0,
-                (wt.ty * renderer.resolution) | 0
-            );
-
             dx = dx | 0;
             dy = dy | 0;
-        }
-        else
-        {
-            renderer.context.setTransform(
-                wt.a,
-                wt.b,
-                wt.c,
-                wt.d,
-                wt.tx * renderer.resolution,
-                wt.ty * renderer.resolution
-            );
         }
 
         const resolution = texture.baseTexture.resolution;

--- a/packages/mixin-cache-as-bitmap/src/index.js
+++ b/packages/mixin-cache-as-bitmap/src/index.js
@@ -303,6 +303,7 @@ DisplayObject.prototype._initCachedDisplayObjectCanvas = function _initCachedDis
     this.alpha = 1;
 
     const cachedRenderTarget = renderer.context;
+    const cachedProjectionTransform = renderer._projTransform;
 
     bounds.ceil(settings.RESOLUTION);
 
@@ -328,11 +329,10 @@ DisplayObject.prototype._initCachedDisplayObjectCanvas = function _initCachedDis
     // set all properties to there original so we can render to a texture
     this.renderCanvas = this._cacheData.originalRenderCanvas;
 
-    // renderTexture.render(this, m, true);
     renderer.render(this, renderTexture, true, m, false);
-
     // now restore the state be setting the new properties
     renderer.context = cachedRenderTarget;
+    renderer._projTransform = cachedProjectionTransform;
 
     this.renderCanvas = this._renderCachedCanvas;
     // the rest is the same as for WebGL


### PR DESCRIPTION
Our Canvas2d and webgl code regarding render transform differs.

It makes difficult to debug some cases, and it prevents us from refactor all that "temporary parent" code to "pixi/@display" package.

This PR does not add new functionality nor does it change behaviour.  No moving `floor`s around, no doing extra multiplications/divisions, it should be the same code.

I'll add some resolution-related examples a bit later.

+81-158 , yeah, that's a good balance!