### PR TITLE
TypeScript 3.8 and import type

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -227,7 +227,7 @@
         "no-confusing-arrow": [1, { "allowParens": true }],
         "no-const-assign": 1,
         "no-dupe-class-members": 0,
-        "no-duplicate-imports": 1,
+        "no-duplicate-imports": 0,
         "no-new-symbol": 1,
         "no-restricted-imports": 0,
         "no-this-before-super": 1,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11241,9 +11241,9 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz",
-			"integrity": "sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
 		"uglify-js": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,6 @@
     "rollup-plugin-terser": "^4.0.4",
     "rollup-plugin-typescript": "^1.0.1",
     "tsd-jsdoc": "^2.1.3",
-    "typescript": "^3.6.2"
+    "typescript": "^3.8.3"
   }
 }

--- a/packages/accessibility/src/AccessibilityManager.ts
+++ b/packages/accessibility/src/AccessibilityManager.ts
@@ -1,8 +1,11 @@
-import { Renderer, AbstractRenderer } from '@pixi/core';
-import { Container, DisplayObject } from '@pixi/display';
-import { Rectangle } from '@pixi/math';
+import { DisplayObject } from '@pixi/display';
 import { isMobile, removeItems } from '@pixi/utils';
-import { accessibleTarget, IAccessibleHTMLElement } from './accessibleTarget';
+import { accessibleTarget } from './accessibleTarget';
+
+import type { Rectangle } from '@pixi/math';
+import type { Container } from '@pixi/display';
+import type { Renderer, AbstractRenderer } from '@pixi/core';
+import type { IAccessibleHTMLElement } from './accessibleTarget';
 
 // add some extra variables to the container..
 DisplayObject.mixin(accessibleTarget);

--- a/packages/accessibility/src/accessibleTarget.ts
+++ b/packages/accessibility/src/accessibleTarget.ts
@@ -1,4 +1,4 @@
-import { DisplayObject } from '@pixi/display';
+import type { DisplayObject } from '@pixi/display';
 
 export type PointerEvents = 'auto'
 | 'none'

--- a/packages/app/src/Application.ts
+++ b/packages/app/src/Application.ts
@@ -1,6 +1,9 @@
-import { Container, IDestroyOptions } from '@pixi/display';
-import { autoDetectRenderer, Renderer, IRendererOptionsAuto, AbstractRenderer } from '@pixi/core';
-import { Rectangle } from '@pixi/math';
+import { Container } from '@pixi/display';
+import { autoDetectRenderer } from '@pixi/core';
+
+import type { Rectangle } from '@pixi/math';
+import type { Renderer, IRendererOptionsAuto, AbstractRenderer } from '@pixi/core';
+import type { IDestroyOptions } from '@pixi/display';
 
 export interface IApplicationPlugin {
     init: (...params: any[]) => any;

--- a/packages/app/src/ResizePlugin.ts
+++ b/packages/app/src/ResizePlugin.ts
@@ -1,6 +1,6 @@
-import { CanvasRenderer } from '@pixi/canvas-renderer';
-import { Renderer } from '@pixi/core';
-import { IApplicationOptions } from './Application';
+import type { CanvasRenderer } from '@pixi/canvas-renderer';
+import type { Renderer } from '@pixi/core';
+import type { IApplicationOptions } from './Application';
 
 /**
  * Middleware for for Application's resize functionality

--- a/packages/core/src/AbstractRenderer.ts
+++ b/packages/core/src/AbstractRenderer.ts
@@ -1,11 +1,12 @@
 import { hex2string, hex2rgb, deprecation, EventEmitter } from '@pixi/utils';
 import { Matrix, Rectangle } from '@pixi/math';
-import { RENDERER_TYPE, SCALE_MODES } from '@pixi/constants';
+import { RENDERER_TYPE } from '@pixi/constants';
 import { settings } from '@pixi/settings';
 import { DisplayObject, TemporaryDisplayObject } from '@pixi/display';
 import { RenderTexture } from './renderTexture/RenderTexture';
 
-import { IRenderingContext } from './IRenderingContext';
+import type { SCALE_MODES } from '@pixi/constants';
+import type { IRenderingContext } from './IRenderingContext';
 
 const tempMatrix = new Matrix();
 

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -1,4 +1,4 @@
-import { AbstractRenderer, IRendererOptions, IRendererPlugins } from './AbstractRenderer';
+import { AbstractRenderer } from './AbstractRenderer';
 import { sayHello, isWebGLSupported } from '@pixi/utils';
 import { MaskSystem } from './mask/MaskSystem';
 import { StencilSystem } from './mask/StencilSystem';
@@ -19,12 +19,12 @@ import { UniformGroup } from './shader/UniformGroup';
 import { Matrix } from '@pixi/math';
 import { Runner } from '@pixi/runner';
 
-// import types
-import { RenderTexture } from './renderTexture/RenderTexture';
-import { DisplayObject } from '@pixi/display';
-import { System } from './System';
-import { IRenderingContext } from './IRenderingContext';
-import { Extract } from '@pixi/extract';
+import type { IRendererOptions, IRendererPlugins } from './AbstractRenderer';
+import type { RenderTexture } from './renderTexture/RenderTexture';
+import type { DisplayObject } from '@pixi/display';
+import type { System } from './System';
+import type { IRenderingContext } from './IRenderingContext';
+import type { Extract } from '@pixi/extract';
 
 export interface IRendererPluginConstructor {
     new (renderer: Renderer): IRendererPlugin;

--- a/packages/core/src/System.ts
+++ b/packages/core/src/System.ts
@@ -1,4 +1,5 @@
-import { Renderer } from './Renderer';
+import type { Renderer } from './Renderer';
+
 /**
  * System is a base class used for extending systems used by the {@link PIXI.Renderer}
  *

--- a/packages/core/src/autoDetectRenderer.ts
+++ b/packages/core/src/autoDetectRenderer.ts
@@ -1,5 +1,5 @@
 import { Renderer } from './Renderer';
-import { IRendererOptions } from './AbstractRenderer';
+import type { IRendererOptions } from './AbstractRenderer';
 
 export interface IRendererOptionsAuto extends IRendererOptions
 {

--- a/packages/core/src/batch/AbstractBatchRenderer.ts
+++ b/packages/core/src/batch/AbstractBatchRenderer.ts
@@ -11,9 +11,9 @@ import { settings } from '@pixi/settings';
 import { premultiplyBlendMode, premultiplyTint, nextPow2, log2 } from '@pixi/utils';
 import { ENV } from '@pixi/constants';
 
-import { Renderer, Shader } from '@pixi/core';
-import { BatchShaderGenerator } from './BatchShaderGenerator';
-import { BatchGeometry } from './BatchGeometry';
+import type { Renderer, Shader } from '@pixi/core';
+import type { BatchShaderGenerator } from './BatchShaderGenerator';
+import type { BatchGeometry } from './BatchGeometry';
 
 /**
  * Renderer dedicated to drawing and batching sprites.

--- a/packages/core/src/batch/BatchDrawCall.ts
+++ b/packages/core/src/batch/BatchDrawCall.ts
@@ -1,5 +1,7 @@
-import { DRAW_MODES, BLEND_MODES } from '@pixi/constants';
-import { BatchTextureArray } from './BatchTextureArray';
+import { DRAW_MODES } from '@pixi/constants';
+
+import type { BLEND_MODES } from '@pixi/constants';
+import type { BatchTextureArray } from './BatchTextureArray';
 
 /**
  * Used by the batcher to draw batches.

--- a/packages/core/src/batch/BatchPluginFactory.ts
+++ b/packages/core/src/batch/BatchPluginFactory.ts
@@ -5,7 +5,7 @@ import { AbstractBatchRenderer } from './AbstractBatchRenderer';
 import defaultVertex from './texture.vert';
 import defaultFragment from './texture.frag';
 
-import { Renderer } from '@pixi/core';
+import type { Renderer } from '@pixi/core';
 
 export interface IBatchFactoryOptions
 {

--- a/packages/core/src/batch/BatchSystem.ts
+++ b/packages/core/src/batch/BatchSystem.ts
@@ -1,7 +1,7 @@
 import { System } from '../System';
 import { ObjectRenderer } from './ObjectRenderer';
 
-import { Renderer, BaseTexture, BatchTextureArray } from '@pixi/core';
+import type { Renderer, BaseTexture, BatchTextureArray } from '@pixi/core';
 
 /**
  * System plugin to the renderer to manage batching.

--- a/packages/core/src/batch/BatchTextureArray.ts
+++ b/packages/core/src/batch/BatchTextureArray.ts
@@ -1,4 +1,4 @@
-import { BaseTexture } from '@pixi/core';
+import type { BaseTexture } from '@pixi/core';
 
 /**
  * Used by the batcher to build texture batches.

--- a/packages/core/src/batch/ObjectRenderer.ts
+++ b/packages/core/src/batch/ObjectRenderer.ts
@@ -1,4 +1,4 @@
-import { Renderer } from '@pixi/core';
+import type { Renderer } from '@pixi/core';
 
 /**
  * Base for a common object renderer that can be used as a

--- a/packages/core/src/context/ContextSystem.ts
+++ b/packages/core/src/context/ContextSystem.ts
@@ -1,8 +1,8 @@
-import { IRenderingContext, Renderer } from '@pixi/core';
-
 import { ENV } from '@pixi/constants';
 import { System } from '../System';
 import { settings } from '../settings';
+
+import type { IRenderingContext, Renderer } from '@pixi/core';
 
 let CONTEXT_UID_COUNTER = 0;
 

--- a/packages/core/src/filters/Filter.ts
+++ b/packages/core/src/filters/Filter.ts
@@ -5,10 +5,10 @@ import { settings } from '@pixi/settings';
 import defaultVertex from './defaultFilter.vert';
 import defaultFragment from './defaultFilter.frag';
 
-import { RenderTexture } from '@pixi/core';
-import { FilterSystem } from './FilterSystem';
-import { FilterState } from './FilterState';
-import { BLEND_MODES, CLEAR_MODES } from '@pixi/constants';
+import type { RenderTexture } from '@pixi/core';
+import type { FilterSystem } from './FilterSystem';
+import type { FilterState } from './FilterState';
+import type { BLEND_MODES, CLEAR_MODES } from '@pixi/constants';
 
 /**
  * Filter is a special type of WebGL shader that is applied to the screen.

--- a/packages/core/src/filters/FilterState.ts
+++ b/packages/core/src/filters/FilterState.ts
@@ -1,7 +1,8 @@
-import { Filter } from './Filter';
-import { IFilterTarget } from './IFilterTarget';
-import { RenderTexture } from '@pixi/core';
 import { Rectangle } from '@pixi/math';
+
+import type { Filter } from './Filter';
+import type { IFilterTarget } from './IFilterTarget';
+import type { RenderTexture } from '@pixi/core';
 
 /**
  * System plugin to the renderer to manage filter states.

--- a/packages/core/src/filters/FilterSystem.ts
+++ b/packages/core/src/filters/FilterSystem.ts
@@ -6,11 +6,11 @@ import { Rectangle, Matrix } from '@pixi/math';
 import { UniformGroup } from '../shader/UniformGroup';
 import { DRAW_MODES, CLEAR_MODES } from '@pixi/constants';
 import { deprecation } from '@pixi/utils';
-
 import { FilterState } from './FilterState';
-import { Filter } from './Filter';
-import { IFilterTarget } from './IFilterTarget';
-import { Renderer, RenderTexture, ISpriteMaskTarget } from '@pixi/core';
+
+import type { Filter } from './Filter';
+import type { IFilterTarget } from './IFilterTarget';
+import type { Renderer, RenderTexture, ISpriteMaskTarget } from '@pixi/core';
 
 /**
  * System plugin to the renderer to manage the filters.

--- a/packages/core/src/filters/IFilterTarget.ts
+++ b/packages/core/src/filters/IFilterTarget.ts
@@ -1,4 +1,4 @@
-import { Rectangle } from '@pixi/math';
+import type { Rectangle } from '@pixi/math';
 
 export interface IFilterTarget
 {

--- a/packages/core/src/filters/spriteMask/SpriteMaskFilter.ts
+++ b/packages/core/src/filters/spriteMask/SpriteMaskFilter.ts
@@ -5,8 +5,8 @@ import vertex from './spriteMaskFilter.vert';
 import fragment from './spriteMaskFilter.frag';
 import { TextureMatrix } from '../../textures/TextureMatrix';
 
-import { FilterSystem } from '../FilterSystem';
-import { IMaskTarget, Texture, RenderTexture } from '@pixi/core';
+import type { FilterSystem } from '../FilterSystem';
+import type { IMaskTarget, Texture, RenderTexture } from '@pixi/core';
 
 export interface ISpriteMaskTarget extends IMaskTarget
 {

--- a/packages/core/src/framebuffer/Framebuffer.ts
+++ b/packages/core/src/framebuffer/Framebuffer.ts
@@ -3,7 +3,7 @@ import { BaseTexture } from '../textures/BaseTexture';
 import { DepthResource } from '../textures/resources/DepthResource';
 import { FORMATS, MIPMAP_MODES, TYPES, MSAA_QUALITY } from '@pixi/constants';
 
-import { GLFramebuffer } from './GLFramebuffer';
+import type { GLFramebuffer } from './GLFramebuffer';
 
 /**
  * Frame buffer used by the BaseRenderTexture

--- a/packages/core/src/framebuffer/FramebufferSystem.ts
+++ b/packages/core/src/framebuffer/FramebufferSystem.ts
@@ -5,7 +5,7 @@ import { settings } from '../settings';
 import { Framebuffer } from './Framebuffer';
 import { GLFramebuffer } from './GLFramebuffer';
 
-import { Renderer, IRenderingContext } from '@pixi/core';
+import type { Renderer, IRenderingContext } from '@pixi/core';
 
 const tempRectangle = new Rectangle();
 

--- a/packages/core/src/framebuffer/GLFramebuffer.ts
+++ b/packages/core/src/framebuffer/GLFramebuffer.ts
@@ -1,5 +1,6 @@
-import { Framebuffer } from './Framebuffer';
 import { MSAA_QUALITY } from '@pixi/constants';
+
+import type { Framebuffer } from './Framebuffer';
 
 /**
  * Internal framebuffer for WebGL context

--- a/packages/core/src/geometry/Attribute.ts
+++ b/packages/core/src/geometry/Attribute.ts
@@ -1,4 +1,4 @@
-import { TYPES } from '@pixi/constants';
+import type { TYPES } from '@pixi/constants';
 
 /* eslint-disable max-len */
 

--- a/packages/core/src/geometry/Buffer.ts
+++ b/packages/core/src/geometry/Buffer.ts
@@ -1,5 +1,6 @@
 import { Runner } from '@pixi/runner';
-import { GLBuffer } from './GLBuffer';
+
+import type { GLBuffer } from './GLBuffer';
 
 let UID = 0;
 /* eslint-disable max-len */

--- a/packages/core/src/geometry/Geometry.ts
+++ b/packages/core/src/geometry/Geometry.ts
@@ -1,9 +1,11 @@
 import { Attribute } from './Attribute';
-import { Buffer, IArrayBuffer } from './Buffer';
+import { Buffer } from './Buffer';
 import { interleaveTypedArrays } from './utils/interleaveTypedArrays';
 import { getBufferType } from './utils/getBufferType';
-import { TYPES } from '@pixi/constants';
 import { Runner } from '@pixi/runner';
+
+import type { TYPES } from '@pixi/constants';
+import type { IArrayBuffer } from './Buffer';
 
 const byteSizeMap: {[key: number]: number} = { 5126: 4, 5123: 2, 5121: 1 };
 let UID = 0;

--- a/packages/core/src/geometry/GeometrySystem.ts
+++ b/packages/core/src/geometry/GeometrySystem.ts
@@ -1,10 +1,11 @@
 import { System } from '../System';
 import { GLBuffer } from './GLBuffer';
-import { ENV, DRAW_MODES } from '@pixi/constants';
+import { ENV } from '@pixi/constants';
 import { settings } from '../settings';
 
-import { Renderer, IRenderingContext, Geometry, Shader, Program } from '@pixi/core';
-import { Buffer } from './Buffer';
+import type { DRAW_MODES } from '@pixi/constants';
+import type { Renderer, IRenderingContext, Geometry, Shader, Program } from '@pixi/core';
+import type { Buffer } from './Buffer';
 
 const byteSizeMap: {[key: number]: number} = { 5126: 4, 5123: 2, 5121: 1 };
 

--- a/packages/core/src/geometry/ViewableBuffer.ts
+++ b/packages/core/src/geometry/ViewableBuffer.ts
@@ -1,4 +1,4 @@
-import { ITypedArray } from './Buffer';
+import type { ITypedArray } from './Buffer';
 
 /**
  * Flexible wrapper around `ArrayBuffer` that also provides

--- a/packages/core/src/geometry/utils/getBufferType.ts
+++ b/packages/core/src/geometry/utils/getBufferType.ts
@@ -1,4 +1,4 @@
-import { ITypedArray } from '../Buffer';
+import type { ITypedArray } from '../Buffer';
 
 export function getBufferType(array: ITypedArray): string|null
 {

--- a/packages/core/src/geometry/utils/interleaveTypedArrays.ts
+++ b/packages/core/src/geometry/utils/interleaveTypedArrays.ts
@@ -1,5 +1,6 @@
-import { ITypedArray } from '../Buffer';
 import { getBufferType } from './getBufferType';
+
+import type { ITypedArray } from '../Buffer';
 
 /* eslint-disable object-shorthand */
 const map: {[x: string]: any} = {

--- a/packages/core/src/geometry/utils/setVertexAttribArrays.ts
+++ b/packages/core/src/geometry/utils/setVertexAttribArrays.ts
@@ -1,4 +1,4 @@
-import { IRenderingContext } from '@pixi/core';
+import type { IRenderingContext } from '@pixi/core';
 
 // var GL_MAP = {};
 

--- a/packages/core/src/mask/AbstractMaskSystem.ts
+++ b/packages/core/src/mask/AbstractMaskSystem.ts
@@ -1,7 +1,8 @@
 import { System } from '../System';
 
-import { MaskData } from './MaskData';
-import { Renderer } from '@pixi/core';
+import type { MaskData } from './MaskData';
+import type { Renderer } from '@pixi/core';
+
 /**
  * System plugin to the renderer to manage masks of certain type
  *

--- a/packages/core/src/mask/MaskData.ts
+++ b/packages/core/src/mask/MaskData.ts
@@ -1,7 +1,7 @@
 import { MASK_TYPES } from '@pixi/constants';
 
-import { Rectangle, Matrix } from '@pixi/math';
-import { Renderer, IFilterTarget } from '@pixi/core';
+import type { Rectangle, Matrix } from '@pixi/math';
+import type { Renderer, IFilterTarget } from '@pixi/core';
 
 export interface IMaskTarget extends IFilterTarget
 {

--- a/packages/core/src/mask/MaskSystem.ts
+++ b/packages/core/src/mask/MaskSystem.ts
@@ -1,9 +1,10 @@
 import { System } from '../System';
-import { IMaskTarget, MaskData } from './MaskData';
+import { MaskData } from './MaskData';
 import { SpriteMaskFilter } from '../filters/spriteMask/SpriteMaskFilter';
 import { MASK_TYPES } from '@pixi/constants';
 
-import { Renderer } from '@pixi/core';
+import type { IMaskTarget } from './MaskData';
+import type { Renderer } from '@pixi/core';
 
 /**
  * System plugin to the renderer to manage masks.

--- a/packages/core/src/mask/ScissorSystem.ts
+++ b/packages/core/src/mask/ScissorSystem.ts
@@ -1,7 +1,8 @@
 import { AbstractMaskSystem } from './AbstractMaskSystem';
 
-import { Renderer } from '@pixi/core';
-import { MaskData } from './MaskData';
+import type { Renderer } from '@pixi/core';
+import type { MaskData } from './MaskData';
+
 /**
  * System plugin to the renderer to manage scissor rects (used for masks).
  *

--- a/packages/core/src/mask/StencilSystem.ts
+++ b/packages/core/src/mask/StencilSystem.ts
@@ -1,7 +1,8 @@
 import { AbstractMaskSystem } from './AbstractMaskSystem';
 
-import { Renderer } from '@pixi/core';
-import { IMaskTarget, MaskData } from './MaskData';
+import type { Renderer } from '@pixi/core';
+import type { IMaskTarget, MaskData } from './MaskData';
+
 /**
  * System plugin to the renderer to manage stencils (used for masks).
  *

--- a/packages/core/src/projection/ProjectionSystem.ts
+++ b/packages/core/src/projection/ProjectionSystem.ts
@@ -1,7 +1,8 @@
 import { System } from '../System';
-import { Rectangle, Matrix } from '@pixi/math';
+import { Matrix } from '@pixi/math';
 
-import { Renderer } from '@pixi/core';
+import type { Rectangle } from '@pixi/math';
+import type { Renderer } from '@pixi/core';
 
 /**
  * System plugin to the renderer to manage the projection matrix.

--- a/packages/core/src/renderTexture/BaseRenderTexture.ts
+++ b/packages/core/src/renderTexture/BaseRenderTexture.ts
@@ -1,8 +1,9 @@
-import { BaseTexture, IBaseTextureOptions } from '../textures/BaseTexture';
+import { BaseTexture } from '../textures/BaseTexture';
 import { Framebuffer } from '../framebuffer/Framebuffer';
 
-import { MaskData } from '@pixi/core';
-import { CanvasRenderTarget } from '@pixi/utils';
+import type { IBaseTextureOptions } from '../textures/BaseTexture';
+import type { MaskData } from '@pixi/core';
+import type { CanvasRenderTarget } from '@pixi/utils';
 
 /**
  * A BaseRenderTexture is a special texture that allows any PixiJS display object to be rendered to it.

--- a/packages/core/src/renderTexture/RenderTexture.ts
+++ b/packages/core/src/renderTexture/RenderTexture.ts
@@ -1,8 +1,8 @@
 import { BaseRenderTexture } from './BaseRenderTexture';
 import { Texture } from '../textures/Texture';
 
-import { Rectangle } from '@pixi/math';
-import { Framebuffer, IBaseTextureOptions } from '@pixi/core';
+import type { Rectangle } from '@pixi/math';
+import type { Framebuffer, IBaseTextureOptions } from '@pixi/core';
 
 /**
  * A RenderTexture is a special texture that allows any PixiJS display object to be rendered to it.

--- a/packages/core/src/renderTexture/RenderTexturePool.ts
+++ b/packages/core/src/renderTexture/RenderTexturePool.ts
@@ -2,8 +2,8 @@ import { RenderTexture } from './RenderTexture';
 import { BaseRenderTexture } from './BaseRenderTexture';
 import { nextPow2 } from '@pixi/utils';
 
-import { IBaseTextureOptions } from '../textures/BaseTexture';
-import { ISize } from '@pixi/math';
+import type { IBaseTextureOptions } from '../textures/BaseTexture';
+import type { ISize } from '@pixi/math';
 
 /**
  * Experimental!

--- a/packages/core/src/renderTexture/RenderTextureSystem.ts
+++ b/packages/core/src/renderTexture/RenderTextureSystem.ts
@@ -2,11 +2,10 @@ import { System } from '../System';
 import { Rectangle } from '@pixi/math';
 import { BUFFER_BITS } from '@pixi/constants';
 
-import { Renderer } from '../Renderer';
-import { RenderTexture } from './RenderTexture';
-import { BaseRenderTexture } from './BaseRenderTexture';
-
-import { MaskData } from '@pixi/core';
+import type { Renderer } from '../Renderer';
+import type { RenderTexture } from './RenderTexture';
+import type { BaseRenderTexture } from './BaseRenderTexture';
+import type { MaskData } from '@pixi/core';
 
 const tempRect = new Rectangle();
 

--- a/packages/core/src/shader/Program.ts
+++ b/packages/core/src/shader/Program.ts
@@ -1,4 +1,3 @@
-// import * as from '../systems/shader/shader';
 import { setPrecision,
     defaultValue,
     compileProgram,
@@ -12,7 +11,7 @@ import defaultVertex from './defaultProgram.vert';
 import { settings } from '@pixi/settings';
 import { PRECISION } from '@pixi/constants';
 
-import { GLProgram } from './GLProgram';
+import type { GLProgram } from './GLProgram';
 
 let UID = 0;
 

--- a/packages/core/src/shader/ShaderSystem.ts
+++ b/packages/core/src/shader/ShaderSystem.ts
@@ -1,11 +1,9 @@
 import { System } from '../System';
-import { GLProgram, IGLUniformData } from './GLProgram';
-import { generateUniformsSync,
-    unsafeEvalSupported,
-    defaultValue,
-    compileProgram } from './utils';
+import { GLProgram } from './GLProgram';
+import { generateUniformsSync, unsafeEvalSupported, defaultValue, compileProgram } from './utils';
 
-import { Renderer, IRenderingContext, Shader, Program, UniformGroup } from '@pixi/core';
+import type { IGLUniformData } from './GLProgram';
+import type { Renderer, IRenderingContext, Shader, Program, UniformGroup } from '@pixi/core';
 
 let UID = 0;
 // defualt sync data so we don't create a new one each time!

--- a/packages/core/src/shader/utils/checkMaxIfStatementsInShader.ts
+++ b/packages/core/src/shader/utils/checkMaxIfStatementsInShader.ts
@@ -1,4 +1,4 @@
-import { IRenderingContext } from '@pixi/core';
+import type { IRenderingContext } from '@pixi/core';
 
 const fragTemplate = [
     'precision mediump float;',

--- a/packages/core/src/shader/utils/generateUniformsSync.ts
+++ b/packages/core/src/shader/utils/generateUniformsSync.ts
@@ -1,5 +1,6 @@
-import { UniformGroup } from '../UniformGroup';
 import { uniformParsers } from './uniformParsers';
+
+import type { UniformGroup } from '../UniformGroup';
 
 // cv = CachedValue
 // v = value

--- a/packages/core/src/state/StateSystem.ts
+++ b/packages/core/src/state/StateSystem.ts
@@ -3,7 +3,7 @@ import { System } from '../System';
 import { State } from './State';
 import { BLEND_MODES } from '@pixi/constants';
 
-import { Renderer, IRenderingContext } from '@pixi/core';
+import type { Renderer, IRenderingContext } from '@pixi/core';
 
 const BLEND = 0;
 const OFFSET = 1;

--- a/packages/core/src/textures/BaseTexture.ts
+++ b/packages/core/src/textures/BaseTexture.ts
@@ -1,12 +1,11 @@
 import { BaseTextureCache, EventEmitter, isPow2, TextureCache, uid } from '@pixi/utils';
 import { FORMATS, SCALE_MODES, TARGETS, TYPES, ALPHA_MODES, MIPMAP_MODES, WRAP_MODES } from '@pixi/constants';
-
 import { Resource } from './resources/Resource';
 import { BufferResource } from './resources/BufferResource';
 import { autoDetectResource } from './resources/autoDetectResource';
-import { GLTexture } from './GLTexture';
-
 import { settings } from '@pixi/settings';
+
+import type { GLTexture } from './GLTexture';
 
 const defaultBufferOptions = {
     scaleMode: SCALE_MODES.NEAREST,

--- a/packages/core/src/textures/Texture.ts
+++ b/packages/core/src/textures/Texture.ts
@@ -1,4 +1,4 @@
-import { BaseTexture, IBaseTextureOptions, ImageSource } from './BaseTexture';
+import { BaseTexture } from './BaseTexture';
 import { ImageResource } from './resources/ImageResource';
 import { CanvasResource } from './resources/CanvasResource';
 import { TextureUvs } from './TextureUvs';
@@ -6,7 +6,8 @@ import { settings } from '@pixi/settings';
 import { Rectangle, Point } from '@pixi/math';
 import { uid, TextureCache, getResolutionOfUrl, EventEmitter } from '@pixi/utils';
 
-import { TextureMatrix } from './TextureMatrix';
+import type { IBaseTextureOptions, ImageSource } from './BaseTexture';
+import type { TextureMatrix } from './TextureMatrix';
 
 const DEFAULT_UVS = new TextureUvs();
 

--- a/packages/core/src/textures/TextureGCSystem.ts
+++ b/packages/core/src/textures/TextureGCSystem.ts
@@ -2,7 +2,7 @@ import { System } from '../System';
 import { GC_MODES } from '@pixi/constants';
 import { settings } from '@pixi/settings';
 
-import { Renderer } from '@pixi/core';
+import type { Renderer } from '@pixi/core';
 
 /**
  * System plugin to the renderer to manage texture garbage collection on the GPU,

--- a/packages/core/src/textures/TextureMatrix.ts
+++ b/packages/core/src/textures/TextureMatrix.ts
@@ -1,6 +1,6 @@
 import { Matrix } from '@pixi/math';
 
-import { Texture } from './Texture';
+import type { Texture } from './Texture';
 
 const tempMat = new Matrix();
 

--- a/packages/core/src/textures/TextureSystem.ts
+++ b/packages/core/src/textures/TextureSystem.ts
@@ -4,8 +4,8 @@ import { GLTexture } from './GLTexture';
 import { removeItems } from '@pixi/utils';
 import { MIPMAP_MODES, WRAP_MODES, SCALE_MODES, TYPES } from '@pixi/constants';
 
-import { Texture } from './Texture';
-import { Renderer, IRenderingContext } from '@pixi/core';
+import type { Texture } from './Texture';
+import type { Renderer, IRenderingContext } from '@pixi/core';
 
 /**
  * System plugin to the renderer to manage textures.

--- a/packages/core/src/textures/TextureUvs.ts
+++ b/packages/core/src/textures/TextureUvs.ts
@@ -1,4 +1,6 @@
-import { groupD8, Rectangle, ISize } from '@pixi/math';
+import { groupD8 } from '@pixi/math';
+
+import type { Rectangle, ISize } from '@pixi/math';
 
 /**
  * Stores a texture's frame in UV coordinates, in

--- a/packages/core/src/textures/resources/ArrayResource.ts
+++ b/packages/core/src/textures/resources/ArrayResource.ts
@@ -1,11 +1,12 @@
 import { Resource } from './Resource';
-import { BaseImageResource } from './BaseImageResource';
-import { BaseTexture } from '../BaseTexture';
-import { Renderer } from '../../Renderer';
-import { GLTexture } from '../GLTexture';
 import { TARGETS } from '@pixi/constants';
+import { BaseTexture } from '../BaseTexture';
 import { autoDetectResource } from './autoDetectResource';
-import { ISize } from '@pixi/math';
+
+import type { BaseImageResource } from './BaseImageResource';
+import type { Renderer } from '../../Renderer';
+import type { GLTexture } from '../GLTexture';
+import type { ISize } from '@pixi/math';
 
 /**
  * A resource that contains a number of sources.

--- a/packages/core/src/textures/resources/BaseImageResource.ts
+++ b/packages/core/src/textures/resources/BaseImageResource.ts
@@ -2,7 +2,7 @@ import { Resource } from './Resource';
 import { determineCrossOrigin } from '@pixi/utils';
 import { ALPHA_MODES } from '@pixi/constants';
 
-import { BaseTexture, Renderer, GLTexture, ImageSource } from '@pixi/core';
+import type { BaseTexture, Renderer, GLTexture, ImageSource } from '@pixi/core';
 
 /**
  * Base for all the image/canvas resources

--- a/packages/core/src/textures/resources/BufferResource.ts
+++ b/packages/core/src/textures/resources/BufferResource.ts
@@ -1,8 +1,8 @@
 import { Resource } from './Resource';
 import { ALPHA_MODES } from '@pixi/constants';
-import { ISize } from '@pixi/math';
 
-import { BaseTexture, Renderer, GLTexture } from '@pixi/core';
+import type { ISize } from '@pixi/math';
+import type { BaseTexture, Renderer, GLTexture } from '@pixi/core';
 
 /**
  * @interface SharedArrayBuffer

--- a/packages/core/src/textures/resources/CubeResource.ts
+++ b/packages/core/src/textures/resources/CubeResource.ts
@@ -1,10 +1,10 @@
 import { ArrayResource } from './ArrayResource';
-import { Resource } from './Resource';
 import { TARGETS } from '@pixi/constants';
-import { ISize } from '@pixi/math';
-import { ArrayFixed } from '@pixi/utils';
 
-import { BaseTexture, Renderer, GLTexture } from '@pixi/core';
+import type { Resource } from './Resource';
+import type { ISize } from '@pixi/math';
+import type { ArrayFixed } from '@pixi/utils';
+import type { BaseTexture, Renderer, GLTexture } from '@pixi/core';
 
 /**
  * Constructor options for CubeResource

--- a/packages/core/src/textures/resources/DepthResource.ts
+++ b/packages/core/src/textures/resources/DepthResource.ts
@@ -1,7 +1,7 @@
-import { BaseTexture, GLTexture, Renderer } from '@pixi/core';
-
 import { ALPHA_MODES } from '@pixi/constants';
 import { BufferResource } from './BufferResource';
+
+import type { BaseTexture, GLTexture, Renderer } from '@pixi/core';
 
 /**
  * Resource type for DepthTexture.

--- a/packages/core/src/textures/resources/ImageResource.ts
+++ b/packages/core/src/textures/resources/ImageResource.ts
@@ -2,7 +2,7 @@ import { BaseImageResource } from './BaseImageResource';
 import { settings } from '@pixi/settings';
 import { ALPHA_MODES } from '@pixi/constants';
 
-import { BaseTexture, Renderer, GLTexture } from '@pixi/core';
+import type { BaseTexture, Renderer, GLTexture } from '@pixi/core';
 
 export interface IImageResourceOptions
 {

--- a/packages/core/src/textures/resources/Resource.ts
+++ b/packages/core/src/textures/resources/Resource.ts
@@ -1,6 +1,6 @@
 import { Runner } from '@pixi/runner';
 
-import { BaseTexture, Renderer, GLTexture } from '@pixi/core';
+import type { BaseTexture, Renderer, GLTexture } from '@pixi/core';
 
 /**
  * Base resource class for textures that manages validation and uploading, depending on its type.

--- a/packages/core/src/textures/resources/SVGResource.ts
+++ b/packages/core/src/textures/resources/SVGResource.ts
@@ -1,7 +1,7 @@
 import { uid } from '@pixi/utils';
 import { BaseImageResource } from './BaseImageResource';
 
-import { ISize } from '@pixi/math';
+import type { ISize } from '@pixi/math';
 
 export interface ISVGResourceOptions
 {

--- a/packages/core/src/textures/resources/autoDetectResource.ts
+++ b/packages/core/src/textures/resources/autoDetectResource.ts
@@ -1,9 +1,11 @@
 import { Resource } from './Resource';
-import { ImageResource, IImageResourceOptions } from './ImageResource';
-import { ISize } from '@pixi/math';
-import { ICubeResourceOptions } from './CubeResource';
-import { ISVGResourceOptions } from './SVGResource';
-import { IVideoResourceOptions } from './VideoResource';
+import { ImageResource } from './ImageResource';
+
+import type { IImageResourceOptions } from './ImageResource';
+import type{ ISize } from '@pixi/math';
+import type{ ICubeResourceOptions } from './CubeResource';
+import type{ ISVGResourceOptions } from './SVGResource';
+import type{ IVideoResourceOptions } from './VideoResource';
 
 /**
  * Allow flexible options for resource plugins

--- a/packages/core/src/utils/QuadUv.ts
+++ b/packages/core/src/utils/QuadUv.ts
@@ -1,7 +1,7 @@
 import { Geometry } from '../geometry/Geometry';
 import { Buffer } from '../geometry/Buffer';
 
-import { Rectangle } from '@pixi/math';
+import type { Rectangle } from '@pixi/math';
 
 /**
  * Helper class to create a quad with uvs like in v4

--- a/packages/display/src/Bounds.ts
+++ b/packages/display/src/Bounds.ts
@@ -1,4 +1,6 @@
-import { Rectangle, IPoint, Transform, Matrix } from '@pixi/math';
+import { Rectangle } from '@pixi/math';
+
+import type { IPoint, Transform, Matrix } from '@pixi/math';
 
 /**
  * 'Builder' pattern for bounds rectangles.

--- a/packages/display/src/Container.ts
+++ b/packages/display/src/Container.ts
@@ -1,7 +1,9 @@
-import { MaskData, Renderer } from '@pixi/core';
 import { settings } from '@pixi/settings';
 import { removeItems } from '@pixi/utils';
-import { DisplayObject, IDestroyOptions } from './DisplayObject';
+import { DisplayObject } from './DisplayObject';
+
+import type { MaskData, Renderer } from '@pixi/core';
+import type { IDestroyOptions } from './DisplayObject';
 
 function sortChildren(a: DisplayObject, b: DisplayObject): number
 {

--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -1,9 +1,11 @@
-import { Filter, MaskData, Renderer } from '@pixi/core';
-import { DEG_TO_RAD, IPoint, Matrix, ObservablePoint, Point, RAD_TO_DEG, Rectangle, Transform } from '@pixi/math';
+import { DEG_TO_RAD, Matrix, Point, RAD_TO_DEG, Rectangle, Transform } from '@pixi/math';
 import { EventEmitter } from '@pixi/utils';
 import { Container } from './Container';
 import { Bounds } from './Bounds';
-import { IAccessibleTarget } from '@pixi/accessibility';
+
+import type { Filter, MaskData, Renderer } from '@pixi/core';
+import type { IPoint, ObservablePoint } from '@pixi/math';
+import type { IAccessibleTarget } from '@pixi/accessibility';
 
 export interface IDestroyOptions {
     children?: boolean;

--- a/packages/extract/src/Extract.ts
+++ b/packages/extract/src/Extract.ts
@@ -1,7 +1,9 @@
-import { RenderTexture, Renderer, IRendererPlugin } from '@pixi/core';
 import { CanvasRenderTarget } from '@pixi/utils';
 import { Rectangle } from '@pixi/math';
-import { DisplayObject } from '@pixi/display';
+import { RenderTexture } from '@pixi/core';
+
+import type { Renderer, IRendererPlugin } from '@pixi/core';
+import type { DisplayObject } from '@pixi/display';
 
 const TEMP_RECT = new Rectangle();
 const BYTES_PER_PIXEL = 4;

--- a/packages/filters/filter-blur/src/BlurFilter.ts
+++ b/packages/filters/filter-blur/src/BlurFilter.ts
@@ -1,7 +1,10 @@
-import { Filter, systems, RenderTexture } from '@pixi/core';
+import { Filter } from '@pixi/core';
 import { settings } from '@pixi/settings';
 import { BlurFilterPass } from './BlurFilterPass';
-import { CLEAR_MODES, BLEND_MODES } from '@pixi/constants';
+import { CLEAR_MODES } from '@pixi/constants';
+
+import type { RenderTexture, systems } from '@pixi/core';
+import type { BLEND_MODES } from '@pixi/constants';
 
 /**
  * The BlurFilter applies a Gaussian blur to an object.

--- a/packages/filters/filter-blur/src/BlurFilterPass.ts
+++ b/packages/filters/filter-blur/src/BlurFilterPass.ts
@@ -1,9 +1,10 @@
-import { Filter, RenderTexture } from '@pixi/core';
+import { Filter } from '@pixi/core';
 import { settings } from '@pixi/settings';
 import { generateBlurVertSource } from './generateBlurVertSource';
 import { generateBlurFragSource } from './generateBlurFragSource';
 import { CLEAR_MODES } from '@pixi/constants';
-import { FilterSystem } from 'packages/core/src/systems';
+
+import type { RenderTexture, systems } from '@pixi/core';
 
 /**
  * The BlurFilterPass applies a horizontal or vertical Gaussian blur to an object.
@@ -58,7 +59,9 @@ export class BlurFilterPass extends Filter
      * @param {PIXI.RenderTexture} output - The output target.
      * @param {PIXI.CLEAR_MODES} clearMode - How to clear
      */
-    public apply(filterManager: FilterSystem, input: RenderTexture, output: RenderTexture, clearMode: CLEAR_MODES): void
+    public apply(
+        filterManager: systems.FilterSystem, input: RenderTexture, output: RenderTexture, clearMode: CLEAR_MODES
+    ): void
     {
         if (output)
         {

--- a/packages/filters/filter-blur/src/getMaxBlurKernelSize.ts
+++ b/packages/filters/filter-blur/src/getMaxBlurKernelSize.ts
@@ -1,4 +1,4 @@
-import { IRenderingContext } from '@pixi/core';
+import type { IRenderingContext } from '@pixi/core';
 
 export function getMaxKernelSize(gl: IRenderingContext): number
 {

--- a/packages/filters/filter-color-matrix/src/ColorMatrixFilter.ts
+++ b/packages/filters/filter-color-matrix/src/ColorMatrixFilter.ts
@@ -1,8 +1,7 @@
 import { Filter, defaultFilterVertex } from '@pixi/core';
 import fragment from './colorMatrix.frag';
 
-// Type Import
-import { ArrayFixed } from '@pixi/utils';
+import type { ArrayFixed } from '@pixi/utils';
 
 export type ColorMatrix = ArrayFixed<number, 20>;
 

--- a/packages/filters/filter-displacement/src/DisplacementFilter.ts
+++ b/packages/filters/filter-displacement/src/DisplacementFilter.ts
@@ -1,8 +1,10 @@
-import { CLEAR_MODES } from '@pixi/constants';
-import { Filter, RenderTexture, systems, Texture, ISpriteMaskTarget } from '@pixi/core';
+import { Filter } from '@pixi/core';
 import { Matrix, Point } from '@pixi/math/src';
 import fragment from './displacement.frag';
 import vertex from './displacement.vert';
+
+import type { CLEAR_MODES } from '@pixi/constants';
+import type { RenderTexture, systems, Texture, ISpriteMaskTarget } from '@pixi/core';
 
 /**
  * The DisplacementFilter class uses the pixel values from the specified texture

--- a/packages/graphics/src/Graphics.ts
+++ b/packages/graphics/src/Graphics.ts
@@ -8,28 +8,20 @@ import {
     RoundedRectangle,
     Matrix,
     SHAPES,
-    IShape,
 } from '@pixi/math';
 
-import {
-    Texture,
-    Shader,
-    UniformGroup, State, Renderer, BatchDrawCall,
-} from '@pixi/core';
-
-import {
-    BezierUtils,
-    QuadraticUtils,
-    ArcUtils,
-    Star,
-} from './utils';
-
+import { Texture, UniformGroup, State, Renderer, BatchDrawCall } from '@pixi/core';
+import { BezierUtils, QuadraticUtils, ArcUtils, Star } from './utils';
 import { hex2rgb, deprecation } from '@pixi/utils';
 import { GraphicsGeometry } from './GraphicsGeometry';
 import { FillStyle } from './styles/FillStyle';
 import { LineStyle } from './styles/LineStyle';
 import { BLEND_MODES } from '@pixi/constants';
-import { Container, IDestroyOptions } from '@pixi/display';
+import { Container } from '@pixi/display';
+import { Shader } from '@pixi/core';
+
+import type { IShape } from '@pixi/math';
+import type { IDestroyOptions } from '@pixi/display';
 
 /**
  * Batch element computed from Graphics geometry

--- a/packages/graphics/src/GraphicsData.ts
+++ b/packages/graphics/src/GraphicsData.ts
@@ -1,6 +1,6 @@
-import { Matrix, SHAPES, IShape } from '@pixi/math';
-import { FillStyle } from './styles/FillStyle';
-import { LineStyle } from './styles/LineStyle';
+import type { Matrix, SHAPES, IShape } from '@pixi/math';
+import type { FillStyle } from './styles/FillStyle';
+import type { LineStyle } from './styles/LineStyle';
 
 /**
  * A class to contain data useful for Graphics objects

--- a/packages/graphics/src/GraphicsGeometry.ts
+++ b/packages/graphics/src/GraphicsGeometry.ts
@@ -4,7 +4,8 @@ import {
     BatchPart,
     FILL_COMMANDS,
     BATCH_POOL,
-    DRAW_CALL_POOL } from './utils';
+    DRAW_CALL_POOL,
+} from './utils';
 
 import {
     BatchGeometry,
@@ -15,12 +16,14 @@ import {
 } from '@pixi/core';
 
 import { DRAW_MODES, WRAP_MODES } from '@pixi/constants';
-import { SHAPES, Point, Matrix, Circle, Ellipse, Polygon, Rectangle, RoundedRectangle } from '@pixi/math';
+import { SHAPES, Point, Matrix } from '@pixi/math';
 import { GraphicsData } from './GraphicsData';
 import { premultiplyTint } from '@pixi/utils';
 import { Bounds } from '@pixi/display';
-import { FillStyle } from './styles/FillStyle';
-import { LineStyle } from './styles/LineStyle';
+
+import type { Circle, Ellipse, Polygon, Rectangle, RoundedRectangle } from '@pixi/math';
+import type { FillStyle } from './styles/FillStyle';
+import type { LineStyle } from './styles/LineStyle';
 
 /**
  * @description Complex shape type

--- a/packages/graphics/src/styles/FillStyle.ts
+++ b/packages/graphics/src/styles/FillStyle.ts
@@ -1,5 +1,5 @@
 import { Texture } from '@pixi/core';
-import { Matrix } from '@pixi/math';
+import type { Matrix } from '@pixi/math';
 
 /**
  * Fill style object for Graphics.

--- a/packages/graphics/src/utils/BatchPart.ts
+++ b/packages/graphics/src/utils/BatchPart.ts
@@ -1,5 +1,5 @@
-import { LineStyle } from '../styles/LineStyle';
-import { FillStyle } from '../styles/FillStyle';
+import type { LineStyle } from '../styles/LineStyle';
+import type { FillStyle } from '../styles/FillStyle';
 
 /**
  * A structure to hold interim batch objects for Graphics.

--- a/packages/graphics/src/utils/IShapeBuildCommand.ts
+++ b/packages/graphics/src/utils/IShapeBuildCommand.ts
@@ -1,5 +1,5 @@
-import { GraphicsData } from '../GraphicsData';
-import { GraphicsGeometry } from '../GraphicsGeometry';
+import type { GraphicsData } from '../GraphicsData';
+import type { GraphicsGeometry } from '../GraphicsGeometry';
 
 export interface IShapeBuildCommand {
     build(graphicsData: GraphicsData): void;

--- a/packages/graphics/src/utils/buildCircle.ts
+++ b/packages/graphics/src/utils/buildCircle.ts
@@ -1,6 +1,8 @@
 // for type only
-import { SHAPES, Circle, Ellipse } from '@pixi/math';
-import { IShapeBuildCommand } from './IShapeBuildCommand';
+import { SHAPES } from '@pixi/math';
+
+import type { Circle, Ellipse } from '@pixi/math';
+import type { IShapeBuildCommand } from './IShapeBuildCommand';
 
 /**
  * Builds a circle to draw

--- a/packages/graphics/src/utils/buildLine.ts
+++ b/packages/graphics/src/utils/buildLine.ts
@@ -1,8 +1,8 @@
-import { Point, SHAPES, Polygon } from '@pixi/math';
+import { Point, SHAPES } from '@pixi/math';
 
-// for type only
-import { GraphicsData } from '../GraphicsData';
-import { GraphicsGeometry } from '../GraphicsGeometry';
+import type { Polygon } from '@pixi/math';
+import type { GraphicsData } from '../GraphicsData';
+import type { GraphicsGeometry } from '../GraphicsGeometry';
 
 /**
  * Builds a line to draw using the polygon method.

--- a/packages/graphics/src/utils/buildPoly.ts
+++ b/packages/graphics/src/utils/buildPoly.ts
@@ -1,8 +1,7 @@
 import { earcut } from '@pixi/utils';
 
-// for type only
-import { IShapeBuildCommand } from './IShapeBuildCommand';
-import { Polygon } from '@pixi/math';
+import type { IShapeBuildCommand } from './IShapeBuildCommand';
+import type { Polygon } from '@pixi/math';
 
 /**
  * Builds a polygon to draw

--- a/packages/graphics/src/utils/buildRectangle.ts
+++ b/packages/graphics/src/utils/buildRectangle.ts
@@ -1,6 +1,5 @@
-// for type only
-import { IShapeBuildCommand } from './IShapeBuildCommand';
-import { Rectangle } from '@pixi/math';
+import type { IShapeBuildCommand } from './IShapeBuildCommand';
+import type { Rectangle } from '@pixi/math';
 
 /**
  * Builds a rectangle to draw

--- a/packages/graphics/src/utils/buildRoundedRectangle.ts
+++ b/packages/graphics/src/utils/buildRoundedRectangle.ts
@@ -1,8 +1,8 @@
 import { earcut } from '@pixi/utils';
 
 // for type only
-import { IShapeBuildCommand } from './IShapeBuildCommand';
-import { RoundedRectangle } from '@pixi/math';
+import type { IShapeBuildCommand } from './IShapeBuildCommand';
+import type { RoundedRectangle } from '@pixi/math';
 
 /**
  * Calculate a single point for a quadratic bezier curve.

--- a/packages/loaders/src/AppLoaderPlugin.ts
+++ b/packages/loaders/src/AppLoaderPlugin.ts
@@ -1,5 +1,6 @@
 import { Loader } from './Loader';
-import { IApplicationOptions } from '@pixi/app';
+
+import type { IApplicationOptions } from '@pixi/app';
 /**
  * Application plugin for supporting loader option. Installing the LoaderPlugin
  * is not necessary if using **pixi.js** or **pixi.js-legacy**.

--- a/packages/loaders/src/Loader.ts
+++ b/packages/loaders/src/Loader.ts
@@ -1,5 +1,7 @@
-import { Loader as ResourceLoader, middleware, Resource } from 'resource-loader';
+import { Loader as ResourceLoader, middleware } from 'resource-loader';
 import { TextureLoader } from './TextureLoader';
+
+import type { Resource } from 'resource-loader';
 
 /**
  * The new loader, extends Resource Loader by Chad Engler: https://github.com/englercj/resource-loader

--- a/packages/loaders/src/LoaderResource.ts
+++ b/packages/loaders/src/LoaderResource.ts
@@ -1,7 +1,8 @@
 import { Resource } from 'resource-loader';
-import { Texture } from '@pixi/core';
-import { Spritesheet } from '@pixi/spritesheet';
-import { Dict } from '@pixi/utils';
+
+import type { Spritesheet } from '@pixi/spritesheet';
+import type { Texture } from '@pixi/core';
+import type { Dict } from '@pixi/utils';
 
 export interface IResourceMetadata extends Resource.IMetadata {
     imageMetadata?: any;

--- a/packages/loaders/src/TextureLoader.ts
+++ b/packages/loaders/src/TextureLoader.ts
@@ -1,6 +1,7 @@
 import { Resource } from 'resource-loader';
 import { Texture } from '@pixi/core';
-import { ILoaderResource } from './LoaderResource';
+
+import type { ILoaderResource } from './LoaderResource';
 
 /**
  * Loader plugin for handling Texture resources.

--- a/packages/math/src/Matrix.ts
+++ b/packages/math/src/Matrix.ts
@@ -1,7 +1,8 @@
-import { IPoint } from './IPoint';
 import { Point } from './Point';
 import { PI_2 } from './const';
-import { Transform } from './Transform';
+
+import type { Transform } from './Transform';
+import type { IPoint } from './IPoint';
 
 /**
  * The PixiJS Matrix as a class makes it a lot faster.

--- a/packages/math/src/ObservablePoint.ts
+++ b/packages/math/src/ObservablePoint.ts
@@ -1,4 +1,4 @@
-import { IPoint } from './IPoint';
+import type { IPoint } from './IPoint';
 
 /**
  * The Point object represents a location in a two-dimensional coordinate system, where x represents

--- a/packages/math/src/Point.ts
+++ b/packages/math/src/Point.ts
@@ -1,4 +1,4 @@
-import { IPoint } from './IPoint';
+import type { IPoint } from './IPoint';
 
 /**
  * The Point object represents a location in a two-dimensional coordinate system, where x represents

--- a/packages/math/src/shapes/Polygon.ts
+++ b/packages/math/src/shapes/Polygon.ts
@@ -1,5 +1,5 @@
 import { SHAPES } from '../const';
-import { IPoint } from '../IPoint';
+import type { IPoint } from '../IPoint';
 
 /**
  * A class to define a shape via user defined co-orinates.

--- a/packages/mesh-extras/src/NineSlicePlane.ts
+++ b/packages/mesh-extras/src/NineSlicePlane.ts
@@ -1,5 +1,7 @@
-import { Texture, ITypedArray } from '@pixi/core';
+import { Texture } from '@pixi/core';
 import { SimplePlane } from './SimplePlane';
+
+import type { ITypedArray } from '@pixi/core';
 
 const DEFAULT_BORDER_SIZE = 10;
 

--- a/packages/mesh-extras/src/SimpleMesh.ts
+++ b/packages/mesh-extras/src/SimpleMesh.ts
@@ -1,8 +1,8 @@
 import { Mesh, MeshGeometry, MeshMaterial } from '@pixi/mesh';
+import { Texture } from '@pixi/core';
 
-// Import Types
-import { Texture, ITypedArray, IArrayBuffer, Renderer } from '@pixi/core';
-import { DRAW_MODES } from '@pixi/constants';
+import type { ITypedArray, IArrayBuffer, Renderer } from '@pixi/core';
+import type { DRAW_MODES } from '@pixi/constants';
 
 /**
  * The Simple Mesh class mimics Mesh in PixiJS v4, providing easy-to-use constructor arguments.

--- a/packages/mesh-extras/src/SimplePlane.ts
+++ b/packages/mesh-extras/src/SimplePlane.ts
@@ -1,6 +1,8 @@
-import { Texture, Renderer } from '@pixi/core';
+import { Texture } from '@pixi/core';
 import { Mesh, MeshMaterial } from '@pixi/mesh';
 import { PlaneGeometry } from './geometry/PlaneGeometry';
+
+import type{ Renderer } from '@pixi/core';
 
 /**
  * The SimplePlane allows you to draw a texture across several points and then manipulate these points

--- a/packages/mesh-extras/src/SimpleRope.ts
+++ b/packages/mesh-extras/src/SimpleRope.ts
@@ -1,8 +1,9 @@
 import { Mesh, MeshMaterial } from '@pixi/mesh';
 import { WRAP_MODES } from '@pixi/constants';
 import { RopeGeometry } from './geometry/RopeGeometry';
-import { Texture, Renderer } from '@pixi/core';
-import { IPoint } from '@pixi/math';
+
+import type { Texture, Renderer } from '@pixi/core';
+import type { IPoint } from '@pixi/math';
 
 /**
  * The rope allows you to draw a texture across several points and then manipulate these points

--- a/packages/mesh-extras/src/geometry/RopeGeometry.ts
+++ b/packages/mesh-extras/src/geometry/RopeGeometry.ts
@@ -1,5 +1,5 @@
 import { MeshGeometry } from '@pixi/mesh';
-import { IPoint } from '@pixi/math';
+import type { IPoint } from '@pixi/math';
 
 /**
  * RopeGeometry allows you to draw a geometry across several points and then manipulate these points.

--- a/packages/mesh/src/Mesh.ts
+++ b/packages/mesh/src/Mesh.ts
@@ -1,10 +1,14 @@
-import { State, Geometry, Buffer, Texture, Renderer } from '@pixi/core';
-import { Point, Polygon, IPoint } from '@pixi/math';
+import { State } from '@pixi/core';
+import { Point, Polygon } from '@pixi/math';
 import { BLEND_MODES, DRAW_MODES } from '@pixi/constants';
-import { Container, IDestroyOptions } from '@pixi/display';
+import { Container } from '@pixi/display';
 import { settings } from '@pixi/settings';
 import { MeshBatchUvs } from './MeshBatchUvs';
 import { MeshMaterial } from './MeshMaterial';
+
+import type { IDestroyOptions } from '@pixi/display';
+import type { Texture, Renderer, Geometry, Buffer } from '@pixi/core';
+import type { IPoint } from '@pixi/math';
 
 const tempPoint = new Point();
 const tempPolygon = new Polygon();

--- a/packages/mesh/src/MeshBatchUvs.ts
+++ b/packages/mesh/src/MeshBatchUvs.ts
@@ -1,4 +1,4 @@
-import { TextureMatrix, Buffer } from '@pixi/core';
+import type { TextureMatrix, Buffer } from '@pixi/core';
 
 /**
  * Class controls cache for UV mapping from Texture normal space to BaseTexture normal space.

--- a/packages/mesh/src/MeshGeometry.ts
+++ b/packages/mesh/src/MeshGeometry.ts
@@ -1,5 +1,7 @@
 import { TYPES } from '@pixi/constants';
-import { Buffer, Geometry, IArrayBuffer } from '@pixi/core';
+import { Buffer, Geometry } from '@pixi/core';
+
+import type { IArrayBuffer } from '@pixi/core';
 
 /**
  * Standard 2D geometry used in PixiJS.

--- a/packages/mesh/src/MeshMaterial.ts
+++ b/packages/mesh/src/MeshMaterial.ts
@@ -1,8 +1,10 @@
-import { Program, Shader, Texture, TextureMatrix } from '@pixi/core';
+import { Program, Shader, TextureMatrix } from '@pixi/core';
 import { Matrix } from '@pixi/math';
 import { premultiplyTintToRgba } from '@pixi/utils';
 import fragment from './shader/mesh.frag';
 import vertex from './shader/mesh.vert';
+
+import type { Texture } from '@pixi/core';
 
 export interface IMeshMaterialOptions {
     alpha?: number;

--- a/packages/sprite-animated/src/AnimatedSprite.ts
+++ b/packages/sprite-animated/src/AnimatedSprite.ts
@@ -1,7 +1,7 @@
 import { Texture } from '@pixi/core';
 import { Sprite } from '@pixi/sprite';
 import { Ticker, UPDATE_PRIORITY } from '@pixi/ticker';
-import { IDestroyOptions } from '@pixi/display';
+import type { IDestroyOptions } from '@pixi/display';
 
 /**
  * An AnimatedSprite is a simple way to display an animation depicted by a list of textures.

--- a/packages/sprite-tiling/src/TilingSprite.ts
+++ b/packages/sprite-tiling/src/TilingSprite.ts
@@ -1,8 +1,10 @@
-import { Renderer, Texture, TextureMatrix, TextureSource, IBaseTextureOptions } from '@pixi/core';
-import { IDestroyOptions } from '@pixi/display';
-import { IPoint, Point, Rectangle, Transform, ObservablePoint, ISize } from '@pixi/math';
+import { Texture, TextureMatrix } from '@pixi/core';
+import { Point, Rectangle, Transform  } from '@pixi/math';
 import { Sprite } from '@pixi/sprite';
 import { deprecation } from '@pixi/utils';
+import type { Renderer, IBaseTextureOptions, TextureSource } from '@pixi/core';
+import type { IDestroyOptions } from '@pixi/display';
+import type { IPoint, ISize, ObservablePoint } from '@pixi/math';
 
 const tempPoint = new Point();
 

--- a/packages/sprite-tiling/src/TilingSpriteRenderer.ts
+++ b/packages/sprite-tiling/src/TilingSpriteRenderer.ts
@@ -1,4 +1,4 @@
-import { ObjectRenderer, Shader, State, QuadUv, Renderer } from '@pixi/core';
+import { ObjectRenderer, Shader, State, QuadUv } from '@pixi/core';
 import { WRAP_MODES } from '@pixi/constants';
 import { Matrix } from '@pixi/math';
 import { premultiplyTintToRgba, correctBlendMode } from '@pixi/utils';
@@ -6,7 +6,9 @@ import { premultiplyTintToRgba, correctBlendMode } from '@pixi/utils';
 import vertex from './tilingSprite.vert';
 import fragment from './tilingSprite.frag';
 import fragmentSimple from './tilingSprite_simple.frag';
-import { TilingSprite } from './TilingSprite';
+
+import type { Renderer } from '@pixi/core';
+import type { TilingSprite } from './TilingSprite';
 
 const tempMat = new Matrix();
 

--- a/packages/sprite/src/Sprite.ts
+++ b/packages/sprite/src/Sprite.ts
@@ -1,9 +1,13 @@
 import { BLEND_MODES } from '@pixi/constants';
-import { IBaseTextureOptions, Renderer, Texture, TextureSource } from '@pixi/core';
-import { Container, IDestroyOptions } from '@pixi/display';
-import { IPoint, ObservablePoint, Point, Rectangle } from '@pixi/math';
+import { Texture } from '@pixi/core';
+import { Container } from '@pixi/display';
+import { ObservablePoint, Point, Rectangle } from '@pixi/math';
 import { settings } from '@pixi/settings';
 import { sign } from '@pixi/utils';
+
+import type { IBaseTextureOptions, Renderer, TextureSource } from '@pixi/core';
+import type { IDestroyOptions } from '@pixi/display';
+import type { IPoint } from '@pixi/math';
 
 const tempPoint = new Point();
 const indices = new Uint16Array([0, 1, 2, 0, 2, 3]);

--- a/packages/spritesheet/src/Spritesheet.ts
+++ b/packages/spritesheet/src/Spritesheet.ts
@@ -1,6 +1,8 @@
 import { Rectangle } from '@pixi/math';
-import { Texture, BaseTexture, resources } from '@pixi/core';
-import { getResolutionOfUrl, Dict } from '@pixi/utils';
+import { Texture } from '@pixi/core';
+import { getResolutionOfUrl } from '@pixi/utils';
+import type { Dict } from '@pixi/utils';
+import type { BaseTexture, resources } from '@pixi/core';
 
 /**
  * Utility class for maintaining reference to a collection

--- a/packages/spritesheet/src/SpritesheetLoader.ts
+++ b/packages/spritesheet/src/SpritesheetLoader.ts
@@ -1,6 +1,8 @@
 import { url } from '@pixi/utils';
 import { Spritesheet } from './Spritesheet';
-import { LoaderResource, Loader, ILoaderResource } from '@pixi/loaders';
+import { LoaderResource } from '@pixi/loaders';
+import type { Loader, ILoaderResource } from '@pixi/loaders';
+
 /**
  * {@link PIXI.Loader Loader} middleware for loading texture atlases that have been created with
  * TexturePacker or similar JSON-based spritesheet.

--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -1,15 +1,16 @@
 /* eslint max-depth: [2, 8] */
 import { Sprite } from '@pixi/sprite';
-import { Texture, Renderer } from '@pixi/core';
+import { Texture  } from '@pixi/core';
 import { settings } from '@pixi/settings';
 import { Rectangle } from '@pixi/math';
 import { sign, trimCanvas, hex2rgb, string2hex } from '@pixi/utils';
 import { TEXT_GRADIENT } from './const';
-import { TextStyle, ITextStyle } from './TextStyle';
+import { TextStyle } from './TextStyle';
 import { TextMetrics } from './TextMetrics';
 
-// TODO: import type
-import { IDestroyOptions } from '@pixi/display';
+import type { IDestroyOptions } from '@pixi/display';
+import type { Renderer } from '@pixi/core';
+import type { ITextStyle } from './TextStyle';
 
 const defaultDestroyOptions: IDestroyOptions = {
     texture: true,

--- a/packages/ticker/src/TickerPlugin.ts
+++ b/packages/ticker/src/TickerPlugin.ts
@@ -1,6 +1,7 @@
-import { Ticker } from './Ticker';
 import { UPDATE_PRIORITY } from './const';
-import { IApplicationOptions } from '@pixi/app';
+import { Ticker } from './Ticker';
+
+import type { IApplicationOptions } from '@pixi/app';
 
 /**
  * Middleware for for Application Ticker.

--- a/packages/utils/src/media/caches.ts
+++ b/packages/utils/src/media/caches.ts
@@ -1,4 +1,4 @@
-import { Program, Texture, BaseTexture } from '@pixi/core';
+import type { Program, Texture, BaseTexture } from '@pixi/core';
 
 /**
  * @todo Describe property usage


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
I've updated our version of TypeScript to 3.8 so we can use the new [import type](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-exports) feature.

I also removed the eslint rule for `no-duplicate-imports` to allow for this to work.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
