### PR TITLE
Remove forceFXAA Application and Renderer option

### DIFF
--- a/packages/app/src/Application.ts
+++ b/packages/app/src/Application.ts
@@ -12,7 +12,6 @@ export interface IApplicationPlugin {
 
 export interface IApplicationOptions extends IRendererOptionsAuto {
     autoStart?: boolean;
-    forceFXAA?: boolean;
     sharedTicker?: boolean;
     sharedLoader?: boolean;
     resizeTo?: Window | HTMLElement;
@@ -66,8 +65,6 @@ export class Application
      *  (shown if not transparent).
      * @param {boolean} [options.clearBeforeRender=true] - This sets if the renderer will clear the canvas or
      *   not before the new render pass.
-     * @param {boolean} [options.forceFXAA=false] - Forces FXAA antialiasing to be used over native.
-     *  FXAA is faster, but may not always look as great. **(WebGL only)**.
      * @param {string} [options.powerPreference] - Parameter passed to webgl context, set to "high-performance"
      *  for devices with dual graphics card. **(WebGL only)**.
      * @param {boolean} [options.sharedTicker=false] - `true` to use PIXI.Ticker.shared, `false` to create new ticker.

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -98,8 +98,6 @@ export class Renderer extends AbstractRenderer
      *   resolutions other than 1.
      * @param {boolean} [options.antialias=false] - Sets antialias. If not available natively then FXAA
      *  antialiasing is used.
-     * @param {boolean} [options.forceFXAA=false] - Forces FXAA antialiasing to be used over native.
-     *  FXAA is faster, but may not always look as great.
      * @param {number} [options.resolution=1] - The resolution / device pixel ratio of the renderer.
      *  The resolution of the renderer retina would be 2.
      * @param {boolean} [options.clearBeforeRender=true] - This sets if the renderer will clear

--- a/packages/core/src/autoDetectRenderer.ts
+++ b/packages/core/src/autoDetectRenderer.ts
@@ -30,8 +30,6 @@ export interface IRendererOptionsAuto extends IRendererOptions
  * @param {boolean} [options.forceCanvas=false] - prevents selection of WebGL renderer, even if such is present, this
  *   option only is available when using **pixi.js-legacy** or **@pixi/canvas-renderer** modules, otherwise
  *   it is ignored.
- * @param {boolean} [options.forceFXAA=false] - forces FXAA antialiasing to be used over native.
- *  FXAA is faster, but may not always look as great **webgl only**
  * @param {string} [options.powerPreference] - Parameter passed to webgl context, set to "high-performance"
  *  for devices with dual graphics card **webgl only**
  * @return {PIXI.Renderer|PIXI.CanvasRenderer} Returns WebGL renderer if available, otherwise CanvasRenderer

--- a/packages/settings/src/settings.ts
+++ b/packages/settings/src/settings.ts
@@ -5,7 +5,6 @@ import { canUploadSameBuffer } from './utils/canUploadSameBuffer';
 export interface IRenderOptions {
     view: HTMLCanvasElement;
     antialias: boolean;
-    forceFXAA: boolean;
     autoDensity: boolean;
     transparent: boolean;
     backgroundColor: number;
@@ -142,7 +141,6 @@ export const settings: ISettings = {
      * @property {HTMLCanvasElement} view=null
      * @property {number} resolution=1
      * @property {boolean} antialias=false
-     * @property {boolean} forceFXAA=false
      * @property {boolean} autoDensity=false
      * @property {boolean} transparent=false
      * @property {number} backgroundColor=0x000000
@@ -155,7 +153,6 @@ export const settings: ISettings = {
     RENDER_OPTIONS: {
         view: null,
         antialias: false,
-        forceFXAA: false,
         autoDensity: false,
         transparent: false,
         backgroundColor: 0x000000,


### PR DESCRIPTION
Partially fixes #6444 

We have long discarded the use of `forceFXAA` functionality (last implemented in v3), this removes from docs and typings.