### PR TITLE
Fix: Text gradients don't account for texture padding

### DIFF
--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -476,8 +476,12 @@ export class Text extends Sprite
         // generated with the incorrect dimensions
         const dropShadowCorrection = (style.dropShadow) ? style.dropShadowDistance : 0;
 
-        const width = Math.ceil(this.canvas.width / this._resolution) - dropShadowCorrection;
-        const height = Math.ceil(this.canvas.height / this._resolution) - dropShadowCorrection;
+        // should also take padding into account, padding can offset the gradient
+        const padding = style.padding || 0;
+
+        // only minus x1 padding here, not x2, as gradient creation is x1 y1 x2 y2, not x y width height
+        const width = Math.ceil(this.canvas.width / this._resolution) - dropShadowCorrection - padding;
+        const height = Math.ceil(this.canvas.height / this._resolution) - dropShadowCorrection - padding;
 
         // make a copy of the style settings, so we can manipulate them later
         const fill = fillStyle.slice();
@@ -505,7 +509,7 @@ export class Text extends Sprite
         if (style.fillGradientType === TEXT_GRADIENT.LINEAR_VERTICAL)
         {
             // start the gradient at the top center of the canvas, and end at the bottom middle of the canvas
-            gradient = this.context.createLinearGradient(width / 2, 0, width / 2, height);
+            gradient = this.context.createLinearGradient(width / 2, padding, width / 2, height);
 
             // we need to repeat the gradient so that each individual line of text has the same vertical gradient effect
             // ['#FF0000', '#00FF00', '#0000FF'] over 2 lines would create stops at 0.125, 0.25, 0.375, 0.625, 0.75, 0.875
@@ -545,7 +549,7 @@ export class Text extends Sprite
         else
         {
             // start the gradient at the center left of the canvas, and end at the center right of the canvas
-            gradient = this.context.createLinearGradient(0, height / 2, width, height / 2);
+            gradient = this.context.createLinearGradient(padding, height / 2, width, height / 2);
 
             // can just evenly space out the gradients in this case, as multiple lines makes no difference
             // to an even left to right gradient


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Texts with gradients don't take the style's padding property into account, and assumed the gradient should be applied to the whole canvas size. On multiline vertical gradients, this caused each successive line to be more offset on the gradient.

For example, the following style with extreme padding to highlight the issue (screenshots from the TextStyle generator):
```json
{
    "fill": [
        "#fff0a1",
        "#face08",
        "#db8c00"
    ],
    "fontWeight": "bold",
    "padding": 20
}
```

Current behaviour (can see the gradient seams for the multiple lines):
![GradientPadding-Broken](https://user-images.githubusercontent.com/1192064/76095745-b72ea800-5fbc-11ea-8f27-f28c759cc045.png)

Fixed behaviour:
![GradientPadding-Fixed](https://user-images.githubusercontent.com/1192064/76095791-c9a8e180-5fbc-11ea-92b8-8d847f20e59e.png)

Playground demo: https://pixiplayground.com/#/edit/Ko5N0jUy1hAgUalGWisJn

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
  - Of those not already failing
