### PR TITLE
Public animated sprite update

### DIFF
--- a/packages/sprite-animated/src/AnimatedSprite.ts
+++ b/packages/sprite-animated/src/AnimatedSprite.ts
@@ -49,7 +49,7 @@ export class AnimatedSprite extends Sprite
     private _textures: Texture[];
     private _durations: number[];
     private _autoUpdate: boolean;
-    private _isAutoUpdating: boolean;
+    private _isConnectedToTicker: boolean;
     private _currentTime: number;
 
     /**
@@ -83,7 +83,15 @@ export class AnimatedSprite extends Sprite
          * @private
          */
         this._autoUpdate = autoUpdate;
-        this._isAutoUpdating = false;
+
+        /**
+         * `true` if the instance is currently connected to PIXI.Ticker.shared to auto update animation time.
+         *
+         * @type {boolean}
+         * @default false
+         * @private
+         */
+        this._isConnectedToTicker = false;
 
         /**
          * The speed that the AnimatedSprite will play at. Higher is faster, lower is slower.
@@ -159,10 +167,10 @@ export class AnimatedSprite extends Sprite
         }
 
         this._playing = false;
-        if (this._autoUpdate && this._isAutoUpdating)
+        if (this._autoUpdate && this._isConnectedToTicker)
         {
             Ticker.shared.remove(this.update, this);
-            this._isAutoUpdating = false;
+            this._isConnectedToTicker = false;
         }
     }
 
@@ -178,10 +186,10 @@ export class AnimatedSprite extends Sprite
         }
 
         this._playing = true;
-        if (this._autoUpdate && !this._isAutoUpdating)
+        if (this._autoUpdate && !this._isConnectedToTicker)
         {
             Ticker.shared.add(this.update, this, UPDATE_PRIORITY.HIGH);
-            this._isAutoUpdating = true;
+            this._isConnectedToTicker = true;
         }
     }
 
@@ -472,15 +480,15 @@ export class AnimatedSprite extends Sprite
         {
             this._autoUpdate = value;
 
-            if (!this._autoUpdate && this._isAutoUpdating)
+            if (!this._autoUpdate && this._isConnectedToTicker)
             {
                 Ticker.shared.remove(this.update, this);
-                this._isAutoUpdating = false;
+                this._isConnectedToTicker = false;
             }
-            else if (this._autoUpdate && !this._isAutoUpdating && this._playing)
+            else if (this._autoUpdate && !this._isConnectedToTicker && this._playing)
             {
                 Ticker.shared.add(this.update, this);
-                this._isAutoUpdating = true;
+                this._isConnectedToTicker = true;
             }
         }
     }

--- a/packages/sprite-animated/src/AnimatedSprite.ts
+++ b/packages/sprite-animated/src/AnimatedSprite.ts
@@ -221,10 +221,9 @@ export class AnimatedSprite extends Sprite
     /**
      * Updates the object transform for rendering.
      *
-     * @private
      * @param {number} deltaTime - Time since last tick.
      */
-    private update(deltaTime: number): void
+    update(deltaTime: number): void
     {
         const elapsed = this.animationSpeed * deltaTime;
         const previousFrame = this.currentFrame;

--- a/packages/sprite-animated/src/AnimatedSprite.ts
+++ b/packages/sprite-animated/src/AnimatedSprite.ts
@@ -49,6 +49,7 @@ export class AnimatedSprite extends Sprite
     private _textures: Texture[];
     private _durations: number[];
     private _autoUpdate: boolean;
+    private _isAutoUpdating: boolean;
     private _currentTime: number;
 
     /**
@@ -76,11 +77,13 @@ export class AnimatedSprite extends Sprite
 
         /**
          * `true` uses PIXI.Ticker.shared to auto update animation time.
+         *
          * @type {boolean}
          * @default true
          * @private
          */
         this._autoUpdate = autoUpdate;
+        this._isAutoUpdating = false;
 
         /**
          * The speed that the AnimatedSprite will play at. Higher is faster, lower is slower.
@@ -156,9 +159,10 @@ export class AnimatedSprite extends Sprite
         }
 
         this._playing = false;
-        if (this._autoUpdate)
+        if (this._autoUpdate && this._isAutoUpdating)
         {
             Ticker.shared.remove(this.update, this);
+            this._isAutoUpdating = false;
         }
     }
 
@@ -174,9 +178,10 @@ export class AnimatedSprite extends Sprite
         }
 
         this._playing = true;
-        if (this._autoUpdate)
+        if (this._autoUpdate && this._isAutoUpdating)
         {
             Ticker.shared.add(this.update, this, UPDATE_PRIORITY.HIGH);
+            this._isAutoUpdating = true;
         }
     }
 
@@ -449,6 +454,35 @@ export class AnimatedSprite extends Sprite
     get playing(): boolean
     {
         return this._playing;
+    }
+
+    /**
+     * Whether to use PIXI.Ticker.shared to auto update animation time
+     *
+     * @member {boolean}
+     */
+    get autoUpdate(): boolean
+    {
+        return this._autoUpdate;
+    }
+
+    set autoUpdate(value) // eslint-disable-line require-jsdoc
+    {
+        if (value !== this._autoUpdate)
+        {
+            this._autoUpdate = value;
+
+            if (!this._autoUpdate && this._isAutoUpdating)
+            {
+                Ticker.shared.remove(this.update, this);
+                this._isAutoUpdating = false;
+            }
+            else if (this._autoUpdate && !this._isAutoUpdating && this._playing)
+            {
+                Ticker.shared.add(this.update, this);
+                this._isAutoUpdating = true;
+            }
+        }
     }
 }
 

--- a/packages/sprite-animated/src/AnimatedSprite.ts
+++ b/packages/sprite-animated/src/AnimatedSprite.ts
@@ -178,7 +178,7 @@ export class AnimatedSprite extends Sprite
         }
 
         this._playing = true;
-        if (this._autoUpdate && this._isAutoUpdating)
+        if (this._autoUpdate && !this._isAutoUpdating)
         {
             Ticker.shared.add(this.update, this, UPDATE_PRIORITY.HIGH);
             this._isAutoUpdating = true;

--- a/packages/sprite-animated/test/AnimatedSprite.js
+++ b/packages/sprite-animated/test/AnimatedSprite.js
@@ -38,6 +38,7 @@ describe('PIXI.AnimatedSprite', function ()
         it('should be correct with autoUpdate=true but then turned off via setter', function ()
         {
             this.sprite = new AnimatedSprite(this.textures, true);
+            expect(this.sprite._autoUpdate).to.be.true;
             this.sprite.autoUpdate = false;
             expect(this.sprite._autoUpdate).to.be.false;
         });

--- a/packages/sprite-animated/test/AnimatedSprite.js
+++ b/packages/sprite-animated/test/AnimatedSprite.js
@@ -34,6 +34,13 @@ describe('PIXI.AnimatedSprite', function ()
             this.sprite = new AnimatedSprite(this.textures, false);
             expect(this.sprite._autoUpdate).to.be.false;
         });
+
+        it('should be correct with autoUpdate=true but then turned off via setter', function ()
+        {
+            this.sprite = new AnimatedSprite(this.textures, true);
+            this.sprite.autoUpdate = false;
+            expect(this.sprite._autoUpdate).to.be.false;
+        });
     });
 
     describe('.stop()', function ()


### PR DESCRIPTION
New autoUpdate setter getter for AnimatedSprite, that matches behaviour as in the VideoResource autoUpdate setter getter

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
