### PR TITLE
V4 backport localbounds

### DIFF
--- a/src/core/display/Bounds.js
+++ b/src/core/display/Bounds.js
@@ -40,6 +40,15 @@ export default class Bounds
         this.maxY = -Infinity;
 
         this.rect = null;
+
+        /**
+         * It is updated to _boundsID of corresponding object to keep bounds in sync with content.
+         * Updated from outside, thus public modifier.
+         *
+         * @member {number}
+         * @public
+         */
+        this.updateID = -1;
     }
 
     /**
@@ -58,8 +67,6 @@ export default class Bounds
      */
     clear()
     {
-        this.updateID++;
-
         this.minX = Infinity;
         this.minY = Infinity;
         this.maxX = -Infinity;

--- a/src/core/display/Container.js
+++ b/src/core/display/Container.js
@@ -373,7 +373,35 @@ export default class Container extends DisplayObject
             }
         }
 
-        this._lastBoundsID = this._boundsID;
+        this._bounds.updateID = this._boundsID;
+    }
+
+    /**
+     * Retrieves the local bounds of the displayObject as a rectangle object.
+     *
+     * @param {PIXI.Rectangle} [rect] - Optional rectangle to store the result of the bounds calculation.
+     * @param {boolean} [skipChildrenUpdate=false] Setting to `true` will stop re-calculation of children transforms,
+     *  it was default behaviour of pixi 4.0-5.2 and caused many problems to users.
+     * @return {PIXI.Rectangle} The rectangular bounding area.
+     */
+    getLocalBounds(rect, skipChildrenUpdate = false)
+    {
+        const result = super.getLocalBounds(rect);
+
+        if (!skipChildrenUpdate)
+        {
+            for (let i = 0, j = this.children.length; i < j; ++i)
+            {
+                const child = this.children[i];
+
+                if (child.visible)
+                {
+                    child.updateTransform();
+                }
+            }
+        }
+
+        return result;
     }
 
     /**

--- a/src/core/display/DisplayObject.js
+++ b/src/core/display/DisplayObject.js
@@ -110,7 +110,7 @@ export default class DisplayObject extends EventEmitter
          * @member {PIXI.Bounds}
          * @private
          */
-        this._localBounds = null;
+        this._$localBounds = null;
 
         /**
          * The original, cached mask of the object
@@ -252,9 +252,9 @@ export default class DisplayObject extends EventEmitter
             rect = this._localBoundsRect;
         }
 
-        if (!this._localBounds)
+        if (!this._$localBounds)
         {
-            this._localBounds = new Bounds();
+            this._$localBounds = new Bounds();
         }
 
         const transformRef = this.transform;
@@ -266,7 +266,7 @@ export default class DisplayObject extends EventEmitter
         const worldBounds = this._bounds;
         const worldBoundsID = this._boundsID;
 
-        this._bounds = this._localBounds;
+        this._bounds = this._$localBounds;
 
         const bounds = this.getBounds(false, rect);
 

--- a/src/core/display/DisplayObject.js
+++ b/src/core/display/DisplayObject.js
@@ -215,7 +215,7 @@ export default class DisplayObject extends EventEmitter
             }
         }
 
-        if (this._bounds.updateID)
+        if (this._bounds.updateID !== this._boundsID)
         {
             this.calculateBounds();
             this._bounds.updateID = this._boundsID;

--- a/src/core/graphics/Graphics.js
+++ b/src/core/graphics/Graphics.js
@@ -905,6 +905,7 @@ export default class Graphics extends Container
 
         this.currentPath = null;
         this._spriteRect = null;
+        this._boundsID++;
 
         return this;
     }

--- a/src/extras/cacheAsBitmap.js
+++ b/src/extras/cacheAsBitmap.js
@@ -376,7 +376,7 @@ DisplayObject.prototype._calculateCachedBounds = function _calculateCachedBounds
     this._bounds.clear();
     this._cacheData.sprite.transform._worldID = this.transform._worldID;
     this._cacheData.sprite._calculateBounds();
-    this._lastBoundsID = this._boundsID;
+    this._bounds.updateID = this._boundsID;
 };
 
 /**

--- a/test/core/Container.js
+++ b/test/core/Container.js
@@ -630,6 +630,55 @@ describe('PIXI.Container', function ()
         });
     });
 
+    describe('getLocalBounds', function ()
+    {
+        it('should recalculate children transform by default', function ()
+        {
+            const root = new PIXI.Container();
+            const container = new PIXI.Container();
+            const child = new PIXI.Container();
+
+            root.addChild(container);
+            container.addChild(child);
+
+            container.position.set(10, 10);
+            child.position.set(20, 30);
+
+            container.updateTransform();
+            container.getLocalBounds();
+
+            expect(child.transform.worldTransform.tx).to.equal(30);
+            expect(child.transform.worldTransform.ty).to.equal(40);
+        });
+
+        it('should recalculate bounds if children position was changed', function ()
+        {
+            const root = new PIXI.Container();
+            const container = new PIXI.Container();
+            const child = new PIXI.Container();
+            let bounds = null;
+
+            child._calculateBounds = function ()
+            {
+                this._bounds.addFrame(this.transform, 0, 0, 1, 1);
+            };
+
+            root.addChild(container);
+            container.addChild(child);
+            container.position.set(10, 10);
+            container.updateTransform();
+
+            child.position.set(20, 30);
+            bounds = container.getLocalBounds();
+            expect(bounds.x).to.equal(20);
+            expect(bounds.y).to.equal(30);
+            child.position.set(5, 5);
+            bounds = container.getLocalBounds();
+            expect(bounds.x).to.equal(5);
+            expect(bounds.y).to.equal(5);
+        });
+    });
+
     describe('width', function ()
     {
         it('should reflect scale', function ()


### PR DESCRIPTION
Our v5 bounds update has a few good tests that allow us to backport our epic bounds fixes to v4!

Cumulative changes from PR's: #6365 #6334 #6304 

All this code was CTRL+C - ed.

`_localBounds` from v5 is renamed to `_$localBounds` , because name collision with field in v4 Graphics.

@tywang2006 confirmed that there are people who want to use the fix in production.
