### PR TITLE
Fixes incorrect mentions of deprecated namespaces

### DIFF
--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -485,7 +485,7 @@ export class Renderer extends AbstractRenderer
      * @property {PIXI.accessibility.AccessibilityManager} accessibility Support tabbing interactive elements.
      * @property {PIXI.extract.Extract} extract Extract image data from renderer.
      * @property {PIXI.interaction.InteractionManager} interaction Handles mouse, touch and pointer events.
-     * @property {PIXI.prepare.Prepare} prepare Pre-render display objects.
+     * @property {PIXI.Prepare} prepare Pre-render display objects.
      */
 
     static __plugins: IRendererPlugins;

--- a/packages/prepare/test/BasePrepare.js
+++ b/packages/prepare/test/BasePrepare.js
@@ -1,6 +1,6 @@
 const { BasePrepare } = require('../');
 
-describe('PIXI.prepare.BasePrepare', function ()
+describe('PIXI.BasePrepare', function ()
 {
     it('should create a new, empty, BasePrepare', function ()
     {

--- a/packages/prepare/test/CountLimiter.js
+++ b/packages/prepare/test/CountLimiter.js
@@ -1,6 +1,6 @@
 const { CountLimiter } = require('../');
 
-describe('PIXI.prepare.CountLimiter', function ()
+describe('PIXI.CountLimiter', function ()
 {
     it('should limit to specified number per beginFrame()', function ()
     {

--- a/packages/prepare/test/Prepare.js
+++ b/packages/prepare/test/Prepare.js
@@ -3,7 +3,7 @@ const { Renderer, Texture } = require('@pixi/core');
 const { Container } = require('@pixi/display');
 const { Graphics } = require('@pixi/graphics');
 
-describe('PIXI.prepare.Prepare', function ()
+describe('PIXI.Prepare', function ()
 {
     it('should upload graphics vao and textures', function ()
     {

--- a/packages/text/src/TextStyle.ts
+++ b/packages/text/src/TextStyle.ts
@@ -768,7 +768,7 @@ export class TextStyle implements ITextStyle
      *
      * @return {string} Font style string, for passing to `TextMetrics.measureFont()`
      */
-    public toFontString()
+    public toFontString(): string
     {
         // build canvas api font setting from individual components. Convert a numeric this.fontSize to px
         const fontSizeString = (typeof this.fontSize === 'number') ? `${this.fontSize}px` : this.fontSize;

--- a/packages/ticker/src/const.ts
+++ b/packages/ticker/src/const.ts
@@ -12,7 +12,7 @@
  * @property {number} HIGH=25 High priority updating, {@link PIXI.VideoBaseTexture} and {@link PIXI.AnimatedSprite}
  * @property {number} NORMAL=0 Default priority for ticker events, see {@link PIXI.Ticker#add}.
  * @property {number} LOW=-25 Low priority used for {@link PIXI.Application} rendering.
- * @property {number} UTILITY=-50 Lowest priority used for {@link PIXI.prepare.BasePrepare} utility.
+ * @property {number} UTILITY=-50 Lowest priority used for {@link PIXI.BasePrepare} utility.
  */
 export enum UPDATE_PRIORITY {
     INTERACTION = 50,


### PR DESCRIPTION
##### Description of change
Docs updates after prepare plugin namespace change - https://github.com/pixijs/pixi.js/commit/c8cda62ed5899de901fb766b8aa7e12e176d620a
Also fixed a missing typescript return type 

##### Pre-Merge Checklist
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
