### PR TITLE
Fix Typescript global type to export type

### DIFF
--- a/types/assemble.js
+++ b/types/assemble.js
@@ -65,11 +65,8 @@ const eventTypes = fs.readFileSync(path.join(__dirname, 'events.d.ts'), 'utf8');
 const loaderTypes = fs.readFileSync(path.join(__dirname, 'loader.d.ts'), 'utf8');
 
 // Lastly, tsd-jsdoc doesn't support this yet, so we'll inject the module
-// declaration at the end, so that users can use ambient namespace typings
-// like `import 'pixi.js';` OR module typings `import * as PIXI from 'pixi.js';`
-const declareModule = `declare module "${bundle}" {
-    export = PIXI;
-}`;
+// declaration at the end
+const declareModule = `export = PIXI;`;
 
 fs.writeFileSync(tempPath, [buffer, eventTypes, loaderTypes, declareModule].join('\n'));
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change

This should address https://github.com/pixijs/pixi.js/issues/6445

For a reproduction of this bug see my repo here: https://github.com/JacobFischer/pixi-ts-global-error

Simply put, this exports the `PIXI` type instead of not exporting anything which makes them ambient declarations in Typescript that cause `PIXI` to exist as a global in all projects that use pixi.js + Typescript, regardless if pixi is truly a global or not.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Documentation is changed or added
- [X] Lint process passed (`npm run lint`)
- [X] Tests passed (`npm run test`)
