### PR TITLE
Fix filters to sum padding instead of max padding

### DIFF
--- a/packages/core/src/filters/FilterSystem.ts
+++ b/packages/core/src/filters/FilterSystem.ts
@@ -26,6 +26,7 @@ export class FilterSystem extends System
     public statePool: Array<FilterState>;
     public texturePool: RenderTexturePool;
     public forceClear: boolean;
+    public useMaxPadding: boolean;
     protected quad: Quad;
     protected quadUv: QuadUv;
     protected activeState: FilterState;
@@ -112,6 +113,14 @@ export class FilterSystem extends System
          * @member {boolean}
          */
         this.forceClear = false;
+
+        /**
+         * Old padding behavior is to use the max amount instead of sum padding.
+         * Use this flag if you need the old behavior.
+         * @member {boolean}
+         * @default false
+         */
+        this.useMaxPadding = false;
     }
 
     /**
@@ -137,8 +146,12 @@ export class FilterSystem extends System
 
             // lets use the lowest resolution..
             resolution = Math.min(resolution, filter.resolution);
-            // and the largest amount of padding!
-            padding = Math.max(padding, filter.padding);
+            // figure out the padding required for filters
+            padding = this.useMaxPadding
+                // old behavior: use largest amount of padding!
+                ? Math.max(padding, filter.padding)
+                // new behavior: sum the padding
+                : padding + filter.padding;
             // only auto fit if all filters are autofit
             autoFit = autoFit || filter.autoFit;
 


### PR DESCRIPTION
Fixes #6303

### Changed

* Filter `padding` is now additive if you have multiple filters. 
* Adds `useMaxPadding` on FilterSystem for the old behavior, e.g., `renderer.filter.useMaxPadding = true;` (default is `false`)

**Current (v5.2.1)**
https://jsfiddle.net/bigtimebuddy/tz3w5cju/
![Screen Shot 2020-04-03 at 1 14 07 PM](https://user-images.githubusercontent.com/864393/78401191-08768b00-75ad-11ea-8ca5-7cce639f0902.png)

**This PR (fixed)**
https://jsfiddle.net/bigtimebuddy/9whkty5L/
![Screen Shot 2020-04-03 at 1 13 59 PM](https://user-images.githubusercontent.com/864393/78401179-044a6d80-75ad-11ea-92ec-5e4936590ae3.png)
