### PR TITLE
Fixes SimpleRope on Canvas renderer

### DIFF
--- a/packages/canvas/canvas-mesh/src/SimpleRope.js
+++ b/packages/canvas/canvas-mesh/src/SimpleRope.js
@@ -11,9 +11,9 @@ import { SimpleRope } from '@pixi/mesh-extras';
 SimpleRope.prototype._renderCanvas = function _renderCanvas(renderer)
 {
     if (this.autoUpdate
-        || this.geometry.width !== this.shader.texture.height)
+        || this.geometry._width !== this.shader.texture.height)
     {
-        this.geometry.width = this.shader.texture.height;
+        this.geometry._width = this.shader.texture.height;
         this.geometry.update();
     }
 


### PR DESCRIPTION
Was trying to set a property that only had a getter
Change the code to match the WebGL renderer code style, using _width instead
https://github.com/pixijs/pixi.js/issues/6531