### PR TITLE
Unsubscribe from baseTexture loaded event on Texture::destroy

### DIFF
--- a/packages/core/src/textures/Texture.ts
+++ b/packages/core/src/textures/Texture.ts
@@ -288,6 +288,7 @@ export class Texture extends EventEmitter
                 this.baseTexture.destroy();
             }
 
+            this.baseTexture.off('loaded', this.onBaseTextureUpdated, this);
             this.baseTexture.off('update', this.onBaseTextureUpdated, this);
 
             this.baseTexture = null;

--- a/packages/core/test/Texture.js
+++ b/packages/core/test/Texture.js
@@ -138,6 +138,15 @@ describe('PIXI.Texture', function ()
         texture.destroy(true);
     });
 
+    it('should not throw if base texture loaded after destroy', function ()
+    {
+        const base = new BaseTexture();
+        const texture = new Texture(base);
+
+        texture.destroy();
+        base.emit('loaded', base);
+    });
+
     it('should clone a minimal texture', function ()
     {
         const baseTexture = new BaseTexture();


### PR DESCRIPTION
##### Description of change
Texture should not receive onBaseTextureUpdated once destroyed. But it left 'loaded' event subscription active.

##### Pre-Merge Checklist
- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
