### PR TITLE
Handle extreme radius inputs for rounded rect

### DIFF
--- a/packages/graphics/src/utils/buildRoundedRectangle.ts
+++ b/packages/graphics/src/utils/buildRoundedRectangle.ts
@@ -99,26 +99,38 @@ export const buildRoundedRectangle: IShapeBuildCommand = {
         const width = rrectData.width;
         const height = rrectData.height;
 
-        const radius = rrectData.radius;
+        // Don't allow negative radius or greater than half the smallest width
+        const radius = Math.max(0, Math.min(rrectData.radius, Math.min(width, height) / 2));
 
         points.length = 0;
 
-        quadraticBezierCurve(x, y + radius,
-            x, y,
-            x + radius, y,
-            points);
-        quadraticBezierCurve(x + width - radius,
-            y, x + width, y,
-            x + width, y + radius,
-            points);
-        quadraticBezierCurve(x + width, y + height - radius,
-            x + width, y + height,
-            x + width - radius, y + height,
-            points);
-        quadraticBezierCurve(x + radius, y + height,
-            x, y + height,
-            x, y + height - radius,
-            points);
+        // No radius, do a simple rectangle
+        if (!radius)
+        {
+            points.push(x, y,
+                x + width, y,
+                x + width, y + height,
+                x, y + height);
+        }
+        else
+        {
+            quadraticBezierCurve(x, y + radius,
+                x, y,
+                x + radius, y,
+                points);
+            quadraticBezierCurve(x + width - radius,
+                y, x + width, y,
+                x + width, y + radius,
+                points);
+            quadraticBezierCurve(x + width, y + height - radius,
+                x + width, y + height,
+                x + width - radius, y + height,
+                points);
+            quadraticBezierCurve(x + radius, y + height,
+                x, y + height,
+                x, y + height - radius,
+                points);
+        }
 
         // this tiny number deals with the issue that occurs when points overlap and earcut fails to triangulate the item.
         // TODO - fix this properly, this is not very elegant.. but it works for now.


### PR DESCRIPTION
The issue with rendering rounded rectangle was there were some very strange results when the radius was larger than half the smallest size or negative. This should resolve these cases. The rendering mirrors how CSS behaves with `border-radius`.

**Bug (v5.2.1)**
https://jsfiddle.net/bigtimebuddy/hgje6tpy/

**Fixed**
https://jsfiddle.net/bigtimebuddy/at18sdop/