### PR TITLE
Fix issue with preparing Graphics without shader

### DIFF
--- a/packages/prepare/src/Prepare.ts
+++ b/packages/prepare/src/Prepare.ts
@@ -67,7 +67,7 @@ function uploadGraphics(renderer: AbstractRenderer | BasePrepare, item: IDisplay
     // if its not batchable - update vao for particular shader
     if (!geometry.batchable)
     {
-        (renderer as Renderer).geometry.bind(geometry, (item as any)._resolveDirectShader());
+        (renderer as Renderer).geometry.bind(geometry, (item as any)._resolveDirectShader((renderer as Renderer)));
     }
 
     return true;


### PR DESCRIPTION
_resolveDirectShader is needed in a renderer parameter, otherwise it will fail [there](https://github.com/pixijs/pixi.js/blob/dev/packages/graphics/src/Graphics.ts#L1157)

##### Description of change
Just passing down renderer to the _resolveDirectShader.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
