### PR TITLE
Proposed v5.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,24 @@
 language: node_js
-node_js:
-    - "8"
 
-env:
-  - CXX=g++-4.8
+services:
+    - xvfb
+
+node_js:
+    - "10"
 
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8
+env:
+  - CXX=g++-4.8
 
 install:
-    - npm install xvfb-maybe
     - npm install
     - npm install codecov -g
 
-cache:
-  directories:
-    - node_modules
-
-before_script:
-  - export DISPLAY=':99.0'
-  - Xvfb :99 -screen 0 1024x768x24 -extension RANDR &
-
 script:
-  - xvfb-maybe npm run coverage:ci
+  - npm run coverage:ci
   - codecov
   - npm run dist
 

--- a/packages/accessibility/src/AccessibilityManager.js
+++ b/packages/accessibility/src/AccessibilityManager.js
@@ -1,6 +1,7 @@
-import { accessibleTarget } from './accessibleTarget';
-import { removeItems, isMobile } from '@pixi/utils';
+import { isMobile, removeItems } from '@pixi/utils';
+
 import { DisplayObject } from '@pixi/display';
+import { accessibleTarget } from './accessibleTarget';
 
 // add some extra variables to the container..
 DisplayObject.mixin(accessibleTarget);
@@ -132,6 +133,19 @@ export class AccessibilityManager
          */
         this.isMobileAccessibility = false;
 
+        /**
+         * count to throttle div updates on android devices
+         * @type number
+         * @private
+         */
+        this.androidUpdateCount = 0;
+
+        /**
+         * the frequency to update the div elements ()
+         * @private
+         */
+        this.androidUpdateFrequency = 500; // 2fps
+
         // let listen for tab.. once pressed we can fire up and show the accessibility layer
         window.addEventListener('keydown', this._onKeyDown, false);
     }
@@ -152,7 +166,7 @@ export class AccessibilityManager
         hookDiv.style.left = `${DIV_HOOK_POS_Y}px`;
         hookDiv.style.zIndex = DIV_HOOK_ZINDEX;
         hookDiv.style.backgroundColor = '#FF0000';
-        hookDiv.title = 'HOOK DIV';
+        hookDiv.title = 'select to enable accessability for this content';
 
         hookDiv.addEventListener('focus', () =>
         {
@@ -270,6 +284,19 @@ export class AccessibilityManager
      */
     update()
     {
+        /* On Android default web browser, tab order seems to be calculated by position rather than tabIndex,
+        *  moving buttons can cause focus to flicker between two buttons making it hard/impossible to navigate,
+        *  so I am just running update every half a second, seems to fix it.
+        */
+        const now = performance.now();
+
+        if (isMobile.android.device && now < this.androidUpdateCount)
+        {
+            return;
+        }
+
+        this.androidUpdateCount = now + this.androidUpdateFrequency;
+
         if (!this.renderer.renderingToScreen)
         {
             return;
@@ -279,8 +306,11 @@ export class AccessibilityManager
         this.updateAccessibleObjects(this.renderer._lastObjectRendered);
 
         const rect = this.renderer.view.getBoundingClientRect();
-        const sx = rect.width / this.renderer.width;
-        const sy = rect.height / this.renderer.height;
+
+        const resolution = this.renderer.resolution;
+
+        const sx = (rect.width / this.renderer.width) * resolution;
+        const sy = (rect.height / this.renderer.height) * resolution;
 
         let div = this.div;
 
@@ -303,11 +333,6 @@ export class AccessibilityManager
                 child._accessibleDiv = null;
 
                 i--;
-
-                if (this.children.length === 0)
-                {
-                    this.deactivate();
-                }
             }
             else
             {

--- a/packages/canvas/canvas-graphics/src/CanvasGraphicsRenderer.js
+++ b/packages/canvas/canvas-graphics/src/CanvasGraphicsRenderer.js
@@ -31,6 +31,38 @@ export class CanvasGraphicsRenderer
     }
 
     /**
+     * calculates fill/stroke style for canvas
+     *
+     * @private
+     * @param {PIXI.FillStyle} style
+     * @param {number} tint
+     * @returns {string|CanvasPattern}
+     */
+    _calcCanvasStyle(style, tint)
+    {
+        let res;
+
+        if (style.texture)
+        {
+            if (style.texture.valid)
+            {
+                res = canvasUtils.getTintedPattern(style.texture, tint);
+                this.setPatternTransform(res, style.matrix || Matrix.IDENTITY);
+            }
+            else
+            {
+                res = '#808080';
+            }
+        }
+        else
+        {
+            res = `#${(`00000${(tint | 0).toString(16)}`).substr(-6)}`;
+        }
+
+        return res;
+    }
+
+    /**
      * Renders a Graphics object to a canvas.
      *
      * @param {PIXI.Graphics} graphics - the actual graphics object to render
@@ -67,27 +99,11 @@ export class CanvasGraphicsRenderer
 
             if (fillStyle.visible)
             {
-                if (fillStyle.texture)
-                {
-                    contextFillStyle = canvasUtils.getTintedPattern(fillStyle.texture, data._fillTint);
-                    this.setPatternTransform(contextFillStyle, fillStyle.matrix || Matrix.IDENTITY);
-                }
-                else
-                {
-                    contextFillStyle = `#${(`00000${(data._fillTint | 0).toString(16)}`).substr(-6)}`;
-                }
+                contextFillStyle = this._calcCanvasStyle(fillStyle, data._fillTint);
             }
             if (lineStyle.visible)
             {
-                if (fillStyle.texture)
-                {
-                    contextStrokeStyle = canvasUtils.getTintedPattern(lineStyle.texture, data._lineTint);
-                    this.setPatternTransform(contextStrokeStyle, lineStyle.matrix || Matrix.IDENTITY);
-                }
-                else
-                {
-                    contextStrokeStyle = `#${(`00000${(data._lineTint | 0).toString(16)}`).substr(-6)}`;
-                }
+                contextStrokeStyle = this._calcCanvasStyle(lineStyle, data._lineTint);
             }
 
             context.lineWidth = lineStyle.width;

--- a/packages/canvas/canvas-graphics/src/CanvasGraphicsRenderer.js
+++ b/packages/canvas/canvas-graphics/src/CanvasGraphicsRenderer.js
@@ -40,16 +40,8 @@ export class CanvasGraphicsRenderer
         const context = renderer.context;
         const worldAlpha = graphics.worldAlpha;
         const transform = graphics.transform.worldTransform;
-        const resolution = renderer.resolution;
 
-        context.setTransform(
-            transform.a * resolution,
-            transform.b * resolution,
-            transform.c * resolution,
-            transform.d * resolution,
-            transform.tx * resolution,
-            transform.ty * resolution
-        );
+        renderer.setContextTransform(transform);
 
         // update tint if graphics was dirty
         if (graphics.canvasTintDirty !== graphics.geometry.dirty

--- a/packages/canvas/canvas-graphics/src/Graphics.js
+++ b/packages/canvas/canvas-graphics/src/Graphics.js
@@ -11,7 +11,7 @@ const tempMatrix = new Matrix();
  * or the **@pixi/canvas-graphics** package.
  * @method generateCanvasTexture
  * @memberof PIXI.Graphics#
- * @param {number} scaleMode - The scale mode of the texture.
+ * @param {PIXI.SCALE_MODES} scaleMode - The scale mode of the texture.
  * @param {number} resolution - The resolution of the texture.
  * @return {PIXI.Texture} The new texture.
  */

--- a/packages/canvas/canvas-mesh/src/CanvasMeshRenderer.js
+++ b/packages/canvas/canvas-mesh/src/CanvasMeshRenderer.js
@@ -25,36 +25,11 @@ export class CanvasMeshRenderer
     render(mesh)
     {
         const renderer = this.renderer;
-        const context = renderer.context;
-
         const transform = mesh.worldTransform;
-        const res = renderer.resolution;
-
-        if (mesh.roundPixels)
-        {
-            context.setTransform(
-                transform.a * res,
-                transform.b * res,
-                transform.c * res,
-                transform.d * res,
-                (transform.tx * res) | 0,
-                (transform.ty * res) | 0
-            );
-        }
-        else
-        {
-            context.setTransform(
-                transform.a * res,
-                transform.b * res,
-                transform.c * res,
-                transform.d * res,
-                transform.tx * res,
-                transform.ty * res
-            );
-        }
 
         renderer.context.globalAlpha = mesh.worldAlpha;
         renderer.setBlendMode(mesh.blendMode);
+        renderer.setContextTransform(transform, mesh.roundPixels);
 
         if (mesh.drawMode !== DRAW_MODES.TRIANGLES)
         {

--- a/packages/canvas/canvas-mesh/src/NineSlicePlane.js
+++ b/packages/canvas/canvas-mesh/src/NineSlicePlane.js
@@ -37,7 +37,6 @@ NineSlicePlane.prototype._renderCanvas = function _renderCanvas(renderer)
 {
     const context = renderer.context;
     const transform = this.worldTransform;
-    const res = renderer.resolution;
     const isTinted = this.tint !== 0xFFFFFF;
     const texture = this.texture;
 
@@ -89,29 +88,7 @@ NineSlicePlane.prototype._renderCanvas = function _renderCanvas(renderer)
 
     context.globalAlpha = this.worldAlpha;
     renderer.setBlendMode(this.blendMode);
-
-    if (this.roundPixels)
-    {
-        context.setTransform(
-            transform.a * res,
-            transform.b * res,
-            transform.c * res,
-            transform.d * res,
-            (transform.tx * res) | 0,
-            (transform.ty * res) | 0
-        );
-    }
-    else
-    {
-        context.setTransform(
-            transform.a * res,
-            transform.b * res,
-            transform.c * res,
-            transform.d * res,
-            transform.tx * res,
-            transform.ty * res
-        );
-    }
+    renderer.setContextTransform(transform, this.roundPixels);
 
     for (let row = 0; row < 3; row++)
     {

--- a/packages/canvas/canvas-mesh/src/NineSlicePlane.js
+++ b/packages/canvas/canvas-mesh/src/NineSlicePlane.js
@@ -41,6 +41,11 @@ NineSlicePlane.prototype._renderCanvas = function _renderCanvas(renderer)
     const isTinted = this.tint !== 0xFFFFFF;
     const texture = this.texture;
 
+    if (!texture.valid)
+    {
+        return;
+    }
+
     // Work out tinting
     if (isTinted)
     {

--- a/packages/canvas/canvas-mesh/src/SimpleRope.js
+++ b/packages/canvas/canvas-mesh/src/SimpleRope.js
@@ -11,9 +11,9 @@ import { SimpleRope } from '@pixi/mesh-extras';
 SimpleRope.prototype._renderCanvas = function _renderCanvas(renderer)
 {
     if (this.autoUpdate
-        || this.geometry.width !== this.shader.texture.height)
+        || this.geometry._width !== this.shader.texture.height)
     {
-        this.geometry.width = this.shader.texture.height;
+        this.geometry._width = this.shader.texture.height;
         this.geometry.update();
     }
 

--- a/packages/canvas/canvas-particles/src/ParticleContainer.js
+++ b/packages/canvas/canvas-particles/src/ParticleContainer.js
@@ -39,6 +39,11 @@ ParticleContainer.prototype.renderCanvas = function renderCanvas(renderer)
             continue;
         }
 
+        if (!child._texture.valid)
+        {
+            continue;
+        }
+
         const frame = child._texture.frame;
 
         context.globalAlpha = this.worldAlpha * child.alpha;

--- a/packages/canvas/canvas-particles/src/ParticleContainer.js
+++ b/packages/canvas/canvas-particles/src/ParticleContainer.js
@@ -53,15 +53,7 @@ ParticleContainer.prototype.renderCanvas = function renderCanvas(renderer)
             // this is the fastest  way to optimise! - if rotation is 0 then we can avoid any kind of setTransform call
             if (isRotated)
             {
-                context.setTransform(
-                    transform.a,
-                    transform.b,
-                    transform.c,
-                    transform.d,
-                    transform.tx * renderer.resolution,
-                    transform.ty * renderer.resolution
-                );
-
+                renderer.setContextTransform(transform, false, 1);
                 isRotated = false;
             }
 
@@ -82,28 +74,7 @@ ParticleContainer.prototype.renderCanvas = function renderCanvas(renderer)
 
             const childTransform = child.worldTransform;
 
-            if (this.roundPixels)
-            {
-                context.setTransform(
-                    childTransform.a,
-                    childTransform.b,
-                    childTransform.c,
-                    childTransform.d,
-                    (childTransform.tx * renderer.resolution) | 0,
-                    (childTransform.ty * renderer.resolution) | 0
-                );
-            }
-            else
-            {
-                context.setTransform(
-                    childTransform.a,
-                    childTransform.b,
-                    childTransform.c,
-                    childTransform.d,
-                    childTransform.tx * renderer.resolution,
-                    childTransform.ty * renderer.resolution
-                );
-            }
+            renderer.setContextTransform(childTransform, this.roundPixels, 1);
 
             positionX = ((child.anchor.x) * (-frame.width)) + 0.5;
             positionY = ((child.anchor.y) * (-frame.height)) + 0.5;

--- a/packages/canvas/canvas-renderer/src/BaseTexture.js
+++ b/packages/canvas/canvas-renderer/src/BaseTexture.js
@@ -11,5 +11,5 @@ BaseTexture.prototype.getDrawableSource = function getDrawableSource()
 {
     const resource = this.resource;
 
-    return resource ? (resource.bitmap || resource.source) : this.source;
+    return resource ? (resource.bitmap || resource.source) : null;
 };

--- a/packages/canvas/canvas-renderer/src/CanvasRenderer.js
+++ b/packages/canvas/canvas-renderer/src/CanvasRenderer.js
@@ -4,6 +4,9 @@ import { CanvasMaskManager } from './utils/CanvasMaskManager';
 import { mapCanvasBlendModesToPixi } from './utils/mapCanvasBlendModesToPixi';
 import { RENDERER_TYPE, SCALE_MODES, BLEND_MODES } from '@pixi/constants';
 import { settings } from '@pixi/settings';
+import { Matrix } from '@pixi/math';
+
+const tempMatrix = new Matrix();
 
 /**
  * The CanvasRenderer draws the scene and all its content onto a 2d canvas.
@@ -107,6 +110,13 @@ export class CanvasRenderer extends AbstractRenderer
         this._activeBlendMode = null;
         this._outerBlend = false;
 
+        /**
+         * Projection transform, passed in render() stored here
+         * @type {null}
+         * @private
+         */
+        this._projTransform = null;
+
         this.renderingToScreen = false;
 
         sayHello('Canvas');
@@ -175,6 +185,8 @@ export class CanvasRenderer extends AbstractRenderer
 
         const context = this.context;
 
+        this._projTransform = transform || null;
+
         if (!renderTexture)
         {
             this._lastObjectRendered = displayObject;
@@ -184,33 +196,10 @@ export class CanvasRenderer extends AbstractRenderer
         {
             // update the scene graph
             const cacheParent = displayObject.parent;
-            const tempWt = this._tempDisplayObjectParent.transform.worldTransform;
-
-            if (transform)
-            {
-                transform.copyTo(tempWt);
-                // Canvas Renderer doesn't use "context.translate"
-                // nor does it store current translation in projectionSystem
-                // we re-calculate all matrices,
-                // its not like CanvasRenderer can survive more than 1000 elements
-                displayObject.transform._parentID = -1;
-            }
-            else
-            {
-                // in this case matrix cache in displayObject works like expected
-                tempWt.identity();
-            }
 
             displayObject.parent = this._tempDisplayObjectParent;
-
             displayObject.updateTransform();
             displayObject.parent = cacheParent;
-            if (transform)
-            {
-                // Clear the matrix cache one more time,
-                // we dont have our computations to affect standard "transform=null" case
-                displayObject.transform._parentID = -1;
-            }
             // displayObject.hitArea = //TODO add a temp hit area
         }
 
@@ -249,8 +238,56 @@ export class CanvasRenderer extends AbstractRenderer
         context.restore();
 
         this.resolution = rootResolution;
+        this._projTransform = null;
 
         this.emit('postrender');
+    }
+
+    /**
+     * sets matrix of context
+     * called only from render() methods
+     * takes care about resolution
+     * @param {PIXI.Matrix} transform world matrix of current element
+     * @param {boolean} [roundPixels] whether to round (tx,ty) coords
+     * @param {number} [localResolution] If specified, used instead of `renderer.resolution` for local scaling
+     */
+    setContextTransform(transform, roundPixels, localResolution)
+    {
+        let mat = transform;
+        const proj = this._projTransform;
+        const resolution = this.resolution;
+
+        localResolution = localResolution || resolution;
+
+        if (proj)
+        {
+            mat = tempMatrix;
+            mat.copyFrom(transform);
+            mat.prepend(proj);
+        }
+
+        if (roundPixels)
+        {
+            this.context.setTransform(
+                mat.a * localResolution,
+                mat.b * localResolution,
+                mat.c * localResolution,
+                mat.d * localResolution,
+                (mat.tx * resolution) | 0,
+                (mat.ty * resolution) | 0
+            );
+        }
+        else
+        {
+            this.context.setTransform(
+                mat.a * localResolution,
+                mat.b * localResolution,
+                mat.c * localResolution,
+                mat.d * localResolution,
+                mat.tx * resolution,
+                mat.ty * resolution
+            );
+        }
     }
 
     /**

--- a/packages/canvas/canvas-renderer/src/canvasUtils.js
+++ b/packages/canvas/canvas-renderer/src/canvasUtils.js
@@ -44,7 +44,7 @@ export const canvasUtils = {
         }
         else
         {
-            canvas = canvasUtils.canvas || document.createElement('canvas');
+            canvas = document.createElement('canvas');
         }
 
         canvasUtils.tintMethod(texture, color, canvas);
@@ -63,11 +63,43 @@ export const canvasUtils = {
         else
         {
             texture.tintCache[stringColor] = canvas;
-            // if we are not converting the texture to an image then we need to lose the reference to the canvas
-            canvasUtils.canvas = null;
         }
 
         return canvas;
+    },
+
+    /**
+     * Basically this method just needs a sprite and a color and tints the sprite with the given color.
+     *
+     * @memberof PIXI.canvasUtils
+     * @param {PIXI.Sprite} sprite - the sprite to tint
+     * @param {number} color - the color to use to tint the sprite with
+     * @return {HTMLCanvasElement} The tinted canvas
+     */
+    getTintedPattern: (texture, color) =>
+    {
+        color = canvasUtils.roundColor(color);
+
+        const stringColor = `#${(`00000${(color | 0).toString(16)}`).substr(-6)}`;
+
+        texture.patternCache = texture.patternCache || {};
+
+        let pattern = texture.patternCache[stringColor];
+
+        if (pattern && pattern.tintId === texture._updateID)
+        {
+            return pattern;
+        }
+        if (!canvasUtils.canvas)
+        {
+            canvasUtils.canvas = document.createElement('canvas');
+        }
+        canvasUtils.tintMethod(texture, color, canvasUtils.canvas);
+        pattern = canvasUtils.canvas.getContext('2d').createPattern(canvasUtils.canvas, 'repeat');
+        pattern.tintId = texture._updateID;
+        texture.patternCache[stringColor] = pattern;
+
+        return pattern;
     },
 
     /**

--- a/packages/canvas/canvas-renderer/src/utils/CanvasMaskManager.js
+++ b/packages/canvas/canvas-renderer/src/utils/CanvasMaskManager.js
@@ -40,7 +40,7 @@ export class CanvasMaskManager
         this.recursiveFindShapes(maskObject, foundShapes);
         if (foundShapes.length > 0)
         {
-            const { context, resolution } = renderer;
+            const { context } = renderer;
 
             context.beginPath();
 
@@ -49,14 +49,7 @@ export class CanvasMaskManager
                 const shape = foundShapes[i];
                 const transform = shape.transform.worldTransform;
 
-                this.renderer.context.setTransform(
-                    transform.a * resolution,
-                    transform.b * resolution,
-                    transform.c * resolution,
-                    transform.d * resolution,
-                    transform.tx * resolution,
-                    transform.ty * resolution
-                );
+                this.renderer.setContextTransform(transform);
 
                 this.renderGraphicsShape(shape);
             }

--- a/packages/canvas/canvas-renderer/test/CanvasRenderer.js
+++ b/packages/canvas/canvas-renderer/test/CanvasRenderer.js
@@ -32,19 +32,25 @@ describe('PIXI.CanvasRenderer', function ()
         }
     });
 
-    it('should clear matrix cache in case of translation', function ()
+    it('should update transform in case of temp parent', function ()
     {
         // this test works only for CanvasRenderer, WebGLRenderer behaviour is different
         const renderer = new CanvasRenderer(1, 1);
         const cont = new Container();
+        const par = new Container();
+
+        par.position.set(5, 10);
+        par.addChild(cont);
 
         renderer.render(cont, undefined, undefined, new Matrix().translate(10, 20));
-        expect(cont.worldTransform.tx).to.equal(10);
-        expect(cont.worldTransform.ty).to.equal(20);
+        expect(cont.worldTransform.tx).to.equal(0);
+        expect(cont.worldTransform.ty).to.equal(0);
+
+        renderer.render(par);
+        expect(cont.worldTransform.tx).to.equal(5);
+        expect(cont.worldTransform.ty).to.equal(10);
+
         renderer.render(cont, undefined, undefined, new Matrix().translate(-20, 30));
-        expect(cont.worldTransform.tx).to.equal(-20);
-        expect(cont.worldTransform.ty).to.equal(30);
-        renderer.render(cont);
         expect(cont.worldTransform.tx).to.equal(0);
         expect(cont.worldTransform.ty).to.equal(0);
     });

--- a/packages/canvas/canvas-sprite-tiling/src/TilingSprite.js
+++ b/packages/canvas/canvas-sprite-tiling/src/TilingSprite.js
@@ -21,7 +21,6 @@ TilingSprite.prototype._renderCanvas = function _renderCanvas(renderer)
 
     const context = renderer.context;
     const transform = this.worldTransform;
-    const resolution = renderer.resolution;
     const baseTexture = texture.baseTexture;
     const source = baseTexture.getDrawableSource();
     const baseTextureResolution = baseTexture.resolution;
@@ -54,14 +53,8 @@ TilingSprite.prototype._renderCanvas = function _renderCanvas(renderer)
 
     // set context state..
     context.globalAlpha = this.worldAlpha;
-    context.setTransform(transform.a * resolution,
-        transform.b * resolution,
-        transform.c * resolution,
-        transform.d * resolution,
-        transform.tx * resolution,
-        transform.ty * resolution);
-
     renderer.setBlendMode(this.blendMode);
+    renderer.setContextTransform(transform);
 
     // fill the pattern!
     context.fillStyle = this._canvasPattern;

--- a/packages/canvas/canvas-sprite/src/CanvasSpriteRenderer.js
+++ b/packages/canvas/canvas-sprite/src/CanvasSpriteRenderer.js
@@ -59,7 +59,7 @@ export class CanvasSpriteRenderer
 
         const source = texture.baseTexture.getDrawableSource();
 
-        if (texture.orig.width <= 0 || texture.orig.height <= 0 || !source)
+        if (texture.orig.width <= 0 || texture.orig.height <= 0 || !texture.valid || !source)
         {
             return;
         }

--- a/packages/canvas/canvas-sprite/src/CanvasSpriteRenderer.js
+++ b/packages/canvas/canvas-sprite/src/CanvasSpriteRenderer.js
@@ -105,31 +105,12 @@ export class CanvasSpriteRenderer
         dx -= width / 2;
         dy -= height / 2;
 
+        renderer.setContextTransform(wt, sprite.roundPixels, 1);
         // Allow for pixel rounding
         if (sprite.roundPixels)
         {
-            renderer.context.setTransform(
-                wt.a,
-                wt.b,
-                wt.c,
-                wt.d,
-                (wt.tx * renderer.resolution) | 0,
-                (wt.ty * renderer.resolution) | 0
-            );
-
             dx = dx | 0;
             dy = dy | 0;
-        }
-        else
-        {
-            renderer.context.setTransform(
-                wt.a,
-                wt.b,
-                wt.c,
-                wt.d,
-                wt.tx * renderer.resolution,
-                wt.ty * renderer.resolution
-            );
         }
 
         const resolution = texture.baseTexture.resolution;

--- a/packages/core/src/AbstractRenderer.js
+++ b/packages/core/src/AbstractRenderer.js
@@ -242,7 +242,7 @@ export class AbstractRenderer extends EventEmitter
      * This can be quite useful if your displayObject is complicated and needs to be reused multiple times.
      *
      * @param {PIXI.DisplayObject} displayObject - The displayObject the object will be generated from.
-     * @param {number} scaleMode - Should be one of the scaleMode consts.
+     * @param {PIXI.SCALE_MODES} scaleMode - The scale mode of the texture.
      * @param {number} resolution - The resolution / device pixel ratio of the texture being generated.
      * @param {PIXI.Rectangle} [region] - The region of the displayObject, that shall be rendered,
      *        if no region is specified, defaults to the local bounds of the displayObject.
@@ -256,7 +256,13 @@ export class AbstractRenderer extends EventEmitter
         if (region.width === 0) region.width = 1;
         if (region.height === 0) region.height = 1;
 
-        const renderTexture = RenderTexture.create(region.width | 0, region.height | 0, scaleMode, resolution);
+        const renderTexture = RenderTexture.create(
+            {
+                width: region.width | 0,
+                height: region.height | 0,
+                scaleMode,
+                resolution,
+            });
 
         tempMatrix.tx = -region.x;
         tempMatrix.ty = -region.y;

--- a/packages/core/src/context/ContextSystem.js
+++ b/packages/core/src/context/ContextSystem.js
@@ -1,6 +1,6 @@
+import { ENV } from '@pixi/constants';
 import { System } from '../System';
 import { settings } from '../settings';
-import { ENV } from '@pixi/constants';
 
 let CONTEXT_UID = 0;
 
@@ -160,7 +160,7 @@ export class ContextSystem extends System
         {
             Object.assign(this.extensions, {
                 drawBuffers: gl.getExtension('WEBGL_draw_buffers'),
-                depthTexture: gl.getExtension('WEBKIT_WEBGL_depth_texture'),
+                depthTexture: gl.getExtension('WEBGL_depth_texture'),
                 loseContext: gl.getExtension('WEBGL_lose_context'),
                 vertexArrayObject: gl.getExtension('OES_vertex_array_object')
                     || gl.getExtension('MOZ_OES_vertex_array_object')

--- a/packages/core/src/filters/FilterSystem.js
+++ b/packages/core/src/filters/FilterSystem.js
@@ -163,8 +163,19 @@ export class FilterSystem extends System
             filterClamp: new Float32Array(4),
         }, true);
 
-        this._pixelsWidth = renderer.view.width;
-        this._pixelsHeight = renderer.view.height;
+        /**
+         * Whether to clear output renderTexture in AUTO/BLIT mode. See {@link PIXI.CLEAR_MODES}
+         * @member {boolean}
+         */
+        this.forceClear = false;
+
+        /**
+         * Old padding behavior is to use the max amount instead of sum padding.
+         * Use this flag if you need the old behavior.
+         * @member {boolean}
+         * @default false
+         */
+        this.useMaxPadding = false;
     }
 
     /**
@@ -190,8 +201,12 @@ export class FilterSystem extends System
 
             // lets use the lowest resolution..
             resolution = Math.min(resolution, filter.resolution);
-            // and the largest amount of padding!
-            padding = Math.max(padding, filter.padding);
+            // figure out the padding required for filters
+            padding = this.useMaxPadding
+                // old behavior: use largest amount of padding!
+                ? Math.max(padding, filter.padding)
+                // new behavior: sum the padding
+                : padding + filter.padding;
             // only auto fit if all filters are autofit
             autoFit = autoFit || filter.autoFit;
 

--- a/packages/core/src/framebuffer/Framebuffer.js
+++ b/packages/core/src/framebuffer/Framebuffer.js
@@ -1,7 +1,7 @@
 import { Runner } from '@pixi/runner';
 import { BaseTexture } from '../textures/BaseTexture';
 import { DepthResource } from '../textures/resources/DepthResource';
-import { FORMATS, TYPES } from '@pixi/constants';
+import { FORMATS, TYPES, SCALE_MODES } from '@pixi/constants';
 
 /**
  * Frame buffer used by the BaseRenderTexture
@@ -55,11 +55,13 @@ export class Framebuffer
     addColorTexture(index = 0, texture)
     {
         // TODO add some validation to the texture - same width / height etc?
-        this.colorTextures[index] = texture || new BaseTexture(null, { scaleMode: 0,
+        this.colorTextures[index] = texture || new BaseTexture(null, {
+            scaleMode: SCALE_MODES.NEAREST,
             resolution: 1,
             mipmap: false,
             width: this.width,
-            height: this.height });
+            height: this.height,
+        });
 
         this.dirtyId++;
         this.dirtyFormat++;
@@ -75,14 +77,16 @@ export class Framebuffer
     addDepthTexture(texture)
     {
         /* eslint-disable max-len */
-        this.depthTexture = texture || new BaseTexture(new DepthResource(null, { width: this.width, height: this.height }), { scaleMode: 0,
+        this.depthTexture = texture || new BaseTexture(new DepthResource(null, { width: this.width, height: this.height }), {
+            scaleMode: SCALE_MODES.NEAREST,
             resolution: 1,
             width: this.width,
             height: this.height,
             mipmap: false,
             format: FORMATS.DEPTH_COMPONENT,
-            type: TYPES.UNSIGNED_SHORT });
-        /* eslint-disable max-len */
+            type: TYPES.UNSIGNED_SHORT,
+        });
+
         this.dirtyId++;
         this.dirtyFormat++;
 

--- a/packages/core/src/renderTexture/RenderTexture.js
+++ b/packages/core/src/renderTexture/RenderTexture.js
@@ -14,7 +14,7 @@ import { Texture } from '../textures/Texture';
  *
  * ```js
  * let renderer = PIXI.autoDetectRenderer();
- * let renderTexture = PIXI.RenderTexture.create(800, 600);
+ * let renderTexture = PIXI.RenderTexture.create({ width: 800, height: 600 });
  * let sprite = PIXI.Sprite.from("spinObj_01.png");
  *
  * sprite.position.x = 800/2;

--- a/packages/core/src/textures/Texture.js
+++ b/packages/core/src/textures/Texture.js
@@ -274,6 +274,7 @@ export class Texture extends EventEmitter
                 this.baseTexture.destroy();
             }
 
+            this.baseTexture.off('loaded', this.onBaseTextureUpdated, this);
             this.baseTexture.off('update', this.onBaseTextureUpdated, this);
 
             this.baseTexture = null;

--- a/packages/core/src/textures/Texture.js
+++ b/packages/core/src/textures/Texture.js
@@ -297,7 +297,13 @@ export class Texture extends EventEmitter
      */
     clone()
     {
-        return new Texture(this.baseTexture, this.frame, this.orig, this.trim, this.rotate, this.defaultAnchor);
+        return new Texture(this.baseTexture,
+            this.frame.clone(),
+            this.orig.clone(),
+            this.trim && this.trim.clone(),
+            this.rotate,
+            this.defaultAnchor
+        );
     }
 
     /**

--- a/packages/core/src/textures/TextureSystem.js
+++ b/packages/core/src/textures/TextureSystem.js
@@ -421,7 +421,7 @@ export class TextureSystem extends System
         if (glTexture.mipmap)
         {
             /* eslint-disable max-len */
-            gl.texParameteri(texture.target, gl.TEXTURE_MIN_FILTER, texture.scaleMode ? gl.LINEAR_MIPMAP_LINEAR : gl.NEAREST_MIPMAP_NEAREST);
+            gl.texParameteri(texture.target, gl.TEXTURE_MIN_FILTER, texture.scaleMode === SCALE_MODES.LINEAR ? gl.LINEAR_MIPMAP_LINEAR : gl.NEAREST_MIPMAP_NEAREST);
             /* eslint-disable max-len */
 
             const anisotropicExt = this.renderer.context.extensions.anisotropicFiltering;
@@ -435,9 +435,9 @@ export class TextureSystem extends System
         }
         else
         {
-            gl.texParameteri(texture.target, gl.TEXTURE_MIN_FILTER, texture.scaleMode ? gl.LINEAR : gl.NEAREST);
+            gl.texParameteri(texture.target, gl.TEXTURE_MIN_FILTER, texture.scaleMode === SCALE_MODES.LINEAR ? gl.LINEAR : gl.NEAREST);
         }
 
-        gl.texParameteri(texture.target, gl.TEXTURE_MAG_FILTER, texture.scaleMode ? gl.LINEAR : gl.NEAREST);
+        gl.texParameteri(texture.target, gl.TEXTURE_MAG_FILTER, texture.scaleMode === SCALE_MODES.LINEAR ? gl.LINEAR : gl.NEAREST);
     }
 }

--- a/packages/core/src/textures/resources/DepthResource.js
+++ b/packages/core/src/textures/resources/DepthResource.js
@@ -1,5 +1,5 @@
-import { BufferResource } from './BufferResource';
 import { ALPHA_MODES } from '@pixi/constants';
+import { BufferResource } from './BufferResource';
 
 /**
  * Resource type for DepthTexture.
@@ -33,7 +33,7 @@ export class DepthResource extends BufferResource
                 baseTexture.height,
                 baseTexture.format,
                 baseTexture.type,
-                this.data
+                this.data,
             );
         }
         else
@@ -44,13 +44,14 @@ export class DepthResource extends BufferResource
             gl.texImage2D(
                 baseTexture.target,
                 0,
-                gl.DEPTH_COMPONENT16, // Needed for depth to render properly in webgl2.0
+                //  gl.DEPTH_COMPONENT16 Needed for depth to render properly in webgl2.0
+                renderer.context.webGLVersion === 1 ? gl.DEPTH_COMPONENT : gl.DEPTH_COMPONENT16,
                 baseTexture.width,
                 baseTexture.height,
                 0,
                 baseTexture.format,
                 baseTexture.type,
-                this.data
+                this.data,
             );
         }
 

--- a/packages/core/src/textures/resources/ImageResource.js
+++ b/packages/core/src/textures/resources/ImageResource.js
@@ -117,17 +117,17 @@ export class ImageResource extends BaseImageResource
      */
     load(createBitmap)
     {
-        if (createBitmap !== undefined)
-        {
-            this.createBitmap = createBitmap;
-        }
-
         if (this._load)
         {
             return this._load;
         }
 
-        this._load = new Promise((resolve) =>
+        if (createBitmap !== undefined)
+        {
+            this.createBitmap = createBitmap;
+        }
+
+        this._load = new Promise((resolve, reject) =>
         {
             this.url = this.source.src;
             const { source } = this;
@@ -161,7 +161,12 @@ export class ImageResource extends BaseImageResource
             else
             {
                 source.onload = completed;
-                source.onerror = (event) => this.onError.run(event);
+                source.onerror = (event) =>
+                {
+                    // Avoids Promise freezing when resource broken
+                    reject(event);
+                    this.onError.emit(event);
+                };
             }
         });
 

--- a/packages/core/src/textures/resources/SVGResource.js
+++ b/packages/core/src/textures/resources/SVGResource.js
@@ -125,12 +125,22 @@ export class SVGResource extends BaseImageResource
 
         tempImage.onerror = (event) =>
         {
+            if (!this._resolve)
+            {
+                return;
+            }
+
             tempImage.onerror = null;
             this.onError.run(event);
         };
 
         tempImage.onload = () =>
         {
+            if (!this._resolve)
+            {
+                return;
+            }
+
             const svgWidth = tempImage.width;
             const svgHeight = tempImage.height;
 

--- a/packages/core/test/ImageResource.js
+++ b/packages/core/test/ImageResource.js
@@ -90,6 +90,23 @@ describe('PIXI.resources.ImageResource', function ()
         });
     });
 
+    it('should handle error when resource is broken', function ()
+    {
+        const image = new Image();
+
+        image.src = '/';
+
+        const resource = new ImageResource(image, {
+            autoLoad: false,
+            createBitmap: false,
+        });
+
+        return resource.load().catch((error) =>
+        {
+            expect(error).to.be.not.null;
+        });
+    });
+
     it('should handle the loaded event with createBitmapImage using global setting', function ()
     {
         const old = settings.CREATE_IMAGE_BITMAP;

--- a/packages/core/test/Texture.js
+++ b/packages/core/test/Texture.js
@@ -138,6 +138,25 @@ describe('PIXI.Texture', function ()
         texture.destroy(true);
     });
 
+    it('should clone a minimal texture', function ()
+    {
+        const baseTexture = new BaseTexture();
+        const frame = new Rectangle(0, 0, 10, 10);
+        const texture = new Texture(baseTexture, frame);
+        const clone = texture.clone();
+        const toJSON = ({ x, y, width, height }) => ({ x, y, width, height });
+
+        expect(clone.baseTexture).to.equal(baseTexture);
+        expect(clone.frame).to.not.equal(texture.frame);
+        expect(toJSON(clone.frame)).to.deep.equal(toJSON(texture.frame));
+        expect(clone.trim).to.be.undefined;
+        expect(clone.orig).to.not.equal(texture.orig);
+        expect(toJSON(clone.orig)).to.deep.equal(toJSON(texture.orig));
+
+        clone.destroy();
+        texture.destroy(true);
+    });
+
     it('should clone a texture', function ()
     {
         const baseTexture = new BaseTexture();
@@ -148,13 +167,18 @@ describe('PIXI.Texture', function ()
         const anchor = new Point(1, 0.5);
         const texture = new Texture(baseTexture, frame, orig, trim, rotate, anchor);
         const clone = texture.clone();
+        const toJSON = ({ x, y, width, height }) => ({ x, y, width, height });
 
         expect(clone.baseTexture).to.equal(baseTexture);
+        expect(clone.defaultAnchor).to.not.equal(texture.defaultAnchor);
         expect(clone.defaultAnchor.x).to.equal(texture.defaultAnchor.x);
         expect(clone.defaultAnchor.y).to.equal(texture.defaultAnchor.y);
-        expect(clone.frame).to.equal(texture.frame);
-        expect(clone.trim).to.equal(texture.trim);
-        expect(clone.orig).to.equal(texture.orig);
+        expect(clone.frame).to.not.equal(texture.frame);
+        expect(toJSON(clone.frame)).to.deep.equal(toJSON(texture.frame));
+        expect(clone.trim).to.not.equal(texture.trim);
+        expect(toJSON(clone.trim)).to.deep.equal(toJSON(texture.trim));
+        expect(clone.orig).to.not.equal(texture.orig);
+        expect(toJSON(clone.orig)).to.deep.equal(toJSON(texture.orig));
         expect(clone.rotate).to.equal(texture.rotate);
 
         clone.destroy();

--- a/packages/core/test/Texture.js
+++ b/packages/core/test/Texture.js
@@ -138,6 +138,15 @@ describe('PIXI.Texture', function ()
         texture.destroy(true);
     });
 
+    it('should not throw if base texture loaded after destroy', function ()
+    {
+        const base = new BaseTexture();
+        const texture = new Texture(base);
+
+        texture.destroy();
+        base.emit('loaded', base);
+    });
+
     it('should clone a minimal texture', function ()
     {
         const baseTexture = new BaseTexture();

--- a/packages/extract/src/Extract.js
+++ b/packages/extract/src/Extract.js
@@ -129,7 +129,7 @@ export class Extract
         const width = Math.floor((frame.width * resolution) + 1e-4);
         const height = Math.floor((frame.height * resolution) + 1e-4);
 
-        const canvasBuffer = new CanvasRenderTarget(width, height, 1);
+        let canvasBuffer = new CanvasRenderTarget(width, height, 1);
 
         const webglPixels = new Uint8Array(BYTES_PER_PIXEL * width * height);
 
@@ -156,8 +156,15 @@ export class Extract
         // pulling pixels
         if (flipY)
         {
-            canvasBuffer.context.scale(1, -1);
-            canvasBuffer.context.drawImage(canvasBuffer.canvas, 0, -height);
+            const target = new CanvasRenderTarget(canvasBuffer.width, canvasBuffer.height, 1);
+
+            target.context.scale(1, -1);
+
+            // we can't render to itself because we should be empty before render.
+            target.context.drawImage(canvasBuffer.canvas, 0, -height);
+
+            canvasBuffer.destroy();
+            canvasBuffer = target;
         }
 
         if (generated)

--- a/packages/graphics/src/const.js
+++ b/packages/graphics/src/const.js
@@ -20,7 +20,7 @@ export const GRAPHICS_CURVES = {
     maxSegments: 2048,
     _segmentsCount(length, defaultSegments = 20)
     {
-        if (!this.adaptive || !length || Number.isNaN(length))
+        if (!this.adaptive || !length || isNaN(length))
         {
             return defaultSegments;
         }

--- a/packages/graphics/src/styles/LineStyle.js
+++ b/packages/graphics/src/styles/LineStyle.js
@@ -47,10 +47,10 @@ export class LineStyle extends FillStyle
         this.width = 0;
 
         /**
-         * The alignment of any lines drawn (0.5 = middle, 1 = outter, 0 = inner).
+         * The alignment of any lines drawn (0.5 = middle, 1 = outer, 0 = inner).
          *
          * @member {number}
-         * @default 0
+         * @default 0.5
          */
         this.alignment = 0.5;
 

--- a/packages/graphics/src/utils/buildCircle.js
+++ b/packages/graphics/src/utils/buildCircle.js
@@ -49,6 +49,9 @@ export const buildCircle = {
 
         const seg = (Math.PI * 2) / totalSegs;
 
+        // Push center
+        points.push(x, y);
+
         for (let i = 0; i < totalSegs - 0.5; i++)
         {
             points.push(
@@ -57,10 +60,8 @@ export const buildCircle = {
             );
         }
 
-        points.push(
-            points[0],
-            points[1]
-        );
+        // Join last point over first point on circumference
+        points.push(points[2], points[3]);
     },
 
     triangulate(graphicsData, graphicsGeometry)
@@ -72,9 +73,10 @@ export const buildCircle = {
         let vertPos = verts.length / 2;
         const center = vertPos;
 
-        verts.push(graphicsData.shape.x, graphicsData.shape.y);
+        // Push center (special point)
+        verts.push(points[0], points[1]);
 
-        for (let i = 0; i < points.length; i += 2)
+        for (let i = 2; i < points.length; i += 2)
         {
             verts.push(points[i], points[i + 1]);
 

--- a/packages/graphics/src/utils/buildCircle.js
+++ b/packages/graphics/src/utils/buildCircle.js
@@ -49,9 +49,6 @@ export const buildCircle = {
 
         const seg = (Math.PI * 2) / totalSegs;
 
-        // Push center
-        points.push(x, y);
-
         for (let i = 0; i < totalSegs - 0.5; i++)
         {
             points.push(
@@ -60,8 +57,7 @@ export const buildCircle = {
             );
         }
 
-        // Join last point over first point on circumference
-        points.push(points[2], points[3]);
+        points.push(points[0], points[1]);
     },
 
     triangulate(graphicsData, graphicsGeometry)
@@ -73,10 +69,17 @@ export const buildCircle = {
         let vertPos = verts.length / 2;
         const center = vertPos;
 
-        // Push center (special point)
-        verts.push(points[0], points[1]);
+        const circle = graphicsData.shape;
+        const matrix = graphicsData.matrix;
+        const x = circle.x;
+        const y = circle.y;
 
-        for (let i = 2; i < points.length; i += 2)
+        // Push center (special point)
+        verts.push(
+            graphicsData.matrix ? (matrix.a * x) + (matrix.c * y) + matrix.tx : x,
+            graphicsData.matrix ? (matrix.b * x) + (matrix.d * y) + matrix.ty : y);
+
+        for (let i = 0; i < points.length; i += 2)
         {
             verts.push(points[i], points[i + 1]);
 

--- a/packages/graphics/src/utils/buildRoundedRectangle.js
+++ b/packages/graphics/src/utils/buildRoundedRectangle.js
@@ -22,26 +22,38 @@ export const buildRoundedRectangle = {
         const width = rrectData.width;
         const height = rrectData.height;
 
-        const radius = rrectData.radius;
+        // Don't allow negative radius or greater than half the smallest width
+        const radius = Math.max(0, Math.min(rrectData.radius, Math.min(width, height) / 2));
 
         points.length = 0;
 
-        quadraticBezierCurve(x, y + radius,
-            x, y,
-            x + radius, y,
-            points);
-        quadraticBezierCurve(x + width - radius,
-            y, x + width, y,
-            x + width, y + radius,
-            points);
-        quadraticBezierCurve(x + width, y + height - radius,
-            x + width, y + height,
-            x + width - radius, y + height,
-            points);
-        quadraticBezierCurve(x + radius, y + height,
-            x, y + height,
-            x, y + height - radius,
-            points);
+        // No radius, do a simple rectangle
+        if (!radius)
+        {
+            points.push(x, y,
+                x + width, y,
+                x + width, y + height,
+                x, y + height);
+        }
+        else
+        {
+            quadraticBezierCurve(x, y + radius,
+                x, y,
+                x + radius, y,
+                points);
+            quadraticBezierCurve(x + width - radius,
+                y, x + width, y,
+                x + width, y + radius,
+                points);
+            quadraticBezierCurve(x + width, y + height - radius,
+                x + width, y + height,
+                x + width - radius, y + height,
+                points);
+            quadraticBezierCurve(x + radius, y + height,
+                x, y + height,
+                x, y + height - radius,
+                points);
+        }
 
         // this tiny number deals with the issue that occurs when points overlap and earcut fails to triangulate the item.
         // TODO - fix this properly, this is not very elegant.. but it works for now.

--- a/packages/graphics/test/index.js
+++ b/packages/graphics/test/index.js
@@ -627,8 +627,9 @@ describe('PIXI.Graphics', function ()
                 renderer.render(graphics);
                 const points = graphics.geometry.graphicsData[0].points;
 
-                const firstX = points[0];
-                const firstY = points[1];
+                // The first point is center, not first point on circumference
+                const firstX = points[2];
+                const firstY = points[3];
 
                 const lastX = points[points.length - 2];
                 const lastY = points[points.length - 1];

--- a/packages/graphics/test/index.js
+++ b/packages/graphics/test/index.js
@@ -628,8 +628,8 @@ describe('PIXI.Graphics', function ()
                 const points = graphics.geometry.graphicsData[0].points;
 
                 // The first point is center, not first point on circumference
-                const firstX = points[2];
-                const firstY = points[3];
+                const firstX = points[0];
+                const firstY = points[1];
 
                 const lastX = points[points.length - 2];
                 const lastY = points[points.length - 1];

--- a/packages/mixin-cache-as-bitmap/src/index.js
+++ b/packages/mixin-cache-as-bitmap/src/index.js
@@ -303,6 +303,7 @@ DisplayObject.prototype._initCachedDisplayObjectCanvas = function _initCachedDis
     this.alpha = 1;
 
     const cachedRenderTarget = renderer.context;
+    const cachedProjectionTransform = renderer._projTransform;
 
     bounds.ceil(settings.RESOLUTION);
 
@@ -328,11 +329,10 @@ DisplayObject.prototype._initCachedDisplayObjectCanvas = function _initCachedDis
     // set all properties to there original so we can render to a texture
     this.renderCanvas = this._cacheData.originalRenderCanvas;
 
-    // renderTexture.render(this, m, true);
     renderer.render(this, renderTexture, true, m, false);
-
     // now restore the state be setting the new properties
     renderer.context = cachedRenderTarget;
+    renderer._projTransform = cachedProjectionTransform;
 
     this.renderCanvas = this._renderCachedCanvas;
     // the rest is the same as for WebGL

--- a/packages/mixin-cache-as-bitmap/src/index.js
+++ b/packages/mixin-cache-as-bitmap/src/index.js
@@ -185,7 +185,7 @@ DisplayObject.prototype._initCachedDisplayObject = function _initCachedDisplayOb
     // for now we cache the current renderTarget that the WebGL renderer is currently using.
     // this could be more elegant..
     const cachedRenderTexture = renderer.renderTexture.current;
-    const cachedSourceFrame = renderer.renderTexture.sourceFrame;
+    const cachedSourceFrame = renderer.renderTexture.sourceFrame.clone();
     const cachedProjectionTransform = renderer.projection.transform;
 
     // We also store the filter stack - I will definitely look to change how this works a little later down the line.

--- a/packages/mixin-cache-as-bitmap/test/index.js
+++ b/packages/mixin-cache-as-bitmap/test/index.js
@@ -1,4 +1,5 @@
-const { DisplayObject } = require('@pixi/display');
+const { DisplayObject, Container } = require('@pixi/display');
+const { Renderer, Filter } = require('@pixi/core');
 
 require('../');
 
@@ -18,5 +19,44 @@ describe('PIXI.DisplayObject#cacheAsBitmap', function ()
         const obj = new DisplayObject();
 
         obj.cacheAsBitmap = true;
+    });
+
+    it('should respect filters', function ()
+    {
+        const par = new Container();
+        const obj = new Container();
+        let renderer = null;
+
+        par.filters = [new Filter()];
+        par.addChild(obj);
+
+        obj.position.set(5, 15);
+        obj.updateTransform();
+        obj.cacheAsBitmap = true;
+        obj._calculateBounds = function ()
+        {
+            this._bounds.clear();
+            this._bounds.addFrame(this.transform, 0, 0, 10, 11);
+        };
+
+        try
+        {
+            renderer = new Renderer();
+            renderer.filter.push(par, par.filters);
+            obj.render(renderer);
+
+            const frame = renderer.renderTexture.sourceFrame;
+
+            expect(obj._cacheData.sprite.width).to.equal(10);
+            expect(obj._cacheData.sprite.height).to.equal(11);
+            expect(frame.x).to.equal(5);
+            expect(frame.y).to.equal(15);
+            expect(frame.width).to.equal(10);
+            expect(frame.height).to.equal(11);
+        }
+        finally
+        {
+            renderer.destroy();
+        }
     });
 });

--- a/packages/prepare/src/Prepare.js
+++ b/packages/prepare/src/Prepare.js
@@ -113,7 +113,7 @@ function uploadGraphics(renderer, item)
     // if its not batchable - update vao for particular shader
     if (!geometry.batchable)
     {
-        renderer.geometry.bind(geometry, item._resolveDirectShader());
+        renderer.geometry.bind(geometry, item._resolveDirectShader(renderer));
     }
 
     return true;

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -24,6 +24,6 @@
     "dist"
   ],
   "dependencies": {
-    "ismobilejs": "^1.0.3"
+    "ismobilejs": "^1.1.0"
   }
 }

--- a/packages/settings/src/utils/isMobile.js
+++ b/packages/settings/src/utils/isMobile.js
@@ -3,6 +3,6 @@
 // designed for Node-only environments
 import isMobileCall from 'ismobilejs';
 
-const isMobile = isMobileCall();
+const isMobile = isMobileCall(window.navigator);
 
 export { isMobile };

--- a/packages/sprite-animated/src/AnimatedSprite.js
+++ b/packages/sprite-animated/src/AnimatedSprite.js
@@ -58,8 +58,6 @@ export class AnimatedSprite extends Sprite
          */
         this._durations = null;
 
-        this.textures = textures;
-
         /**
          * `true` uses PIXI.Ticker.shared to auto update animation time.
          * @type {boolean}
@@ -136,6 +134,8 @@ export class AnimatedSprite extends Sprite
          * @private
          */
         this._previousFrame = null;
+
+        this.textures = textures;
     }
 
     /**
@@ -420,6 +420,7 @@ export class AnimatedSprite extends Sprite
                 this._durations.push(value[i].time);
             }
         }
+        this._previousFrame = null;
         this.gotoAndStop(0);
         this.updateTexture();
     }

--- a/packages/sprite-animated/src/AnimatedSprite.js
+++ b/packages/sprite-animated/src/AnimatedSprite.js
@@ -127,13 +127,15 @@ export class AnimatedSprite extends Sprite
          */
         this._currentTime = 0;
 
+        this._playing = false;
+
         /**
-         * Indicates if the AnimatedSprite is currently playing.
+         * The texture index that was displayed last time
          *
-         * @member {boolean}
-         * @readonly
+         * @member {number}
+         * @private
          */
-        this.playing = false;
+        this._previousFrame = null;
     }
 
     /**
@@ -252,8 +254,7 @@ export class AnimatedSprite extends Sprite
 
         if (this._currentTime < 0 && !this.loop)
         {
-            this._currentTime = 0;
-            this.stop();
+            this.gotoAndStop(0);
 
             if (this.onComplete)
             {
@@ -262,8 +263,7 @@ export class AnimatedSprite extends Sprite
         }
         else if (this._currentTime >= this._textures.length && !this.loop)
         {
-            this._currentTime = this._textures.length - 1;
-            this.stop();
+            this.gotoAndStop(this._textures.length - 1);
 
             if (this.onComplete)
             {
@@ -295,7 +295,16 @@ export class AnimatedSprite extends Sprite
      */
     updateTexture()
     {
-        this._texture = this._textures[this.currentFrame];
+        const currentFrame = this.currentFrame;
+
+        if (this._previousFrame === currentFrame)
+        {
+            return;
+        }
+
+        this._previousFrame = currentFrame;
+
+        this._texture = this._textures[currentFrame];
         this._textureID = -1;
         this._textureTrimmedID = -1;
         this._cachedTint = 0xFFFFFF;

--- a/packages/sprite-animated/test/AnimatedSprite.js
+++ b/packages/sprite-animated/test/AnimatedSprite.js
@@ -34,6 +34,14 @@ describe('PIXI.AnimatedSprite', function ()
             this.sprite = new AnimatedSprite(this.textures, false);
             expect(this.sprite._autoUpdate).to.be.false;
         });
+
+        it('should be correct with autoUpdate=true but then turned off via setter', function ()
+        {
+            this.sprite = new AnimatedSprite(this.textures, true);
+            expect(this.sprite._autoUpdate).to.be.true;
+            this.sprite.autoUpdate = false;
+            expect(this.sprite._autoUpdate).to.be.false;
+        });
     });
 
     describe('.stop()', function ()

--- a/packages/sprite-animated/test/AnimatedSprite.js
+++ b/packages/sprite-animated/test/AnimatedSprite.js
@@ -316,4 +316,34 @@ describe('PIXI.AnimatedSprite', function ()
             expect(this.sprite.playing).to.be.true;
         });
     });
+
+    describe('.textures', function ()
+    {
+        it('should set the first frame when setting new textures', function (done)
+        {
+            const orig1 = Texture.EMPTY.clone();
+            const orig2 = Texture.EMPTY.clone();
+            const orig3 = Texture.EMPTY.clone();
+            const sprite = new AnimatedSprite([orig1, orig2, orig3]);
+
+            sprite.gotoAndPlay(0);
+            sprite.loop = false;
+
+            sprite.onComplete = () =>
+            {
+                sprite.gotoAndStop(0);
+
+                const frame1 = Texture.EMPTY.clone();
+                const frame2 = Texture.EMPTY.clone();
+                const frame3 = Texture.EMPTY.clone();
+
+                sprite.textures = [frame1, frame2, frame3];
+
+                expect(sprite.currentFrame).to.equal(0);
+                expect(sprite._texture).to.equal(frame1);
+
+                done();
+            };
+        });
+    });
 });

--- a/packages/sprite-animated/test/AnimatedSprite.js
+++ b/packages/sprite-animated/test/AnimatedSprite.js
@@ -100,7 +100,7 @@ describe('PIXI.AnimatedSprite', function ()
     {
         before(function ()
         {
-            this.sprite = new AnimatedSprite([Texture.EMPTY, Texture.EMPTY, Texture.EMPTY]);
+            this.sprite = new AnimatedSprite([Texture.WHITE, Texture.WHITE, Texture.EMPTY]);
             this.sprite.animationSpeed = 0.5;
             this.sprite.loop = false;
         });
@@ -124,6 +124,17 @@ describe('PIXI.AnimatedSprite', function ()
             };
             this.sprite.play();
             expect(this.sprite.playing).to.be.true;
+        });
+
+        it('should the current texture be the last item in textures', function (done)
+        {
+            this.sprite.play();
+            this.sprite.onComplete = () =>
+            {
+                expect(this.sprite.texture === this.sprite.textures[this.sprite.currentFrame]).to.be.true;
+                this.sprite.onComplete = null;
+                done();
+            };
         });
     });
 
@@ -223,7 +234,7 @@ describe('PIXI.AnimatedSprite', function ()
     {
         before(function ()
         {
-            this.sprite = new AnimatedSprite([Texture.EMPTY, Texture.EMPTY, Texture.EMPTY]);
+            this.sprite = new AnimatedSprite([Texture.EMPTY, Texture.WHITE, Texture.EMPTY]);
             this.sprite.animationSpeed = 1;
             this.sprite.loop = false;
         });

--- a/packages/sprite/src/Sprite.js
+++ b/packages/sprite/src/Sprite.js
@@ -166,8 +166,6 @@ export class Sprite extends Container
         // Batchable stuff..
         // TODO could make this a mixin?
         this.indices = indices;
-        this.size = 4;
-        this.start = 0;
 
         /**
          * Plugin that is responsible for rendering this element.

--- a/packages/spritesheet/src/SpritesheetLoader.js
+++ b/packages/spritesheet/src/SpritesheetLoader.js
@@ -54,8 +54,13 @@ export class SpritesheetLoader
                 return;
             }
 
+            const { baseTexture } = res.texture;
+
+            // Don't need this Texture anymore
+            res.texture.destroy();
+
             const spritesheet = new Spritesheet(
-                res.texture.baseTexture,
+                baseTexture,
                 resource.data,
                 resource.url
             );

--- a/packages/spritesheet/test/SpritesheetLoader.js
+++ b/packages/spritesheet/test/SpritesheetLoader.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const { Loader, LoaderResource } = require('@pixi/loaders');
 const { Texture, BaseTexture } = require('@pixi/core');
+const { BaseTextureCache, TextureCache } = require('@pixi/utils');
 const { SpritesheetLoader, Spritesheet } = require('../');
 
 describe('PIXI.SpritesheetLoader', function ()
@@ -16,12 +17,17 @@ describe('PIXI.SpritesheetLoader', function ()
         Loader.registerPlugin(SpritesheetLoader);
 
         const loader = new Loader();
+        const baseTextures = Object.keys(BaseTextureCache).length;
+        const textures = Object.keys(TextureCache).length;
 
         loader.add('building1', path.join(__dirname, 'resources/building1.json'));
         loader.load((loader, resources) =>
         {
             expect(resources.building1).to.be.instanceof(LoaderResource);
             expect(resources.building1.spritesheet).to.be.instanceof(Spritesheet);
+            resources.building1.spritesheet.destroy(true);
+            expect(Object.keys(BaseTextureCache).length).to.equal(baseTextures);
+            expect(Object.keys(TextureCache).length).to.equal(textures);
             loader.reset();
             done();
         });

--- a/packages/text-bitmap/src/BitmapText.js
+++ b/packages/text-bitmap/src/BitmapText.js
@@ -579,7 +579,7 @@ export class BitmapText extends Container
         const info = xml.getElementsByTagName('info')[0];
         const common = xml.getElementsByTagName('common')[0];
         const pages = xml.getElementsByTagName('page');
-        const res = getResolutionOfUrl(pages[0].getAttribute('file'), settings.RESOLUTION);
+        const res = getResolutionOfUrl(pages[0].getAttribute('file'));
         const pagesTextures = {};
 
         data.font = info.getAttribute('face');

--- a/packages/text/src/Text.js
+++ b/packages/text/src/Text.js
@@ -225,7 +225,10 @@ export class Text extends Sprite
             else
             {
                 // set canvas text styles
-                context.fillStyle = this._generateFillStyle(style, lines);
+                context.fillStyle = this._generateFillStyle(style, lines, measured);
+                // TODO: Can't have different types for getter and setter. The getter shouldn't have the number type as
+                //       the setter converts to string. See this thread for more details:
+                //       https://github.com/microsoft/TypeScript/issues/2521
                 context.strokeStyle = style.stroke;
 
                 context.shadowColor = 0;
@@ -436,7 +439,7 @@ export class Text extends Sprite
      * @param {string[]} lines - The lines of text.
      * @return {string|number|CanvasGradient} The fill style
      */
-    _generateFillStyle(style, lines)
+    _generateFillStyle(style, lines, metrics)
     {
         if (!Array.isArray(style.fill))
         {
@@ -450,9 +453,6 @@ export class Text extends Sprite
         // the gradient will be evenly spaced out according to how large the array is.
         // ['#FF0000', '#00FF00', '#0000FF'] would created stops at 0.25, 0.5 and 0.75
         let gradient;
-        let totalIterations;
-        let currentIteration;
-        let stop;
 
         // a dropshadow will enlarge the canvas and result in the gradient being
         // generated with the incorrect dimensions
@@ -461,9 +461,8 @@ export class Text extends Sprite
         // should also take padding into account, padding can offset the gradient
         const padding = style.padding || 0;
 
-        // only minus x1 padding here, not x2, as gradient creation is x1 y1 x2 y2, not x y width height
-        const width = Math.ceil(this.canvas.width / this._resolution) - dropShadowCorrection - padding;
-        const height = Math.ceil(this.canvas.height / this._resolution) - dropShadowCorrection - padding;
+        const width = Math.ceil(this.canvas.width / this._resolution) - dropShadowCorrection - (padding * 2);
+        const height = Math.ceil(this.canvas.height / this._resolution) - dropShadowCorrection - (padding * 2);
 
         // make a copy of the style settings, so we can manipulate them later
         const fill = style.fill.slice();
@@ -491,12 +490,10 @@ export class Text extends Sprite
         if (style.fillGradientType === TEXT_GRADIENT.LINEAR_VERTICAL)
         {
             // start the gradient at the top center of the canvas, and end at the bottom middle of the canvas
-            gradient = this.context.createLinearGradient(width / 2, padding, width / 2, height);
+            gradient = this.context.createLinearGradient(width / 2, padding, width / 2, height + padding);
 
             // we need to repeat the gradient so that each individual line of text has the same vertical gradient effect
             // ['#FF0000', '#00FF00', '#0000FF'] over 2 lines would create stops at 0.125, 0.25, 0.375, 0.625, 0.75, 0.875
-            totalIterations = (fill.length + 1) * lines.length;
-            currentIteration = 0;
 
             // There's potential for floating point precision issues at the seams between gradient repeats.
             // The loop below generates the stops in order, so track the last generated one to prevent
@@ -504,26 +501,37 @@ export class Text extends Sprite
             // the first and last colors getting swapped.
             let lastIterationStop = 0;
 
+            // Actual height of the text itself, not counting spacing for lineHeight/leading/dropShadow etc
+            const textHeight = metrics.fontProperties.fontSize + style.strokeThickness;
+
+            // textHeight, but as a 0-1 size in global gradient stop space
+            const gradStopLineHeight = textHeight / height;
+
             for (let i = 0; i < lines.length; i++)
             {
-                currentIteration += 1;
+                const thisLineTop = metrics.lineHeight * i;
+
                 for (let j = 0; j < fill.length; j++)
                 {
+                    // 0-1 stop point for the current line, multiplied to global space afterwards
+                    let lineStop = 0;
+
                     if (typeof fillGradientStops[j] === 'number')
                     {
-                        stop = (fillGradientStops[j] / lines.length) + (i / lines.length);
+                        lineStop = fillGradientStops[j];
                     }
                     else
                     {
-                        stop = currentIteration / totalIterations;
+                        lineStop = j / fill.length;
                     }
 
+                    const globalStop = (thisLineTop / height) + (lineStop * gradStopLineHeight);
+
                     // Prevent color stop generation going backwards from floating point imprecision
-                    let clampedStop = Math.max(lastIterationStop, stop);
+                    let clampedStop = Math.max(lastIterationStop, globalStop);
 
                     clampedStop = Math.min(clampedStop, 1); // Cap at 1 as well for safety's sake to avoid a possible throw.
                     gradient.addColorStop(clampedStop, fill[j]);
-                    currentIteration++;
                     lastIterationStop = clampedStop;
                 }
             }
@@ -531,15 +539,17 @@ export class Text extends Sprite
         else
         {
             // start the gradient at the center left of the canvas, and end at the center right of the canvas
-            gradient = this.context.createLinearGradient(padding, height / 2, width, height / 2);
+            gradient = this.context.createLinearGradient(padding, height / 2, width + padding, height / 2);
 
             // can just evenly space out the gradients in this case, as multiple lines makes no difference
             // to an even left to right gradient
-            totalIterations = fill.length + 1;
-            currentIteration = 1;
+            const totalIterations = fill.length + 1;
+            let currentIteration = 1;
 
             for (let i = 0; i < fill.length; i++)
             {
+                let stop;
+
                 if (typeof fillGradientStops[i] === 'number')
                 {
                     stop = fillGradientStops[i];

--- a/packages/text/src/Text.js
+++ b/packages/text/src/Text.js
@@ -458,8 +458,12 @@ export class Text extends Sprite
         // generated with the incorrect dimensions
         const dropShadowCorrection = (style.dropShadow) ? style.dropShadowDistance : 0;
 
-        const width = Math.ceil(this.canvas.width / this._resolution) - dropShadowCorrection;
-        const height = Math.ceil(this.canvas.height / this._resolution) - dropShadowCorrection;
+        // should also take padding into account, padding can offset the gradient
+        const padding = style.padding || 0;
+
+        // only minus x1 padding here, not x2, as gradient creation is x1 y1 x2 y2, not x y width height
+        const width = Math.ceil(this.canvas.width / this._resolution) - dropShadowCorrection - padding;
+        const height = Math.ceil(this.canvas.height / this._resolution) - dropShadowCorrection - padding;
 
         // make a copy of the style settings, so we can manipulate them later
         const fill = style.fill.slice();
@@ -487,7 +491,7 @@ export class Text extends Sprite
         if (style.fillGradientType === TEXT_GRADIENT.LINEAR_VERTICAL)
         {
             // start the gradient at the top center of the canvas, and end at the bottom middle of the canvas
-            gradient = this.context.createLinearGradient(width / 2, 0, width / 2, height);
+            gradient = this.context.createLinearGradient(width / 2, padding, width / 2, height);
 
             // we need to repeat the gradient so that each individual line of text has the same vertical gradient effect
             // ['#FF0000', '#00FF00', '#0000FF'] over 2 lines would create stops at 0.125, 0.25, 0.375, 0.625, 0.75, 0.875
@@ -527,7 +531,7 @@ export class Text extends Sprite
         else
         {
             // start the gradient at the center left of the canvas, and end at the center right of the canvas
-            gradient = this.context.createLinearGradient(0, height / 2, width, height / 2);
+            gradient = this.context.createLinearGradient(padding, height / 2, width, height / 2);
 
             // can just evenly space out the gradients in this case, as multiple lines makes no difference
             // to an even left to right gradient

--- a/packages/text/src/Text.js
+++ b/packages/text/src/Text.js
@@ -48,7 +48,13 @@ export class Text extends Sprite
      */
     constructor(text, style, canvas)
     {
-        canvas = canvas || document.createElement('canvas');
+        let ownCanvas = false;
+
+        if (!canvas)
+        {
+            canvas = document.createElement('canvas');
+            ownCanvas = true;
+        }
 
         canvas.width = 3;
         canvas.height = 3;
@@ -59,6 +65,17 @@ export class Text extends Sprite
         texture.trim = new Rectangle();
 
         super(texture);
+
+        /**
+         * Keep track if this Text object created it's own canvas
+         * element (`true`) or uses the constructor argument (`false`).
+         * Used to workaround a GC issues with Safari < 13 when
+         * destroying Text. See `destroy` for more info.
+         *
+         * @member {boolean}
+         * @private
+         */
+        this._ownCanvas = ownCanvas;
 
         /**
          * The canvas element that everything is drawn to
@@ -557,6 +574,13 @@ export class Text extends Sprite
         options = Object.assign({}, defaultDestroyOptions, options);
 
         super.destroy(options);
+
+        // set canvas width and height to 0 to workaround memory leak in Safari < 13
+        // https://stackoverflow.com/questions/52532614/total-canvas-memory-use-exceeds-the-maximum-limit-safari-12
+        if (this._ownCanvas)
+        {
+            this.canvas.height = this.canvas.width = 0;
+        }
 
         // make sure to reset the the context and canvas.. dont want this hanging around in memory!
         this.context = null;

--- a/packages/text/src/Text.js
+++ b/packages/text/src/Text.js
@@ -476,6 +476,13 @@ export class Text extends Sprite
             // ['#FF0000', '#00FF00', '#0000FF'] over 2 lines would create stops at 0.125, 0.25, 0.375, 0.625, 0.75, 0.875
             totalIterations = (fill.length + 1) * lines.length;
             currentIteration = 0;
+
+            // There's potential for floating point precision issues at the seams between gradient repeats.
+            // The loop below generates the stops in order, so track the last generated one to prevent
+            // floating point precision from making us go the teeniest bit backwards, resulting in
+            // the first and last colors getting swapped.
+            let lastIterationStop = 0;
+
             for (let i = 0; i < lines.length; i++)
             {
                 currentIteration += 1;
@@ -489,8 +496,14 @@ export class Text extends Sprite
                     {
                         stop = currentIteration / totalIterations;
                     }
-                    gradient.addColorStop(stop, fill[j]);
+
+                    // Prevent color stop generation going backwards from floating point imprecision
+                    let clampedStop = Math.max(lastIterationStop, stop);
+
+                    clampedStop = Math.min(clampedStop, 1); // Cap at 1 as well for safety's sake to avoid a possible throw.
+                    gradient.addColorStop(clampedStop, fill[j]);
                     currentIteration++;
+                    lastIterationStop = clampedStop;
                 }
             }
         }

--- a/packages/text/test/Text.js
+++ b/packages/text/test/Text.js
@@ -75,6 +75,29 @@ describe('PIXI.Text', function ()
 
     describe('destroy', function ()
     {
+        it('should now clear canvas size on imported canvas', function ()
+        {
+            const canvas = document.createElement('canvas');
+            const text = new Text('blah', {}, canvas);
+            const { width, height } = canvas;
+
+            text.destroy();
+
+            expect(canvas.width).to.equal(width);
+            expect(canvas.height).to.equal(height);
+        });
+
+        it('should clear size on owned canvas during destroy', function ()
+        {
+            const text = new Text('blah', {});
+            const { canvas } = text;
+
+            text.destroy();
+
+            expect(canvas.width).to.equal(0);
+            expect(canvas.height).to.equal(0);
+        });
+
         it('should call through to Sprite.destroy', function ()
         {
             const text = new Text('foo');


### PR DESCRIPTION
I cherry-picked most of the bug fixes that weren't totally wrapped up in the TypeScript convert. Welcome feedback here on anything that should be included in this release. Generally, I tried to get bugs only and a few small low-risk features.

## :gift: Added

* Accessibility feature updates (#6264)
  * Fix for android quirk (refreshing divs at 60fps messes the index order)
  * Fix for resolution of Renderer not being taken into account for accessibility layer
  * Fix where if the div elements total became zero, the accessibility manager was being permanently deactivated (even if new ones were added)
  * Made copy on hook div be a little more helpful
* Add public update to AnimatedSprite (#6464)
* Support beginTextureFill() and lineTextureStyle() for canvas2d (#6367, #6404)
* Line height & leading support for vertical text gradients (#6469)

## :bug: Fixed

* Fix ImageResource load behavior (#6374)
* Fix canvas baseTexture.source deprecation if texture is not valid (#6403)
* Travis configuration update (#6418)
* Support depth texture on WebGL 1 (#6420)
* Fix floating point imprecision could break vertical text gradient generation (#6423)
* Fixes usage of isNaN (#6426)
* Fix extract plugin alpha and flipping bug (#6430)
* Canvas transform improvements (#6443)
* Workaround Safari < 13 GC bug disposing Text canvases (#6427)
* Fix text gradient not accounting for texture padding. (#6462)
* Fix filter outside of cacheAsBitmap (#6466)
* `Texture.clone` should clone `orig`, `frame`, `trim` Rectangles (#6482)
* Fix AnimatedSprite's current texture index does not match current frame index (#6487, #6513)
* Fix ambiguous reference to scaleModes (#6489)
* Remove unused Sprite members (#6496)
* Unsubscribe from baseTexture loaded event on Texture destroy (#6534)
* Fix SimpleRope on Canvas renderer (#6532)
* Clamp extreme radius inputs for RoundedRectangle (#6539)
* Fix issue with preparing Graphics without shader (#6540)
* Fix ismobilejs breakage (#6551)
* Fix documentation typo (#6555, #6554)
* Fix Texture leak with SpritesheetLoader (#6508)
* Fix example code for RenderTexture.create (#6559)
* Fix SVG disposed while loading (#6486)
* Add support for setMatrix with drawEllipse and drawCircle (#6562, #6565)
* Fix filters to sum padding instead of max padding (#6520)
* Support BitmapText resolution on high-density displays (#6564)