### PR TITLE
Fix ismobilejs breakage

### DIFF
--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -24,6 +24,6 @@
     "dist"
   ],
   "dependencies": {
-    "ismobilejs": "^1.0.3"
+    "ismobilejs": "^1.1.0"
   }
 }

--- a/packages/settings/src/utils/isMobile.ts
+++ b/packages/settings/src/utils/isMobile.ts
@@ -3,6 +3,6 @@
 // designed for Node-only environments
 import isMobileCall from 'ismobilejs';
 
-const isMobile = isMobileCall();
+const isMobile = isMobileCall(window.navigator);
 
 export { isMobile };


### PR DESCRIPTION
This was bumping up in a few places namely: #6550 #6546 #6511

Since the release of ismobilejs@1.1.0, there's no longer a default user-agent/navigator argument.  This was breaking for our users trying to build against `ismobilejs@^1.0.3`