### PR TITLE
Fixed example code for RenderTexture.create()

### DIFF
--- a/packages/core/src/renderTexture/RenderTexture.ts
+++ b/packages/core/src/renderTexture/RenderTexture.ts
@@ -17,7 +17,7 @@ import type { IBaseTextureOptions } from '../textures/BaseTexture';
  *
  * ```js
  * let renderer = PIXI.autoDetectRenderer();
- * let renderTexture = PIXI.RenderTexture.create(800, 600);
+ * let renderTexture = PIXI.RenderTexture.create({ width: 800, height: 600 });
  * let sprite = PIXI.Sprite.from("spinObj_01.png");
  *
  * sprite.position.x = 800/2;


### PR DESCRIPTION
I ran into this when looking at the documentation.
Skimming the readme I failed to see guidlines for comment/doc only changes.
I hope this is enough.