### PR TITLE
Removed center from points

### DIFF
--- a/packages/graphics/src/GraphicsData.ts
+++ b/packages/graphics/src/GraphicsData.ts
@@ -17,6 +17,7 @@ export class GraphicsData
     type: SHAPES;
     points: number[];
     holes: Array<GraphicsData>;
+
     /**
      *
      * @param {PIXI.Circle|PIXI.Ellipse|PIXI.Polygon|PIXI.Rectangle|PIXI.RoundedRectangle} shape - The shape object to draw.

--- a/packages/graphics/src/GraphicsData.ts
+++ b/packages/graphics/src/GraphicsData.ts
@@ -17,7 +17,6 @@ export class GraphicsData
     type: SHAPES;
     points: number[];
     holes: Array<GraphicsData>;
-
     /**
      *
      * @param {PIXI.Circle|PIXI.Ellipse|PIXI.Polygon|PIXI.Rectangle|PIXI.RoundedRectangle} shape - The shape object to draw.

--- a/packages/graphics/src/utils/buildCircle.ts
+++ b/packages/graphics/src/utils/buildCircle.ts
@@ -53,9 +53,6 @@ export const buildCircle: IShapeBuildCommand = {
 
         const seg = (Math.PI * 2) / totalSegs;
 
-        // Push center
-        points.push(x, y);
-
         for (let i = 0; i < totalSegs - 0.5; i++)
         {
             points.push(
@@ -64,8 +61,7 @@ export const buildCircle: IShapeBuildCommand = {
             );
         }
 
-        // Join last point over first point on circumference
-        points.push(points[2], points[3]);
+        points.push(points[0], points[1]);
     },
 
     triangulate(graphicsData, graphicsGeometry)
@@ -77,10 +73,17 @@ export const buildCircle: IShapeBuildCommand = {
         let vertPos = verts.length / 2;
         const center = vertPos;
 
-        // Push center (special point)
-        verts.push(points[0], points[1]);
+        const circle = (graphicsData.shape) as Circle;
+        const matrix = graphicsData.matrix;
+        const x = circle.x;
+        const y = circle.y;
 
-        for (let i = 2; i < points.length; i += 2)
+        // Push center (special point)
+        verts.push(
+            graphicsData.matrix ? (matrix.a * x) + (matrix.c * y) + matrix.tx : x,
+            graphicsData.matrix ? (matrix.b * x) + (matrix.d * y) + matrix.ty : y);
+
+        for (let i = 0; i < points.length; i += 2)
         {
             verts.push(points[i], points[i + 1]);
 

--- a/packages/graphics/test/index.js
+++ b/packages/graphics/test/index.js
@@ -711,8 +711,8 @@ describe('PIXI.Graphics', function ()
                 const points = graphics.geometry.graphicsData[0].points;
 
                 // The first point is center, not first point on circumference
-                const firstX = points[2];
-                const firstY = points[3];
+                const firstX = points[0];
+                const firstY = points[1];
 
                 const lastX = points[points.length - 2];
                 const lastY = points[points.length - 1];


### PR DESCRIPTION
#6562 made a regression in the stroke. The "points" array is used to do a stroke, and adding the center there add a line from the center to circumference. This reverts that and transforms the center in `triangulate` instead.