### PR TITLE
Fixed 6563

### DIFF
--- a/packages/graphics/src/GraphicsGeometry.ts
+++ b/packages/graphics/src/GraphicsGeometry.ts
@@ -630,8 +630,8 @@ export class GraphicsGeometry extends BatchGeometry
             const fill = data.fillStyle;
             const line = data.lineStyle;
 
-            if (fill && !fill.texture.baseTexture.valid) return false;
-            if (line && !line.texture.baseTexture.valid) return false;
+            if (fill && !fill.texture.baseTexture.valid && fill.texture !== Texture.EMPTY) return false;
+            if (line && !line.texture.baseTexture.valid && line.texture !== Texture.EMPTY) return false;
         }
 
         return true;

--- a/packages/graphics/test/index.js
+++ b/packages/graphics/test/index.js
@@ -1,5 +1,5 @@
 // const MockPointer = require('../interaction/MockPointer');
-const { Renderer, BatchRenderer, Texture } = require('@pixi/core');
+const { Renderer, BatchRenderer, Texture, BaseTexture } = require('@pixi/core');
 const { Graphics, GRAPHICS_CURVES, FillStyle, LineStyle, graphicsUtils } = require('../');
 const { FILL_COMMANDS, buildLine } = graphicsUtils;
 const { BLEND_MODES } = require('@pixi/constants');
@@ -801,7 +801,7 @@ describe('PIXI.Graphics', function ()
         it('validateBatching should return false if any of textures is invalid', function ()
         {
             const graphics = new Graphics();
-            const invalidTex = Texture.EMPTY;
+            const invalidTex = new Texture(new BaseTexture());
             const validTex = Texture.WHITE;
 
             graphics.beginTextureFill({ texture: invalidTex });


### PR DESCRIPTION
#6563 

`Texture.EMPTY` is never "valid" because its base's width & height is zero.