### PR TITLE
Allow Graphics rendering even when not all textures are loaded; update again when textures load.

### DIFF
--- a/packages/graphics/src/GraphicsGeometry.ts
+++ b/packages/graphics/src/GraphicsGeometry.ts
@@ -630,8 +630,8 @@ export class GraphicsGeometry extends BatchGeometry
             const fill = data.fillStyle;
             const line = data.lineStyle;
 
-            if (fill && !fill.texture.baseTexture.valid) return false;
-            if (line && !line.texture.baseTexture.valid) return false;
+            if (fill && !fill.texture.baseTexture.valid && fill.texture !== Texture.EMPTY) return false;
+            if (line && !line.texture.baseTexture.valid && line.texture !== Texture.EMPTY) return false;
         }
 
         return true;

--- a/packages/graphics/src/GraphicsGeometry.ts
+++ b/packages/graphics/src/GraphicsGeometry.ts
@@ -518,15 +518,6 @@ export class GraphicsGeometry extends BatchGeometry
 
                 nextTexture.wrapMode = WRAP_MODES.REPEAT;
 
-                if (!style.texture.baseTexture.valid)
-                {
-                    continue;
-                }
-                else
-                {
-                    ++validTextureCount;
-                }
-
                 if (j === 0)
                 {
                     this.processFill(data);
@@ -556,6 +547,14 @@ export class GraphicsGeometry extends BatchGeometry
 
                 this.addUvs(this.points, uvs, style.texture, attribIndex, size, style.matrix);
             }
+        }
+
+        for (let i = 0; i < graphicsData.length; i++)
+        {
+            const data = graphicsData[i];
+
+            if (data.fillStyle.texture.baseTexture.valid) ++validTextureCount;
+            if (data.lineStyle.texture.baseTexture.valid) ++validTextureCount;
         }
 
         this._validTextureCount = validTextureCount;

--- a/packages/graphics/src/GraphicsGeometry.ts
+++ b/packages/graphics/src/GraphicsGeometry.ts
@@ -507,6 +507,11 @@ export class GraphicsGeometry extends BatchGeometry
 
                 nextTexture.wrapMode = WRAP_MODES.REPEAT;
 
+                if (!style.texture.baseTexture.valid)
+                {
+                    continue;
+                }
+
                 if (j === 0)
                 {
                     this.processFill(data);
@@ -622,16 +627,6 @@ export class GraphicsGeometry extends BatchGeometry
         if (this.dirty === this.cacheDirty || !this.graphicsData.length)
         {
             return false;
-        }
-
-        for (let i = 0, l = this.graphicsData.length; i < l; i++)
-        {
-            const data = this.graphicsData[i];
-            const fill = data.fillStyle;
-            const line = data.lineStyle;
-
-            if (fill && !fill.texture.baseTexture.valid && fill.texture !== Texture.EMPTY) return false;
-            if (line && !line.texture.baseTexture.valid && line.texture !== Texture.EMPTY) return false;
         }
 
         return true;

--- a/packages/graphics/test/index.js
+++ b/packages/graphics/test/index.js
@@ -798,6 +798,39 @@ describe('PIXI.Graphics', function ()
 
     describe('geometry', function ()
     {
+        it('validateBatching should return false if no texture loaded', function ()
+        {
+            const graphics = new Graphics();
+            const invalidTex = Texture.EMPTY;
+
+            graphics.beginTextureFill({ texture: invalidTex });
+            graphics.lineTextureStyle({ texture: invalidTex, width: 1 });
+            graphics.drawRect(0, 0, 10, 10);
+
+            const geometry = graphics.geometry;
+
+            geometry.cacheDirty = geometry.dirty;// assume that everything else is update-to-date
+
+            expect(geometry.validateBatching()).to.be.false;
+        });
+
+        it('validateBatching should return true if a texture loaded', function ()
+        {
+            const graphics = new Graphics();
+            const validTex = Texture.WHITE;
+
+            graphics.beginTextureFill({ texture: validTex });
+            graphics.drawRect(0, 0, 10, 10);
+            graphics.beginTextureFill({ texture: validTex });
+            graphics.drawRect(0, 0, 10, 10);
+
+            const geometry = graphics.geometry;
+
+            geometry.cacheDirty = geometry.dirty;// assume everything else to be update-to-date
+
+            expect(geometry.validateBatching()).to.be.true;
+        });
+
         it('should be batchable if graphicsData is empty', function ()
         {
             const graphics = new Graphics();

--- a/packages/graphics/test/index.js
+++ b/packages/graphics/test/index.js
@@ -1,5 +1,5 @@
 // const MockPointer = require('../interaction/MockPointer');
-const { Renderer, BatchRenderer, Texture } = require('@pixi/core');
+const { Renderer, BatchRenderer, Texture, BaseTexture } = require('@pixi/core');
 const { Graphics, GRAPHICS_CURVES, FillStyle, LineStyle, graphicsUtils } = require('../');
 const { FILL_COMMANDS, buildLine } = graphicsUtils;
 const { BLEND_MODES } = require('@pixi/constants');
@@ -801,7 +801,7 @@ describe('PIXI.Graphics', function ()
         it('validateBatching should return false if any of textures is invalid', function ()
         {
             const graphics = new Graphics();
-            const invalidTex = Texture.EMPTY;
+            const invalidTex = new Texture(new BaseTexture());
             const validTex = Texture.WHITE;
 
             graphics.beginTextureFill({ texture: invalidTex });

--- a/packages/graphics/test/index.js
+++ b/packages/graphics/test/index.js
@@ -1,5 +1,5 @@
 // const MockPointer = require('../interaction/MockPointer');
-const { Renderer, BatchRenderer, Texture, BaseTexture } = require('@pixi/core');
+const { Renderer, BatchRenderer, Texture } = require('@pixi/core');
 const { Graphics, GRAPHICS_CURVES, FillStyle, LineStyle, graphicsUtils } = require('../');
 const { FILL_COMMANDS, buildLine } = graphicsUtils;
 const { BLEND_MODES } = require('@pixi/constants');
@@ -798,37 +798,6 @@ describe('PIXI.Graphics', function ()
 
     describe('geometry', function ()
     {
-        it('validateBatching should return false if any of textures is invalid', function ()
-        {
-            const graphics = new Graphics();
-            const invalidTex = new Texture(new BaseTexture());
-            const validTex = Texture.WHITE;
-
-            graphics.beginTextureFill({ texture: invalidTex });
-            graphics.drawRect(0, 0, 10, 10);
-            graphics.beginTextureFill({ texture: validTex });
-            graphics.drawRect(0, 0, 10, 10);
-
-            const geometry = graphics.geometry;
-
-            expect(geometry.validateBatching()).to.be.false;
-        });
-
-        it('validateBatching should return true if all textures is valid', function ()
-        {
-            const graphics = new Graphics();
-            const validTex = Texture.WHITE;
-
-            graphics.beginTextureFill({ texture: validTex });
-            graphics.drawRect(0, 0, 10, 10);
-            graphics.beginTextureFill({ texture: validTex });
-            graphics.drawRect(0, 0, 10, 10);
-
-            const geometry = graphics.geometry;
-
-            expect(geometry.validateBatching()).to.be.true;
-        });
-
         it('should be batchable if graphicsData is empty', function ()
         {
             const graphics = new Graphics();


### PR DESCRIPTION
The previous `validateBatching` would return false only when we didn't need to update the batching; however, it also didn't let the `Graphics` render until all textures had loaded (became `valid`).

I've now changed this to:

* Allow rendering when not all textures have loaded.

* Update when a texture has loaded (when `_validTextureCount` changes).

#6563 