### PR TITLE
Hotfix for Spritesheet memory leak PR #6508

### DIFF
--- a/packages/spritesheet/src/Spritesheet.ts
+++ b/packages/spritesheet/src/Spritesheet.ts
@@ -345,10 +345,7 @@ export class Spritesheet
         this.textures = null;
         if (destroyBase)
         {
-            if (this._texture)
-            {
-                this._texture.destroy();
-            }
+            this._texture?.destroy();
             this.baseTexture.destroy();
         }
         this._texture = null;

--- a/packages/spritesheet/src/Spritesheet.ts
+++ b/packages/spritesheet/src/Spritesheet.ts
@@ -1,8 +1,8 @@
 import { Rectangle } from '@pixi/math';
-import { Texture } from '@pixi/core';
+import { Texture, BaseTexture } from '@pixi/core';
 import { getResolutionOfUrl } from '@pixi/utils';
 import type { Dict } from '@pixi/utils';
-import type { BaseTexture, resources } from '@pixi/core';
+import type { resources } from '@pixi/core';
 
 /**
  * Utility class for maintaining reference to a collection
@@ -44,25 +44,34 @@ export class Spritesheet
     public data: any;
     public resolution: number;
 
+    private _texture: Texture;
     private _frames: Dict<any>;
     private _frameKeys: string[];
     private _batchIndex: number;
     private _callback: (textures: Dict<Texture>) => void;
 
     /**
-     * @param {PIXI.BaseTexture} baseTexture Reference to the source BaseTexture object.
+     * @param {PIXI.BaseTexture|PIXI.Texture} baseTexture Reference to the source BaseTexture object.
      * @param {Object} data - Spritesheet image data.
      * @param {string} [resolutionFilename] - The filename to consider when determining
      *        the resolution of the spritesheet. If not provided, the imageUrl will
      *        be used on the BaseTexture.
      */
-    constructor(baseTexture: BaseTexture, data: any, resolutionFilename: string = null)
+    constructor(texture: BaseTexture | Texture, data: any, resolutionFilename: string = null)
     {
         /**
-         * Reference to ths source texture
+         * Reference to original source image from the Loader. This reference is retained so we
+         * can destroy the Texture later on. It is never used internally.
+         * @type {PIXI.Texture}
+         * @private
+         */
+        this._texture = texture instanceof Texture ? texture : null;
+
+        /**
+         * Reference to ths source texture.
          * @type {PIXI.BaseTexture}
          */
-        this.baseTexture = baseTexture;
+        this.baseTexture = texture instanceof BaseTexture ? texture : this._texture.baseTexture;
 
         /**
          * A map containing all textures of the sprite sheet.
@@ -334,6 +343,10 @@ export class Spritesheet
         this._frameKeys = null;
         this.data = null;
         this.textures = null;
+        if (this._texture)
+        {
+            this._texture.destroy();
+        }
         if (destroyBase)
         {
             this.baseTexture.destroy();

--- a/packages/spritesheet/src/Spritesheet.ts
+++ b/packages/spritesheet/src/Spritesheet.ts
@@ -343,14 +343,15 @@ export class Spritesheet
         this._frameKeys = null;
         this.data = null;
         this.textures = null;
-        if (this._texture)
-        {
-            this._texture.destroy();
-        }
         if (destroyBase)
         {
+            if (this._texture)
+            {
+                this._texture.destroy();
+            }
             this.baseTexture.destroy();
         }
+        this._texture = null;
         this.baseTexture = null;
     }
 }

--- a/packages/spritesheet/src/SpritesheetLoader.ts
+++ b/packages/spritesheet/src/SpritesheetLoader.ts
@@ -61,6 +61,16 @@ export class SpritesheetLoader
 
             // Don't need this Texture anymore
             res.texture.destroy();
+            // @popelyshev: before 5.3 people had access to it! This is a breaking change!
+            res.texture = null;
+            Object.defineProperty(res, 'texture',
+                {
+                    get()
+                    {
+                        throw new Error('`resource.texture` for spritesheets is deprecated since 5.3, '
+                            + 'Please use resource.spritesheet.baseTexture');
+                    },
+                });
 
             const spritesheet = new Spritesheet(
                 baseTexture,

--- a/packages/spritesheet/src/SpritesheetLoader.ts
+++ b/packages/spritesheet/src/SpritesheetLoader.ts
@@ -57,23 +57,8 @@ export class SpritesheetLoader
                 return;
             }
 
-            const { baseTexture } = res.texture;
-
-            // Don't need this Texture anymore
-            res.texture.destroy();
-            // @popelyshev: before 5.3 people had access to it! This is a breaking change!
-            res.texture = null;
-            Object.defineProperty(res, 'texture',
-                {
-                    get()
-                    {
-                        throw new Error('`resource.texture` for spritesheets is deprecated since 5.3, '
-                            + 'Please use resource.spritesheet.baseTexture');
-                    },
-                });
-
             const spritesheet = new Spritesheet(
-                baseTexture,
+                res.texture,
                 resource.data,
                 resource.url
             );


### PR DESCRIPTION
Thanks to #6508 pixi-tilemap `basic.html` example broke. Other people could use `atlasResource.texture` it too, so this is now a breaking change. Now imagine what could happen if they will get **destroyed texture**!

You guys can push changes to this branch, I honestly don't care what you decide about it. At the least please leave `texture = null` here. Please cherry-pick it for `5.2.2`.