### PR TITLE
Text rendering with atlas-based glyph caching 

### DIFF
--- a/packages/text/src/GlyphManager.ts
+++ b/packages/text/src/GlyphManager.ts
@@ -17,7 +17,7 @@ const GLYPH_PADDING = 2;
  * @ignore
  * @class
  */
-export class GlyphLoc
+class GlyphLoc
 {
     public canvas: HTMLCanvasElement;
     public context: CanvasRenderingContext2D;
@@ -74,6 +74,8 @@ export class GlyphLoc
         this.references = 0;
     }
 }
+
+export { GlyphLoc };
 
 /**
  * This is the record for where and on which texture each glyph is cached.

--- a/packages/text/src/GlyphManager.ts
+++ b/packages/text/src/GlyphManager.ts
@@ -1,14 +1,243 @@
-import { RenderTexture } from 'pixi.js';
+import { Renderer, Texture } from '@pixi/core';
+import { Rectangle } from '@pixi/math';
 import { GlyphTiles } from './glyph-tiles';
+import { TextStyle, ITextStyle } from './TextStyle';
+import { TextMetrics } from './TextMetrics';
+import { settings } from '@pixi/settings';
+import { generateFillStyle } from './utils/generateFillStyle';
 
+// Min. size that a glyph must occupy.
+const TILE_SIZE = 24;
+
+// Min. padding around a glyph
+const GLYPH_PADDING = 2;
+
+/**
+ * @ignore
+ */
+export class GlyphLoc
+{
+    public canvas: HTMLCanvasElement;
+    public context: CanvasRenderingContext2D;
+    public texture: Texture;
+    public resolution: number;
+
+    public metrics: TextMetrics;
+
+    constructor(
+        canvas: HTMLCanvasElement,
+        context: CanvasRenderingContext2D,
+        texture: Texture,
+        resolution: number)
+    {
+        this.canvas = canvas;
+        this.context = context;
+        this.texture = texture;
+        this.resolution = resolution;
+    }
+}
+
+/**
+ * This is the record for where and on which texture each glyph is cached.
+ *
+ * @ignore
+ * @class
+ */
 export class GlyphManager
 {
-    private _atlasList: Array<RenderTexture>;
+    private _atlasDimen: number;
+    private _tileRows: number;
+    private _tileColumns: number;
+
+    private _canvasList: Array<HTMLCanvasElement>;
+    private _contextList: Array<CanvasRenderingContext2D>;
     private _atlasTiles: Array<GlyphTiles>;
 
-    constructor()
+    private _glyphMap: Map<string, GlyphLoc>;
+
+    /**
+     * @param {PIXI.Renderer} renderer
+     */
+    constructor(renderer: Renderer)
     {
-        this._atlasList = [];
+        this._atlasDimen = Math.min(1024, renderer.gl.getParameter(renderer.gl.MAX_TEXTURE_SIZE));
+        this._tileRows = Math.floor(this._atlasDimen / TILE_SIZE);
+        this._tileColumns = Math.floor(this._atlasDimen / TILE_SIZE);
+
+        this._canvasList = [];
+        this._contextList = [];
         this._atlasTiles = [];
+
+        this._glyphMap = new Map<string, GlyphLoc>();
+    }
+
+    id(char: string, style: Partial<ITextStyle>, resolution: number): string
+    {
+        return `[${char}]<${this.styleToString(style)}>@${resolution}`;
+    }
+
+    storeGlyph(char: string, style: TextStyle, resolution: number): GlyphLoc
+    {
+        if (style.fontSize > 512)
+        {
+            throw new Error('Can\'t store >512px glyph');
+        }
+
+        let { width, height } = TextMetrics.measureText(char, style, false);
+
+        width *= resolution;
+        height *= resolution;
+
+        const charWidth = width + (2 * GLYPH_PADDING);
+        const charHeight = height + (2 * GLYPH_PADDING);
+
+        const tilesHorz = Math.ceil(charWidth / TILE_SIZE);
+        const tilesVert = Math.ceil(charHeight / TILE_SIZE);
+
+        for (let i = 0; i < this._atlasTiles.length; i++)
+        {
+            const tileManager = this._atlasTiles[i];
+            const tileRects = tileManager.getBlankTileRects();
+
+            for (let j = 0; j < tileRects.length; j++)
+            {
+                const rect = tileRects[j];
+
+                if (rect.width >= tilesHorz && rect.height >= tilesVert)
+                {
+                    // TextureCache returns same texture for canvas.
+                    const texture = Texture.from(this._canvasList[i]).clone();
+
+                    texture.frame = new Rectangle(
+                        (rect.x * TILE_SIZE) + GLYPH_PADDING,
+                        (rect.y * TILE_SIZE) + GLYPH_PADDING,
+                        width,
+                        height);
+                    texture.updateUvs();
+
+                    const loc = new GlyphLoc(
+                        this._canvasList[i],
+                        this._contextList[i],
+                        texture,
+                        resolution);
+
+                    tileManager.reserveTileRect(new Rectangle(rect.x, rect.y, tilesHorz, tilesVert));
+                    this._renderGlyph(char, style, loc);
+
+                    this._glyphMap.set(this.id(char, style, resolution), loc);
+
+                    return loc;
+                }
+            }
+        }
+
+        const canvas = document.createElement('canvas');
+
+        canvas.width = canvas.height = 1024;
+        const texture = Texture.from(canvas);
+
+        texture.frame = new Rectangle(GLYPH_PADDING, GLYPH_PADDING, width, height);
+        texture.updateUvs();
+        const tileManager = new GlyphTiles(this._tileRows, this._tileColumns);
+        const context = canvas.getContext('2d');
+
+        this._canvasList.push(canvas);
+        this._contextList.push(context);
+        this._atlasTiles.push(tileManager);
+
+        const loc = new GlyphLoc(canvas, context, texture, resolution);
+
+        this._renderGlyph(char, style, loc);
+        tileManager.reserveTileRect(new Rectangle(0, 0,
+            Math.ceil(charWidth / TILE_SIZE),
+            Math.ceil(charHeight / TILE_SIZE)));
+
+        this._glyphMap.set(this.id(char, style, resolution), loc);
+
+        return loc;
+    }
+
+    /**
+     * Locates the glyph based off its unique id given by {@code PIXI.GlyphManager#id}
+     * @param {string} glyphId
+     */
+    locate(glyphId: string): GlyphLoc
+    {
+        return this._glyphMap.get(glyphId);
+    }
+
+    /**
+     * Generates a string uniquely identifying the style.
+     * @return {string}
+     */
+    public styleToString(style: any): string
+    {
+        return `
+            ${style.dropShadow}
+            ${style.dropShadowAlpha}
+            ${style.dropShadowBlur}
+            ${style.dropShadowColor}
+            ${style.dropShadowAngle}
+            ${style.dropShadowDistance}
+            ${style.fill}
+            ${style.fillGradientStops}
+            ${style.fillGradientType}
+            ${style.fontFamily}
+            ${style.fontSize}
+            ${style.fontStyle}
+            ${style.fontVariant}
+            ${style.fontWeight}
+            ${style.lineHeight}
+            ${style.leading}
+            ${style.lineJoin}
+            ${style.miterLimit}
+            ${style.padding}
+            ${style.stroke}
+            ${style.strokeThickness}
+        `;
+    }
+
+    private _renderGlyph(char: string, style: TextStyle, loc: GlyphLoc): void
+    {
+        const {
+            canvas,
+            context,
+        } = loc;
+
+        const { x, y } = loc.texture.frame;
+        const measured = TextMetrics.measureText(char, style, style.wordWrap, canvas);
+
+        loc.metrics = measured;
+
+        // context.fillStyle = 'red';
+        // context.fillRect(loc.position.x, loc.position.y, loc.size.x, loc.size.y);
+
+        context.translate(x, y);
+        context.scale(loc.resolution, loc.resolution);
+
+        context.fillStyle = generateFillStyle(canvas, context, style, settings.RESOLUTION, [char], measured);
+
+        context.strokeStyle = style.stroke as string;
+
+        context.font = style.toFontString();
+        context.lineWidth = style.strokeThickness;
+        context.textBaseline = style.textBaseline;
+        context.lineJoin = style.lineJoin;
+        context.miterLimit = style.miterLimit;
+        context.shadowColor = '0';
+        context.shadowBlur = 0;
+        context.shadowOffsetX = 0;
+        context.shadowOffsetY = 0;
+
+        if (style.stroke && style.strokeThickness)
+        {
+            loc.context.strokeText(char, 0, 0);
+        }
+        if (style.fill)
+        {
+            loc.context.fillText(char, 0, measured.lineHeight - measured.fontProperties.descent);
+        }
+
+        context.setTransform();
     }
 }

--- a/packages/text/src/GlyphManager.ts
+++ b/packages/text/src/GlyphManager.ts
@@ -1,0 +1,14 @@
+import { RenderTexture } from 'pixi.js';
+import { GlyphTiles } from './glyph-tiles';
+
+export class GlyphManager
+{
+    private _atlasList: Array<RenderTexture>;
+    private _atlasTiles: Array<GlyphTiles>;
+
+    constructor()
+    {
+        this._atlasList = [];
+        this._atlasTiles = [];
+    }
+}

--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -10,7 +10,7 @@ import { TEXT_GRADIENT } from './const';
 import { TextStyle } from './TextStyle';
 import { TextMetrics } from './TextMetrics';
 
-import type { IDestroyOptions } from '@pixi/display';
+import { IDestroyOptions } from '@pixi/display';
 import { Renderer } from '@pixi/core';
 import type { ITextStyle } from './TextStyle';
 import { BLEND_MODES } from '@pixi/constants';
@@ -659,10 +659,19 @@ export class Text extends Sprite
      */
     protected _calculateBounds(): void
     {
-        this.updateText(true);
-        this.calculateVertices();
-        // if we have already done this on THIS frame.
-        this._bounds.addQuad(this.vertexData);
+        if (this.fallbackMode)
+        {
+            this.updateText(true);
+            this.calculateVertices();
+            // if we have already done this on THIS frame.
+            this._bounds.addQuad(this.vertexData);
+        }
+        else
+        {
+            const metrics = TextMetrics.measureText(this._text, this._style, this._style.wordWrap);
+
+            this._bounds.addFrame(this.transform, 0, 0, metrics.width, metrics.height);
+        }
     }
 
     /**
@@ -849,18 +858,17 @@ export class Text extends Sprite
      */
     get width(): number
     {
-        this.updateText(true);
+        const owidth = TextMetrics.measureText(this._text, this._style, this._style.wordWrap).width;
 
-        return Math.abs(this.scale.x) * this._texture.orig.width;
+        return Math.abs(this.scale.x) * owidth;
     }
 
     set width(value) // eslint-disable-line require-jsdoc
     {
-        this.updateText(true);
-
+        const owidth = TextMetrics.measureText(this._text, this._style, this._style.wordWrap).width;
         const s = sign(this.scale.x) || 1;
 
-        this.scale.x = s * value / this._texture.orig.width;
+        this.scale.x = s * value / owidth;
         this._width = value;
     }
 
@@ -871,18 +879,17 @@ export class Text extends Sprite
      */
     get height(): number
     {
-        this.updateText(true);
+        const oheight = TextMetrics.measureText(this._text, this._style, this._style.wordWrap).height;
 
-        return Math.abs(this.scale.y) * this._texture.orig.height;
+        return Math.abs(this.scale.y) * oheight;
     }
 
     set height(value) // eslint-disable-line require-jsdoc
     {
-        this.updateText(true);
-
+        const oheight = TextMetrics.measureText(this._text, this._style, this._style.wordWrap).height;
         const s = sign(this.scale.y) || 1;
 
-        this.scale.y = s * value / this._texture.orig.height;
+        this.scale.y = s * value / oheight;
         this._height = value;
     }
 

--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -170,6 +170,8 @@ export class Text extends Sprite
 
         /**
          * References to the glyphs used
+         *
+         * @member {Array<object>}
          */
         this._glyphLocs = [];
 

--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -496,8 +496,8 @@ export class Text extends Sprite
                 _batchRGB: hex2rgb(0xffffff) as Array<number>,
                 _tintRGB: 0xffffff,
                 _texture: glyph.texture,
-                alpha: 0.5,
-                worldAlpha: 1 };
+                alpha: this.alpha,
+                worldAlpha: this.worldAlpha };
 
             batches.push(batch);
         }

--- a/packages/text/src/TextStyle.ts
+++ b/packages/text/src/TextStyle.ts
@@ -797,6 +797,14 @@ export class TextStyle implements ITextStyle
 
         return `${this.fontStyle} ${this.fontVariant} ${this.fontWeight} ${fontSizeString} ${(fontFamilies as string[]).join(',')}`;
     }
+
+    /**
+     * Generates a string uniquely identifying this style.
+     * @return {string}
+     */
+    public toString(): string {
+
+    }
 }
 
 /**

--- a/packages/text/src/TextStyle.ts
+++ b/packages/text/src/TextStyle.ts
@@ -797,14 +797,6 @@ export class TextStyle implements ITextStyle
 
         return `${this.fontStyle} ${this.fontVariant} ${this.fontWeight} ${fontSizeString} ${(fontFamilies as string[]).join(',')}`;
     }
-
-    /**
-     * Generates a string uniquely identifying this style.
-     * @return {string}
-     */
-    public toString(): string {
-
-    }
 }
 
 /**

--- a/packages/text/src/glyph-tiles/GlyphTiles.ts
+++ b/packages/text/src/glyph-tiles/GlyphTiles.ts
@@ -17,22 +17,8 @@ export class GlyphTiles
 
     constructor(rows: number, columns: number)
     {
-        /**
-         * The number of tile rows
-         * @member {number}
-         */
         this.rows = rows;
-
-        /**
-         * The number of tile columns
-         * @member {number}
-         */
         this.columns = columns;
-
-        /**
-         * A 2D boolean array tracking which tiles are "used"
-         * @member {boolean[]}
-         */
         this.tiles = new Array(rows * columns);
 
         for (let i = 0; i < this.tiles.length; i++)
@@ -40,10 +26,6 @@ export class GlyphTiles
             this.tiles[i] = false;
         }
 
-        /**
-         * {@code TileMerger} for merging tiles into rectangles.
-         * @member {PIXI.TileMerger}
-         */
         this._tileMerger = new TileMerger(rows, columns);
     }
 

--- a/packages/text/src/glyph-tiles/GlyphTiles.ts
+++ b/packages/text/src/glyph-tiles/GlyphTiles.ts
@@ -1,0 +1,96 @@
+import { Rectangle } from '@pixi/math';
+import { TileMerger } from './TileMerger';
+
+/**
+ * {@code GlyphTiles} is used to find free tiles in glyph-atlases that can be used to store a glyph.
+ *
+ * @ignore
+ * @class
+ */
+export class GlyphTiles
+{
+    private rows: number;
+    private columns: number;
+
+    private tiles: boolean[];
+    private _tileMerger: TileMerger;
+    private filledPoints: number;
+
+    constructor(rows: number, columns: number)
+    {
+        /**
+         * The number of tile rows
+         * @member {number}
+         */
+        this.rows = rows;
+
+        /**
+         * The number of tile columns
+         * @member {number}
+         */
+        this.columns = columns;
+
+        /**
+         * A 2D boolean array tracking which tiles are "used"
+         * @member {boolean[]}
+         */
+        this.tiles = new Array(rows * columns);
+
+        for (let i = 0; i < this.tiles.length; i++)
+        {
+            this.tiles[i] = false;
+        }
+
+        /**
+         * {@code TileMerger} for merging tiles into rectangles.
+         * @member {PIXI.TileMerger}
+         */
+        this._tileMerger = new TileMerger(rows, columns);
+        this.filledPoints = 0;
+    }
+
+    get filledLength(): number
+    {
+        return this.filledPoints;
+    }
+
+    getBlankTileRects(): Rectangle[]
+    {
+        return this._searchTileRects(0, 0, this.columns - 1, this.rows - 1, false);
+    }
+
+    private _searchTileRects(
+        left: number, top: number, right: number, bottom: number, framesToBeRendered = true
+    ): Rectangle[]
+    {
+        let frames = 0;
+
+        this._tileMerger.load((gridArray) =>
+        {
+            const rowJump = this.columns - right + left - 1;
+
+            for (let row = top, point = (row * this.columns) + left; row <= bottom; row++, point += rowJump)
+            {
+                for (let column = left; column <= right; column++, point++)
+                {
+                    if (!this.tiles[point])
+                    {
+                        gridArray[point] = true;
+                        this.tiles[point] = framesToBeRendered;
+                        ++frames;
+                        ++this.filledPoints;
+                    }
+                }
+            }
+        });
+
+        const tileRects = this._tileMerger.heal();
+
+        if (tileRects.length > frames)
+        {
+            throw new Error('Can\'t split');
+        }
+
+        return tileRects;
+    }
+}

--- a/packages/text/src/glyph-tiles/GlyphTiles.ts
+++ b/packages/text/src/glyph-tiles/GlyphTiles.ts
@@ -52,6 +52,24 @@ export class GlyphTiles
         return this._searchTileRects(0, 0, this.columns - 1, this.rows - 1, false);
     }
 
+    clearTileRect(tileRect: Rectangle): void
+    {
+        const {
+            left,
+            top,
+            right,
+            bottom,
+        } = tileRect;
+
+        for (let r = top; r <= bottom; r++)
+        {
+            for (let c = left; c <= right; c++)
+            {
+                this.tiles[(r * this.columns) + c] = false;
+            }
+        }
+    }
+
     reserveTileRect(tileRect: Rectangle): void
     {
         const {

--- a/packages/text/src/glyph-tiles/GlyphTiles.ts
+++ b/packages/text/src/glyph-tiles/GlyphTiles.ts
@@ -14,7 +14,6 @@ export class GlyphTiles
 
     private tiles: boolean[];
     private _tileMerger: TileMerger;
-    private filledPoints: number;
 
     constructor(rows: number, columns: number)
     {
@@ -46,17 +45,29 @@ export class GlyphTiles
          * @member {PIXI.TileMerger}
          */
         this._tileMerger = new TileMerger(rows, columns);
-        this.filledPoints = 0;
-    }
-
-    get filledLength(): number
-    {
-        return this.filledPoints;
     }
 
     getBlankTileRects(): Rectangle[]
     {
         return this._searchTileRects(0, 0, this.columns - 1, this.rows - 1, false);
+    }
+
+    reserveTileRect(tileRect: Rectangle): void
+    {
+        const {
+            left,
+            top,
+            right,
+            bottom,
+        } = tileRect;
+
+        for (let r = top; r <= bottom; r++)
+        {
+            for (let c = left; c <= right; c++)
+            {
+                this.tiles[(r * this.columns) + c] = true;
+            }
+        }
     }
 
     private _searchTileRects(
@@ -78,13 +89,12 @@ export class GlyphTiles
                         gridArray[point] = true;
                         this.tiles[point] = framesToBeRendered;
                         ++frames;
-                        ++this.filledPoints;
                     }
                 }
             }
         });
 
-        const tileRects = this._tileMerger.heal();
+        const tileRects = this._tileMerger.mergeAll();
 
         if (tileRects.length > frames)
         {

--- a/packages/text/src/glyph-tiles/GlyphTiles.ts
+++ b/packages/text/src/glyph-tiles/GlyphTiles.ts
@@ -43,9 +43,9 @@ export class GlyphTiles
             bottom,
         } = tileRect;
 
-        for (let r = top; r <= bottom; r++)
+        for (let r = top; r < bottom; r++)
         {
-            for (let c = left; c <= right; c++)
+            for (let c = left; c < right; c++)
             {
                 this.tiles[(r * this.columns) + c] = false;
             }
@@ -61,11 +61,18 @@ export class GlyphTiles
             bottom,
         } = tileRect;
 
-        for (let r = top; r <= bottom; r++)
+        for (let r = top; r < bottom; r++)
         {
-            for (let c = left; c <= right; c++)
+            for (let c = left; c < right; c++)
             {
-                this.tiles[(r * this.columns) + c] = true;
+                const i = (r * this.columns) + c;
+
+                if (this.tiles[i])
+                {
+                    throw new Error('Tile already reserved');
+                }
+
+                this.tiles[i] = true;
             }
         }
     }

--- a/packages/text/src/glyph-tiles/TileMerger.ts
+++ b/packages/text/src/glyph-tiles/TileMerger.ts
@@ -1,0 +1,318 @@
+import { Rectangle } from 'pixi.js';
+
+const rangePool: Range[] = [];
+
+/**
+ * new interval from pool
+ * @returns {Range}
+ */
+function newRange(): Range
+{
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    return rangePool.pop() || new Range();
+}
+
+export class Range
+{
+    start: number;
+    end: number;
+    mark: boolean;
+
+    constructor(start?: number, end?: number, mark = false)
+    {
+        this.start = 0;
+        this.end = 0;
+        this.set(start, end, mark);
+    }
+
+    get length(): number
+    {
+        return this.end - this.start + 1;
+    }
+
+    overlaps(start: number, end: number): boolean
+    {
+        if (start < this.start)
+        {
+            return end > this.start && end < this.end;
+        }
+
+        return start < this.end;
+    }
+
+    fits(start: number, end: number): boolean
+    {
+        return this.start <= start && this.end >= end;
+    }
+
+    splitAround(start: number, end: number, mark = true): Range[]
+    {
+        const beforeSize = start - this.start;
+        const afterSize = this.end - end;
+
+        const subintervals = [];
+
+        if (beforeSize > 0)
+        {
+            subintervals.push(newRange().set(this.start, start - 1));
+        }
+
+        subintervals.push(newRange().set(start, end, mark));
+
+        if (afterSize > 0)
+        {
+            subintervals.push(newRange().set(end + 1, this.end));
+            // subintervals[subintervals.length - 1].isend = true;
+        }
+
+        return subintervals;
+    }
+
+    set(start: number, end: number, mark = false): Range
+    {
+        this.start = start;
+        this.end = end;
+        this.mark = mark;
+
+        return this;
+    }
+
+    destroy(): void
+    {
+        rangePool.push(this);
+        this.mark = false;
+    }
+}
+
+// Merges the vacant tiles in a grid into "rectangles" of tiles.
+export class TileMerger
+{
+    rows: number;
+    columns: number;
+    area: number;
+
+    _tiles: boolean[];
+    _intervalTable: Range[][];
+
+    _breakerContext: { subIntervals: Range[]; mappedRects: Rectangle[] };
+
+    constructor(rows: number, columns: number)
+    {
+        this.rows = rows;
+        this.columns = columns;
+        this.area = rows * columns;
+        this._tiles = new Array(rows * columns);
+        this._intervalTable = new Array(rows);
+
+        this._breakerContext = {
+            subIntervals: null,
+            mappedRects: null,
+        };
+    }
+
+    /**
+     * Reset this healer to a new configuration. The grid size is increased if needed.
+     *
+     * @param {number} rows
+     * @param {number} columns
+     * @param {Function} loader - should initialize the grid for healing
+     */
+    reset(rows: number, columns: number, loader: (arg: boolean[]) => void): void
+    {
+        this.rows = rows;
+        this.columns = columns;
+        this.area = rows * columns;
+
+        if (this._tiles.length < this.area)
+        {
+            this._tiles.length = this.area;
+        }
+
+        if (loader)
+        {
+            this.load(loader);
+        }
+    }
+
+    load(loader: (arg: boolean[]) => void, resetValues = true): void
+    {
+        if (resetValues)
+        {
+            for (let i = 0; i < this.area; i++)
+            {
+                this._tiles[i] = false;
+            }
+        }
+
+        loader(this._tiles);
+    }
+
+    heal(): Rectangle[]
+    {
+        const intervals = this._buildRangeTable();
+
+        const basket = [];
+        let current: Rectangle[] = [];
+        let next = [];
+
+        // Merge
+        for (let i = 0; i < this.rows; i++)
+        {
+            const { subIntervals, mappedRects } = this._breakIntervals(intervals[i], current);
+
+            for (let f = 0; f < mappedRects.length; f++)
+            {
+                mappedRects[f].height++;
+            }
+
+            next = mappedRects;
+
+            for (let t = 0, length = subIntervals.length; t < length; t++)
+            {
+                const { start, length: size, mark } = subIntervals[t];
+
+                if (!mark)
+                {
+                    next.push(new Rectangle(start, i, size, 1));
+                }
+            }
+
+            for (let c = 0; c < current.length; c++)
+            {
+                if (current[c].y !== i && next.indexOf(current[c]) === -1)
+                {
+                    basket.push(current[c]); // not in current anymore
+                }
+            }
+
+            for (let z = 0; z < subIntervals.length; z++)
+            {
+                subIntervals[z].destroy();
+            }
+
+            current = next;
+        }
+
+        for (let i = 0; i < this._intervalTable.length; i++)
+        {
+            const intervals = this._intervalTable[i];
+
+            if (intervals)
+            {
+                intervals.length = 0;
+            }
+        }
+
+        basket.push(...current);
+
+        return basket;
+    }
+
+    // Create an array indexed for each row, containing sets of continous intervals
+    // grid elements. It updates the result in `this._intervalTable`.
+    private _buildRangeTable(): Range[][]
+    {
+        const intervals = this._intervalTable;
+        let inout = false; // in = true, out = false
+        let start = -1;
+
+        // Interval creation
+        for (let i = 0; i < this.rows; i++)
+        {
+            if (intervals[i])
+            {
+                intervals[i].length = 0;
+            }
+            else
+            {
+                intervals[i] = [];
+            }
+
+            for (let j = 0; j < this.columns; j++)
+            {
+                const value = this._tiles[(i * this.columns) + j];
+
+                if (value !== inout)
+                {
+                    if (value)
+                    { // interval start
+                        start = j;
+                        inout = true;
+                    }
+                    else
+                    { // interval end
+                        intervals[i].push(newRange().set(start, j - 1));
+                        inout = false;
+                    }
+                }
+            }
+
+            if (inout)
+            { // interval ends at last column
+                intervals[i].push(newRange().set(start, this.columns - 1));
+                inout = false;
+            }
+        }
+
+        this._intervalTable = intervals;
+
+        return intervals;
+    }
+
+    // Finds the set of subintervals, equivalent to the given intervals, such that
+    // each interval completely fits inside a rectangle's breadth or doesn't overlap
+    // at all.
+    //
+    // The intervals that fit inside a rectangle's breadth are "marked".
+    //
+    // This also separates a list of rectangle that have a mapping to a subinterval in
+    // `this.breakerContext.brokeRects`.
+    private _breakIntervals(intervals: Range[], rects: Rectangle[]):
+        { subIntervals: Range[]; mappedRects: Rectangle[]}
+    {
+        const rectsCount = rects.length;
+
+        const subIntervals = [...intervals];
+        const mappedRects = [];
+
+        for (let subIndex = 0, rectSearchStart = 0; subIndex < subIntervals.length; subIndex++)
+        {
+            let interval = subIntervals[subIndex];
+
+            let s = rectSearchStart; let
+                fitFound = false;
+
+            for (fitFound = false; s < rectsCount; s++)
+            {
+                const currentRect = rects[s];
+
+                if (interval.fits(currentRect.left, currentRect.right - 1))
+                {
+                    mappedRects.push(currentRect);
+
+                    const splitSubs = interval.splitAround(currentRect.left, currentRect.right - 1, true);
+
+                    subIntervals.splice(subIndex, 1, ...splitSubs);
+                    subIndex += splitSubs.length - 1;
+                    interval = subIntervals[subIndex];
+
+                    fitFound = true;
+                }
+                else if (fitFound)
+                {
+                    break; // if this is not a fit and fit already found, that means later rects can't fit either
+                }
+            }
+
+            if (fitFound)
+            {
+                rectSearchStart = s; // next interval overlap with rects before
+            }
+        }
+
+        this._breakerContext.subIntervals = subIntervals;
+        this._breakerContext.mappedRects = mappedRects;
+
+        return this._breakerContext;
+    }
+}

--- a/packages/text/src/glyph-tiles/TileMerger.ts
+++ b/packages/text/src/glyph-tiles/TileMerger.ts
@@ -109,13 +109,6 @@ export class TileMerger
         };
     }
 
-    /**
-     * Reset this healer to a new configuration. The grid size is increased if needed.
-     *
-     * @param {number} rows
-     * @param {number} columns
-     * @param {Function} loader - should initialize the grid for healing
-     */
     reset(rows: number, columns: number, loader: (arg: boolean[]) => void): void
     {
         this.rows = rows;

--- a/packages/text/src/glyph-tiles/index.ts
+++ b/packages/text/src/glyph-tiles/index.ts
@@ -1,1 +1,2 @@
 export { GlyphTiles } from './GlyphTiles';
+export { TileMerger } from './TileMerger';

--- a/packages/text/src/glyph-tiles/index.ts
+++ b/packages/text/src/glyph-tiles/index.ts
@@ -1,0 +1,1 @@
+export { GlyphTiles } from './GlyphTiles';

--- a/packages/text/src/index.ts
+++ b/packages/text/src/index.ts
@@ -3,3 +3,6 @@ export * from './TextStyle';
 export * from './TextMetrics';
 
 export * from './const';
+
+// For unit-testing only
+export * from './glyph-tiles';

--- a/packages/text/src/utils/generateFillStyle.ts
+++ b/packages/text/src/utils/generateFillStyle.ts
@@ -1,0 +1,150 @@
+import { TextStyle } from '../TextStyle';
+import { TextMetrics } from '../TextMetrics';
+import { TEXT_GRADIENT } from '../const';
+
+/**
+ * Generates the fill style. Can automatically generate a gradient based on the fill style being an array
+ *
+ * @private
+ * @param {object} style - The style.
+ * @param {string[]} lines - The lines of text.
+ * @return {string|number|CanvasGradient} The fill style
+ */
+export function generateFillStyle(
+    canvas: HTMLCanvasElement,
+    context: CanvasRenderingContext2D,
+    style: TextStyle,
+    resolution: number,
+    lines: string[],
+    metrics: TextMetrics
+): string|CanvasGradient|CanvasPattern
+{
+    // TODO: Can't have different types for getter and setter. The getter shouldn't have the number type as
+    //       the setter converts to string. See this thread for more details:
+    //       https://github.com/microsoft/TypeScript/issues/2521
+    const fillStyle: string|string[]|CanvasGradient|CanvasPattern = style.fill as any;
+
+    if (!Array.isArray(fillStyle))
+    {
+        return fillStyle;
+    }
+    else if (fillStyle.length === 1)
+    {
+        return fillStyle[0];
+    }
+
+    // the gradient will be evenly spaced out according to how large the array is.
+    // ['#FF0000', '#00FF00', '#0000FF'] would created stops at 0.25, 0.5 and 0.75
+    let gradient: string[]|CanvasGradient;
+
+    // a dropshadow will enlarge the canvas and result in the gradient being
+    // generated with the incorrect dimensions
+    const dropShadowCorrection = (style.dropShadow) ? style.dropShadowDistance : 0;
+
+    // should also take padding into account, padding can offset the gradient
+    const padding = style.padding || 0;
+
+    const width = Math.ceil(canvas.width / resolution) - dropShadowCorrection - (padding * 2);
+    const height = Math.ceil(canvas.height / resolution) - dropShadowCorrection - (padding * 2);
+
+    // make a copy of the style settings, so we can manipulate them later
+    const fill = fillStyle.slice();
+    const fillGradientStops = style.fillGradientStops.slice();
+
+    // wanting to evenly distribute the fills. So an array of 4 colours should give fills of 0.25, 0.5 and 0.75
+    if (!fillGradientStops.length)
+    {
+        const lengthPlus1 = fill.length + 1;
+
+        for (let i = 1; i < lengthPlus1; ++i)
+        {
+            fillGradientStops.push(i / lengthPlus1);
+        }
+    }
+
+    // stop the bleeding of the last gradient on the line above to the top gradient of the this line
+    // by hard defining the first gradient colour at point 0, and last gradient colour at point 1
+    fill.unshift(fillStyle[0]);
+    fillGradientStops.unshift(0);
+
+    fill.push(fillStyle[fillStyle.length - 1]);
+    fillGradientStops.push(1);
+
+    if (style.fillGradientType === TEXT_GRADIENT.LINEAR_VERTICAL)
+    {
+        // start the gradient at the top center of the canvas, and end at the bottom middle of the canvas
+        gradient = context.createLinearGradient(width / 2, padding, width / 2, height + padding);
+
+        // we need to repeat the gradient so that each individual line of text has the same vertical gradient effect
+        // ['#FF0000', '#00FF00', '#0000FF'] over 2 lines would create stops at 0.125, 0.25, 0.375, 0.625, 0.75, 0.875
+
+        // There's potential for floating point precision issues at the seams between gradient repeats.
+        // The loop below generates the stops in order, so track the last generated one to prevent
+        // floating point precision from making us go the teeniest bit backwards, resulting in
+        // the first and last colors getting swapped.
+        let lastIterationStop = 0;
+
+        // Actual height of the text itself, not counting spacing for lineHeight/leading/dropShadow etc
+        const textHeight = metrics.fontProperties.fontSize + style.strokeThickness;
+
+        // textHeight, but as a 0-1 size in global gradient stop space
+        const gradStopLineHeight = textHeight / height;
+
+        for (let i = 0; i < lines.length; i++)
+        {
+            const thisLineTop = metrics.lineHeight * i;
+
+            for (let j = 0; j < fill.length; j++)
+            {
+                // 0-1 stop point for the current line, multiplied to global space afterwards
+                let lineStop = 0;
+
+                if (typeof fillGradientStops[j] === 'number')
+                {
+                    lineStop = fillGradientStops[j];
+                }
+                else
+                {
+                    lineStop = j / fill.length;
+                }
+
+                const globalStop = (thisLineTop / height) + (lineStop * gradStopLineHeight);
+
+                // Prevent color stop generation going backwards from floating point imprecision
+                let clampedStop = Math.max(lastIterationStop, globalStop);
+
+                clampedStop = Math.min(clampedStop, 1); // Cap at 1 as well for safety's sake to avoid a possible throw.
+                gradient.addColorStop(clampedStop, fill[j]);
+                lastIterationStop = clampedStop;
+            }
+        }
+    }
+    else
+    {
+        // start the gradient at the center left of the canvas, and end at the center right of the canvas
+        gradient = context.createLinearGradient(padding, height / 2, width + padding, height / 2);
+
+        // can just evenly space out the gradients in this case, as multiple lines makes no difference
+        // to an even left to right gradient
+        const totalIterations = fill.length + 1;
+        let currentIteration = 1;
+
+        for (let i = 0; i < fill.length; i++)
+        {
+            let stop: number;
+
+            if (typeof fillGradientStops[i] === 'number')
+            {
+                stop = fillGradientStops[i];
+            }
+            else
+            {
+                stop = currentIteration / totalIterations;
+            }
+            gradient.addColorStop(stop, fill[i]);
+            currentIteration++;
+        }
+    }
+
+    return gradient;
+}

--- a/packages/text/test/GlyphTiles.js
+++ b/packages/text/test/GlyphTiles.js
@@ -1,0 +1,32 @@
+const { GlyphTiles } = require('../');
+const { Rectangle } = require('@pixi/math');
+const expect = require('chai').expect;
+
+describe('module:@pixi/text.GlyphTiles', function ()
+{
+    it('should return one blank tile-rect when newly created', function ()
+    {
+        const glyphTiles = new GlyphTiles(5, 5);
+        const tileRects = glyphTiles.getBlankTileRects();
+
+        expect(tileRects.length).to.equal(1);
+
+        const rect = tileRects[0];
+
+        expect(rect.x).to.equal(0);
+        expect(rect.y).to.equal(0);
+        expect(rect.width).to.equal(5);
+        expect(rect.height).to.equal(5);
+    });
+
+    it('should return two tile-rects after taking a corner-rectangle', function ()
+    {
+        const glyphTiles = new GlyphTiles(32, 32);
+
+        glyphTiles.reserveTileRect(new Rectangle(0, 0, 1, 1));
+
+        const rects = glyphTiles.getBlankTileRects();
+
+        expect(rects.length).to.equal(2);
+    });
+});

--- a/packages/text/test/Text.js
+++ b/packages/text/test/Text.js
@@ -203,6 +203,8 @@ describe('PIXI.Text', function ()
         {
             const text = new Text('');
 
+            text.fallbackMode = true;
+
             text.updateText();
 
             expect(text.canvas.width).to.be.above(1);

--- a/packages/text/test/index.js
+++ b/packages/text/test/index.js
@@ -1,3 +1,4 @@
 require('./Text');
 require('./TextStyle');
 require('./TextMetrics');
+require('./GlyphTiles');


### PR DESCRIPTION
Proposal #6524 

##### Description of change
This PR introduces a more efficient method of rendering text in WebGL. Instead of rendering each `PIXI.Text` instance into its own canvas, each letter is rendered into a shared atlas via the "glyph manager".

This, unfortunately, does not work under certain circumstances. For that, the "fallbackMode" flag will make the text render using the old method:

+ when horizontal gradients are used (this is because the color of each letter depends not only on the style but also on its position in the local space)

+ when drop shadows are used. Since Safari has a bug with gradients+shadows, we had a "hack" to correctly render gradients+drop-shadows in our old method. However, you can't use that with shared glyphs (because you can't "throw" the text far away, it might render over another glyph).

+ large strokes. Technically, all strokes are rendered before all fills. Not doing so only works until the strokes don't start overlapping other characters. This is why I limited the stroke size to 10% of the font size. If larger, the fallback mode is enabled.

-----

**How are glyphs "stored"?**

The glyph manager maintains a list of 1024x1024 canvases. Each canvas is divided into a grid of 16x16 tiles. To find space for a glyph, a "rectangle of tiles" is found that has enough space for it. A rectangle merging algorithm is used to find the largest rectangles.

**Have you measured the benefits?**

Yes.

+ When there are multiple Text instances, characters are still shared and that saves canvas memory.

+ When a large number of characters are rendered, the repeated characters aren't rendered twice.

I'll try to create a fiddle for what I've tested.

**Are you garbage collecting characters?**

Yes, see `GlyphManager#prune`. Each glyph has a "references" semaphore. When it becomes zero, the glyph will be garbage collected (see `Text#_updateGlyphs`).

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
