### PR TITLE
Fixes #6604 slow runs on CI timing out mocha

### DIFF
--- a/packages/core/test/MaskSystem.js
+++ b/packages/core/test/MaskSystem.js
@@ -136,6 +136,8 @@ describe('PIXI.systems.MaskSystem', function ()
 
     it('should correctly calculate alpha mask area if filter is present', function ()
     {
+        // fixes slow runs on CI #6604
+        this.timeout(5000);
         // the bug was fixed in #5444
         this.renderer.resize(10, 10);
 


### PR DESCRIPTION
This is a temporary fix for slow test processing time for this one test. There may be others, but this one seems the most consistently hovering around the 2000 ms timeout. 