### PR TITLE
Build for all push branches including ones with slashes

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -2,11 +2,11 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ '*' ]
+    branches: [ '**' ]
   release:
     types: [ 'created' ]
   pull_request:
-    branches: [ '*' ]
+    branches: [ '**' ]
 
 jobs:
   build:


### PR DESCRIPTION
Follow-up to #6600 comment about not building branches that are `feature/*` or basically contain any `/`. We want to build on all branches pushes, regardless of name.