### PR TITLE
Add `null` as valid type for DisplayObject's mask

### DIFF
--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -221,7 +221,7 @@ export abstract class DisplayObject extends EventEmitter
         /**
          * The original, cached mask of the object.
          *
-         * @member {PIXI.Graphics|PIXI.Sprite|null}
+         * @member {PIXI.Container|PIXI.MaskData|null}
          * @protected
          */
         this._mask = null;
@@ -775,9 +775,9 @@ export abstract class DisplayObject extends EventEmitter
      * sprite.mask = graphics;
      * @todo At the moment, PIXI.CanvasRenderer doesn't support PIXI.Sprite as mask.
      *
-     * @member {PIXI.Container|PIXI.MaskData}
+     * @member {PIXI.Container|PIXI.MaskData|null}
      */
-    get mask(): Container|MaskData
+    get mask(): Container|MaskData|null
     {
         return this._mask;
     }


### PR DESCRIPTION
Fixes #6606 

Clear-up typings for `mask` property.
