### PR TITLE
Introduces optional Graphics Extras Package

### DIFF
--- a/packages/graphics-extras/README.md
+++ b/packages/graphics-extras/README.md
@@ -1,0 +1,25 @@
+# @pixi/graphics-extras
+
+Adds the follow methods to Graphics:
+
+* `drawTorus`
+* `drawChamferRect`
+* `drawFilletRect`
+* `drawRegularPolygon`
+
+## Installation
+
+```bash
+npm install @pixi/graphics-extras
+```
+
+## Usage
+
+```js
+import { Graphics } from '@pixi/graphics';
+import '@pixi/graphics-extras';
+
+const shapes = new Graphics()
+    .beginFill(0xffffff)
+    .drawTorus(0, 0, 20, 100);
+```

--- a/packages/graphics-extras/global.d.ts
+++ b/packages/graphics-extras/global.d.ts
@@ -1,0 +1,8 @@
+declare namespace GlobalMixins
+{
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface Graphics extends Partial<import('@pixi/graphics-extras').IGraphicsExtras>
+    {
+
+    }
+}

--- a/packages/graphics-extras/package.json
+++ b/packages/graphics-extras/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@pixi/graphics-extras",
+  "version": "5.2.4",
+  "main": "lib/graphics-extras.js",
+  "module": "lib/graphics-extras.es.js",
+  "bundle": "dist/graphics-extras.js",
+  "bundleNoExports": true,
+  "description": "Additional Graphics functions for drawing special shapes.",
+  "author": "Matt Karl <matt@mattkarl.com>",
+  "homepage": "http://pixijs.com/",
+  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pixijs/pixi.js.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "lib",
+    "dist"
+  ],
+  "dependencies": {
+    "@pixi/graphics": "5.2.4"
+  }
+}

--- a/packages/graphics-extras/src/drawChamferRect.ts
+++ b/packages/graphics-extras/src/drawChamferRect.ts
@@ -8,7 +8,7 @@ import type { Graphics } from '@pixi/graphics';
  * @method PIXI.Graphics#drawChamferRect
  * @param {number} x - Upper left corner of rect
  * @param {number} y - Upper right corner of rect
- * @param {nmber} width - Width of rect
+ * @param {number} width - Width of rect
  * @param {number} height - Height of rect
  * @param {number} chamfer - accept negative or positive values
  * @return {PIXI.Graphics} Returns self.

--- a/packages/graphics-extras/src/drawChamferRect.ts
+++ b/packages/graphics-extras/src/drawChamferRect.ts
@@ -1,0 +1,45 @@
+import type { Graphics } from '@pixi/graphics';
+
+/**
+ * Draw Rectangle with chamfer corners.
+ *
+ * _Note: Only available with **@pixi/graphics-extras**._
+ *
+ * @method PIXI.Graphics#drawChamferRect
+ * @param {number} x - Upper left corner of rect
+ * @param {number} y - Upper right corner of rect
+ * @param {nmber} width - Width of rect
+ * @param {number} height - Height of rect
+ * @param {number} chamfer - accept negative or positive values
+ * @return {PIXI.Graphics} Returns self.
+ */
+export function drawChamferRect(this: Graphics,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    chamfer: number): Graphics
+{
+    if (chamfer === 0)
+    {
+        return this.drawRect(x, y, width, height);
+    }
+
+    const maxChamfer = Math.min(width, height) / 2;
+    const inset = Math.min(maxChamfer, Math.max(-maxChamfer, chamfer));
+    const right = x + width;
+    const bottom = y + height;
+    const dir = inset < 0 ? -inset : 0;
+    const size = Math.abs(inset);
+
+    return this
+        .moveTo(x, y + size)
+        .arcTo(x + dir, y + dir, x + size, y, size)
+        .lineTo(right - size, y)
+        .arcTo(right - dir, y + dir, right, y + size, size)
+        .lineTo(right, bottom - size)
+        .arcTo(right - dir, bottom - dir, x + width - size, bottom, size)
+        .lineTo(x + size, bottom)
+        .arcTo(x + dir, bottom - dir, x, bottom - size, size)
+        .closePath();
+}

--- a/packages/graphics-extras/src/drawFilletRect.ts
+++ b/packages/graphics-extras/src/drawFilletRect.ts
@@ -8,7 +8,7 @@ import type { Graphics } from '@pixi/graphics';
  * @method PIXI.Graphics#drawFilletRect
  * @param {number} x - Upper left corner of rect
  * @param {number} y - Upper right corner of rect
- * @param {nmber} width - Width of rect
+ * @param {number} width - Width of rect
  * @param {number} height - Height of rect
  * @param {number} fillet - non-zero real number, size of corner cutout
  * @return {PIXI.Graphics} Returns self.

--- a/packages/graphics-extras/src/drawFilletRect.ts
+++ b/packages/graphics-extras/src/drawFilletRect.ts
@@ -1,0 +1,52 @@
+import type { Graphics } from '@pixi/graphics';
+
+/**
+ * Draw Rectangle with fillet corners.
+ *
+ * _Note: Only available with **@pixi/graphics-extras**._
+ *
+ * @method PIXI.Graphics#drawFilletRect
+ * @param {number} x - Upper left corner of rect
+ * @param {number} y - Upper right corner of rect
+ * @param {nmber} width - Width of rect
+ * @param {number} height - Height of rect
+ * @param {number} fillet - non-zero real number, size of corner cutout
+ * @return {PIXI.Graphics} Returns self.
+ */
+export function drawFilletRect(this: Graphics,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    fillet: number): Graphics
+{
+    if (fillet <= 0)
+    {
+        return this.drawRect(x, y, width, height);
+    }
+
+    const inset = Math.min(fillet, Math.min(width, height) / 2);
+    const right = x + width;
+    const bottom = y + height;
+    const points = [
+        x + inset, y,
+        right - inset, y,
+        right, y + inset,
+        right, bottom - inset,
+        right - inset, bottom,
+        x + inset, bottom,
+        x, bottom - inset,
+        x, y + inset,
+    ];
+
+    // Remove overlapping points
+    for (let i = points.length - 1; i >= 2; i -= 2)
+    {
+        if (points[i] === points[i - 2] && points[i - 1] === points[i - 3])
+        {
+            points.splice(i - 1, 2);
+        }
+    }
+
+    return this.drawPolygon(points);
+}

--- a/packages/graphics-extras/src/drawRegularPolygon.ts
+++ b/packages/graphics-extras/src/drawRegularPolygon.ts
@@ -1,0 +1,39 @@
+import type { Graphics } from '@pixi/graphics';
+
+/**
+ * Draw a regular polygon where all sides are the same length.
+ *
+ * _Note: Only available with **@pixi/graphics-extras**._
+ *
+ * @method PIXI.Graphics#drawRegularPolygon
+ * @param {number} x - X position
+ * @param {number} y - Y position
+ * @param {number} radius - Polygon radius
+ * @param {number} sides - Minimum value is 3
+ * @param {number} rotation - Starting rotation values in radians..
+ * @return {PIXI.Graphics}
+ */
+export function drawRegularPolygon(this: Graphics,
+    x: number,
+    y: number,
+    radius: number,
+    sides: number,
+    rotation = 0): Graphics
+{
+    sides = Math.max(sides | 0, 3);
+    const startAngle = (-1 * Math.PI / 2) + rotation;
+    const delta = (Math.PI * 2) / sides;
+    const polygon = [];
+
+    for (let i = 0; i < sides; i++)
+    {
+        const angle = (i * delta) + startAngle;
+
+        polygon.push(
+            x + (radius * Math.cos(angle)),
+            y + (radius * Math.sin(angle))
+        );
+    }
+
+    return this.drawPolygon(polygon);
+}

--- a/packages/graphics-extras/src/drawTorus.ts
+++ b/packages/graphics-extras/src/drawTorus.ts
@@ -1,0 +1,37 @@
+import type { Graphics } from '@pixi/graphics';
+
+/**
+ * Draw a torus shape, like a donut. Can be used for something like a circle loader.
+ *
+ * _Note: Only available with **@pixi/graphics-extras**._
+ *
+ * @method PIXI.Graphics#drawTorus
+ * @param {number} x - X position
+ * @param {number} y - Y position
+ * @param {number} innerRadius - Inner circle radius
+ * @param {number} outerRadius - Outer circle radius
+ * @param {number} sweep - How much of the circle to fill, in radius
+ * @return {PIXI.Graphics}
+ */
+export function drawTorus(this: Graphics,
+    x: number,
+    y: number,
+    innerRadius: number,
+    outerRadius: number,
+    startArc = 0,
+    endArc: number = Math.PI * 2): Graphics
+{
+    if ((endArc - startArc) >= Math.PI * 2)
+    {
+        return this
+            .drawCircle(x, y, outerRadius)
+            .beginHole()
+            .drawCircle(x, y, innerRadius)
+            .endHole();
+    }
+
+    return this
+        .arc(x, y, innerRadius, endArc, startArc, true)
+        .arc(x, y, outerRadius, startArc, endArc, false)
+        .closePath();
+}

--- a/packages/graphics-extras/src/index.ts
+++ b/packages/graphics-extras/src/index.ts
@@ -1,0 +1,20 @@
+import { Graphics } from '@pixi/graphics';
+import { drawTorus } from './drawTorus';
+import { drawChamferRect } from './drawChamferRect';
+import { drawFilletRect } from './drawFilletRect';
+import { drawRegularPolygon } from './drawRegularPolygon';
+
+export interface IGraphicsExtras {
+    drawTorus: typeof drawTorus;
+    drawChamferRect: typeof drawChamferRect;
+    drawFilletRect: typeof drawFilletRect;
+    drawRegularPolygon: typeof drawRegularPolygon;
+}
+
+// Assign extras to Graphics
+Object.defineProperties(Graphics.prototype, {
+    drawTorus: { value: drawTorus },
+    drawChamferRect: { value: drawChamferRect },
+    drawFilletRect: { value: drawFilletRect },
+    drawRegularPolygon: { value: drawRegularPolygon },
+});

--- a/packages/graphics/global.d.ts
+++ b/packages/graphics/global.d.ts
@@ -1,0 +1,8 @@
+declare namespace GlobalMixins
+{
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface Graphics
+    {
+
+    }
+}

--- a/packages/graphics/src/Graphics.ts
+++ b/packages/graphics/src/Graphics.ts
@@ -60,6 +60,8 @@ const temp = new Float32Array(3);
 // a default shaders map used by graphics..
 const DEFAULT_SHADERS: {[key: string]: Shader} = {};
 
+export interface Graphics extends GlobalMixins.Graphics, Container {}
+
 /**
  * The Graphics class contains methods used to draw primitive shapes such as lines, circles and
  * rectangles to the display, and to color and fill them.


### PR DESCRIPTION
## Overview

This introduces a new package: **@pixi/graphics-extras** to provide some convenience drawing functions for various shapes. Ideally this would've been the place where `drawStar` was included too.

This PR was inspired by some draw experiments I did over the past year with Graphics. I thought these would be useful as a package. I added this package as opt-in (i.e., not included in the default bundles **pixi.js** or **pixi.js-legacy**).

### Demos

**Regular Polygon:**
https://jsfiddle.net/bigtimebuddy/rqpbnj6d/

**Torus:**
https://jsfiddle.net/bigtimebuddy/mzq0yLv8/

**Fillet and Chamfer Rectangles:**
https://jsfiddle.net/bigtimebuddy/jzsgep42/

### Links

[Documentation](http://pixijs.download/dev-graphics-extras/docs/PIXI.Graphics.html)
https://pixijs.download/dev-graphics-extras/packages/graphics-extras.js