### PR TITLE
Fix docs for graphicsUtils namespace and members

### DIFF
--- a/packages/graphics/src/utils/Star.ts
+++ b/packages/graphics/src/utils/Star.ts
@@ -5,7 +5,7 @@ import { Polygon, PI_2 } from '@pixi/math';
  *
  * @class
  * @extends PIXI.Polygon
- * @memberof PIXI
+ * @memberof PIXI.graphicsUtils
  * @param {number} x - Center X position of the star
  * @param {number} y - Center Y position of the star
  * @param {number} points - The number of points of the star, must be > 1

--- a/packages/graphics/src/utils/index.ts
+++ b/packages/graphics/src/utils/index.ts
@@ -56,6 +56,6 @@ export const BATCH_POOL: Array<BatchPart> = [];
  * Draw call pool, stores unused draw calls for preventing allocations.
  *
  * @memberof PIXI.graphicsUtils
- * @name {Array<PIXI.BatchDrawCall>} DRAW_CALL_POOL
+ * @member {Array<PIXI.BatchDrawCall>} DRAW_CALL_POOL
  */
 export const DRAW_CALL_POOL: Array<BatchDrawCall> = [];

--- a/packages/graphics/src/utils/index.ts
+++ b/packages/graphics/src/utils/index.ts
@@ -1,7 +1,8 @@
 /**
  * Generalized convenience utilities for Graphics.
  *
- * @namespace PIXI.graphicsUtils
+ * @namespace graphicsUtils
+ * @memberof PIXI
  */
 
 import { buildPoly } from './buildPoly';
@@ -33,7 +34,7 @@ import { IShapeBuildCommand } from './IShapeBuildCommand';
  * Map of fill commands for each shape type.
  *
  * @memberof PIXI.graphicsUtils
- * @member {Object}
+ * @member {Object} FILL_COMMANDS
  */
 export const FILL_COMMANDS: Record<SHAPES, IShapeBuildCommand> = {
     [SHAPES.POLY]: buildPoly,
@@ -47,7 +48,7 @@ export const FILL_COMMANDS: Record<SHAPES, IShapeBuildCommand> = {
  * Batch pool, stores unused batches for preventing allocations.
  *
  * @memberof PIXI.graphicsUtils
- * @type {Array<PIXI.graphicsUtils.BatchPart>}
+ * @member {Array<PIXI.graphicsUtils.BatchPart>} BATCH_POOL
  */
 export const BATCH_POOL: Array<BatchPart> = [];
 
@@ -55,6 +56,6 @@ export const BATCH_POOL: Array<BatchPart> = [];
  * Draw call pool, stores unused draw calls for preventing allocations.
  *
  * @memberof PIXI.graphicsUtils
- * @type {Array<PIXI.BatchDrawCall>}
+ * @name {Array<PIXI.BatchDrawCall>} DRAW_CALL_POOL
  */
 export const DRAW_CALL_POOL: Array<BatchDrawCall> = [];


### PR DESCRIPTION
Fixes #6648 - Star polygon class is part of `graphicsUtils` namespace not root.

Also, members of this class documented incorrectly. Fixed the names.

```
exports.BATCH_POOL
exports.DRAW_CALL_POOL
exports.FILL_COMMANDS
```

Current dev (broken)
http://pixijs.download/dev/docs/PIXI.graphicsUtils.html

This PR (fixed)
http://pixijs.download/dev-graphics-docs/docs/PIXI.graphicsUtils.html
