### PR TITLE
Replace global for window in polyfill

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -11,11 +11,3 @@ declare module '*.vert' {
 }
 
 declare module 'es6-promise-polyfill'
-
-declare namespace NodeJS {
-    interface Global {
-        performance: Performance|{[x: string]: any};
-        requestAnimationFrame: (callback: FrameRequestCallback) => NodeJS.Timeout;
-        cancelAnimationFrame: (handle: number) => void;
-    }
-}

--- a/packages/polyfill/src/requestAnimationFrame.ts
+++ b/packages/polyfill/src/requestAnimationFrame.ts
@@ -21,34 +21,34 @@ if (!(Date.now && Date.prototype.getTime))
 }
 
 // performance.now
-if (!(global.performance && global.performance.now))
+if (!(window.performance && window.performance.now))
 {
     const startTime = Date.now();
 
-    if (!global.performance)
+    if (!window.performance)
     {
-        global.performance = {};
+        (window as any).performance = {};
     }
 
-    global.performance.now = (): number => Date.now() - startTime;
+    window.performance.now = (): number => Date.now() - startTime;
 }
 
 // requestAnimationFrame
 let lastTime = Date.now();
 const vendors = ['ms', 'moz', 'webkit', 'o'];
 
-for (let x = 0; x < vendors.length && !global.requestAnimationFrame; ++x)
+for (let x = 0; x < vendors.length && !window.requestAnimationFrame; ++x)
 {
     const p = vendors[x];
 
-    global.requestAnimationFrame = (global as any)[`${p}RequestAnimationFrame`];
-    global.cancelAnimationFrame = (global as any)[`${p}CancelAnimationFrame`]
-        || (global as any)[`${p}CancelRequestAnimationFrame`];
+    window.requestAnimationFrame = (window as any)[`${p}RequestAnimationFrame`];
+    window.cancelAnimationFrame = (window as any)[`${p}CancelAnimationFrame`]
+        || (window as any)[`${p}CancelRequestAnimationFrame`];
 }
 
-if (!global.requestAnimationFrame)
+if (!window.requestAnimationFrame)
 {
-    global.requestAnimationFrame = (callback: (...parms: any[]) => void): NodeJS.Timeout =>
+    window.requestAnimationFrame = (callback: (...parms: any[]) => void): number =>
     {
         if (typeof callback !== 'function')
         {
@@ -65,7 +65,7 @@ if (!global.requestAnimationFrame)
 
         lastTime = currentTime;
 
-        return setTimeout(() =>
+        return window.setTimeout(() =>
         {
             lastTime = Date.now();
             callback(performance.now());
@@ -73,7 +73,7 @@ if (!global.requestAnimationFrame)
     };
 }
 
-if (!global.cancelAnimationFrame)
+if (!window.cancelAnimationFrame)
 {
-    global.cancelAnimationFrame = (id: number): void => clearTimeout(id);
+    window.cancelAnimationFrame = (id: number): void => clearTimeout(id);
 }


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
After updating the polyfill package to TypeScript the pixi examples page no longer works.

As discussed here [pixijs/examples#66](https://github.com/pixijs/examples/issues/66) this was due to the `commonjs` rollup plugin not being compatible with TypeScript.

To fix this i replaced `global` with `window` as @bigtimebuddy suggested.

This should also fix #6668 

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
