### PR TITLE
Remove interaction and accessibility namespaces

### DIFF
--- a/bundles/pixi.js-legacy/src/index.ts
+++ b/bundles/pixi.js-legacy/src/index.ts
@@ -1,4 +1,4 @@
-import { accessibility, interaction } from 'pixi.js';
+import { AccessibilityManager, InteractionManager } from 'pixi.js';
 import { CanvasRenderer, canvasUtils } from '@pixi/canvas-renderer';
 import { CanvasMeshRenderer } from '@pixi/canvas-mesh';
 import { CanvasGraphicsRenderer } from '@pixi/canvas-graphics';
@@ -10,10 +10,10 @@ import '@pixi/canvas-particles';
 import '@pixi/canvas-display';
 import '@pixi/canvas-text';
 
-CanvasRenderer.registerPlugin('accessibility', accessibility.AccessibilityManager);
+CanvasRenderer.registerPlugin('accessibility', AccessibilityManager);
 CanvasRenderer.registerPlugin('extract', CanvasExtract);
 CanvasRenderer.registerPlugin('graphics', CanvasGraphicsRenderer);
-CanvasRenderer.registerPlugin('interaction', interaction.InteractionManager);
+CanvasRenderer.registerPlugin('interaction', InteractionManager);
 CanvasRenderer.registerPlugin('mesh', CanvasMeshRenderer);
 CanvasRenderer.registerPlugin('prepare', CanvasPrepare);
 CanvasRenderer.registerPlugin('sprite', CanvasSpriteRenderer);

--- a/bundles/pixi.js/src/index.ts
+++ b/bundles/pixi.js/src/index.ts
@@ -1,8 +1,8 @@
 import '@pixi/polyfill';
 
-import * as accessibility from '@pixi/accessibility';
-import * as interaction from '@pixi/interaction';
 import * as utils from '@pixi/utils';
+import { AccessibilityManager } from '@pixi/accessibility';
+import { InteractionManager } from '@pixi/interaction';
 import { Application } from '@pixi/app';
 import { Renderer, BatchRenderer } from '@pixi/core';
 import { Extract } from '@pixi/extract';
@@ -29,9 +29,9 @@ import '@pixi/mixin-get-global-position';
 import { useDeprecated } from './useDeprecated';
 
 // Install renderer plugins
-Renderer.registerPlugin('accessibility', accessibility.AccessibilityManager);
+Renderer.registerPlugin('accessibility', AccessibilityManager);
 Renderer.registerPlugin('extract', Extract);
-Renderer.registerPlugin('interaction', interaction.InteractionManager);
+Renderer.registerPlugin('interaction', InteractionManager);
 Renderer.registerPlugin('particle', ParticleRenderer);
 Renderer.registerPlugin('prepare', Prepare);
 Renderer.registerPlugin('batch', BatchRenderer);
@@ -96,6 +96,7 @@ export const filters = {
 };
 
 // Export ES for those importing specifically by name,
+export * from '@pixi/accessibility';
 export * from '@pixi/app';
 export * from '@pixi/constants';
 export * from '@pixi/core';
@@ -103,6 +104,7 @@ export * from '@pixi/display';
 export * from '@pixi/extract';
 export * from '@pixi/graphics';
 export * from '@pixi/loaders';
+export * from '@pixi/interaction';
 export * from '@pixi/math';
 export * from '@pixi/mesh';
 export * from '@pixi/mesh-extras';
@@ -118,8 +120,6 @@ export * from '@pixi/text-bitmap';
 export * from '@pixi/ticker';
 export * from '@pixi/settings';
 export {
-    accessibility,
-    interaction,
     utils,
     useDeprecated,
 };

--- a/bundles/pixi.js/src/useDeprecated.ts
+++ b/bundles/pixi.js/src/useDeprecated.ts
@@ -19,6 +19,8 @@ import type {
     Transform,
     groupD8,
     Matrix } from '@pixi/math';
+import type { InteractionManager, InteractionData, InteractionEvent } from '@pixi/interaction';
+import type { AccessibilityManager } from '@pixi/accessibility';
 import type { Ticker } from '@pixi/ticker';
 import type { Graphics, GraphicsData } from '@pixi/graphics';
 import type { Sprite } from '@pixi/sprite';
@@ -207,6 +209,80 @@ export function useDeprecated(this: any): void
                 deprecation('5.2.0', 'PIXI.GroupD8 namespace has moved to PIXI.groupD8');
 
                 return PIXI.groupD8;
+            },
+        },
+    });
+
+    /**
+     * @namespace PIXI.accessibility
+     * @see PIXI
+     * @deprecated since 5.3.0
+     */
+    PIXI.accessibility = {};
+
+    Object.defineProperties(PIXI.accessibility, {
+        /**
+         * @class PIXI.accessibility.AccessibilityManager
+         * @deprecated since 5.3.0
+         * @see PIXI.AccessibilityManager
+         */
+        AccessibilityManager: {
+            get(): typeof AccessibilityManager
+            {
+                deprecation('5.3.0', 'PIXI.accessibility.AccessibilityManager moved to PIXI.AccessibilityManager');
+
+                return PIXI.AccessibilityManager;
+            },
+        },
+    });
+
+    /**
+     * @namespace PIXI.interaction
+     * @see PIXI
+     * @deprecated since 5.3.0
+     */
+    PIXI.interaction = {};
+
+    Object.defineProperties(PIXI.interaction, {
+        /**
+         * @class PIXI.interaction.InteractionManager
+         * @deprecated since 5.3.0
+         * @see PIXI.InteractionManager
+         */
+        InteractionManager: {
+            get(): typeof InteractionManager
+            {
+                deprecation('5.3.0', 'PIXI.accessibility.InteractionManager moved to PIXI.InteractionManager');
+
+                return PIXI.InteractionManager;
+            },
+        },
+
+        /**
+         * @class PIXI.interaction.InteractionData
+         * @deprecated since 5.3.0
+         * @see PIXI.InteractionData
+         */
+        InteractionData: {
+            get(): typeof InteractionData
+            {
+                deprecation('5.3.0', 'PIXI.accessibility.InteractionData moved to PIXI.InteractionData');
+
+                return PIXI.InteractionData;
+            },
+        },
+
+        /**
+         * @class PIXI.interaction.InteractionEvent
+         * @deprecated since 5.3.0
+         * @see PIXI.InteractionEvent
+         */
+        InteractionEvent: {
+            get(): typeof InteractionEvent
+            {
+                deprecation('5.3.0', 'PIXI.accessibility.InteractionEvent moved to PIXI.InteractionEvent');
+
+                return PIXI.InteractionEvent;
             },
         },
     });

--- a/bundles/pixi.js/test/index.js
+++ b/bundles/pixi.js/test/index.js
@@ -22,7 +22,6 @@ describe('PIXI', function ()
     {
         expect(window.PIXI).to.not.be.undefined;
         expect(PIXI).to.not.be.undefined;
-        expect(PIXI.interaction).to.not.be.undefined;
         expect(PIXI.settings).to.not.be.undefined;
         expect(PIXI.utils).to.not.be.undefined;
     });

--- a/packages/accessibility/src/AccessibilityManager.ts
+++ b/packages/accessibility/src/AccessibilityManager.ts
@@ -32,7 +32,7 @@ const DIV_HOOK_ZINDEX = 2;
  * An instance of this class is automatically created by default, and can be found at `renderer.plugins.accessibility`
  *
  * @class
- * @memberof PIXI.accessibility
+ * @memberof PIXI
  */
 export class AccessibilityManager
 {

--- a/packages/accessibility/src/accessibleTarget.ts
+++ b/packages/accessibility/src/accessibleTarget.ts
@@ -32,18 +32,18 @@ export interface IAccessibleHTMLElement extends HTMLElement {
 
 /**
  * Default property values of accessible objects
- * used by {@link PIXI.accessibility.AccessibilityManager}.
+ * used by {@link PIXI.AccessibilityManager}.
  *
  * @private
  * @function accessibleTarget
- * @memberof PIXI.accessibility
+ * @memberof PIXI
  * @type {Object}
  * @example
  *      function MyObject() {}
  *
  *      Object.assign(
  *          MyObject.prototype,
- *          PIXI.accessibility.accessibleTarget
+ *          PIXI.accessibleTarget
  *      );
  */
 export const accessibleTarget: IAccessibleTarget = {

--- a/packages/accessibility/src/index.ts
+++ b/packages/accessibility/src/index.ts
@@ -1,9 +1,2 @@
-/**
- * This namespace contains an accessibility plugin for allowing interaction via the keyboard.
- *
- * Do not instantiate this plugin directly. It is available from the `renderer.plugins` property.
- * See {@link PIXI.CanvasRenderer#plugins} or {@link PIXI.Renderer#plugins}.
- * @namespace PIXI.accessibility
- */
 export * from './accessibleTarget';
 export * from './AccessibilityManager';

--- a/packages/canvas/canvas-renderer/src/CanvasRenderer.ts
+++ b/packages/canvas/canvas-renderer/src/CanvasRenderer.ts
@@ -453,9 +453,9 @@ export class CanvasRenderer extends AbstractRenderer
      * @name PIXI.CanvasRenderer#plugins
      * @type {object}
      * @readonly
-     * @property {PIXI.accessibility.AccessibilityManager} accessibility Support tabbing interactive elements.
+     * @property {PIXI.AccessibilityManager} accessibility Support tabbing interactive elements.
      * @property {PIXI.CanvasExtract} extract Extract image data from renderer.
-     * @property {PIXI.interaction.InteractionManager} interaction Handles mouse, touch and pointer events.
+     * @property {PIXI.InteractionManager} interaction Handles mouse, touch and pointer events.
      * @property {PIXI.CanvasPrepare} prepare Pre-render display objects.
      */
 

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -483,9 +483,9 @@ export class Renderer extends AbstractRenderer
      * @name PIXI.Renderer#plugins
      * @type {object}
      * @readonly
-     * @property {PIXI.accessibility.AccessibilityManager} accessibility Support tabbing interactive elements.
-     * @property {PIXI.extract.Extract} extract Extract image data from renderer.
-     * @property {PIXI.interaction.InteractionManager} interaction Handles mouse, touch and pointer events.
+     * @property {PIXI.AccessibilityManager} accessibility Support tabbing interactive elements.
+     * @property {PIXI.Extract} extract Extract image data from renderer.
+     * @property {PIXI.InteractionManager} interaction Handles mouse, touch and pointer events.
      * @property {PIXI.Prepare} prepare Pre-render display objects.
      */
 

--- a/packages/interaction/src/InteractionData.ts
+++ b/packages/interaction/src/InteractionData.ts
@@ -8,7 +8,7 @@ export type InteractivePointerEvent = PointerEvent | TouchEvent | MouseEvent;
  * Holds all information related to an Interaction event
  *
  * @class
- * @memberof PIXI.interaction
+ * @memberof PIXI
  */
 export class InteractionData
 {

--- a/packages/interaction/src/InteractionEvent.ts
+++ b/packages/interaction/src/InteractionEvent.ts
@@ -7,7 +7,7 @@ export type InteractionCallback = (interactionEvent: InteractionEvent, displayOb
  * Event class that mimics native DOM events.
  *
  * @class
- * @memberof PIXI.interaction
+ * @memberof PIXI
  */
 export class InteractionEvent
 {
@@ -51,7 +51,7 @@ export class InteractionEvent
 
         /**
          * The object which caused this event to be dispatched.
-         * For listener callback see {@link PIXI.interaction.InteractionEvent.currentTarget}.
+         * For listener callback see {@link PIXI.InteractionEvent.currentTarget}.
          *
          * @member {PIXI.DisplayObject}
          */
@@ -74,7 +74,7 @@ export class InteractionEvent
         /**
          * InteractionData related to this event
          *
-         * @member {PIXI.interaction.InteractionData}
+         * @member {PIXI.InteractionData}
          */
         this.data = null;
     }

--- a/packages/interaction/src/InteractionManager.ts
+++ b/packages/interaction/src/InteractionManager.ts
@@ -54,7 +54,7 @@ export interface DelayedEvent {
  *
  * @class
  * @extends PIXI.utils.EventEmitter
- * @memberof PIXI.interaction
+ * @memberof PIXI
  */
 export class InteractionManager extends EventEmitter
 {
@@ -126,7 +126,7 @@ export class InteractionManager extends EventEmitter
         /**
          * The mouse data
          *
-         * @member {PIXI.interaction.InteractionData}
+         * @member {PIXI.InteractionData}
          */
         this.mouse = new InteractionData();
         this.mouse.identifier = MOUSE_POINTER_ID;
@@ -139,7 +139,7 @@ export class InteractionManager extends EventEmitter
          * Actively tracked InteractionData
          *
          * @private
-         * @member {Object.<number,PIXI.interaction.InteractionData>}
+         * @member {Object.<number,PIXI.InteractionData>}
          */
         this.activeInteractionData = {};
         this.activeInteractionData[MOUSE_POINTER_ID] = this.mouse;
@@ -148,7 +148,7 @@ export class InteractionManager extends EventEmitter
          * Pool of unused InteractionData
          *
          * @private
-         * @member {PIXI.interaction.InteractionData[]}
+         * @member {PIXI.InteractionData[]}
          */
         this.interactionDataPool = [];
 
@@ -313,7 +313,7 @@ export class InteractionManager extends EventEmitter
          * TreeSearch component that is used to hitTest stage tree
          *
          * @private
-         * @member {PIXI.interaction.TreeSearch}
+         * @member {PIXI.TreeSearch}
          */
         this.search = new TreeSearch();
 
@@ -321,190 +321,190 @@ export class InteractionManager extends EventEmitter
          * Fired when a pointer device button (usually a mouse left-button) is pressed on the display
          * object.
          *
-         * @event PIXI.interaction.InteractionManager#mousedown
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @event PIXI.InteractionManager#mousedown
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
          * Fired when a pointer device secondary button (usually a mouse right-button) is pressed
          * on the display object.
          *
-         * @event PIXI.interaction.InteractionManager#rightdown
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @event PIXI.InteractionManager#rightdown
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
          * Fired when a pointer device button (usually a mouse left-button) is released over the display
          * object.
          *
-         * @event PIXI.interaction.InteractionManager#mouseup
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @event PIXI.InteractionManager#mouseup
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
          * Fired when a pointer device secondary button (usually a mouse right-button) is released
          * over the display object.
          *
-         * @event PIXI.interaction.InteractionManager#rightup
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @event PIXI.InteractionManager#rightup
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
          * Fired when a pointer device button (usually a mouse left-button) is pressed and released on
          * the display object.
          *
-         * @event PIXI.interaction.InteractionManager#click
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @event PIXI.InteractionManager#click
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
          * Fired when a pointer device secondary button (usually a mouse right-button) is pressed
          * and released on the display object.
          *
-         * @event PIXI.interaction.InteractionManager#rightclick
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @event PIXI.InteractionManager#rightclick
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
          * Fired when a pointer device button (usually a mouse left-button) is released outside the
          * display object that initially registered a
-         * [mousedown]{@link PIXI.interaction.InteractionManager#event:mousedown}.
+         * [mousedown]{@link PIXI.InteractionManager#event:mousedown}.
          *
-         * @event PIXI.interaction.InteractionManager#mouseupoutside
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @event PIXI.InteractionManager#mouseupoutside
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
          * Fired when a pointer device secondary button (usually a mouse right-button) is released
          * outside the display object that initially registered a
-         * [rightdown]{@link PIXI.interaction.InteractionManager#event:rightdown}.
+         * [rightdown]{@link PIXI.InteractionManager#event:rightdown}.
          *
-         * @event PIXI.interaction.InteractionManager#rightupoutside
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @event PIXI.InteractionManager#rightupoutside
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
          * Fired when a pointer device (usually a mouse) is moved while over the display object
          *
-         * @event PIXI.interaction.InteractionManager#mousemove
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @event PIXI.InteractionManager#mousemove
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
          * Fired when a pointer device (usually a mouse) is moved onto the display object
          *
-         * @event PIXI.interaction.InteractionManager#mouseover
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @event PIXI.InteractionManager#mouseover
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
          * Fired when a pointer device (usually a mouse) is moved off the display object
          *
-         * @event PIXI.interaction.InteractionManager#mouseout
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @event PIXI.InteractionManager#mouseout
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
          * Fired when a pointer device button is pressed on the display object.
          *
-         * @event PIXI.interaction.InteractionManager#pointerdown
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @event PIXI.InteractionManager#pointerdown
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
          * Fired when a pointer device button is released over the display object.
          * Not always fired when some buttons are held down while others are released. In those cases,
-         * use [mousedown]{@link PIXI.interaction.InteractionManager#event:mousedown} and
-         * [mouseup]{@link PIXI.interaction.InteractionManager#event:mouseup} instead.
+         * use [mousedown]{@link PIXI.InteractionManager#event:mousedown} and
+         * [mouseup]{@link PIXI.InteractionManager#event:mouseup} instead.
          *
-         * @event PIXI.interaction.InteractionManager#pointerup
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @event PIXI.InteractionManager#pointerup
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
          * Fired when the operating system cancels a pointer event
          *
-         * @event PIXI.interaction.InteractionManager#pointercancel
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @event PIXI.InteractionManager#pointercancel
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
          * Fired when a pointer device button is pressed and released on the display object.
          *
-         * @event PIXI.interaction.InteractionManager#pointertap
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @event PIXI.InteractionManager#pointertap
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
          * Fired when a pointer device button is released outside the display object that initially
-         * registered a [pointerdown]{@link PIXI.interaction.InteractionManager#event:pointerdown}.
+         * registered a [pointerdown]{@link PIXI.InteractionManager#event:pointerdown}.
          *
-         * @event PIXI.interaction.InteractionManager#pointerupoutside
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @event PIXI.InteractionManager#pointerupoutside
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
          * Fired when a pointer device is moved while over the display object
          *
-         * @event PIXI.interaction.InteractionManager#pointermove
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @event PIXI.InteractionManager#pointermove
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
          * Fired when a pointer device is moved onto the display object
          *
-         * @event PIXI.interaction.InteractionManager#pointerover
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @event PIXI.InteractionManager#pointerover
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
          * Fired when a pointer device is moved off the display object
          *
-         * @event PIXI.interaction.InteractionManager#pointerout
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @event PIXI.InteractionManager#pointerout
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
          * Fired when a touch point is placed on the display object.
          *
-         * @event PIXI.interaction.InteractionManager#touchstart
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @event PIXI.InteractionManager#touchstart
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
          * Fired when a touch point is removed from the display object.
          *
-         * @event PIXI.interaction.InteractionManager#touchend
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @event PIXI.InteractionManager#touchend
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
          * Fired when the operating system cancels a touch
          *
-         * @event PIXI.interaction.InteractionManager#touchcancel
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @event PIXI.InteractionManager#touchcancel
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
          * Fired when a touch point is placed and removed from the display object.
          *
-         * @event PIXI.interaction.InteractionManager#tap
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @event PIXI.InteractionManager#tap
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
          * Fired when a touch point is removed outside of the display object that initially
-         * registered a [touchstart]{@link PIXI.interaction.InteractionManager#event:touchstart}.
+         * registered a [touchstart]{@link PIXI.InteractionManager#event:touchstart}.
          *
-         * @event PIXI.interaction.InteractionManager#touchendoutside
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @event PIXI.InteractionManager#touchendoutside
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
          * Fired when a touch point is moved along the display object.
          *
-         * @event PIXI.interaction.InteractionManager#touchmove
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @event PIXI.InteractionManager#touchmove
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
@@ -512,7 +512,7 @@ export class InteractionManager extends EventEmitter
          * object. DisplayObject's `interactive` property must be set to `true` to fire event.
          *
          * @event PIXI.DisplayObject#mousedown
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
@@ -520,7 +520,7 @@ export class InteractionManager extends EventEmitter
          * on the display object. DisplayObject's `interactive` property must be set to `true` to fire event.
          *
          * @event PIXI.DisplayObject#rightdown
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
@@ -528,7 +528,7 @@ export class InteractionManager extends EventEmitter
          * object. DisplayObject's `interactive` property must be set to `true` to fire event.
          *
          * @event PIXI.DisplayObject#mouseup
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
@@ -536,7 +536,7 @@ export class InteractionManager extends EventEmitter
          * over the display object. DisplayObject's `interactive` property must be set to `true` to fire event.
          *
          * @event PIXI.DisplayObject#rightup
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
@@ -544,7 +544,7 @@ export class InteractionManager extends EventEmitter
          * the display object. DisplayObject's `interactive` property must be set to `true` to fire event.
          *
          * @event PIXI.DisplayObject#click
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
@@ -552,7 +552,7 @@ export class InteractionManager extends EventEmitter
          * and released on the display object. DisplayObject's `interactive` property must be set to `true` to fire event.
          *
          * @event PIXI.DisplayObject#rightclick
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
@@ -562,7 +562,7 @@ export class InteractionManager extends EventEmitter
          * DisplayObject's `interactive` property must be set to `true` to fire event.
          *
          * @event PIXI.DisplayObject#mouseupoutside
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
@@ -572,7 +572,7 @@ export class InteractionManager extends EventEmitter
          * DisplayObject's `interactive` property must be set to `true` to fire event.
          *
          * @event PIXI.DisplayObject#rightupoutside
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
@@ -580,7 +580,7 @@ export class InteractionManager extends EventEmitter
          * DisplayObject's `interactive` property must be set to `true` to fire event.
          *
          * @event PIXI.DisplayObject#mousemove
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
@@ -588,7 +588,7 @@ export class InteractionManager extends EventEmitter
          * DisplayObject's `interactive` property must be set to `true` to fire event.
          *
          * @event PIXI.DisplayObject#mouseover
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
@@ -596,7 +596,7 @@ export class InteractionManager extends EventEmitter
          * DisplayObject's `interactive` property must be set to `true` to fire event.
          *
          * @event PIXI.DisplayObject#mouseout
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
@@ -604,7 +604,7 @@ export class InteractionManager extends EventEmitter
          * DisplayObject's `interactive` property must be set to `true` to fire event.
          *
          * @event PIXI.DisplayObject#pointerdown
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
@@ -612,7 +612,7 @@ export class InteractionManager extends EventEmitter
          * DisplayObject's `interactive` property must be set to `true` to fire event.
          *
          * @event PIXI.DisplayObject#pointerup
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
@@ -620,7 +620,7 @@ export class InteractionManager extends EventEmitter
          * DisplayObject's `interactive` property must be set to `true` to fire event.
          *
          * @event PIXI.DisplayObject#pointercancel
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
@@ -628,7 +628,7 @@ export class InteractionManager extends EventEmitter
          * DisplayObject's `interactive` property must be set to `true` to fire event.
          *
          * @event PIXI.DisplayObject#pointertap
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
@@ -637,7 +637,7 @@ export class InteractionManager extends EventEmitter
          * DisplayObject's `interactive` property must be set to `true` to fire event.
          *
          * @event PIXI.DisplayObject#pointerupoutside
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
@@ -645,7 +645,7 @@ export class InteractionManager extends EventEmitter
          * DisplayObject's `interactive` property must be set to `true` to fire event.
          *
          * @event PIXI.DisplayObject#pointermove
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
@@ -653,7 +653,7 @@ export class InteractionManager extends EventEmitter
          * DisplayObject's `interactive` property must be set to `true` to fire event.
          *
          * @event PIXI.DisplayObject#pointerover
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
@@ -661,7 +661,7 @@ export class InteractionManager extends EventEmitter
          * DisplayObject's `interactive` property must be set to `true` to fire event.
          *
          * @event PIXI.DisplayObject#pointerout
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
@@ -669,7 +669,7 @@ export class InteractionManager extends EventEmitter
          * DisplayObject's `interactive` property must be set to `true` to fire event.
          *
          * @event PIXI.DisplayObject#touchstart
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
@@ -677,7 +677,7 @@ export class InteractionManager extends EventEmitter
          * DisplayObject's `interactive` property must be set to `true` to fire event.
          *
          * @event PIXI.DisplayObject#touchend
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
@@ -685,7 +685,7 @@ export class InteractionManager extends EventEmitter
          * DisplayObject's `interactive` property must be set to `true` to fire event.
          *
          * @event PIXI.DisplayObject#touchcancel
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
@@ -693,7 +693,7 @@ export class InteractionManager extends EventEmitter
          * DisplayObject's `interactive` property must be set to `true` to fire event.
          *
          * @event PIXI.DisplayObject#tap
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
@@ -702,7 +702,7 @@ export class InteractionManager extends EventEmitter
          * DisplayObject's `interactive` property must be set to `true` to fire event.
          *
          * @event PIXI.DisplayObject#touchendoutside
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         /**
@@ -710,7 +710,7 @@ export class InteractionManager extends EventEmitter
          * DisplayObject's `interactive` property must be set to `true` to fire event.
          *
          * @event PIXI.DisplayObject#touchmove
-         * @param {PIXI.interaction.InteractionEvent} event - Interaction event
+         * @param {PIXI.InteractionEvent} event - Interaction event
          */
 
         this._useSystemTicker = options.useSystemTicker !== undefined ? options.useSystemTicker : true;
@@ -1131,7 +1131,7 @@ export class InteractionManager extends EventEmitter
      * testing the interactive objects and passes the hit across in the function.
      *
      * @protected
-     * @param {PIXI.interaction.InteractionEvent} interactionEvent - event containing the point that
+     * @param {PIXI.InteractionEvent} interactionEvent - event containing the point that
      *  is tested for collision
      * @param {PIXI.Container|PIXI.Sprite|PIXI.TilingSprite} displayObject - the displayObject
      *  that will be hit test (recursively crawls its children)
@@ -1240,7 +1240,7 @@ export class InteractionManager extends EventEmitter
      * Processes the result of the pointer down check and dispatches the event if need be
      *
      * @private
-     * @param {PIXI.interaction.InteractionEvent} interactionEvent - The interaction event wrapping the DOM event
+     * @param {PIXI.InteractionEvent} interactionEvent - The interaction event wrapping the DOM event
      * @param {PIXI.Container|PIXI.Sprite|PIXI.TilingSprite} displayObject - The display object that was tested
      * @param {boolean} hit - the result of the hit test on the display object
      */
@@ -1344,7 +1344,7 @@ export class InteractionManager extends EventEmitter
      * Processes the result of the pointer cancel check and dispatches the event if need be
      *
      * @private
-     * @param {PIXI.interaction.InteractionEvent} interactionEvent - The interaction event wrapping the DOM event
+     * @param {PIXI.InteractionEvent} interactionEvent - The interaction event wrapping the DOM event
      * @param {PIXI.Container|PIXI.Sprite|PIXI.TilingSprite} displayObject - The display object that was tested
      */
     private processPointerCancel(interactionEvent: InteractionEvent, displayObject: DisplayObject): void
@@ -1383,7 +1383,7 @@ export class InteractionManager extends EventEmitter
      * Processes the result of the pointer up check and dispatches the event if need be
      *
      * @private
-     * @param {PIXI.interaction.InteractionEvent} interactionEvent - The interaction event wrapping the DOM event
+     * @param {PIXI.InteractionEvent} interactionEvent - The interaction event wrapping the DOM event
      * @param {PIXI.Container|PIXI.Sprite|PIXI.TilingSprite} displayObject - The display object that was tested
      * @param {boolean} hit - the result of the hit test on the display object
      */
@@ -1527,7 +1527,7 @@ export class InteractionManager extends EventEmitter
      * Processes the result of the pointer move check and dispatches the event if need be
      *
      * @private
-     * @param {PIXI.interaction.InteractionEvent} interactionEvent - The interaction event wrapping the DOM event
+     * @param {PIXI.InteractionEvent} interactionEvent - The interaction event wrapping the DOM event
      * @param {PIXI.Container|PIXI.Sprite|PIXI.TilingSprite} displayObject - The display object that was tested
      * @param {boolean} hit - the result of the hit test on the display object
      */
@@ -1599,7 +1599,7 @@ export class InteractionManager extends EventEmitter
      * Processes the result of the pointer over/out check and dispatches the event if need be
      *
      * @private
-     * @param {PIXI.interaction.InteractionEvent} interactionEvent - The interaction event wrapping the DOM event
+     * @param {PIXI.InteractionEvent} interactionEvent - The interaction event wrapping the DOM event
      * @param {PIXI.Container|PIXI.Sprite|PIXI.TilingSprite} displayObject - The display object that was tested
      * @param {boolean} hit - the result of the hit test on the display object
      */
@@ -1692,7 +1692,7 @@ export class InteractionManager extends EventEmitter
      *
      * @private
      * @param {PointerEvent} event - Normalized pointer event, output from normalizeToPointerData
-     * @return {PIXI.interaction.InteractionData} - Interaction data for the given pointer identifier
+     * @return {PIXI.InteractionData} - Interaction data for the given pointer identifier
      */
     private getInteractionDataForPointerId(event: PointerEvent): InteractionData
     {
@@ -1743,11 +1743,11 @@ export class InteractionManager extends EventEmitter
      * Configure an InteractionEvent to wrap a DOM PointerEvent and InteractionData
      *
      * @private
-     * @param {PIXI.interaction.InteractionEvent} interactionEvent - The event to be configured
+     * @param {PIXI.InteractionEvent} interactionEvent - The event to be configured
      * @param {PointerEvent} pointerEvent - The DOM event that will be paired with the InteractionEvent
-     * @param {PIXI.interaction.InteractionData} interactionData - The InteractionData that will be paired
+     * @param {PIXI.InteractionData} interactionData - The InteractionData that will be paired
      *        with the InteractionEvent
-     * @return {PIXI.interaction.InteractionEvent} the interaction event that was passed in
+     * @return {PIXI.InteractionEvent} the interaction event that was passed in
      */
     private configureInteractionEventForDOMEvent(interactionEvent: InteractionEvent, pointerEvent: PointerEvent,
         interactionData: InteractionData

--- a/packages/interaction/src/InteractionTrackingData.ts
+++ b/packages/interaction/src/InteractionTrackingData.ts
@@ -7,11 +7,11 @@ export interface InteractionTrackingFlags
 }
 
 /**
- * DisplayObjects with the {@link PIXI.interaction.interactiveTarget} mixin use this class to track interactions
+ * DisplayObjects with the {@link PIXI.interactiveTarget} mixin use this class to track interactions
  *
  * @class
  * @private
- * @memberof PIXI.interaction
+ * @memberof PIXI
  */
 export class InteractionTrackingData
 {

--- a/packages/interaction/src/TreeSearch.ts
+++ b/packages/interaction/src/TreeSearch.ts
@@ -8,7 +8,7 @@ import type { Container, DisplayObject } from '@pixi/display';
  *
  * @private
  * @class
- * @memberof PIXI.interaction
+ * @memberof PIXI
  */
 export class TreeSearch
 {
@@ -23,7 +23,7 @@ export class TreeSearch
      * Recursive implementation for findHit
      *
      * @private
-     * @param {PIXI.interaction.InteractionEvent} interactionEvent - event containing the point that
+     * @param {PIXI.InteractionEvent} interactionEvent - event containing the point that
      *  is tested for collision
      * @param {PIXI.Container|PIXI.Sprite|PIXI.TilingSprite} displayObject - the displayObject
      *  that will be hit test (recursively crawls its children)
@@ -184,7 +184,7 @@ export class TreeSearch
      * testing the interactive objects and passes the hit across in the function.
      *
      * @private
-     * @param {PIXI.interaction.InteractionEvent} interactionEvent - event containing the point that
+     * @param {PIXI.InteractionEvent} interactionEvent - event containing the point that
      *  is tested for collision
      * @param {PIXI.Container|PIXI.Sprite|PIXI.TilingSprite} displayObject - the displayObject
      *  that will be hit test (recursively crawls its children)

--- a/packages/interaction/src/index.ts
+++ b/packages/interaction/src/index.ts
@@ -1,10 +1,3 @@
-/**
- * This namespace contains a renderer plugin for handling mouse, pointer, and touch events.
- *
- * Do not instantiate this plugin directly. It is available from the `renderer.plugins` property.
- * See {@link PIXI.CanvasRenderer#plugins} or {@link PIXI.Renderer#plugins}.
- * @namespace PIXI.interaction
- */
 export * from './InteractionData';
 export * from './InteractionManager';
 export * from './interactiveTarget';

--- a/packages/interaction/src/interactiveTarget.ts
+++ b/packages/interaction/src/interactiveTarget.ts
@@ -77,18 +77,18 @@ export interface InteractiveTarget {
 
 /**
  * Default property values of interactive objects
- * Used by {@link PIXI.interaction.InteractionManager} to automatically give all DisplayObjects these properties
+ * Used by {@link PIXI.InteractionManager} to automatically give all DisplayObjects these properties
  *
  * @private
  * @name interactiveTarget
  * @type {Object}
- * @memberof PIXI.interaction
+ * @memberof PIXI
  * @example
  *      function MyObject() {}
  *
  *      Object.assign(
  *          DisplayObject.prototype,
- *          PIXI.interaction.interactiveTarget
+ *          PIXI.interactiveTarget
  *      );
  */
 export const interactiveTarget: InteractiveTarget = {

--- a/packages/ticker/src/Ticker.ts
+++ b/packages/ticker/src/Ticker.ts
@@ -652,7 +652,7 @@ export class Ticker
     }
 
     /**
-     * The system ticker instance used by {@link PIXI.interaction.InteractionManager} and by
+     * The system ticker instance used by {@link PIXI.InteractionManager} and by
      * {@link PIXI.BasePrepare} for core timing functionality that shouldn't usually need to be paused,
      * unlike the `shared` ticker which drives visual animations and rendering which may want to be paused.
      *

--- a/packages/ticker/src/const.ts
+++ b/packages/ticker/src/const.ts
@@ -8,7 +8,7 @@
  * @name UPDATE_PRIORITY
  * @memberof PIXI
  * @enum {number}
- * @property {number} INTERACTION=50 Highest priority, used for {@link PIXI.interaction.InteractionManager}
+ * @property {number} INTERACTION=50 Highest priority, used for {@link PIXI.InteractionManager}
  * @property {number} HIGH=25 High priority updating, {@link PIXI.VideoBaseTexture} and {@link PIXI.AnimatedSprite}
  * @property {number} NORMAL=0 Default priority for ticker events, see {@link PIXI.Ticker#add}.
  * @property {number} LOW=-25 Low priority used for {@link PIXI.Application} rendering.


### PR DESCRIPTION
Recently in v5, we removed `extract` and `prepare` internal namespaces. I would also like to remove `interaction` and `accessibility` namespaces as well. These are not useful for organizing the code since they only contain a small number of classes and it simplifies the code and documentation. Internal namespacing is only really useful for `utils` (which would pollute the root `PIXI` object with lots of generic functions) and `filters` (which we can hang a lot more filters on with pixi-filters). It should also make it easier for users importing types in the future.

**Documentation**
https://pixijs.download/dev-namespace-deprecation/docs/index.html