### PR TITLE
Provide a convenience Texture API to handle invalid URLs more effectively

### DIFF
--- a/packages/core/src/textures/Texture.ts
+++ b/packages/core/src/textures/Texture.ts
@@ -400,8 +400,8 @@ export class Texture extends EventEmitter
      * it does a better job of handling failed URLs more effectively. This also ignores
      * `PIXI.settings.STRICT_TEXTURE_CACHE`. Works for Videos, SVGs, Images.
      * @param {string} url The remote URL to load.
-     * @param {PIXI.IBaseTextureOptions} [options] Optional options to include
-     * @return A Promise that resolves to a Texture.
+     * @param {object} [options] Optional options to include
+     * @return {Promise<PIXI.Texture>} A Promise that resolves to a Texture.
      */
     static fromURL(url: string, options?: IBaseTextureOptions): Promise<Texture>
     {

--- a/packages/core/src/textures/Texture.ts
+++ b/packages/core/src/textures/Texture.ts
@@ -395,6 +395,30 @@ export class Texture extends EventEmitter
     }
 
     /**
+     * Useful for loading textures via URLs. Use instead of `Texture.from` because
+     * it does a better job of handling failed URLs more effectively. This also ignores
+     * `PIXI.settings.STRICT_TEXTURE_CACHE`. Works for Videos, SVGs, Images.
+     * @param {string} url The remote URL to load.
+     * @param {PIXI.IBaseTextureOptions} [options] Optional options to include
+     * @return A Promise that resolves to a Texture.
+     */
+    static fromURL(url: string, options?: IBaseTextureOptions): Promise<Texture>
+    {
+        const resourceOptions = Object.assign({ autoLoad: false }, options?.resourceOptions);
+        const texture = Texture.from(url, Object.assign({ resourceOptions }, options), false);
+        const resource = texture.baseTexture.resource as ImageResource;
+
+        // The texture was already loaded
+        if (texture.baseTexture.valid)
+        {
+            return Promise.resolve(texture);
+        }
+
+        // Manually load the texture, this should allow users to handle load errors
+        return resource.load().then(() => Promise.resolve(texture));
+    }
+
+    /**
      * Create a new Texture with a BufferResource from a Float32Array.
      * RGBA values are floats from 0 to 1.
      * @static

--- a/packages/core/test/Texture.js
+++ b/packages/core/test/Texture.js
@@ -240,6 +240,25 @@ describe('PIXI.Texture', function ()
         texture.destroy(true);
     });
 
+    it('should handle loading an invalid URL', function ()
+    {
+        expect(() => Texture.fromURL('invalid/image.png')).throws;
+    });
+
+    it('should handle loading an cached URL', async function ()
+    {
+        const url = 'noop.png';
+
+        TextureCache[url] = Texture.WHITE;
+
+        expect(Texture.WHITE.valid).to.be.true;
+
+        const texture = await Texture.fromURL(url);
+
+        expect(texture).equals(Texture.WHITE);
+        delete TextureCache[url];
+    });
+
     it('should throw and error in strict from mode', function ()
     {
         const id = 'baz';


### PR DESCRIPTION
This creates a convenience method for loading remote URLs. Fixes #6514. There are currently ways to error handle loads, and they suck and are confusing/verbose to use.  This adds an alternative path for loading Texture by returning a Promise.

### Option 1, manually load resource :-1:

```js
const texture = PIXI.Texture.from('http://path/to/wherever.png', {
  resourceOptions: { autoLoad: false }}
);
await texture.baseTexture.resource.load();
```
### Option 2, subscribe to onError :-1:

```js
const texture = PIXI.Texture.from('http://path/to/wherever.png', {
  resourceOptions: { autoLoad: false }}
);
texture.baseTexture.resource.onError.add(() => {
  // handle error here
});
```

### Options 3, This PR :+1:

```js
const texture = await PIXI.Texture.fromURL('http://path/to/wherever.png');
```