### PR TITLE
Add IBatchableElement to AbstractBatchRenderer

### DIFF
--- a/packages/core/src/batch/AbstractBatchRenderer.ts
+++ b/packages/core/src/batch/AbstractBatchRenderer.ts
@@ -15,6 +15,21 @@ import type { Renderer } from '../Renderer';
 import type { Shader } from '../shader/Shader';
 import type { BatchShaderGenerator } from './BatchShaderGenerator';
 import type { BatchGeometry } from './BatchGeometry';
+import type { Texture } from '../textures/Texture';
+import type { BLEND_MODES } from '@pixi/constants';
+
+/**
+ * Interface for elements like Sprite, Mesh etc. for batching.
+ */
+export interface IBatchableElement {
+    _texture: Texture;
+    vertexData: Float32Array;
+    indices: Uint16Array | Uint32Array | Array<number>;
+    uvs: Float32Array;
+    worldAlpha: number;
+    _tintRGB: number;
+    blendMode: BLEND_MODES;
+}
 
 /**
  * Renderer dedicated to drawing and batching sprites.
@@ -40,7 +55,7 @@ export class AbstractBatchRenderer extends ObjectRenderer
     protected vertexSize: number;
     protected _vertexCount: number;
     protected _indexCount: number;
-    protected _bufferedElements: Array<any>;
+    protected _bufferedElements: Array<IBatchableElement>;
     protected _bufferedTextures: Array<BaseTexture>;
     protected _bufferSize: number;
     protected _shader: Shader;
@@ -356,7 +371,7 @@ export class AbstractBatchRenderer extends ObjectRenderer
      * @param {PIXI.DisplayObject} element - the element to render when
      *    using this renderer
      */
-    render(element: any): void
+    render(element: IBatchableElement): void
     {
         if (!element._texture.valid)
         {
@@ -726,7 +741,7 @@ export class AbstractBatchRenderer extends ObjectRenderer
      * @param {number} aIndex - number of floats already in the attribute buffer
      * @param {number} iIndex - number of indices already in `indexBuffer`
      */
-    packInterleavedGeometry(element: any, attributeBuffer: ViewableBuffer, indexBuffer: Uint16Array,
+    packInterleavedGeometry(element: IBatchableElement, attributeBuffer: ViewableBuffer, indexBuffer: Uint16Array,
         aIndex: number, iIndex: number): void
     {
         const {


### PR DESCRIPTION
I've been working on updating our dependencies to the latest linting toolchain. This exposed a bunch of issues where we were ts-ignoring and using `any` to mask issues.  I'm working on a series of PRs to improve typings and remove more instances using `any` before upgrading eslint.

This PR adds a stricter type to define the interface for batch-able elements.