### PR TITLE
Remove old unnecessary eslint rule

### DIFF
--- a/packages/core/src/AbstractRenderer.ts
+++ b/packages/core/src/AbstractRenderer.ts
@@ -376,7 +376,7 @@ export abstract class AbstractRenderer extends EventEmitter
         return this._backgroundColor;
     }
 
-    set backgroundColor(value) // eslint-disable-line require-jsdoc
+    set backgroundColor(value)
     {
         this._backgroundColor = value;
         this._backgroundColorString = hex2string(value);

--- a/packages/core/src/filters/Filter.ts
+++ b/packages/core/src/filters/Filter.ts
@@ -245,7 +245,7 @@ export class Filter extends Shader
         return this.state.blendMode;
     }
 
-    set blendMode(value) // eslint-disable-line require-jsdoc
+    set blendMode(value)
     {
         this.state.blendMode = value;
     }

--- a/packages/core/src/state/State.ts
+++ b/packages/core/src/state/State.ts
@@ -44,7 +44,7 @@ export class State
         return !!(this.data & (1 << BLEND));
     }
 
-    set blend(value) // eslint-disable-line require-jsdoc
+    set blend(value)
     {
         if (!!(this.data & (1 << BLEND)) !== value)
         {
@@ -63,7 +63,7 @@ export class State
         return !!(this.data & (1 << OFFSET));
     }
 
-    set offsets(value) // eslint-disable-line require-jsdoc
+    set offsets(value)
     {
         if (!!(this.data & (1 << OFFSET)) !== value)
         {
@@ -82,7 +82,7 @@ export class State
         return !!(this.data & (1 << CULLING));
     }
 
-    set culling(value) // eslint-disable-line require-jsdoc
+    set culling(value)
     {
         if (!!(this.data & (1 << CULLING)) !== value)
         {
@@ -101,7 +101,7 @@ export class State
         return !!(this.data & (1 << DEPTH_TEST));
     }
 
-    set depthTest(value) // eslint-disable-line require-jsdoc
+    set depthTest(value)
     {
         if (!!(this.data & (1 << DEPTH_TEST)) !== value)
         {
@@ -119,7 +119,7 @@ export class State
         return !!(this.data & (1 << WINDING));
     }
 
-    set clockwiseFrontFace(value) // eslint-disable-line require-jsdoc
+    set clockwiseFrontFace(value)
     {
         if (!!(this.data & (1 << WINDING)) !== value)
         {
@@ -140,7 +140,7 @@ export class State
         return this._blendMode;
     }
 
-    set blendMode(value) // eslint-disable-line require-jsdoc
+    set blendMode(value)
     {
         this.blend = (value !== BLEND_MODES.NONE);
         this._blendMode = value;
@@ -157,7 +157,7 @@ export class State
         return this._polygonOffset;
     }
 
-    set polygonOffset(value) // eslint-disable-line require-jsdoc
+    set polygonOffset(value)
     {
         this.offsets = !!value;
         this._polygonOffset = value;

--- a/packages/core/src/textures/Texture.ts
+++ b/packages/core/src/textures/Texture.ts
@@ -548,7 +548,7 @@ export class Texture extends EventEmitter
         return this._frame;
     }
 
-    set frame(frame: Rectangle) // eslint-disable-line require-jsdoc
+    set frame(frame: Rectangle)
     {
         this._frame = frame;
 
@@ -595,7 +595,7 @@ export class Texture extends EventEmitter
         return this._rotate;
     }
 
-    set rotate(rotate) // eslint-disable-line require-jsdoc
+    set rotate(rotate)
     {
         this._rotate = rotate;
         if (this.valid)

--- a/packages/core/src/textures/TextureMatrix.ts
+++ b/packages/core/src/textures/TextureMatrix.ts
@@ -109,7 +109,7 @@ export class TextureMatrix
         return this._texture;
     }
 
-    set texture(value: Texture) // eslint-disable-line require-jsdoc
+    set texture(value: Texture)
     {
         this._texture = value;
         this._updateID = -1;

--- a/packages/core/src/textures/resources/VideoResource.ts
+++ b/packages/core/src/textures/resources/VideoResource.ts
@@ -354,7 +354,7 @@ export class VideoResource extends BaseImageResource
         return this._autoUpdate;
     }
 
-    set autoUpdate(value) // eslint-disable-line require-jsdoc
+    set autoUpdate(value)
     {
         if (value !== this._autoUpdate)
         {
@@ -384,7 +384,7 @@ export class VideoResource extends BaseImageResource
         return this._updateFPS;
     }
 
-    set updateFPS(value) // eslint-disable-line require-jsdoc
+    set updateFPS(value)
     {
         if (value !== this._updateFPS)
         {

--- a/packages/display/src/Container.ts
+++ b/packages/display/src/Container.ts
@@ -671,7 +671,7 @@ export class Container extends DisplayObject
         return this.scale.x * this.getLocalBounds().width;
     }
 
-    set width(value) // eslint-disable-line require-jsdoc
+    set width(value)
     {
         const width = this.getLocalBounds().width;
 
@@ -697,7 +697,7 @@ export class Container extends DisplayObject
         return this.scale.y * this.getLocalBounds().height;
     }
 
-    set height(value) // eslint-disable-line require-jsdoc
+    set height(value)
     {
         const height = this.getLocalBounds().height;
 

--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -574,7 +574,7 @@ export abstract class DisplayObject extends EventEmitter
         return this.position.x;
     }
 
-    set x(value) // eslint-disable-line require-jsdoc
+    set x(value)
     {
         this.transform.position.x = value;
     }
@@ -590,7 +590,7 @@ export abstract class DisplayObject extends EventEmitter
         return this.position.y;
     }
 
-    set y(value) // eslint-disable-line require-jsdoc
+    set y(value)
     {
         this.transform.position.y = value;
     }
@@ -628,7 +628,7 @@ export abstract class DisplayObject extends EventEmitter
         return this.transform.position;
     }
 
-    set position(value) // eslint-disable-line require-jsdoc
+    set position(value)
     {
         this.transform.position.copyFrom(value);
     }
@@ -644,7 +644,7 @@ export abstract class DisplayObject extends EventEmitter
         return this.transform.scale;
     }
 
-    set scale(value) // eslint-disable-line require-jsdoc
+    set scale(value)
     {
         this.transform.scale.copyFrom(value);
     }
@@ -660,7 +660,7 @@ export abstract class DisplayObject extends EventEmitter
         return this.transform.pivot;
     }
 
-    set pivot(value) // eslint-disable-line require-jsdoc
+    set pivot(value)
     {
         this.transform.pivot.copyFrom(value);
     }
@@ -676,7 +676,7 @@ export abstract class DisplayObject extends EventEmitter
         return this.transform.skew;
     }
 
-    set skew(value) // eslint-disable-line require-jsdoc
+    set skew(value)
     {
         this.transform.skew.copyFrom(value);
     }
@@ -692,7 +692,7 @@ export abstract class DisplayObject extends EventEmitter
         return this.transform.rotation;
     }
 
-    set rotation(value) // eslint-disable-line require-jsdoc
+    set rotation(value)
     {
         this.transform.rotation = value;
     }
@@ -708,7 +708,7 @@ export abstract class DisplayObject extends EventEmitter
         return this.transform.rotation * RAD_TO_DEG;
     }
 
-    set angle(value) // eslint-disable-line require-jsdoc
+    set angle(value)
     {
         this.transform.rotation = value * DEG_TO_RAD;
     }
@@ -726,7 +726,7 @@ export abstract class DisplayObject extends EventEmitter
         return this._zIndex;
     }
 
-    set zIndex(value) // eslint-disable-line require-jsdoc
+    set zIndex(value)
     {
         this._zIndex = value;
         if (this.parent)
@@ -782,7 +782,7 @@ export abstract class DisplayObject extends EventEmitter
         return this._mask;
     }
 
-    set mask(value) // eslint-disable-line require-jsdoc
+    set mask(value)
     {
         if (this._mask)
         {

--- a/packages/filters/filter-alpha/src/AlphaFilter.ts
+++ b/packages/filters/filter-alpha/src/AlphaFilter.ts
@@ -41,7 +41,7 @@ export class AlphaFilter extends Filter
         return this.uniforms.uAlpha;
     }
 
-    set alpha(value) // eslint-disable-line require-jsdoc
+    set alpha(value)
     {
         this.uniforms.uAlpha = value;
     }

--- a/packages/filters/filter-blur/src/BlurFilter.ts
+++ b/packages/filters/filter-blur/src/BlurFilter.ts
@@ -97,7 +97,7 @@ export class BlurFilter extends Filter
         return this.blurXFilter.blur;
     }
 
-    set blur(value) // eslint-disable-line require-jsdoc
+    set blur(value)
     {
         this.blurXFilter.blur = this.blurYFilter.blur = value;
         this.updatePadding();
@@ -114,7 +114,7 @@ export class BlurFilter extends Filter
         return this.blurXFilter.quality;
     }
 
-    set quality(value) // eslint-disable-line require-jsdoc
+    set quality(value)
     {
         this.blurXFilter.quality = this.blurYFilter.quality = value;
     }
@@ -130,7 +130,7 @@ export class BlurFilter extends Filter
         return this.blurXFilter.blur;
     }
 
-    set blurX(value) // eslint-disable-line require-jsdoc
+    set blurX(value)
     {
         this.blurXFilter.blur = value;
         this.updatePadding();
@@ -147,7 +147,7 @@ export class BlurFilter extends Filter
         return this.blurYFilter.blur;
     }
 
-    set blurY(value) // eslint-disable-line require-jsdoc
+    set blurY(value)
     {
         this.blurYFilter.blur = value;
         this.updatePadding();
@@ -164,7 +164,7 @@ export class BlurFilter extends Filter
         return this.blurYFilter.blendMode;
     }
 
-    set blendMode(value) // eslint-disable-line require-jsdoc
+    set blendMode(value)
     {
         this.blurYFilter.blendMode = value;
     }

--- a/packages/filters/filter-blur/src/BlurFilterPass.ts
+++ b/packages/filters/filter-blur/src/BlurFilterPass.ts
@@ -136,7 +136,7 @@ export class BlurFilterPass extends Filter
         return this.strength;
     }
 
-    set blur(value) // eslint-disable-line require-jsdoc
+    set blur(value)
     {
         this.padding = 1 + (Math.abs(value) * 2);
         this.strength = value;
@@ -154,7 +154,7 @@ export class BlurFilterPass extends Filter
         return this._quality;
     }
 
-    set quality(value) // eslint-disable-line require-jsdoc
+    set quality(value)
     {
         this._quality = value;
         this.passes = value;

--- a/packages/filters/filter-color-matrix/src/ColorMatrixFilter.ts
+++ b/packages/filters/filter-color-matrix/src/ColorMatrixFilter.ts
@@ -573,7 +573,7 @@ export class ColorMatrixFilter extends Filter
         return this.uniforms.m;
     }
 
-    set matrix(value) // eslint-disable-line require-jsdoc
+    set matrix(value)
     {
         this.uniforms.m = value;
     }
@@ -593,7 +593,7 @@ export class ColorMatrixFilter extends Filter
         return this.uniforms.uAlpha;
     }
 
-    set alpha(value) // eslint-disable-line require-jsdoc
+    set alpha(value)
     {
         this.uniforms.uAlpha = value;
     }

--- a/packages/filters/filter-displacement/src/DisplacementFilter.ts
+++ b/packages/filters/filter-displacement/src/DisplacementFilter.ts
@@ -106,7 +106,7 @@ export class DisplacementFilter extends Filter
         return this.uniforms.mapSampler;
     }
 
-    set map(value) // eslint-disable-line require-jsdoc
+    set map(value)
     {
         this.uniforms.mapSampler = value;
     }

--- a/packages/filters/filter-noise/src/NoiseFilter.ts
+++ b/packages/filters/filter-noise/src/NoiseFilter.ts
@@ -41,7 +41,7 @@ export class NoiseFilter extends Filter
         return this.uniforms.uNoise;
     }
 
-    set noise(value) // eslint-disable-line require-jsdoc
+    set noise(value)
     {
         this.uniforms.uNoise = value;
     }
@@ -56,7 +56,7 @@ export class NoiseFilter extends Filter
         return this.uniforms.uSeed;
     }
 
-    set seed(value) // eslint-disable-line require-jsdoc
+    set seed(value)
     {
         this.uniforms.uSeed = value;
     }

--- a/packages/interaction/src/InteractionTrackingData.ts
+++ b/packages/interaction/src/InteractionTrackingData.ts
@@ -76,7 +76,7 @@ export class InteractionTrackingData
         return this._flags;
     }
 
-    set flags(flags) // eslint-disable-line require-jsdoc
+    set flags(flags)
     {
         this._flags = flags;
     }
@@ -103,7 +103,7 @@ export class InteractionTrackingData
         return (this._flags & InteractionTrackingData.FLAGS.OVER) !== 0;
     }
 
-    set over(yn) // eslint-disable-line require-jsdoc
+    set over(yn)
     {
         this._doSet(InteractionTrackingData.FLAGS.OVER, yn);
     }
@@ -119,7 +119,7 @@ export class InteractionTrackingData
         return (this._flags & InteractionTrackingData.FLAGS.RIGHT_DOWN) !== 0;
     }
 
-    set rightDown(yn) // eslint-disable-line require-jsdoc
+    set rightDown(yn)
     {
         this._doSet(InteractionTrackingData.FLAGS.RIGHT_DOWN, yn);
     }
@@ -135,7 +135,7 @@ export class InteractionTrackingData
         return (this._flags & InteractionTrackingData.FLAGS.LEFT_DOWN) !== 0;
     }
 
-    set leftDown(yn) // eslint-disable-line require-jsdoc
+    set leftDown(yn)
     {
         this._doSet(InteractionTrackingData.FLAGS.LEFT_DOWN, yn);
     }

--- a/packages/math/src/ObservablePoint.ts
+++ b/packages/math/src/ObservablePoint.ts
@@ -119,7 +119,7 @@ export class ObservablePoint<T = any> implements IPoint
         return this._x;
     }
 
-    set x(value) // eslint-disable-line require-jsdoc
+    set x(value)
     {
         if (this._x !== value)
         {
@@ -138,7 +138,7 @@ export class ObservablePoint<T = any> implements IPoint
         return this._y;
     }
 
-    set y(value) // eslint-disable-line require-jsdoc
+    set y(value)
     {
         if (this._y !== value)
         {

--- a/packages/math/src/Transform.ts
+++ b/packages/math/src/Transform.ts
@@ -273,7 +273,7 @@ export class Transform
         return this._rotation;
     }
 
-    set rotation(value) // eslint-disable-line require-jsdoc
+    set rotation(value)
     {
         if (this._rotation !== value)
         {

--- a/packages/mesh-extras/src/NineSlicePlane.ts
+++ b/packages/mesh-extras/src/NineSlicePlane.ts
@@ -195,7 +195,7 @@ export class NineSlicePlane extends SimplePlane
         return this._width;
     }
 
-    set width(value) // eslint-disable-line require-jsdoc
+    set width(value)
     {
         this._width = value;
         this._refresh();
@@ -211,7 +211,7 @@ export class NineSlicePlane extends SimplePlane
         return this._height;
     }
 
-    set height(value) // eslint-disable-line require-jsdoc
+    set height(value)
     {
         this._height = value;
         this._refresh();
@@ -227,7 +227,7 @@ export class NineSlicePlane extends SimplePlane
         return this._leftWidth;
     }
 
-    set leftWidth(value) // eslint-disable-line require-jsdoc
+    set leftWidth(value)
     {
         this._leftWidth = value;
         this._refresh();
@@ -243,7 +243,7 @@ export class NineSlicePlane extends SimplePlane
         return this._rightWidth;
     }
 
-    set rightWidth(value) // eslint-disable-line require-jsdoc
+    set rightWidth(value)
     {
         this._rightWidth = value;
         this._refresh();
@@ -259,7 +259,7 @@ export class NineSlicePlane extends SimplePlane
         return this._topHeight;
     }
 
-    set topHeight(value) // eslint-disable-line require-jsdoc
+    set topHeight(value)
     {
         this._topHeight = value;
         this._refresh();
@@ -275,7 +275,7 @@ export class NineSlicePlane extends SimplePlane
         return this._bottomHeight;
     }
 
-    set bottomHeight(value) // eslint-disable-line require-jsdoc
+    set bottomHeight(value)
     {
         this._bottomHeight = value;
         this._refresh();

--- a/packages/particles/src/ParticleContainer.ts
+++ b/packages/particles/src/ParticleContainer.ts
@@ -226,7 +226,7 @@ export class ParticleContainer extends Container
         return this._tint;
     }
 
-    set tint(value) // eslint-disable-line require-jsdoc
+    set tint(value)
     {
         this._tint = value;
         hex2rgb(value, this.tintRgb);

--- a/packages/sprite-animated/src/AnimatedSprite.ts
+++ b/packages/sprite-animated/src/AnimatedSprite.ts
@@ -429,7 +429,7 @@ export class AnimatedSprite extends Sprite
         return this._textures;
     }
 
-    set textures(value) // eslint-disable-line require-jsdoc
+    set textures(value)
     {
         if (value[0] instanceof Texture)
         {
@@ -491,7 +491,7 @@ export class AnimatedSprite extends Sprite
         return this._autoUpdate;
     }
 
-    set autoUpdate(value) // eslint-disable-line require-jsdoc
+    set autoUpdate(value)
     {
         if (value !== this._autoUpdate)
         {

--- a/packages/sprite-tiling/src/TilingSprite.ts
+++ b/packages/sprite-tiling/src/TilingSprite.ts
@@ -92,7 +92,7 @@ export class TilingSprite extends Sprite
         return this.uvMatrix.clampMargin;
     }
 
-    set clampMargin(value) // eslint-disable-line require-jsdoc
+    set clampMargin(value)
     {
         this.uvMatrix.clampMargin = value;
         this.uvMatrix.update(true);
@@ -108,7 +108,7 @@ export class TilingSprite extends Sprite
         return this.tileTransform.scale;
     }
 
-    set tileScale(value) // eslint-disable-line require-jsdoc
+    set tileScale(value)
     {
         this.tileTransform.scale.copyFrom(value as IPoint);
     }
@@ -123,7 +123,7 @@ export class TilingSprite extends Sprite
         return this.tileTransform.position;
     }
 
-    set tilePosition(value) // eslint-disable-line require-jsdoc
+    set tilePosition(value)
     {
         this.tileTransform.position.copyFrom(value as IPoint);
     }
@@ -293,7 +293,7 @@ export class TilingSprite extends Sprite
         return this._width;
     }
 
-    set width(value) // eslint-disable-line require-jsdoc
+    set width(value)
     {
         this._width = value;
     }
@@ -308,7 +308,7 @@ export class TilingSprite extends Sprite
         return this._height;
     }
 
-    set height(value) // eslint-disable-line require-jsdoc
+    set height(value)
     {
         this._height = value;
     }

--- a/packages/sprite/src/Sprite.ts
+++ b/packages/sprite/src/Sprite.ts
@@ -584,7 +584,7 @@ export class Sprite extends Container
         return Math.abs(this.scale.x) * this._texture.orig.width;
     }
 
-    set width(value) // eslint-disable-line require-jsdoc
+    set width(value)
     {
         const s = sign(this.scale.x) || 1;
 
@@ -602,7 +602,7 @@ export class Sprite extends Container
         return Math.abs(this.scale.y) * this._texture.orig.height;
     }
 
-    set height(value) // eslint-disable-line require-jsdoc
+    set height(value)
     {
         const s = sign(this.scale.y) || 1;
 
@@ -633,7 +633,7 @@ export class Sprite extends Container
         return this._anchor;
     }
 
-    set anchor(value) // eslint-disable-line require-jsdoc
+    set anchor(value)
     {
         this._anchor.copyFrom(value);
     }
@@ -650,7 +650,7 @@ export class Sprite extends Container
         return this._tint;
     }
 
-    set tint(value) // eslint-disable-line require-jsdoc
+    set tint(value)
     {
         this._tint = value;
         this._tintRGB = (value >> 16) + (value & 0xff00) + ((value & 0xff) << 16);
@@ -666,7 +666,7 @@ export class Sprite extends Container
         return this._texture;
     }
 
-    set texture(value) // eslint-disable-line require-jsdoc
+    set texture(value)
     {
         if (this._texture === value)
         {

--- a/packages/text-bitmap/src/BitmapText.ts
+++ b/packages/text-bitmap/src/BitmapText.ts
@@ -606,7 +606,7 @@ export class BitmapText extends Container
         return this._tint;
     }
 
-    public set tint(value) // eslint-disable-line require-jsdoc
+    public set tint(value)
     {
         if (this._tint === value) return;
 
@@ -629,7 +629,7 @@ export class BitmapText extends Container
         return this._align;
     }
 
-    public set align(value) // eslint-disable-line require-jsdoc
+    public set align(value)
     {
         if (this._align !== value)
         {
@@ -648,7 +648,7 @@ export class BitmapText extends Container
         return this._fontName;
     }
 
-    public set fontName(value: string) // eslint-disable-line require-jsdoc
+    public set fontName(value: string)
     {
         if (!BitmapFont.available[value])
         {
@@ -672,7 +672,7 @@ export class BitmapText extends Container
         return this._fontSize;
     }
 
-    public set fontSize(value: number) // eslint-disable-line require-jsdoc
+    public set fontSize(value: number)
     {
         if (this._fontSize !== value)
         {
@@ -697,7 +697,7 @@ export class BitmapText extends Container
         return this._anchor;
     }
 
-    public set anchor(value: ObservablePoint) // eslint-disable-line require-jsdoc
+    public set anchor(value: ObservablePoint)
     {
         if (typeof value === 'number')
         {
@@ -719,7 +719,7 @@ export class BitmapText extends Container
         return this._text;
     }
 
-    public set text(text) // eslint-disable-line require-jsdoc
+    public set text(text)
     {
         text = String(text === null || text === undefined ? '' : text);
 
@@ -743,7 +743,7 @@ export class BitmapText extends Container
         return this._maxWidth;
     }
 
-    public set maxWidth(value) // eslint-disable-line require-jsdoc
+    public set maxWidth(value)
     {
         if (this._maxWidth === value)
         {
@@ -791,7 +791,7 @@ export class BitmapText extends Container
         return this._letterSpacing;
     }
 
-    public set letterSpacing(value) // eslint-disable-line require-jsdoc
+    public set letterSpacing(value)
     {
         if (this._letterSpacing !== value)
         {

--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -630,7 +630,7 @@ export class Text extends Sprite
         return Math.abs(this.scale.x) * this._texture.orig.width;
     }
 
-    set width(value) // eslint-disable-line require-jsdoc
+    set width(value)
     {
         this.updateText(true);
 
@@ -652,7 +652,7 @@ export class Text extends Sprite
         return Math.abs(this.scale.y) * this._texture.orig.height;
     }
 
-    set height(value) // eslint-disable-line require-jsdoc
+    set height(value)
     {
         this.updateText(true);
 
@@ -676,7 +676,7 @@ export class Text extends Sprite
         return this._style;
     }
 
-    set style(style) // eslint-disable-line require-jsdoc
+    set style(style)
     {
         style = style || {};
 
@@ -703,7 +703,7 @@ export class Text extends Sprite
         return this._text;
     }
 
-    set text(text) // eslint-disable-line require-jsdoc
+    set text(text)
     {
         text = String(text === null || text === undefined ? '' : text);
 
@@ -726,7 +726,7 @@ export class Text extends Sprite
         return this._resolution;
     }
 
-    set resolution(value) // eslint-disable-line require-jsdoc
+    set resolution(value)
     {
         this._autoResolution = false;
 

--- a/packages/text/src/TextStyle.ts
+++ b/packages/text/src/TextStyle.ts
@@ -219,7 +219,7 @@ export class TextStyle implements ITextStyle
     {
         return this._align;
     }
-    set align(align) // eslint-disable-line require-jsdoc
+    set align(align)
     {
         if (this._align !== align)
         {
@@ -237,7 +237,7 @@ export class TextStyle implements ITextStyle
     {
         return this._breakWords;
     }
-    set breakWords(breakWords) // eslint-disable-line require-jsdoc
+    set breakWords(breakWords)
     {
         if (this._breakWords !== breakWords)
         {
@@ -255,7 +255,7 @@ export class TextStyle implements ITextStyle
     {
         return this._dropShadow;
     }
-    set dropShadow(dropShadow) // eslint-disable-line require-jsdoc
+    set dropShadow(dropShadow)
     {
         if (this._dropShadow !== dropShadow)
         {
@@ -273,7 +273,7 @@ export class TextStyle implements ITextStyle
     {
         return this._dropShadowAlpha;
     }
-    set dropShadowAlpha(dropShadowAlpha) // eslint-disable-line require-jsdoc
+    set dropShadowAlpha(dropShadowAlpha)
     {
         if (this._dropShadowAlpha !== dropShadowAlpha)
         {
@@ -291,7 +291,7 @@ export class TextStyle implements ITextStyle
     {
         return this._dropShadowAngle;
     }
-    set dropShadowAngle(dropShadowAngle) // eslint-disable-line require-jsdoc
+    set dropShadowAngle(dropShadowAngle)
     {
         if (this._dropShadowAngle !== dropShadowAngle)
         {
@@ -309,7 +309,7 @@ export class TextStyle implements ITextStyle
     {
         return this._dropShadowBlur;
     }
-    set dropShadowBlur(dropShadowBlur) // eslint-disable-line require-jsdoc
+    set dropShadowBlur(dropShadowBlur)
     {
         if (this._dropShadowBlur !== dropShadowBlur)
         {
@@ -327,7 +327,7 @@ export class TextStyle implements ITextStyle
     {
         return this._dropShadowColor;
     }
-    set dropShadowColor(dropShadowColor) // eslint-disable-line require-jsdoc
+    set dropShadowColor(dropShadowColor)
     {
         const outputColor = getColor(dropShadowColor);
         if (this._dropShadowColor !== outputColor)
@@ -346,7 +346,7 @@ export class TextStyle implements ITextStyle
     {
         return this._dropShadowDistance;
     }
-    set dropShadowDistance(dropShadowDistance) // eslint-disable-line require-jsdoc
+    set dropShadowDistance(dropShadowDistance)
     {
         if (this._dropShadowDistance !== dropShadowDistance)
         {
@@ -366,7 +366,7 @@ export class TextStyle implements ITextStyle
     {
         return this._fill;
     }
-    set fill(fill) // eslint-disable-line require-jsdoc
+    set fill(fill)
     {
         // TODO: Can't have different types for getter and setter. The getter shouldn't have the number type as
         //       the setter converts to string. See this thread for more details:
@@ -391,7 +391,7 @@ export class TextStyle implements ITextStyle
     {
         return this._fillGradientType;
     }
-    set fillGradientType(fillGradientType) // eslint-disable-line require-jsdoc
+    set fillGradientType(fillGradientType)
     {
         if (this._fillGradientType !== fillGradientType)
         {
@@ -410,7 +410,7 @@ export class TextStyle implements ITextStyle
     {
         return this._fillGradientStops;
     }
-    set fillGradientStops(fillGradientStops) // eslint-disable-line require-jsdoc
+    set fillGradientStops(fillGradientStops)
     {
         if (!areArraysEqual(this._fillGradientStops,fillGradientStops))
         {
@@ -428,7 +428,7 @@ export class TextStyle implements ITextStyle
     {
         return this._fontFamily;
     }
-    set fontFamily(fontFamily) // eslint-disable-line require-jsdoc
+    set fontFamily(fontFamily)
     {
         if (this.fontFamily !== fontFamily)
         {
@@ -447,7 +447,7 @@ export class TextStyle implements ITextStyle
     {
         return this._fontSize;
     }
-    set fontSize(fontSize) // eslint-disable-line require-jsdoc
+    set fontSize(fontSize)
     {
         if (this._fontSize !== fontSize)
         {
@@ -466,7 +466,7 @@ export class TextStyle implements ITextStyle
     {
         return this._fontStyle;
     }
-    set fontStyle(fontStyle) // eslint-disable-line require-jsdoc
+    set fontStyle(fontStyle)
     {
         if (this._fontStyle !== fontStyle)
         {
@@ -485,7 +485,7 @@ export class TextStyle implements ITextStyle
     {
         return this._fontVariant;
     }
-    set fontVariant(fontVariant) // eslint-disable-line require-jsdoc
+    set fontVariant(fontVariant)
     {
         if (this._fontVariant !== fontVariant)
         {
@@ -504,7 +504,7 @@ export class TextStyle implements ITextStyle
     {
         return this._fontWeight;
     }
-    set fontWeight(fontWeight) // eslint-disable-line require-jsdoc
+    set fontWeight(fontWeight)
     {
         if (this._fontWeight !== fontWeight)
         {
@@ -522,7 +522,7 @@ export class TextStyle implements ITextStyle
     {
         return this._letterSpacing;
     }
-    set letterSpacing(letterSpacing) // eslint-disable-line require-jsdoc
+    set letterSpacing(letterSpacing)
     {
         if (this._letterSpacing !== letterSpacing)
         {
@@ -540,7 +540,7 @@ export class TextStyle implements ITextStyle
     {
         return this._lineHeight;
     }
-    set lineHeight(lineHeight) // eslint-disable-line require-jsdoc
+    set lineHeight(lineHeight)
     {
         if (this._lineHeight !== lineHeight)
         {
@@ -558,7 +558,7 @@ export class TextStyle implements ITextStyle
     {
         return this._leading;
     }
-    set leading(leading) // eslint-disable-line require-jsdoc
+    set leading(leading)
     {
         if (this._leading !== leading)
         {
@@ -577,7 +577,7 @@ export class TextStyle implements ITextStyle
     {
         return this._lineJoin;
     }
-    set lineJoin(lineJoin) // eslint-disable-line require-jsdoc
+    set lineJoin(lineJoin)
     {
         if (this._lineJoin !== lineJoin)
         {
@@ -596,7 +596,7 @@ export class TextStyle implements ITextStyle
     {
         return this._miterLimit;
     }
-    set miterLimit(miterLimit) // eslint-disable-line require-jsdoc
+    set miterLimit(miterLimit)
     {
         if (this._miterLimit !== miterLimit)
         {
@@ -615,7 +615,7 @@ export class TextStyle implements ITextStyle
     {
         return this._padding;
     }
-    set padding(padding) // eslint-disable-line require-jsdoc
+    set padding(padding)
     {
         if (this._padding !== padding)
         {
@@ -634,7 +634,7 @@ export class TextStyle implements ITextStyle
     {
         return this._stroke;
     }
-    set stroke(stroke) // eslint-disable-line require-jsdoc
+    set stroke(stroke)
     {
         // TODO: Can't have different types for getter and setter. The getter shouldn't have the number type as
         //       the setter converts to string. See this thread for more details:
@@ -657,7 +657,7 @@ export class TextStyle implements ITextStyle
     {
         return this._strokeThickness;
     }
-    set strokeThickness(strokeThickness) // eslint-disable-line require-jsdoc
+    set strokeThickness(strokeThickness)
     {
         if (this._strokeThickness !== strokeThickness)
         {
@@ -675,7 +675,7 @@ export class TextStyle implements ITextStyle
     {
         return this._textBaseline;
     }
-    set textBaseline(textBaseline) // eslint-disable-line require-jsdoc
+    set textBaseline(textBaseline)
     {
         if (this._textBaseline !== textBaseline)
         {
@@ -693,7 +693,7 @@ export class TextStyle implements ITextStyle
     {
         return this._trim;
     }
-    set trim(trim) // eslint-disable-line require-jsdoc
+    set trim(trim)
     {
         if (this._trim !== trim)
         {
@@ -718,7 +718,7 @@ export class TextStyle implements ITextStyle
     {
         return this._whiteSpace;
     }
-    set whiteSpace(whiteSpace) // eslint-disable-line require-jsdoc
+    set whiteSpace(whiteSpace)
     {
         if (this._whiteSpace !== whiteSpace)
         {
@@ -736,7 +736,7 @@ export class TextStyle implements ITextStyle
     {
         return this._wordWrap;
     }
-    set wordWrap(wordWrap) // eslint-disable-line require-jsdoc
+    set wordWrap(wordWrap)
     {
         if (this._wordWrap !== wordWrap)
         {
@@ -754,7 +754,7 @@ export class TextStyle implements ITextStyle
     {
         return this._wordWrapWidth;
     }
-    set wordWrapWidth(wordWrapWidth) // eslint-disable-line require-jsdoc
+    set wordWrapWidth(wordWrapWidth)
     {
         if (this._wordWrapWidth !== wordWrapWidth)
         {

--- a/packages/ticker/src/Ticker.ts
+++ b/packages/ticker/src/Ticker.ts
@@ -549,7 +549,7 @@ export class Ticker
         return 1000 / this._maxElapsedMS;
     }
 
-    set minFPS(fps) // eslint-disable-line require-jsdoc
+    set minFPS(fps)
     {
         // Minimum must be below the maxFPS
         const minFPS = Math.min(this.maxFPS, fps);

--- a/packages/utils/src/media/CanvasRenderTarget.ts
+++ b/packages/utils/src/media/CanvasRenderTarget.ts
@@ -83,7 +83,7 @@ export class CanvasRenderTarget
         return this.canvas.width;
     }
 
-    set width(val: number) // eslint-disable-line require-jsdoc
+    set width(val: number)
     {
         this.canvas.width = val;
     }
@@ -98,7 +98,7 @@ export class CanvasRenderTarget
         return this.canvas.height;
     }
 
-    set height(val: number) // eslint-disable-line require-jsdoc
+    set height(val: number)
     {
         this.canvas.height = val;
     }


### PR DESCRIPTION
These inline rule exceptions are not longer necessary and is an artifact of earlier version of eslint. 