### PR TITLE
Formalize the Spritesheet format in TypeScript

### DIFF
--- a/packages/core/src/textures/Texture.ts
+++ b/packages/core/src/textures/Texture.ts
@@ -6,6 +6,7 @@ import { settings } from '@pixi/settings';
 import { Rectangle, Point } from '@pixi/math';
 import { uid, TextureCache, getResolutionOfUrl, EventEmitter } from '@pixi/utils';
 
+import type { IPointData } from '@pixi/math';
 import type { IBaseTextureOptions, ImageSource } from './BaseTexture';
 import type { TextureMatrix } from './TextureMatrix';
 
@@ -69,7 +70,7 @@ export class Texture extends EventEmitter
      * @param {PIXI.Point} [anchor] - Default anchor point used for sprite placement / rotation
      */
     constructor(baseTexture: BaseTexture, frame?: Rectangle,
-        orig?: Rectangle, trim?: Rectangle, rotate?: number, anchor?: Point)
+        orig?: Rectangle, trim?: Rectangle, rotate?: number, anchor?: IPointData)
     {
         super();
 

--- a/packages/math/src/IPoint.ts
+++ b/packages/math/src/IPoint.ts
@@ -1,7 +1,11 @@
-export interface IPoint
+export interface IPointData
 {
     x: number;
     y: number;
+}
+
+export interface IPoint extends IPointData
+{
     copyFrom(p: IPoint): this;
     copyTo<T extends IPoint>(p: T): T;
     equals(p: IPoint): boolean;

--- a/packages/spritesheet/src/Spritesheet.ts
+++ b/packages/spritesheet/src/Spritesheet.ts
@@ -33,7 +33,7 @@ export interface ISpritesheetFrameData {
  */
 export interface ISpritesheetData {
     frames: Dict<ISpritesheetFrameData>;
-    animations: Dict<string[]>;
+    animations?: Dict<string[]>;
     meta: {
         scale: string;
     };

--- a/packages/spritesheet/src/Spritesheet.ts
+++ b/packages/spritesheet/src/Spritesheet.ts
@@ -3,6 +3,41 @@ import { Texture, BaseTexture } from '@pixi/core';
 import { getResolutionOfUrl } from '@pixi/utils';
 import type { Dict } from '@pixi/utils';
 import type { resources } from '@pixi/core';
+import type { IPointData } from '@pixi/math';
+
+/**
+ * Represents the JSON data for a spritesheet atlas.
+ */
+export interface ISpritesheetFrameData {
+    frame: {
+        x: number;
+        y: number;
+        w: number;
+        h: number;
+    };
+    trimmed?: boolean;
+    rotated?: boolean;
+    sourceSize?: {
+        w: number;
+        h: number;
+    };
+    spriteSourceSize?: {
+        x: number;
+        y: number;
+    };
+    anchor?: IPointData;
+}
+
+/**
+ * Atlas format.
+ */
+export interface ISpritesheetData {
+    frames: Dict<ISpritesheetFrameData>;
+    animations: Dict<string[]>;
+    meta: {
+        scale: string;
+    };
+}
 
 /**
  * Utility class for maintaining reference to a collection
@@ -41,11 +76,11 @@ export class Spritesheet
     public baseTexture: BaseTexture;
     public textures: Dict<Texture>;
     public animations: Dict<Texture[]>;
-    public data: any;
+    public data: ISpritesheetData;;
     public resolution: number;
 
     private _texture: Texture;
-    private _frames: Dict<any>;
+    private _frames: Dict<ISpritesheetFrameData>;
     private _frameKeys: string[];
     private _batchIndex: number;
     private _callback: (textures: Dict<Texture>) => void;
@@ -57,7 +92,7 @@ export class Spritesheet
      *        the resolution of the spritesheet. If not provided, the imageUrl will
      *        be used on the BaseTexture.
      */
-    constructor(texture: BaseTexture | Texture, data: any, resolutionFilename: string = null)
+    constructor(texture: BaseTexture | Texture, data: ISpritesheetData, resolutionFilename: string = null)
     {
         /**
          * Reference to original source image from the Loader. This reference is retained so we
@@ -99,7 +134,7 @@ export class Spritesheet
          */
         this.data = data;
 
-        const resource: resources.ImageResource = this.baseTexture.resource as any;
+        const resource = this.baseTexture.resource as resources.ImageResource;
 
         /**
          * The resolution of the spritesheet.
@@ -147,7 +182,7 @@ export class Spritesheet
      */
     private _updateResolution(resolutionFilename: string = null): number
     {
-        const scale = this.data.meta.scale;
+        const { scale } = this.data.meta;
 
         // Use a defaultValue of `null` to check if a url-based resolution is set
         let resolution = getResolutionOfUrl(resolutionFilename, null);


### PR DESCRIPTION
We should strictly define the Spritesheet format we're expecting. Remove the `any` references in Spritesheet.