### PR TITLE
Remove uses of ts-ignore in canvasUtils and canvas-graphics

### DIFF
--- a/packages/canvas/canvas-graphics/src/Graphics.ts
+++ b/packages/canvas/canvas-graphics/src/Graphics.ts
@@ -22,9 +22,12 @@ Graphics.prototype.generateCanvasTexture = function generateCanvasTexture(scaleM
 {
     const bounds = this.getLocalBounds();
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
-    const canvasBuffer = RenderTexture.create(bounds.width, bounds.height, scaleMode, resolution);
+    const canvasBuffer = RenderTexture.create({
+        width: bounds.width,
+        height: bounds.height,
+        scaleMode,
+        resolution,
+    });
 
     if (!canvasRenderer)
     {

--- a/packages/canvas/canvas-renderer/src/canvasUtils.ts
+++ b/packages/canvas/canvas-renderer/src/canvasUtils.ts
@@ -315,15 +315,7 @@ export const canvasUtils = {
      * @memberof PIXI.canvasUtils
      * @type {Function}
      */
-    /* eslint-disable @typescript-eslint/no-unused-vars */
-    /* eslint-disable @typescript-eslint/ban-ts-ignore */
-    // @ts-ignore
-    tintMethod: (texture: Texture, color: number, canvas: HTMLCanvasElement): void =>
-    { // jslint-disable no-empty-function
-
-    },
-    /* eslint-enable @typescript-eslint/no-unused-vars */
-    /* eslint-enable @typescript-eslint/ban-ts-ignore */
+    tintMethod: null as (texture: Texture, color: number, canvas: HTMLCanvasElement) => void,
 };
 
 canvasUtils.tintMethod = canvasUtils.canUseMultiply ? canvasUtils.tintWithMultiply : canvasUtils.tintWithPerPixel;


### PR DESCRIPTION
There were two uses of `@ts-ignore` in canvas-renderer and canvas-graphics that were pretty easy to fix and remove all the weird linting exceptions.