### PR TITLE
Improves unused-vars usage, removes inline exceptions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -127,7 +127,7 @@
         "no-undef": 1,
         "no-undef-init": 1,
         "no-undefined": 0,
-        "no-unused-vars": 1,
+        "no-unused-vars": "off",
         "no-use-before-define": [1, "nofunc"],
 
         // Node.js and CommonJS
@@ -256,7 +256,8 @@
           "rules": {
             "@typescript-eslint/semi": 1,
             "@typescript-eslint/no-explicit-any": 0,
-            "@typescript-eslint/interface-name-prefix": 0
+            "@typescript-eslint/interface-name-prefix": 0,
+            "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
           }
         }
     ]

--- a/packages/canvas/canvas-display/src/Container.ts
+++ b/packages/canvas/canvas-display/src/Container.ts
@@ -9,10 +9,7 @@ import type { MaskData } from '@pixi/core';
  * @protected
  * @param {PIXI.CanvasRenderer} renderer - The renderer
  */
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-Container.prototype._renderCanvas = function _renderCanvas(renderer: CanvasRenderer): void
+Container.prototype._renderCanvas = function _renderCanvas(_renderer: CanvasRenderer): void
 {
     // this is where content itself gets rendered...
 };

--- a/packages/canvas/canvas-display/src/DisplayObject.ts
+++ b/packages/canvas/canvas-display/src/DisplayObject.ts
@@ -7,11 +7,7 @@ import type { CanvasRenderer } from '@pixi/canvas-renderer';
  * @memberof PIXI.Container#
  * @param {PIXI.CanvasRenderer} renderer - The renderer
  */
-
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-DisplayObject.prototype.renderCanvas = function renderCanvas(renderer: CanvasRenderer): void
+DisplayObject.prototype.renderCanvas = function renderCanvas(_renderer: CanvasRenderer): void
 {
     // OVERWRITE;
 };

--- a/packages/core/src/batch/ObjectRenderer.ts
+++ b/packages/core/src/batch/ObjectRenderer.ts
@@ -68,7 +68,6 @@ export class ObjectRenderer
      *
      * @param {PIXI.DisplayObject} object - The object to render.
      */
-    /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
     render(_object: any): void
     {
         // render the object

--- a/packages/core/src/filters/Filter.ts
+++ b/packages/core/src/filters/Filter.ts
@@ -224,7 +224,6 @@ export class Filter extends Shader
      *        target, filters, sourceFrame, destinationFrame, renderTarget, resolution
      */
     apply(filterManager: FilterSystem, input: RenderTexture, output: RenderTexture, clearMode: CLEAR_MODES,
-        /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
         _currentState?: FilterState): void
     {
         // do as you please!

--- a/packages/core/src/projection/ProjectionSystem.ts
+++ b/packages/core/src/projection/ProjectionSystem.ts
@@ -123,9 +123,7 @@ export class ProjectionSystem extends System
      *
      * @param {PIXI.Matrix} matrix - The transformation matrix
      */
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
-    setTransform(matrix: Matrix): void // eslint-disable-line @typescript-eslint/no-unused-vars
+    setTransform(_matrix: Matrix): void
     {
         // this._activeRenderTarget.transform = matrix;
     }

--- a/packages/core/src/textures/resources/Resource.ts
+++ b/packages/core/src/textures/resources/Resource.ts
@@ -204,15 +204,10 @@ export abstract class Resource
      * @param {PIXI.GLTexture} glTexture - texture instance for this webgl context
      * @returns {boolean} `true` is success
      */
-    /* eslint-disable @typescript-eslint/no-unused-vars */
-    /* eslint-disable @typescript-eslint/ban-ts-ignore */
-    // @ts-ignore
-    style(renderer: Renderer, baseTexture: BaseTexture, glTexture: GLTexture): boolean
+    style(_renderer: Renderer, _baseTexture: BaseTexture, _glTexture: GLTexture): boolean
     {
         return false;
     }
-    /* eslint-enable @typescript-eslint/no-unused-vars */
-    /* eslint-enable @typescript-eslint/ban-ts-ignore */
 
     /**
      * Clean up anything, this happens when destroying is ready.
@@ -251,13 +246,8 @@ export abstract class Resource
      * @param {*} source - The source object
      * @param {string} extension - The extension of source, if set
      */
-    /* eslint-disable @typescript-eslint/no-unused-vars */
-    /* eslint-disable @typescript-eslint/ban-ts-ignore */
-    // @ts-ignore
-    static test(source: any, extension?: string): boolean
+    static test(_source: any, _extension?: string): boolean
     {
         return false;
     }
-    /* eslint-enable @typescript-eslint/no-unused-vars */
-    /* eslint-enable @typescript-eslint/ban-ts-ignore */
 }

--- a/packages/core/src/textures/resources/VideoResource.ts
+++ b/packages/core/src/textures/resources/VideoResource.ts
@@ -148,7 +148,6 @@ export class VideoResource extends BaseImageResource
      *
      * @param {number} [deltaTime=0] - time delta since last tick
      */
-    /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
     update(_deltaTime = 0): void
     {
         if (!this.destroyed)

--- a/packages/display/src/Container.ts
+++ b/packages/display/src/Container.ts
@@ -103,7 +103,6 @@ export class Container extends DisplayObject
      *
      * @protected
      */
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     protected onChildrenChange(_length: number): void
     {
         /* empty */
@@ -623,7 +622,6 @@ export class Container extends DisplayObject
      * @protected
      * @param {PIXI.Renderer} renderer - The renderer
      */
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     protected _render(_renderer: Renderer): void // eslint-disable-line no-unused-vars
     {
         // this is where content itself gets rendered...

--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -524,7 +524,6 @@ export abstract class DisplayObject extends EventEmitter
      * after calling `destroy()`.
      *
      */
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     destroy(_options?: IDestroyOptions|boolean): void
     {
         if (this.parent)

--- a/packages/graphics/src/utils/ArcUtils.ts
+++ b/packages/graphics/src/utils/ArcUtils.ts
@@ -77,6 +77,7 @@ export class ArcUtils
         };
     }
 
+    /* eslint-disable max-len */
     /**
      * The arc method creates an arc/curve (used to create circles, or parts of circles).
      *
@@ -94,10 +95,8 @@ export class ArcUtils
      *  indicates counter-clockwise.
      * @param {number[]} points - Collection of points to add to
      */
-
-    /* eslint-disable max-len, @typescript-eslint/no-unused-vars, @typescript-eslint/ban-ts-ignore */
-    // @ts-ignore
-    static arc(startX: number, startY: number, cx: number, cy: number, radius: number, startAngle: number, endAngle: number, anticlockwise: boolean, points: Array<number>): void
+    static arc(_startX: number, _startY: number, cx: number, cy: number, radius: number,
+        startAngle: number, endAngle: number, _anticlockwise: boolean, points: Array<number>): void
     {
         const sweep = endAngle - startAngle;
         const n = GRAPHICS_CURVES._segmentsCount(
@@ -125,5 +124,5 @@ export class ArcUtils
             );
         }
     }
-    /* eslint-enable max-len, @typescript-eslint/no-unused-vars, @typescript-eslint/ban-ts-ignore */
+    /* eslint-enable max-len */
 }

--- a/packages/text/src/TextMetrics.ts
+++ b/packages/text/src/TextMetrics.ts
@@ -592,10 +592,8 @@ export class TextMetrics
      * @param  {boolean}  breakWords - The style attr break words
      * @return {boolean} whether to break word or not
      */
-    /* eslint-disable @typescript-eslint/no-unused-vars */
     static canBreakChars(_char: string, _nextChar: string, _token: string, _index: number,
         _breakWords: boolean): boolean
-    /* eslint-enable @typescript-eslint/no-unused-vars */
     {
         return true;
     }


### PR DESCRIPTION
Adds a better linting rule for unused-vars to avoid false-positives. This enforce a TypeScript convention with ESLint.