### PR TITLE
Replace any with unknown in resource test functions

### DIFF
--- a/packages/core/src/textures/resources/BufferResource.ts
+++ b/packages/core/src/textures/resources/BufferResource.ts
@@ -109,7 +109,7 @@ export class BufferResource extends Resource
      * @param {*} source - The source object
      * @return {boolean} `true` if <canvas>
      */
-    static test(source: any): boolean
+    static test(source: unknown): source is Float32Array|Uint8Array|Uint32Array
     {
         return source instanceof Float32Array
             || source instanceof Uint8Array

--- a/packages/core/src/textures/resources/CanvasResource.ts
+++ b/packages/core/src/textures/resources/CanvasResource.ts
@@ -20,7 +20,7 @@ export class CanvasResource extends BaseImageResource
      * @param {HTMLCanvasElement|OffscreenCanvas} source - The source object
      * @return {boolean} `true` if source is HTMLCanvasElement or OffscreenCanvas
      */
-    static test(source: any): source is OffscreenCanvas|HTMLCanvasElement
+    static test(source: unknown): source is OffscreenCanvas|HTMLCanvasElement
     {
         const { OffscreenCanvas } = window;
 

--- a/packages/core/src/textures/resources/CubeResource.ts
+++ b/packages/core/src/textures/resources/CubeResource.ts
@@ -114,7 +114,7 @@ export class CubeResource extends ArrayResource
      * @param {object} source - The source object
      * @return {boolean} `true` if source is an array of 6 elements
      */
-    static test(source: any): source is ArrayFixed<string|Resource, 6>
+    static test(source: unknown): source is ArrayFixed<string|Resource, 6>
     {
         return Array.isArray(source) && source.length === CubeResource.SIDES;
     }

--- a/packages/core/src/textures/resources/ImageBitmapResource.ts
+++ b/packages/core/src/textures/resources/ImageBitmapResource.ts
@@ -16,7 +16,7 @@ export class ImageBitmapResource extends BaseImageResource
      * @param {ImageBitmap} source - The source object
      * @return {boolean} `true` if source is an ImageBitmap
      */
-    static test(source: any): source is ImageBitmap
+    static test(source: unknown): source is ImageBitmap
     {
         return !!window.createImageBitmap && source instanceof ImageBitmap;
     }

--- a/packages/core/src/textures/resources/ImageResource.ts
+++ b/packages/core/src/textures/resources/ImageResource.ts
@@ -319,4 +319,16 @@ export class ImageResource extends BaseImageResource
         this._process = null;
         this._load = null;
     }
+
+    /**
+     * Used to auto-detect the type of resource.
+     *
+     * @static
+     * @param {string|HTMLImageElement} source - The source object
+     * @return {boolean} `true` if source is string or HTMLImageElement
+     */
+    static test(source: unknown): source is string|HTMLImageElement
+    {
+        return typeof source === 'string' || source instanceof HTMLImageElement;
+    }
 }

--- a/packages/core/src/textures/resources/Resource.ts
+++ b/packages/core/src/textures/resources/Resource.ts
@@ -254,7 +254,7 @@ export abstract class Resource
     /* eslint-disable @typescript-eslint/no-unused-vars */
     /* eslint-disable @typescript-eslint/ban-ts-ignore */
     // @ts-ignore
-    static test(source: any, extension?: string): boolean
+    static test(source: unknown, extension?: string): boolean
     {
         return false;
     }

--- a/packages/core/src/textures/resources/SVGResource.ts
+++ b/packages/core/src/textures/resources/SVGResource.ts
@@ -236,7 +236,7 @@ export class SVGResource extends BaseImageResource
      * @param {*} source - The source object
      * @param {string} extension - The extension of source, if set
      */
-    static test(source: any, extension?: string): boolean
+    static test(source: unknown, extension?: string): boolean
     {
         // url file extension is SVG
         return extension === 'svg'

--- a/packages/core/src/textures/resources/VideoResource.ts
+++ b/packages/core/src/textures/resources/VideoResource.ts
@@ -400,7 +400,7 @@ export class VideoResource extends BaseImageResource
      * @param {string} extension - The extension of source, if set
      * @return {boolean} `true` if video source
      */
-    static test(source: any, extension?: string): boolean
+    static test(source: unknown, extension?: string): source is HTMLVideoElement
     {
         return (source instanceof HTMLVideoElement)
             || VideoResource.TYPES.indexOf(extension) > -1;

--- a/packages/core/src/textures/resources/autoDetectResource.ts
+++ b/packages/core/src/textures/resources/autoDetectResource.ts
@@ -1,5 +1,4 @@
 import { Resource } from './Resource';
-import { ImageResource } from './ImageResource';
 
 import type { IImageResourceOptions } from './ImageResource';
 import type{ ISize } from '@pixi/math';
@@ -27,7 +26,7 @@ export type IAutoDetectOptions = ISize
  */
 export interface IResourcePlugin
 {
-    test(source: any, extension: string): boolean;
+    test(source: unknown, extension: string): boolean;
     new (source: any, options?: any): Resource;
 }
 
@@ -88,7 +87,7 @@ export const INSTALLED: Array<IResourcePlugin> = [];
  *        texture should be updated from the video. Leave at 0 to update at every render
  * @return {PIXI.resources.Resource} The created resource.
  */
-export function autoDetectResource(source: any, options?: IAutoDetectOptions): Resource
+export function autoDetectResource(source: unknown, options?: IAutoDetectOptions): Resource
 {
     if (!source)
     {
@@ -118,7 +117,5 @@ export function autoDetectResource(source: any, options?: IAutoDetectOptions): R
         }
     }
 
-    // When in doubt: probably an image
-    // might be appropriate to throw an error or return null
-    return new ImageResource(source, options as IImageResourceOptions);
+    throw new Error('Unrecognized source type to auto-detect Resource');
 }

--- a/packages/core/test/autoDetectResource.js
+++ b/packages/core/test/autoDetectResource.js
@@ -80,4 +80,12 @@ describe('PIXI.resources.autoDetectResource', function ()
 
         expect(resource).to.equal(null);
     });
+
+    it('should throw for unknown types', function ()
+    {
+        expect(() => autoDetectResource({})).throws;
+        expect(() => autoDetectResource(document.createElement('input'))).throws;
+        expect(() => autoDetectResource(2)).throws;
+        expect(() => autoDetectResource(true)).throws;
+    });
 });


### PR DESCRIPTION
### Changes

* Removes more usage of `any` and replaces with `unknown` in resource `test` functions.
* Changes the behavior slightly of `autoDetectResource` to throw an error when a resource type cannot be auto-detected. This is better than just shoving it into an ImageResource.