### PR TITLE
Converts generic string-map types to Dict typing in utils

### DIFF
--- a/packages/core/src/filters/Filter.ts
+++ b/packages/core/src/filters/Filter.ts
@@ -9,6 +9,7 @@ import type { RenderTexture } from '../renderTexture/RenderTexture';
 import type { FilterSystem } from './FilterSystem';
 import type { FilterState } from './FilterState';
 import type { BLEND_MODES, CLEAR_MODES } from '@pixi/constants';
+import type { Dict } from '@pixi/utils';
 
 /**
  * Filter is a special type of WebGL shader that is applied to the screen.
@@ -159,7 +160,7 @@ export class Filter extends Shader
      * @param {string} [fragmentSrc] - The source of the fragment shader.
      * @param {object} [uniforms] - Custom uniforms to use to augment the built-in ones.
      */
-    constructor(vertexSrc?: string, fragmentSrc?: string, uniforms?: {[key: string]: any})
+    constructor(vertexSrc?: string, fragmentSrc?: string, uniforms?: Dict<any>)
     {
         const program = Program.from(vertexSrc || Filter.defaultVertexSrc,
             fragmentSrc || Filter.defaultFragmentSrc);
@@ -281,5 +282,5 @@ export class Filter extends Shader
      * @type {object}
      * @protected
      */
-    static SOURCE_KEY_MAP: {[key: string]: string};
+    static SOURCE_KEY_MAP: Dict<string>;
 }

--- a/packages/core/src/geometry/Geometry.ts
+++ b/packages/core/src/geometry/Geometry.ts
@@ -6,12 +6,13 @@ import { Runner } from '@pixi/runner';
 
 import type { TYPES } from '@pixi/constants';
 import type { IArrayBuffer } from './Buffer';
+import type { Dict } from '@pixi/utils';
 
 const byteSizeMap: {[key: number]: number} = { 5126: 4, 5123: 2, 5121: 1 };
 let UID = 0;
 
 /* eslint-disable object-shorthand */
-const map: {[x: string]: any} = {
+const map: Dict<any> = {
     Float32Array: Float32Array,
     Uint32Array: Uint32Array,
     Int32Array: Int32Array,

--- a/packages/core/src/geometry/GeometrySystem.ts
+++ b/packages/core/src/geometry/GeometrySystem.ts
@@ -10,6 +10,7 @@ import type { Geometry } from './Geometry';
 import type { Shader } from '../shader/Shader';
 import type { Program } from '../shader/Program';
 import type { Buffer } from './Buffer';
+import type { Dict } from '@pixi/utils';
 
 const byteSizeMap: {[key: number]: number} = { 5126: 4, 5123: 2, 5121: 1 };
 
@@ -334,8 +335,8 @@ export class GeometrySystem extends System
 
         const buffers = geometry.buffers;
         const attributes = geometry.attributes;
-        const tempStride: {[x: string]: number} = {};
-        const tempStart: {[x: string]: number} = {};
+        const tempStride: Dict<number> = {};
+        const tempStart: Dict<number> = {};
 
         for (const j in buffers)
         {

--- a/packages/core/src/geometry/utils/interleaveTypedArrays.ts
+++ b/packages/core/src/geometry/utils/interleaveTypedArrays.ts
@@ -1,9 +1,10 @@
 import { getBufferType } from './getBufferType';
 
 import type { ITypedArray } from '../Buffer';
+import type { Dict } from '@pixi/utils';
 
 /* eslint-disable object-shorthand */
-const map: {[x: string]: any} = {
+const map: Dict<any> = {
     Float32Array: Float32Array,
     Uint32Array: Uint32Array,
     Int32Array: Int32Array,
@@ -14,7 +15,7 @@ export function interleaveTypedArrays(arrays: Array<ITypedArray>, sizes: Array<n
 {
     let outSize = 0;
     let stride = 0;
-    const views: {[x: string]: any} = {};
+    const views: Dict<any> = {};
 
     for (let i = 0; i < arrays.length; i++)
     {

--- a/packages/core/src/geometry/utils/setVertexAttribArrays.ts
+++ b/packages/core/src/geometry/utils/setVertexAttribArrays.ts
@@ -1,4 +1,5 @@
 import type { IRenderingContext } from '../../IRenderingContext';
+import type { Dict } from '@pixi/utils';
 
 // var GL_MAP = {};
 
@@ -9,7 +10,7 @@ import type { IRenderingContext } from '../../IRenderingContext';
  * @private
  */
 export function setVertexAttribArrays(gl: IRenderingContext,
-    attribs: {[x: string]: any}, state: {[x: string]: any}): void
+    attribs: Dict<any>, state: Dict<any>): void
 {
     let i;
 

--- a/packages/core/src/shader/GLProgram.ts
+++ b/packages/core/src/shader/GLProgram.ts
@@ -1,3 +1,5 @@
+import type { Dict } from '@pixi/utils';
+
 export class IGLUniformData
 {
     location: WebGLUniformLocation;
@@ -13,8 +15,8 @@ export class IGLUniformData
 export class GLProgram
 {
     public program: WebGLProgram;
-    public uniformData: {[x: string]: any};
-    public uniformGroups: {[x: string]: any};
+    public uniformData: Dict<any>;
+    public uniformGroups: Dict<any>;
     /**
      * Makes a new Pixi program
      *

--- a/packages/core/src/shader/Shader.ts
+++ b/packages/core/src/shader/Shader.ts
@@ -1,6 +1,8 @@
 import { Program } from './Program';
 import { UniformGroup } from './UniformGroup';
 
+import type { Dict } from '@pixi/utils';
+
 /**
  * A helper class for shaders
  *
@@ -15,7 +17,7 @@ export class Shader
      * @param {PIXI.Program} [program] - The program the shader will use.
      * @param {object} [uniforms] - Custom uniforms to use to augment the built-in ones.
      */
-    constructor(program: Program, uniforms: {[x: string]: any})
+    constructor(program: Program, uniforms: Dict<any>)
     {
         /**
          * Program that the shader uses
@@ -90,7 +92,7 @@ export class Shader
      * @readonly
      * @member {object}
      */
-    get uniforms(): {[x: string]: any}
+    get uniforms(): Dict<any>
     {
         return this.uniformGroup.uniforms;
     }
@@ -104,7 +106,7 @@ export class Shader
      *
      * @returns {PIXI.Shader} an shiny new Pixi shader!
      */
-    static from(vertexSrc?: string, fragmentSrc?: string, uniforms?: {[x: string]: any}): Shader
+    static from(vertexSrc?: string, fragmentSrc?: string, uniforms?: Dict<any>): Shader
     {
         const program = Program.from(vertexSrc, fragmentSrc);
 

--- a/packages/core/src/shader/ShaderSystem.ts
+++ b/packages/core/src/shader/ShaderSystem.ts
@@ -8,6 +8,7 @@ import type { IRenderingContext } from '../IRenderingContext';
 import type { Shader } from './Shader';
 import type { Program } from './Program';
 import type { UniformGroup } from './UniformGroup';
+import type { Dict } from '@pixi/utils';
 
 let UID = 0;
 // defualt sync data so we don't create a new one each time!
@@ -117,7 +118,7 @@ export class ShaderSystem extends System
      *
      * @param {object} uniforms - the uniforms values that be applied to the current shader
      */
-    setUniforms(uniforms: {[x: string]: any}): void
+    setUniforms(uniforms: Dict<any>): void
     {
         const shader = this.shader.program;
         const glProgram = shader.glPrograms[this.renderer.CONTEXT_UID];
@@ -178,7 +179,7 @@ export class ShaderSystem extends System
      * @returns {String} Unique signature of the uniform group
      * @private
      */
-    private getSignature(group: UniformGroup, uniformData: {[key: string]: any}): string
+    private getSignature(group: UniformGroup, uniformData: Dict<any>): string
     {
         const uniforms = group.uniforms;
 
@@ -226,7 +227,7 @@ export class ShaderSystem extends System
 
         const program = shader.program;
 
-        const attribMap: {[key: string]: number} = {};
+        const attribMap: Dict<number> = {};
 
         for (const i in program.attributeData)
         {

--- a/packages/core/src/shader/UniformGroup.ts
+++ b/packages/core/src/shader/UniformGroup.ts
@@ -1,3 +1,5 @@
+import type { Dict } from '@pixi/utils';
+
 let UID = 0;
 
 /**
@@ -8,7 +10,7 @@ let UID = 0;
  */
 export class UniformGroup
 {
-    public readonly uniforms: {[key: string]: any};
+    public readonly uniforms: Dict<any>;
     public readonly group: boolean;
     public id: number;
     syncUniforms: {[key: string]: Function};
@@ -19,7 +21,7 @@ export class UniformGroup
      * @param {object} [uniforms] - Custom uniforms to use to augment the built-in ones.
      * @param {boolean} [_static] - Uniforms wont be changed after creation
      */
-    constructor(uniforms: {[key: string]: any}, _static?: boolean)
+    constructor(uniforms: Dict<any>, _static?: boolean)
     {
         /**
          * uniform values
@@ -65,12 +67,12 @@ export class UniformGroup
         this.dirtyId++;
     }
 
-    add(name: string, uniforms: {[key: string]: any}, _static: boolean): void
+    add(name: string, uniforms: Dict<any>, _static: boolean): void
     {
         this.uniforms[name] = new UniformGroup(uniforms, _static);
     }
 
-    static from(uniforms: {[key: string]: any}, _static: boolean): UniformGroup
+    static from(uniforms: Dict<any>, _static: boolean): UniformGroup
     {
         return new UniformGroup(uniforms, _static);
     }

--- a/packages/core/src/shader/utils/compileProgram.ts
+++ b/packages/core/src/shader/utils/compileProgram.ts
@@ -1,3 +1,5 @@
+import type { Dict } from '@pixi/utils';
+
 /**
  * @private
  * @param gl {WebGLRenderingContext} The current WebGL context {WebGLProgram}
@@ -26,7 +28,7 @@ function compileShader(gl: WebGLRenderingContextBase, type: number, src: string)
  * @return {WebGLProgram} the shader program
  */
 export function compileProgram(gl: WebGLRenderingContextBase, vertexSrc: string, fragmentSrc: string,
-    attributeLocations?: {[key: string]: number}): WebGLProgram
+    attributeLocations?: Dict<number>): WebGLProgram
 {
     const glVertShader = compileShader(gl, gl.VERTEX_SHADER, vertexSrc);
     const glFragShader = compileShader(gl, gl.FRAGMENT_SHADER, fragmentSrc);

--- a/packages/core/src/shader/utils/generateUniformsSync.ts
+++ b/packages/core/src/shader/utils/generateUniformsSync.ts
@@ -1,13 +1,14 @@
 import { uniformParsers } from './uniformParsers';
 
 import type { UniformGroup } from '../UniformGroup';
+import type { Dict } from '@pixi/utils';
 
 // cv = CachedValue
 // v = value
 // ud = uniformData
 // uv = uniformValue
 // l = location
-const GLSL_TO_SINGLE_SETTERS_CACHED: {[x: string]: string} = {
+const GLSL_TO_SINGLE_SETTERS_CACHED: Dict<string> = {
 
     float: `
     if(cv !== v)
@@ -55,7 +56,7 @@ const GLSL_TO_SINGLE_SETTERS_CACHED: {[x: string]: string} = {
     sampler2DArray: 'gl.uniform1i(location, v)',
 };
 
-const GLSL_TO_ARRAY_SETTERS: {[x: string]: string} = {
+const GLSL_TO_ARRAY_SETTERS: Dict<string> = {
 
     float:    `gl.uniform1fv(location, v)`,
 
@@ -82,7 +83,7 @@ const GLSL_TO_ARRAY_SETTERS: {[x: string]: string} = {
     sampler2DArray: 'gl.uniform1iv(location, v)',
 };
 
-export function generateUniformsSync(group: UniformGroup, uniformData: {[x: string]: any}): Function
+export function generateUniformsSync(group: UniformGroup, uniformData: Dict<any>): Function
 {
     const funcFragments = [`
         var v = null;

--- a/packages/core/src/shader/utils/mapSize.ts
+++ b/packages/core/src/shader/utils/mapSize.ts
@@ -1,4 +1,6 @@
-const GLSL_TO_SIZE: {[x: string]: number} = {
+import type { Dict } from '@pixi/utils';
+
+const GLSL_TO_SIZE: Dict<number> = {
     float:    1,
     vec2:     2,
     vec3:     3,

--- a/packages/core/src/shader/utils/mapType.ts
+++ b/packages/core/src/shader/utils/mapType.ts
@@ -1,6 +1,8 @@
-let GL_TABLE: {[x: string]: string} = null;
+import type { Dict } from '@pixi/utils';
 
-const GL_TO_GLSL_TYPES: {[x: string]: string} = {
+let GL_TABLE: Dict<string> = null;
+
+const GL_TO_GLSL_TYPES: Dict<string> = {
     FLOAT:       'float',
     FLOAT_VEC2:  'vec2',
     FLOAT_VEC3:  'vec3',

--- a/packages/core/src/textures/resources/VideoResource.ts
+++ b/packages/core/src/textures/resources/VideoResource.ts
@@ -1,6 +1,8 @@
 import { BaseImageResource } from './BaseImageResource';
 import { Ticker } from '@pixi/ticker';
 
+import type { Dict } from '@pixi/utils';
+
 export interface IVideoResourceOptions
 {
     autoLoad?: boolean;
@@ -422,7 +424,7 @@ export class VideoResource extends BaseImageResource
      * @static
      * @readonly
      */
-    static MIME_TYPES: {[ext: string]: string} = {
+    static MIME_TYPES: Dict<string> = {
         ogv: 'video/ogg',
         mov: 'video/quicktime',
         m4v: 'video/mp4',

--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -5,6 +5,7 @@ import { Bounds } from './Bounds';
 
 import type { Filter, MaskData, Renderer } from '@pixi/core';
 import type { IPoint, ObservablePoint } from '@pixi/math';
+import type { Dict } from '@pixi/utils';
 
 export interface IDestroyOptions {
     children?: boolean;
@@ -57,7 +58,7 @@ export abstract class DisplayObject extends EventEmitter
      *
      * @param {object} source - The source of properties and methods to mix in.
      */
-    static mixin(source: {[x: string]: any}): void
+    static mixin(source: Dict<any>): void
     {
         // in ES8/ES2017, this would be really easy:
         // Object.defineProperties(DisplayObject.prototype, Object.getOwnPropertyDescriptors(source));

--- a/packages/utils/src/logging/deprecation.ts
+++ b/packages/utils/src/logging/deprecation.ts
@@ -1,5 +1,7 @@
+import type { Dict } from '../types';
+
 // A map of warning messages already fired
-const warnings: {[key: string]: boolean} = {};
+const warnings: Dict<boolean> = {};
 
 /**
  * Helper for warning developers about deprecated features & settings.


### PR DESCRIPTION
We have a utility for representing simple generic string-key objects called `Dict`, it was used in some places and not others, this harmonizes it across the code base.

```typescript
{[name: string]: number}
```
Becomes
```typescript
Dict<number>
```
