### PR TITLE
Formalizes the Use of IPointData

### DIFF
--- a/packages/core/src/textures/Texture.ts
+++ b/packages/core/src/textures/Texture.ts
@@ -67,7 +67,7 @@ export class Texture extends EventEmitter
      * @param {PIXI.Rectangle} [orig] - The area of original texture
      * @param {PIXI.Rectangle} [trim] - Trimmed rectangle of original texture
      * @param {number} [rotate] - indicates how the texture was rotated by texture packer. See {@link PIXI.groupD8}
-     * @param {PIXI.Point} [anchor] - Default anchor point used for sprite placement / rotation
+     * @param {PIXI.IPointData} [anchor] - Default anchor point used for sprite placement / rotation
      */
     constructor(baseTexture: BaseTexture, frame?: Rectangle,
         orig?: Rectangle, trim?: Rectangle, rotate?: number, anchor?: IPointData)

--- a/packages/display/src/Bounds.ts
+++ b/packages/display/src/Bounds.ts
@@ -1,6 +1,6 @@
 import { Rectangle } from '@pixi/math';
 
-import type { IPoint, Transform, Matrix } from '@pixi/math';
+import type { IPointData, Transform, Matrix } from '@pixi/math';
 
 /**
  * 'Builder' pattern for bounds rectangles.
@@ -107,9 +107,9 @@ export class Bounds
     /**
      * This function should be inlined when its possible.
      *
-     * @param {PIXI.IPoint} point - The point to add.
+     * @param {PIXI.IPointData} point - The point to add.
      */
-    addPoint(point: IPoint): void
+    addPoint(point: IPointData): void
     {
         this.minX = Math.min(this.minX, point.x);
         this.maxX = Math.max(this.maxX, point.x);

--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -4,7 +4,7 @@ import { Container } from './Container';
 import { Bounds } from './Bounds';
 
 import type { Filter, MaskData, Renderer } from '@pixi/core';
-import type { IPoint, ObservablePoint } from '@pixi/math';
+import type { IPointData, ObservablePoint } from '@pixi/math';
 import type { Dict } from '@pixi/utils';
 
 export interface IDestroyOptions {
@@ -400,13 +400,13 @@ export abstract class DisplayObject extends EventEmitter
     /**
      * Calculates the global position of the display object.
      *
-     * @param {PIXI.IPoint} position - The world origin to calculate from.
+     * @param {PIXI.IPointData} position - The world origin to calculate from.
      * @param {PIXI.Point} [point] - A Point object in which to store the value, optional
      *  (otherwise will create a new Point).
      * @param {boolean} [skipUpdate=false] - Should we skip the update transform.
      * @return {PIXI.Point} A point object representing the position of this object.
      */
-    toGlobal(position: IPoint, point?: Point, skipUpdate = false): Point
+    toGlobal(position: IPointData, point?: Point, skipUpdate = false): Point
     {
         if (!skipUpdate)
         {
@@ -434,14 +434,14 @@ export abstract class DisplayObject extends EventEmitter
     /**
      * Calculates the local position of the display object relative to another point.
      *
-     * @param {PIXI.IPoint} position - The world origin to calculate from.
+     * @param {PIXI.IPointData} position - The world origin to calculate from.
      * @param {PIXI.DisplayObject} [from] - The DisplayObject to calculate the global position from.
      * @param {PIXI.Point} [point] - A Point object in which to store the value, optional
      *  (otherwise will create a new Point).
      * @param {boolean} [skipUpdate=false] - Should we skip the update transform
      * @return {PIXI.Point} A point object representing the position of this object
      */
-    toLocal(position: IPoint, from: DisplayObject, point?: Point, skipUpdate?: boolean): Point
+    toLocal(position: IPointData, from: DisplayObject, point?: Point, skipUpdate?: boolean): Point
     {
         if (from)
         {

--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -406,7 +406,7 @@ export abstract class DisplayObject extends EventEmitter
      * @param {boolean} [skipUpdate=false] - Should we skip the update transform.
      * @return {PIXI.Point} A point object representing the position of this object.
      */
-    toGlobal(position: IPointData, point?: Point, skipUpdate = false): Point
+    toGlobal<P extends IPointData = Point>(position: IPointData, point?: P, skipUpdate = false): P
     {
         if (!skipUpdate)
         {
@@ -428,7 +428,7 @@ export abstract class DisplayObject extends EventEmitter
         }
 
         // don't need to update the lot
-        return this.worldTransform.apply(position, point);
+        return this.worldTransform.apply<P>(position, point);
     }
 
     /**
@@ -441,7 +441,7 @@ export abstract class DisplayObject extends EventEmitter
      * @param {boolean} [skipUpdate=false] - Should we skip the update transform
      * @return {PIXI.Point} A point object representing the position of this object
      */
-    toLocal(position: IPointData, from: DisplayObject, point?: Point, skipUpdate?: boolean): Point
+    toLocal<P extends IPointData = Point>(position: IPointData, from: DisplayObject, point?: P, skipUpdate?: boolean): P
     {
         if (from)
         {
@@ -468,7 +468,7 @@ export abstract class DisplayObject extends EventEmitter
         }
 
         // simply apply the matrix..
-        return this.worldTransform.applyInverse(position, point);
+        return this.worldTransform.applyInverse<P>(position, point);
     }
 
     /**

--- a/packages/graphics/src/Graphics.ts
+++ b/packages/graphics/src/Graphics.ts
@@ -20,7 +20,7 @@ import { BLEND_MODES } from '@pixi/constants';
 import { Container } from '@pixi/display';
 import { Shader } from '@pixi/core';
 
-import type { IShape } from '@pixi/math';
+import type { IShape, IPointData } from '@pixi/math';
 import type { IDestroyOptions } from '@pixi/display';
 import { LINE_JOIN, LINE_CAP } from './const';
 
@@ -1200,10 +1200,10 @@ export class Graphics extends Container
     /**
      * Tests if a point is inside this graphics object
      *
-     * @param {PIXI.Point} point - the point to test
+     * @param {PIXI.IPointData} point - the point to test
      * @return {boolean} the result of the test
      */
-    public containsPoint(point: Point): boolean
+    public containsPoint(point: IPointData): boolean
     {
         this.worldTransform.applyInverse(point, Graphics._TEMP_POINT);
 

--- a/packages/graphics/src/GraphicsGeometry.ts
+++ b/packages/graphics/src/GraphicsGeometry.ts
@@ -21,7 +21,7 @@ import { GraphicsData } from './GraphicsData';
 import { premultiplyTint } from '@pixi/utils';
 import { Bounds } from '@pixi/display';
 
-import type { Circle, Ellipse, Polygon, Rectangle, RoundedRectangle } from '@pixi/math';
+import type { Circle, Ellipse, Polygon, Rectangle, RoundedRectangle, IPointData } from '@pixi/math';
 import type { FillStyle } from './styles/FillStyle';
 import type { LineStyle } from './styles/LineStyle';
 
@@ -386,10 +386,10 @@ export class GraphicsGeometry extends BatchGeometry
     /**
      * Check to see if a point is contained within this geometry.
      *
-     * @param {PIXI.Point} point - Point to check if it's contained.
+     * @param {PIXI.IPointData} point - Point to check if it's contained.
      * @return {Boolean} `true` if the point is contained within geometry.
      */
-    public containsPoint(point: Point): boolean
+    public containsPoint(point: IPointData): boolean
     {
         const graphicsData = this.graphicsData;
 

--- a/packages/interaction/src/InteractionData.ts
+++ b/packages/interaction/src/InteractionData.ts
@@ -1,4 +1,4 @@
-import { Point } from '@pixi/math';
+import { Point, IPointData } from '@pixi/math';
 
 import type { DisplayObject } from '@pixi/display';
 
@@ -173,9 +173,9 @@ export class InteractionData
      * @return {PIXI.Point} A point containing the coordinates of the InteractionData position relative
      *  to the DisplayObject
      */
-    public getLocalPosition(displayObject: DisplayObject, point?: Point, globalPos?: Point): Point
+    public getLocalPosition<P extends IPointData = Point>(displayObject: DisplayObject, point?: P, globalPos?: IPointData): P
     {
-        return displayObject.worldTransform.applyInverse(globalPos || this.global, point);
+        return displayObject.worldTransform.applyInverse<P>(globalPos || this.global, point);
     }
 
     /**

--- a/packages/interaction/src/InteractionManager.ts
+++ b/packages/interaction/src/InteractionManager.ts
@@ -8,7 +8,7 @@ import { EventEmitter } from '@pixi/utils';
 import { interactiveTarget } from './interactiveTarget';
 
 import type { AbstractRenderer } from '@pixi/core';
-import type { Point } from '@pixi/math';
+import type { Point, IPointData } from '@pixi/math';
 
 // Mix interactiveTarget into DisplayObject.prototype,
 // after deprecation has been handled
@@ -1101,11 +1101,11 @@ export class InteractionManager extends EventEmitter
      * resulting value is stored in the point. This takes into account the fact that the DOM
      * element could be scaled and positioned anywhere on the screen.
      *
-     * @param  {PIXI.Point} point - the point that the result will be stored in
+     * @param  {PIXI.IPointData} point - the point that the result will be stored in
      * @param  {number} x - the x coord of the position to map
      * @param  {number} y - the y coord of the position to map
      */
-    public mapPositionToPoint(point: Point, x: number, y: number): void
+    public mapPositionToPoint(point: IPointData, x: number, y: number): void
     {
         let rect;
 

--- a/packages/math/src/IPoint.ts
+++ b/packages/math/src/IPoint.ts
@@ -1,32 +1,17 @@
-export interface IPointData
-{
-    x: number;
-    y: number;
-}
+import { IPointData } from './IPointData';
 
 export interface IPoint extends IPointData
 {
-    copyFrom(p: IPoint): this;
+    copyFrom(p: IPointData): this;
     copyTo<T extends IPoint>(p: T): T;
-    equals(p: IPoint): boolean;
+    equals(p: IPointData): boolean;
     set(x?: number, y?: number): void;
 }
 /**
  * Common interface for points. Both Point and ObservablePoint implement it
  * @memberof PIXI
  * @interface IPoint
- */
-
-/**
- * X coord
- * @memberof PIXI.IPoint#
- * @member {number} x
- */
-
-/**
- * Y coord
- * @memberof PIXI.IPoint#
- * @member {number} y
+ * @extends PIXI.IPointData
  */
 
 /**
@@ -43,7 +28,7 @@ export interface IPoint extends IPointData
  * Copies x and y from the given point
  * @method copyFrom
  * @memberof PIXI.IPoint#
- * @param {PIXI.IPoint} p - The point to copy from
+ * @param {PIXI.IPointData} p - The point to copy from
  * @returns {this} Returns itself.
  */
 
@@ -60,7 +45,7 @@ export interface IPoint extends IPointData
  *
  * @method equals
  * @memberof PIXI.IPoint#
- * @param {PIXI.IPoint} p - The point to check
+ * @param {PIXI.IPointData} p - The point to check
  * @returns {boolean} Whether the given point equal to this point
  */
 

--- a/packages/math/src/IPointData.ts
+++ b/packages/math/src/IPointData.ts
@@ -1,0 +1,23 @@
+export interface IPointData
+{
+    x: number;
+    y: number;
+}
+
+/**
+ * Common interface for points. Both Point and ObservablePoint implement it
+ * @memberof PIXI
+ * @interface IPointData
+ */
+
+/**
+ * X coord
+ * @memberof PIXI.IPointData#
+ * @member {number} x
+ */
+
+/**
+ * Y coord
+ * @memberof PIXI.IPointData#
+ * @member {number} y
+ */

--- a/packages/math/src/Matrix.ts
+++ b/packages/math/src/Matrix.ts
@@ -2,7 +2,7 @@ import { Point } from './Point';
 import { PI_2 } from './const';
 
 import type { Transform } from './Transform';
-import type { IPoint } from './IPoint';
+import type { IPointData } from './IPointData';
 
 /**
  * The PixiJS Matrix as a class makes it a lot faster.
@@ -168,11 +168,11 @@ export class Matrix
      * Get a new position with the current transformation applied.
      * Can be used to go from a child's coordinate space to the world coordinate space. (e.g. rendering)
      *
-     * @param {PIXI.Point} pos - The origin
+     * @param {PIXI.IPointData} pos - The origin
      * @param {PIXI.Point} [newPos] - The point that the new position is assigned to (allowed to be same as input)
      * @return {PIXI.Point} The new point, transformed through this matrix
      */
-    apply(pos: IPoint, newPos?: Point): Point
+    apply(pos: IPointData, newPos?: Point): Point
     {
         newPos = newPos || new Point();
 
@@ -189,11 +189,11 @@ export class Matrix
      * Get a new position with the inverse of the current transformation applied.
      * Can be used to go from the world coordinate space to a child's coordinate space. (e.g. input)
      *
-     * @param {PIXI.Point} pos - The origin
+     * @param {PIXI.IPointData} pos - The origin
      * @param {PIXI.Point} [newPos] - The point that the new position is assigned to (allowed to be same as input)
      * @return {PIXI.Point} The new point, inverse-transformed through this matrix
      */
-    applyInverse(pos: IPoint, newPos?: Point): Point
+    applyInverse(pos: IPointData, newPos?: Point): Point
     {
         newPos = newPos || new Point();
 

--- a/packages/math/src/Matrix.ts
+++ b/packages/math/src/Matrix.ts
@@ -172,9 +172,9 @@ export class Matrix
      * @param {PIXI.Point} [newPos] - The point that the new position is assigned to (allowed to be same as input)
      * @return {PIXI.Point} The new point, transformed through this matrix
      */
-    apply(pos: IPointData, newPos?: Point): Point
+    apply<P extends IPointData = Point>(pos: IPointData, newPos?: P): P
     {
-        newPos = newPos || new Point();
+        newPos = (newPos || new Point()) as P;
 
         const x = pos.x;
         const y = pos.y;
@@ -193,9 +193,9 @@ export class Matrix
      * @param {PIXI.Point} [newPos] - The point that the new position is assigned to (allowed to be same as input)
      * @return {PIXI.Point} The new point, inverse-transformed through this matrix
      */
-    applyInverse(pos: IPointData, newPos?: Point): Point
+    applyInverse<P extends IPointData = Point>(pos: IPointData, newPos?: P): P
     {
-        newPos = newPos || new Point();
+        newPos = (newPos || new Point()) as P;
 
         const id = 1 / ((this.a * this.d) + (this.c * -this.b));
 

--- a/packages/math/src/ObservablePoint.ts
+++ b/packages/math/src/ObservablePoint.ts
@@ -1,3 +1,4 @@
+import type { IPointData } from './IPointData';
 import type { IPoint } from './IPoint';
 
 /**
@@ -70,10 +71,10 @@ export class ObservablePoint<T = any> implements IPoint
     /**
      * Copies x and y from the given point
      *
-     * @param {PIXI.IPoint} p - The point to copy from.
+     * @param {PIXI.IPointData} p - The point to copy from.
      * @returns {this} Returns itself.
      */
-    copyFrom(p: IPoint): this
+    copyFrom(p: IPointData): this
     {
         if (this._x !== p.x || this._y !== p.y)
         {
@@ -101,10 +102,10 @@ export class ObservablePoint<T = any> implements IPoint
     /**
      * Returns true if the given point is equal to this point
      *
-     * @param {PIXI.IPoint} p - The point to check
+     * @param {PIXI.IPointData} p - The point to check
      * @returns {boolean} Whether the given point equal to this point
      */
-    equals(p: IPoint): boolean
+    equals(p: IPointData): boolean
     {
         return (p.x === this._x) && (p.y === this._y);
     }

--- a/packages/math/src/Point.ts
+++ b/packages/math/src/Point.ts
@@ -1,4 +1,5 @@
 import type { IPoint } from './IPoint';
+import type { IPointData } from './IPointData';
 
 /**
  * The Point object represents a location in a two-dimensional coordinate system, where x represents
@@ -45,10 +46,10 @@ export class Point implements IPoint
     /**
      * Copies x and y from the given point
      *
-     * @param {PIXI.IPoint} p - The point to copy from
+     * @param {PIXI.IPointData} p - The point to copy from
      * @returns {this} Returns itself.
      */
-    copyFrom(p: IPoint): this
+    copyFrom(p: IPointData): this
     {
         this.set(p.x, p.y);
 
@@ -71,10 +72,10 @@ export class Point implements IPoint
     /**
      * Returns true if the given point is equal to this point
      *
-     * @param {PIXI.IPoint} p - The point to check
+     * @param {PIXI.IPointData} p - The point to check
      * @returns {boolean} Whether the given point equal to this point
      */
-    equals(p: IPoint): boolean
+    equals(p: IPointData): boolean
     {
         return (p.x === this.x) && (p.y === this.y);
     }

--- a/packages/math/src/index.ts
+++ b/packages/math/src/index.ts
@@ -10,6 +10,7 @@ import { Polygon } from './shapes/Polygon';
 import { Rectangle } from './shapes/Rectangle';
 import { RoundedRectangle } from './shapes/RoundedRectangle';
 
+export * from './IPointData';
 export * from './IPoint';
 export * from './Point';
 export * from './ObservablePoint';

--- a/packages/mesh/src/Mesh.ts
+++ b/packages/mesh/src/Mesh.ts
@@ -8,7 +8,7 @@ import { MeshMaterial } from './MeshMaterial';
 
 import type { IDestroyOptions } from '@pixi/display';
 import type { Texture, Renderer, Geometry, Buffer } from '@pixi/core';
-import type { IPoint } from '@pixi/math';
+import type { IPointData } from '@pixi/math';
 
 const tempPoint = new Point();
 const tempPolygon = new Polygon();
@@ -453,10 +453,10 @@ export class Mesh extends Container
     /**
      * Tests if a point is inside this mesh. Works only for PIXI.DRAW_MODES.TRIANGLES.
      *
-     * @param {PIXI.IPoint} point - the point to test
+     * @param {PIXI.IPointData} point - the point to test
      * @return {boolean} the result of the test
      */
-    public containsPoint(point: IPoint): boolean
+    public containsPoint(point: IPointData): boolean
     {
         if (!this.getBounds().contains(point.x, point.y))
         {

--- a/packages/mixin-cache-as-bitmap/src/index.ts
+++ b/packages/mixin-cache-as-bitmap/src/index.ts
@@ -1,7 +1,7 @@
 import { Texture, BaseTexture, RenderTexture, Renderer, MaskData } from '@pixi/core';
 import { Sprite } from '@pixi/sprite';
 import { Container, DisplayObject, IDestroyOptions } from '@pixi/display';
-import { IPoint, Matrix, Rectangle } from '@pixi/math';
+import { IPointData, Matrix, Rectangle } from '@pixi/math';
 import { uid } from '@pixi/utils';
 import { settings } from '@pixi/settings';
 import { CanvasRenderer } from '@pixi/canvas-renderer';
@@ -29,7 +29,7 @@ export class CacheData
     public originalDestroy: (options?: IDestroyOptions|boolean) => void;
     public originalMask: Container|MaskData;
     public originalFilterArea: Rectangle;
-    public originalContainsPoint: (point: IPoint) => boolean;
+    public originalContainsPoint: (point: IPointData) => boolean;
     public sprite: Sprite;
 
     constructor()

--- a/packages/sprite-tiling/src/TilingSprite.ts
+++ b/packages/sprite-tiling/src/TilingSprite.ts
@@ -4,7 +4,7 @@ import { Sprite } from '@pixi/sprite';
 import { deprecation } from '@pixi/utils';
 import type { Renderer, IBaseTextureOptions, TextureSource } from '@pixi/core';
 import type { IDestroyOptions } from '@pixi/display';
-import type { IPoint, ISize, ObservablePoint } from '@pixi/math';
+import type { IPoint, IPointData, ISize, ObservablePoint } from '@pixi/math';
 
 const tempPoint = new Point();
 
@@ -213,10 +213,10 @@ export class TilingSprite extends Sprite
     /**
      * Checks if a point is inside this tiling sprite.
      *
-     * @param {PIXI.IPoint} point - the point to check
+     * @param {PIXI.IPointData} point - the point to check
      * @return {boolean} Whether or not the sprite contains the point.
      */
-    public containsPoint(point: IPoint): boolean
+    public containsPoint(point: IPointData): boolean
     {
         this.worldTransform.applyInverse(point, tempPoint);
 

--- a/packages/sprite/src/Sprite.ts
+++ b/packages/sprite/src/Sprite.ts
@@ -7,7 +7,7 @@ import { sign } from '@pixi/utils';
 
 import type { IBaseTextureOptions, Renderer, TextureSource } from '@pixi/core';
 import type { IDestroyOptions } from '@pixi/display';
-import type { IPoint } from '@pixi/math';
+import type { IPointData } from '@pixi/math';
 
 const tempPoint = new Point();
 const indices = new Uint16Array([0, 1, 2, 0, 2, 3]);
@@ -476,10 +476,10 @@ export class Sprite extends Container
     /**
      * Tests if a point is inside this sprite
      *
-     * @param {PIXI.IPoint} point - the point to test
+     * @param {PIXI.IPointData} point - the point to test
      * @return {boolean} the result of the test
      */
-    public containsPoint(point: IPoint): boolean
+    public containsPoint(point: IPointData): boolean
     {
         this.worldTransform.applyInverse(point, tempPoint);
 


### PR DESCRIPTION
This was @andrewstart's (excellent) suggestion to use `IPointData` instead of `IPoint`, `Point` or `ObservablePoint`. This means we can use _more_ generic objects instead of having to construct one of the Point classes. For instance:

```typescript
const shapes = new PIXI.Graphics();
shapes.containsPoint({ x: 10, y: 10 });
```