### PR TITLE
Remove the use of Function as a type

### DIFF
--- a/packages/core/src/shader/ShaderSystem.ts
+++ b/packages/core/src/shader/ShaderSystem.ts
@@ -9,6 +9,7 @@ import type { Shader } from './Shader';
 import type { Program } from './Program';
 import type { UniformGroup } from './UniformGroup';
 import type { Dict } from '@pixi/utils';
+import type { UniformsSyncCallback } from './utils';
 
 let UID = 0;
 // defualt sync data so we don't create a new one each time!
@@ -28,7 +29,7 @@ export class ShaderSystem extends System
     public program: Program;
     public id: number;
     public destroyed = false;
-    private cache: { [key: string]: Function };
+    private cache: Dict<UniformsSyncCallback>;
     /**
      * @param {PIXI.Renderer} renderer - The renderer this System works for.
      */
@@ -157,7 +158,7 @@ export class ShaderSystem extends System
         syncFunc(glProgram.uniformData, group.uniforms, this.renderer, syncData);
     }
 
-    createSyncGroups(group: UniformGroup): Function
+    createSyncGroups(group: UniformGroup): UniformsSyncCallback
     {
         const id = this.getSignature(group, this.shader.program.uniformData);
 

--- a/packages/core/src/shader/UniformGroup.ts
+++ b/packages/core/src/shader/UniformGroup.ts
@@ -1,4 +1,5 @@
 import type { Dict } from '@pixi/utils';
+import type { UniformsSyncCallback } from './utils';
 
 let UID = 0;
 
@@ -13,7 +14,7 @@ export class UniformGroup
     public readonly uniforms: Dict<any>;
     public readonly group: boolean;
     public id: number;
-    syncUniforms: {[key: string]: Function};
+    syncUniforms: Dict<UniformsSyncCallback>;
     dirtyId: number;
     static: boolean;
 

--- a/packages/core/src/shader/utils/generateUniformsSync.ts
+++ b/packages/core/src/shader/utils/generateUniformsSync.ts
@@ -3,6 +3,8 @@ import { uniformParsers } from './uniformParsers';
 import type { UniformGroup } from '../UniformGroup';
 import type { Dict } from '@pixi/utils';
 
+export type UniformsSyncCallback = (...args: any[]) => void;
+
 // cv = CachedValue
 // v = value
 // ud = uniformData
@@ -83,7 +85,7 @@ const GLSL_TO_ARRAY_SETTERS: Dict<string> = {
     sampler2DArray: 'gl.uniform1iv(location, v)',
 };
 
-export function generateUniformsSync(group: UniformGroup, uniformData: Dict<any>): Function
+export function generateUniformsSync(group: UniformGroup, uniformData: Dict<any>): UniformsSyncCallback
 {
     const funcFragments = [`
         var v = null;
@@ -142,6 +144,7 @@ export function generateUniformsSync(group: UniformGroup, uniformData: Dict<any>
      * no matter which group is being used
      *
      */
-    return new Function('ud', 'uv', 'renderer', 'syncData', funcFragments.join('\n')); // eslint-disable-line no-new-func
+    // eslint-disable-next-line no-new-func
+    return new Function('ud', 'uv', 'renderer', 'syncData', funcFragments.join('\n')) as UniformsSyncCallback;
 }
 

--- a/packages/core/src/textures/resources/SVGResource.ts
+++ b/packages/core/src/textures/resources/SVGResource.ts
@@ -30,7 +30,7 @@ export class SVGResource extends BaseImageResource
     public readonly scale: number;
     readonly _overrideWidth: number;
     readonly _overrideHeight: number;
-    private _resolve: Function;
+    private _resolve: () => void;
     private _load: Promise<SVGResource>;
     private _crossorigin?: boolean|string;
 


### PR DESCRIPTION
In the newer linting tools `Function` is a discouraged type. Replaced this in the code with more specific types.