### PR TITLE
Remove all remaining instances of @ts-ignore

### DIFF
--- a/packages/mesh/src/Mesh.ts
+++ b/packages/mesh/src/Mesh.ts
@@ -48,15 +48,12 @@ export class Mesh extends Container
     private _transformID: number;
     private _roundPixels: boolean;
     private batchUvs: MeshBatchUvs;
+
+    // Internal-only properties
     uvs: Float32Array;
-    /* eslint-disable @typescript-eslint/ban-ts-ignore */
-    // @ts-ignore
-    private indices: Uint16Array;
-    // @ts-ignore
-    private _tintRGB: number;
-    // @ts-ignore
-    private _texture: Texture;
-    /* eslint-enable @typescript-eslint/ban-ts-ignore */
+    indices: Uint16Array;
+    _tintRGB: number;
+    _texture: Texture;
 
     /**
      * @param {PIXI.Geometry} geometry - the geometry the mesh will use

--- a/packages/mesh/src/MeshBatchUvs.ts
+++ b/packages/mesh/src/MeshBatchUvs.ts
@@ -14,9 +14,9 @@ export class MeshBatchUvs
 
     private _bufferUpdateId: number;
     private _textureUpdateId: number;
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
-    private _updateID: number;
+
+    // Internal-only properties
+    _updateID: number;
 
     /**
      * @param {PIXI.Buffer} uvBuffer - Buffer with normalized uv's

--- a/packages/mesh/src/MeshGeometry.ts
+++ b/packages/mesh/src/MeshGeometry.ts
@@ -22,10 +22,8 @@ import type { IArrayBuffer } from '@pixi/core';
  */
 export class MeshGeometry extends Geometry
 {
-    // TODO: is this needed?
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
-    private _updateId: number;
+    // Internal-only properties
+    _updateId: number;
 
     /**
      * @param {Float32Array|number[]} [vertices] - Positional data on geometry.

--- a/packages/mesh/src/MeshMaterial.ts
+++ b/packages/mesh/src/MeshMaterial.ts
@@ -29,8 +29,8 @@ export class MeshMaterial extends Shader
 
     public batchable: boolean;
     public pluginName: string;
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
+
+    // Internal-only properties
     _tintRGB: number;
 
     private _colorDirty: boolean;

--- a/packages/prepare/src/BasePrepare.ts
+++ b/packages/prepare/src/BasePrepare.ts
@@ -116,9 +116,7 @@ function findTexture(item: IDisplayObjectExtended, queue: Array<any>): boolean
  * @param {PIXI.DisplayObject} item - Item to check
  * @return {boolean} If item was uploaded.
  */
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
-function drawText(helper: AbstractRenderer | BasePrepare, item: IDisplayObjectExtended): boolean
+function drawText(_helper: AbstractRenderer | BasePrepare, item: IDisplayObjectExtended): boolean
 {
     if (item instanceof Text)
     {
@@ -139,9 +137,7 @@ function drawText(helper: AbstractRenderer | BasePrepare, item: IDisplayObjectEx
  * @param {PIXI.DisplayObject} item - Item to check
  * @return {boolean} If item was uploaded.
  */
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
-function calculateTextStyle(helper: AbstractRenderer | BasePrepare, item: IDisplayObjectExtended): boolean
+function calculateTextStyle(_helper: AbstractRenderer | BasePrepare, item: IDisplayObjectExtended): boolean
 {
     if (item instanceof TextStyle)
     {

--- a/packages/sprite/src/Sprite.ts
+++ b/packages/sprite/src/Sprite.ts
@@ -64,8 +64,7 @@ export class Sprite extends Container
     private _transformTrimmedID: number;
     private _tint: number;
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
+    // Internal-only properties
     _tintRGB: number;
 
     /**

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -48,23 +48,7 @@
  */
 export { isMobile } from '@pixi/settings';
 
-/* eslint-disable */
-/*
-    - `eventemitter3` uses CommonJS export
-    - PIXI uses module exports, but thanks to `"esModuleInterop": true` in tsconfig.json this works
-    - Unfortunately `tsconfig.docs.json` (used for documentation genereation) exports to ES6
-      which for reasons unknown just doesn't work even with the interop above
-    - Changing docs' export to ES5 fixes the problem with `eventemitter3` but causes a lot
-      of other bugs when building for docs, therefore it's not a solution
-    - Adding @ts-ignore to this line makes docs build stop complaining about something it doesn't
-      have to care about, but then linter's rule is broken
-    - Therefore the whole thing is wrapped in eslint-disable just to be able to progress with this change
-    - This is a temporary measure. Possibly the best solution would be custom typings for `eventemitter3`
-    stored in this very repository.
- */
-// @ts-ignore
 import EventEmitter from 'eventemitter3';
-/* eslint-enable */
 
 /**
  * A high performance event emitter


### PR DESCRIPTION
This removes the last of the unnecessary `@ts-ignore` instances. In general, `@ts-ignore` should be avoid at all costs.