### PR TITLE
Standardize the use of setter types

### DIFF
--- a/packages/core/src/AbstractRenderer.ts
+++ b/packages/core/src/AbstractRenderer.ts
@@ -376,7 +376,7 @@ export abstract class AbstractRenderer extends EventEmitter
         return this._backgroundColor;
     }
 
-    set backgroundColor(value)
+    set backgroundColor(value: number)
     {
         this._backgroundColor = value;
         this._backgroundColorString = hex2string(value);

--- a/packages/core/src/filters/Filter.ts
+++ b/packages/core/src/filters/Filter.ts
@@ -245,7 +245,7 @@ export class Filter extends Shader
         return this.state.blendMode;
     }
 
-    set blendMode(value)
+    set blendMode(value: BLEND_MODES)
     {
         this.state.blendMode = value;
     }

--- a/packages/core/src/state/State.ts
+++ b/packages/core/src/state/State.ts
@@ -44,7 +44,7 @@ export class State
         return !!(this.data & (1 << BLEND));
     }
 
-    set blend(value)
+    set blend(value: boolean)
     {
         if (!!(this.data & (1 << BLEND)) !== value)
         {
@@ -63,7 +63,7 @@ export class State
         return !!(this.data & (1 << OFFSET));
     }
 
-    set offsets(value)
+    set offsets(value: boolean)
     {
         if (!!(this.data & (1 << OFFSET)) !== value)
         {
@@ -82,7 +82,7 @@ export class State
         return !!(this.data & (1 << CULLING));
     }
 
-    set culling(value)
+    set culling(value: boolean)
     {
         if (!!(this.data & (1 << CULLING)) !== value)
         {
@@ -101,7 +101,7 @@ export class State
         return !!(this.data & (1 << DEPTH_TEST));
     }
 
-    set depthTest(value)
+    set depthTest(value: boolean)
     {
         if (!!(this.data & (1 << DEPTH_TEST)) !== value)
         {
@@ -119,7 +119,7 @@ export class State
         return !!(this.data & (1 << WINDING));
     }
 
-    set clockwiseFrontFace(value)
+    set clockwiseFrontFace(value: boolean)
     {
         if (!!(this.data & (1 << WINDING)) !== value)
         {
@@ -140,7 +140,7 @@ export class State
         return this._blendMode;
     }
 
-    set blendMode(value)
+    set blendMode(value: BLEND_MODES)
     {
         this.blend = (value !== BLEND_MODES.NONE);
         this._blendMode = value;
@@ -157,7 +157,7 @@ export class State
         return this._polygonOffset;
     }
 
-    set polygonOffset(value)
+    set polygonOffset(value: number)
     {
         this.offsets = !!value;
         this._polygonOffset = value;

--- a/packages/core/src/textures/Texture.ts
+++ b/packages/core/src/textures/Texture.ts
@@ -620,7 +620,7 @@ export class Texture extends EventEmitter
         return this._rotate;
     }
 
-    set rotate(rotate)
+    set rotate(rotate: number)
     {
         this._rotate = rotate;
         if (this.valid)

--- a/packages/core/src/textures/resources/VideoResource.ts
+++ b/packages/core/src/textures/resources/VideoResource.ts
@@ -355,7 +355,7 @@ export class VideoResource extends BaseImageResource
         return this._autoUpdate;
     }
 
-    set autoUpdate(value)
+    set autoUpdate(value: boolean)
     {
         if (value !== this._autoUpdate)
         {
@@ -385,7 +385,7 @@ export class VideoResource extends BaseImageResource
         return this._updateFPS;
     }
 
-    set updateFPS(value)
+    set updateFPS(value: number)
     {
         if (value !== this._updateFPS)
         {

--- a/packages/display/src/Container.ts
+++ b/packages/display/src/Container.ts
@@ -669,7 +669,7 @@ export class Container extends DisplayObject
         return this.scale.x * this.getLocalBounds().width;
     }
 
-    set width(value)
+    set width(value: number)
     {
         const width = this.getLocalBounds().width;
 
@@ -695,7 +695,7 @@ export class Container extends DisplayObject
         return this.scale.y * this.getLocalBounds().height;
     }
 
-    set height(value)
+    set height(value: number)
     {
         const height = this.getLocalBounds().height;
 

--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -574,7 +574,7 @@ export abstract class DisplayObject extends EventEmitter
         return this.position.x;
     }
 
-    set x(value)
+    set x(value: number)
     {
         this.transform.position.x = value;
     }
@@ -590,7 +590,7 @@ export abstract class DisplayObject extends EventEmitter
         return this.position.y;
     }
 
-    set y(value)
+    set y(value: number)
     {
         this.transform.position.y = value;
     }
@@ -628,7 +628,7 @@ export abstract class DisplayObject extends EventEmitter
         return this.transform.position;
     }
 
-    set position(value)
+    set position(value: ObservablePoint)
     {
         this.transform.position.copyFrom(value);
     }
@@ -644,7 +644,7 @@ export abstract class DisplayObject extends EventEmitter
         return this.transform.scale;
     }
 
-    set scale(value)
+    set scale(value: ObservablePoint)
     {
         this.transform.scale.copyFrom(value);
     }
@@ -660,7 +660,7 @@ export abstract class DisplayObject extends EventEmitter
         return this.transform.pivot;
     }
 
-    set pivot(value)
+    set pivot(value: ObservablePoint)
     {
         this.transform.pivot.copyFrom(value);
     }
@@ -676,7 +676,7 @@ export abstract class DisplayObject extends EventEmitter
         return this.transform.skew;
     }
 
-    set skew(value)
+    set skew(value: ObservablePoint)
     {
         this.transform.skew.copyFrom(value);
     }
@@ -692,7 +692,7 @@ export abstract class DisplayObject extends EventEmitter
         return this.transform.rotation;
     }
 
-    set rotation(value)
+    set rotation(value: number)
     {
         this.transform.rotation = value;
     }
@@ -708,7 +708,7 @@ export abstract class DisplayObject extends EventEmitter
         return this.transform.rotation * RAD_TO_DEG;
     }
 
-    set angle(value)
+    set angle(value: number)
     {
         this.transform.rotation = value * DEG_TO_RAD;
     }
@@ -726,7 +726,7 @@ export abstract class DisplayObject extends EventEmitter
         return this._zIndex;
     }
 
-    set zIndex(value)
+    set zIndex(value: number)
     {
         this._zIndex = value;
         if (this.parent)
@@ -782,7 +782,7 @@ export abstract class DisplayObject extends EventEmitter
         return this._mask;
     }
 
-    set mask(value)
+    set mask(value: Container|MaskData|null)
     {
         if (this._mask)
         {

--- a/packages/filters/filter-alpha/src/AlphaFilter.ts
+++ b/packages/filters/filter-alpha/src/AlphaFilter.ts
@@ -41,7 +41,7 @@ export class AlphaFilter extends Filter
         return this.uniforms.uAlpha;
     }
 
-    set alpha(value)
+    set alpha(value: number)
     {
         this.uniforms.uAlpha = value;
     }

--- a/packages/filters/filter-blur/src/BlurFilter.ts
+++ b/packages/filters/filter-blur/src/BlurFilter.ts
@@ -97,7 +97,7 @@ export class BlurFilter extends Filter
         return this.blurXFilter.blur;
     }
 
-    set blur(value)
+    set blur(value: number)
     {
         this.blurXFilter.blur = this.blurYFilter.blur = value;
         this.updatePadding();
@@ -114,7 +114,7 @@ export class BlurFilter extends Filter
         return this.blurXFilter.quality;
     }
 
-    set quality(value)
+    set quality(value: number)
     {
         this.blurXFilter.quality = this.blurYFilter.quality = value;
     }
@@ -130,7 +130,7 @@ export class BlurFilter extends Filter
         return this.blurXFilter.blur;
     }
 
-    set blurX(value)
+    set blurX(value: number)
     {
         this.blurXFilter.blur = value;
         this.updatePadding();
@@ -147,7 +147,7 @@ export class BlurFilter extends Filter
         return this.blurYFilter.blur;
     }
 
-    set blurY(value)
+    set blurY(value: number)
     {
         this.blurYFilter.blur = value;
         this.updatePadding();
@@ -164,7 +164,7 @@ export class BlurFilter extends Filter
         return this.blurYFilter.blendMode;
     }
 
-    set blendMode(value)
+    set blendMode(value: BLEND_MODES)
     {
         this.blurYFilter.blendMode = value;
     }
@@ -180,7 +180,7 @@ export class BlurFilter extends Filter
         return this._repeatEdgePixels;
     }
 
-    set repeatEdgePixels(value)
+    set repeatEdgePixels(value: boolean)
     {
         this._repeatEdgePixels = value;
         this.updatePadding();

--- a/packages/filters/filter-blur/src/BlurFilterPass.ts
+++ b/packages/filters/filter-blur/src/BlurFilterPass.ts
@@ -136,7 +136,7 @@ export class BlurFilterPass extends Filter
         return this.strength;
     }
 
-    set blur(value)
+    set blur(value: number)
     {
         this.padding = 1 + (Math.abs(value) * 2);
         this.strength = value;
@@ -154,7 +154,7 @@ export class BlurFilterPass extends Filter
         return this._quality;
     }
 
-    set quality(value)
+    set quality(value: number)
     {
         this._quality = value;
         this.passes = value;

--- a/packages/filters/filter-color-matrix/src/ColorMatrixFilter.ts
+++ b/packages/filters/filter-color-matrix/src/ColorMatrixFilter.ts
@@ -573,7 +573,7 @@ export class ColorMatrixFilter extends Filter
         return this.uniforms.m;
     }
 
-    set matrix(value)
+    set matrix(value: ColorMatrix)
     {
         this.uniforms.m = value;
     }
@@ -593,7 +593,7 @@ export class ColorMatrixFilter extends Filter
         return this.uniforms.uAlpha;
     }
 
-    set alpha(value)
+    set alpha(value: number)
     {
         this.uniforms.uAlpha = value;
     }

--- a/packages/filters/filter-displacement/src/DisplacementFilter.ts
+++ b/packages/filters/filter-displacement/src/DisplacementFilter.ts
@@ -106,7 +106,7 @@ export class DisplacementFilter extends Filter
         return this.uniforms.mapSampler;
     }
 
-    set map(value)
+    set map(value: Texture)
     {
         this.uniforms.mapSampler = value;
     }

--- a/packages/filters/filter-noise/src/NoiseFilter.ts
+++ b/packages/filters/filter-noise/src/NoiseFilter.ts
@@ -41,7 +41,7 @@ export class NoiseFilter extends Filter
         return this.uniforms.uNoise;
     }
 
-    set noise(value)
+    set noise(value: number)
     {
         this.uniforms.uNoise = value;
     }
@@ -56,7 +56,7 @@ export class NoiseFilter extends Filter
         return this.uniforms.uSeed;
     }
 
-    set seed(value)
+    set seed(value: number)
     {
         this.uniforms.uSeed = value;
     }

--- a/packages/graphics/src/Graphics.ts
+++ b/packages/graphics/src/Graphics.ts
@@ -292,7 +292,7 @@ export class Graphics extends Container
         return this._tint;
     }
 
-    public set tint(value)
+    public set tint(value: number)
     {
         this._tint = value;
     }

--- a/packages/interaction/src/InteractionManager.ts
+++ b/packages/interaction/src/InteractionManager.ts
@@ -728,7 +728,7 @@ export class InteractionManager extends EventEmitter
     {
         return this._useSystemTicker;
     }
-    set useSystemTicker(useSystemTicker)
+    set useSystemTicker(useSystemTicker: boolean)
     {
         this._useSystemTicker = useSystemTicker;
 

--- a/packages/interaction/src/InteractionTrackingData.ts
+++ b/packages/interaction/src/InteractionTrackingData.ts
@@ -76,7 +76,7 @@ export class InteractionTrackingData
         return this._flags;
     }
 
-    set flags(flags)
+    set flags(flags: number)
     {
         this._flags = flags;
     }
@@ -103,7 +103,7 @@ export class InteractionTrackingData
         return (this._flags & InteractionTrackingData.FLAGS.OVER) !== 0;
     }
 
-    set over(yn)
+    set over(yn: boolean)
     {
         this._doSet(InteractionTrackingData.FLAGS.OVER, yn);
     }
@@ -119,7 +119,7 @@ export class InteractionTrackingData
         return (this._flags & InteractionTrackingData.FLAGS.RIGHT_DOWN) !== 0;
     }
 
-    set rightDown(yn)
+    set rightDown(yn: boolean)
     {
         this._doSet(InteractionTrackingData.FLAGS.RIGHT_DOWN, yn);
     }
@@ -135,7 +135,7 @@ export class InteractionTrackingData
         return (this._flags & InteractionTrackingData.FLAGS.LEFT_DOWN) !== 0;
     }
 
-    set leftDown(yn)
+    set leftDown(yn: boolean)
     {
         this._doSet(InteractionTrackingData.FLAGS.LEFT_DOWN, yn);
     }

--- a/packages/interaction/src/interactiveTarget.ts
+++ b/packages/interaction/src/interactiveTarget.ts
@@ -141,11 +141,11 @@ export const interactiveTarget: InteractiveTarget = {
      * @member {boolean}
      * @memberof PIXI.DisplayObject#
      */
-    get buttonMode()
+    get buttonMode(): boolean
     {
         return this.cursor === 'pointer';
     },
-    set buttonMode(value)
+    set buttonMode(value: boolean)
     {
         if (value)
         {

--- a/packages/math/src/ObservablePoint.ts
+++ b/packages/math/src/ObservablePoint.ts
@@ -119,7 +119,7 @@ export class ObservablePoint<T = any> implements IPoint
         return this._x;
     }
 
-    set x(value)
+    set x(value: number)
     {
         if (this._x !== value)
         {
@@ -138,7 +138,7 @@ export class ObservablePoint<T = any> implements IPoint
         return this._y;
     }
 
-    set y(value)
+    set y(value: number)
     {
         if (this._y !== value)
         {

--- a/packages/math/src/Transform.ts
+++ b/packages/math/src/Transform.ts
@@ -273,7 +273,7 @@ export class Transform
         return this._rotation;
     }
 
-    set rotation(value)
+    set rotation(value: number)
     {
         if (this._rotation !== value)
         {

--- a/packages/mesh-extras/src/NineSlicePlane.ts
+++ b/packages/mesh-extras/src/NineSlicePlane.ts
@@ -131,7 +131,7 @@ export class NineSlicePlane extends SimplePlane
         return this.geometry.getBuffer('aVertexPosition').data;
     }
 
-    set vertices(value)
+    set vertices(value: ITypedArray)
     {
         this.geometry.getBuffer('aVertexPosition').data = value;
     }
@@ -195,7 +195,7 @@ export class NineSlicePlane extends SimplePlane
         return this._width;
     }
 
-    set width(value)
+    set width(value: number)
     {
         this._width = value;
         this._refresh();
@@ -211,7 +211,7 @@ export class NineSlicePlane extends SimplePlane
         return this._height;
     }
 
-    set height(value)
+    set height(value: number)
     {
         this._height = value;
         this._refresh();
@@ -227,7 +227,7 @@ export class NineSlicePlane extends SimplePlane
         return this._leftWidth;
     }
 
-    set leftWidth(value)
+    set leftWidth(value: number)
     {
         this._leftWidth = value;
         this._refresh();
@@ -243,7 +243,7 @@ export class NineSlicePlane extends SimplePlane
         return this._rightWidth;
     }
 
-    set rightWidth(value)
+    set rightWidth(value: number)
     {
         this._rightWidth = value;
         this._refresh();
@@ -259,7 +259,7 @@ export class NineSlicePlane extends SimplePlane
         return this._topHeight;
     }
 
-    set topHeight(value)
+    set topHeight(value: number)
     {
         this._topHeight = value;
         this._refresh();
@@ -275,7 +275,7 @@ export class NineSlicePlane extends SimplePlane
         return this._bottomHeight;
     }
 
-    set bottomHeight(value)
+    set bottomHeight(value: number)
     {
         this._bottomHeight = value;
         this._refresh();

--- a/packages/mesh-extras/src/SimpleMesh.ts
+++ b/packages/mesh-extras/src/SimpleMesh.ts
@@ -54,7 +54,7 @@ export class SimpleMesh extends Mesh
     {
         return this.geometry.getBuffer('aVertexPosition').data;
     }
-    set vertices(value)
+    set vertices(value: ITypedArray)
     {
         this.geometry.getBuffer('aVertexPosition').data = value;
     }

--- a/packages/mesh-extras/src/SimplePlane.ts
+++ b/packages/mesh-extras/src/SimplePlane.ts
@@ -55,7 +55,7 @@ export class SimplePlane extends Mesh
         geometry.build();
     }
 
-    set texture(value)
+    set texture(value: Texture)
     {
         // Track texture same way sprite does.
         // For generated meshes like NineSlicePlane it can change the geometry.

--- a/packages/mesh/src/Mesh.ts
+++ b/packages/mesh/src/Mesh.ts
@@ -192,7 +192,7 @@ export class Mesh extends Container
      * Alias for {@link PIXI.Mesh#shader}.
      * @member {PIXI.MeshMaterial}
      */
-    set material(value)
+    set material(value: MeshMaterial)
     {
         this.shader = value;
     }
@@ -210,7 +210,7 @@ export class Mesh extends Container
      * @default PIXI.BLEND_MODES.NORMAL;
      * @see PIXI.BLEND_MODES
      */
-    set blendMode(value)
+    set blendMode(value: BLEND_MODES)
     {
         this.state.blendMode = value;
     }
@@ -229,7 +229,7 @@ export class Mesh extends Container
      * @member {boolean}
      * @default false
      */
-    set roundPixels(value)
+    set roundPixels(value: boolean)
     {
         if (this._roundPixels !== value)
         {
@@ -255,7 +255,7 @@ export class Mesh extends Container
         return this.shader.tint;
     }
 
-    set tint(value)
+    set tint(value: number)
     {
         this.shader.tint = value;
     }
@@ -270,7 +270,7 @@ export class Mesh extends Container
         return this.shader.texture;
     }
 
-    set texture(value)
+    set texture(value: Texture)
     {
         this.shader.texture = value;
     }

--- a/packages/mesh/src/MeshMaterial.ts
+++ b/packages/mesh/src/MeshMaterial.ts
@@ -112,7 +112,7 @@ export class MeshMaterial extends Shader
     {
         return this.uniforms.uSampler;
     }
-    set texture(value)
+    set texture(value: Texture)
     {
         if (this.uniforms.uSampler !== value)
         {
@@ -127,7 +127,7 @@ export class MeshMaterial extends Shader
      * @default 1
      * @member {number}
      */
-    set alpha(value)
+    set alpha(value: number)
     {
         if (value === this._alpha) return;
 
@@ -144,7 +144,7 @@ export class MeshMaterial extends Shader
      * @member {number}
      * @default 0xFFFFFF
      */
-    set tint(value)
+    set tint(value: number)
     {
         if (value === this._tint) return;
 

--- a/packages/particles/src/ParticleContainer.ts
+++ b/packages/particles/src/ParticleContainer.ts
@@ -226,7 +226,7 @@ export class ParticleContainer extends Container
         return this._tint;
     }
 
-    set tint(value)
+    set tint(value: number)
     {
         this._tint = value;
         hex2rgb(value, this.tintRgb);

--- a/packages/sprite-animated/src/AnimatedSprite.ts
+++ b/packages/sprite-animated/src/AnimatedSprite.ts
@@ -429,7 +429,7 @@ export class AnimatedSprite extends Sprite
         return this._textures;
     }
 
-    set textures(value)
+    set textures(value: Texture[]|FrameObject[])
     {
         if (value[0] instanceof Texture)
         {
@@ -491,7 +491,7 @@ export class AnimatedSprite extends Sprite
         return this._autoUpdate;
     }
 
-    set autoUpdate(value)
+    set autoUpdate(value: boolean)
     {
         if (value !== this._autoUpdate)
         {

--- a/packages/sprite-tiling/src/TilingSprite.ts
+++ b/packages/sprite-tiling/src/TilingSprite.ts
@@ -92,7 +92,7 @@ export class TilingSprite extends Sprite
         return this.uvMatrix.clampMargin;
     }
 
-    set clampMargin(value)
+    set clampMargin(value: number)
     {
         this.uvMatrix.clampMargin = value;
         this.uvMatrix.update(true);
@@ -108,7 +108,7 @@ export class TilingSprite extends Sprite
         return this.tileTransform.scale;
     }
 
-    set tileScale(value)
+    set tileScale(value: ObservablePoint)
     {
         this.tileTransform.scale.copyFrom(value as IPoint);
     }
@@ -123,7 +123,7 @@ export class TilingSprite extends Sprite
         return this.tileTransform.position;
     }
 
-    set tilePosition(value)
+    set tilePosition(value: ObservablePoint)
     {
         this.tileTransform.position.copyFrom(value as IPoint);
     }
@@ -293,7 +293,7 @@ export class TilingSprite extends Sprite
         return this._width;
     }
 
-    set width(value)
+    set width(value: number)
     {
         this._width = value;
     }
@@ -308,7 +308,7 @@ export class TilingSprite extends Sprite
         return this._height;
     }
 
-    set height(value)
+    set height(value: number)
     {
         this._height = value;
     }

--- a/packages/sprite/src/Sprite.ts
+++ b/packages/sprite/src/Sprite.ts
@@ -560,7 +560,7 @@ export class Sprite extends Container
      * @member {boolean}
      * @default false
      */
-    set roundPixels(value)
+    set roundPixels(value: boolean)
     {
         if (this._roundPixels !== value)
         {
@@ -584,7 +584,7 @@ export class Sprite extends Container
         return Math.abs(this.scale.x) * this._texture.orig.width;
     }
 
-    set width(value)
+    set width(value: number)
     {
         const s = sign(this.scale.x) || 1;
 
@@ -602,7 +602,7 @@ export class Sprite extends Container
         return Math.abs(this.scale.y) * this._texture.orig.height;
     }
 
-    set height(value)
+    set height(value: number)
     {
         const s = sign(this.scale.y) || 1;
 
@@ -633,7 +633,7 @@ export class Sprite extends Container
         return this._anchor;
     }
 
-    set anchor(value)
+    set anchor(value: ObservablePoint)
     {
         this._anchor.copyFrom(value);
     }
@@ -650,7 +650,7 @@ export class Sprite extends Container
         return this._tint;
     }
 
-    set tint(value)
+    set tint(value: number)
     {
         this._tint = value;
         this._tintRGB = (value >> 16) + (value & 0xff00) + ((value & 0xff) << 16);
@@ -666,7 +666,7 @@ export class Sprite extends Container
         return this._texture;
     }
 
-    set texture(value)
+    set texture(value: Texture)
     {
         if (this._texture === value)
         {

--- a/packages/text-bitmap/src/BitmapFont.ts
+++ b/packages/text-bitmap/src/BitmapFont.ts
@@ -356,11 +356,11 @@ export class BitmapFont
         const fontData = new BitmapFontData();
 
         fontData.info[0] = {
-            face: style.fontFamily,
-            size: style.fontSize,
+            face: style.fontFamily as string,
+            size: style.fontSize as number,
         };
         fontData.common[0] = {
-            lineHeight: style.fontSize,
+            lineHeight: style.fontSize as number,
         };
 
         let positionX = 0;

--- a/packages/text-bitmap/src/BitmapText.ts
+++ b/packages/text-bitmap/src/BitmapText.ts
@@ -606,7 +606,7 @@ export class BitmapText extends Container
         return this._tint;
     }
 
-    public set tint(value)
+    public set tint(value: number)
     {
         if (this._tint === value) return;
 
@@ -629,7 +629,7 @@ export class BitmapText extends Container
         return this._align;
     }
 
-    public set align(value)
+    public set align(value: TextStyleAlign)
     {
         if (this._align !== value)
         {
@@ -719,7 +719,7 @@ export class BitmapText extends Container
         return this._text;
     }
 
-    public set text(text)
+    public set text(text: string)
     {
         text = String(text === null || text === undefined ? '' : text);
 
@@ -743,7 +743,7 @@ export class BitmapText extends Container
         return this._maxWidth;
     }
 
-    public set maxWidth(value)
+    public set maxWidth(value: number)
     {
         if (this._maxWidth === value)
         {
@@ -791,7 +791,7 @@ export class BitmapText extends Container
         return this._letterSpacing;
     }
 
-    public set letterSpacing(value)
+    public set letterSpacing(value: number)
     {
         if (this._letterSpacing !== value)
         {

--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -630,7 +630,7 @@ export class Text extends Sprite
         return Math.abs(this.scale.x) * this._texture.orig.width;
     }
 
-    set width(value)
+    set width(value: number)
     {
         this.updateText(true);
 
@@ -652,7 +652,7 @@ export class Text extends Sprite
         return Math.abs(this.scale.y) * this._texture.orig.height;
     }
 
-    set height(value)
+    set height(value: number)
     {
         this.updateText(true);
 
@@ -676,7 +676,7 @@ export class Text extends Sprite
         return this._style;
     }
 
-    set style(style)
+    set style(style: TextStyle|Partial<ITextStyle>)
     {
         style = style || {};
 
@@ -703,7 +703,7 @@ export class Text extends Sprite
         return this._text;
     }
 
-    set text(text)
+    set text(text: string)
     {
         text = String(text === null || text === undefined ? '' : text);
 
@@ -726,7 +726,7 @@ export class Text extends Sprite
         return this._resolution;
     }
 
-    set resolution(value)
+    set resolution(value: number)
     {
         this._autoResolution = false;
 

--- a/packages/text/src/TextMetrics.ts
+++ b/packages/text/src/TextMetrics.ts
@@ -139,8 +139,8 @@ export class TextMetrics
         // (toDataURI, getImageData functions)
         if (fontProperties.fontSize === 0)
         {
-            fontProperties.fontSize = style.fontSize;
-            fontProperties.ascent = style.fontSize;
+            fontProperties.fontSize = style.fontSize as number;
+            fontProperties.ascent = style.fontSize as number;
         }
 
         const context = canvas.getContext('2d');

--- a/packages/text/src/TextStyle.ts
+++ b/packages/text/src/TextStyle.ts
@@ -25,8 +25,8 @@ export interface ITextStyle {
     fill: TextStyleFill;
     fillGradientType: TEXT_GRADIENT;
     fillGradientStops: number[];
-    fontFamily: string;
-    fontSize: number;
+    fontFamily: string | string[];
+    fontSize: number | string;
     fontStyle: TextStyleFontStyle;
     fontVariant: TextStyleFontVariant;
     fontWeight: TextStyleFontWeight;
@@ -111,8 +111,8 @@ export class TextStyle implements ITextStyle
     protected _fill: TextStyleFill;
     protected _fillGradientType: TEXT_GRADIENT;
     protected _fillGradientStops: number[];
-    protected _fontFamily: string;
-    protected _fontSize: number;
+    protected _fontFamily: string|string[];
+    protected _fontSize: number|string;
     protected _fontStyle: TextStyleFontStyle;
     protected _fontVariant: TextStyleFontVariant;
     protected _fontWeight: TextStyleFontWeight;
@@ -215,11 +215,11 @@ export class TextStyle implements ITextStyle
      *
      * @member {string}
      */
-    get align()
+    get align(): TextStyleAlign
     {
         return this._align;
     }
-    set align(align)
+    set align(align: TextStyleAlign)
     {
         if (this._align !== align)
         {
@@ -233,11 +233,11 @@ export class TextStyle implements ITextStyle
      *
      * @member {boolean}
      */
-    get breakWords()
+    get breakWords(): boolean
     {
         return this._breakWords;
     }
-    set breakWords(breakWords)
+    set breakWords(breakWords: boolean)
     {
         if (this._breakWords !== breakWords)
         {
@@ -251,11 +251,11 @@ export class TextStyle implements ITextStyle
      *
      * @member {boolean}
      */
-    get dropShadow()
+    get dropShadow(): boolean
     {
         return this._dropShadow;
     }
-    set dropShadow(dropShadow)
+    set dropShadow(dropShadow: boolean)
     {
         if (this._dropShadow !== dropShadow)
         {
@@ -269,11 +269,11 @@ export class TextStyle implements ITextStyle
      *
      * @member {number}
      */
-    get dropShadowAlpha()
+    get dropShadowAlpha(): number
     {
         return this._dropShadowAlpha;
     }
-    set dropShadowAlpha(dropShadowAlpha)
+    set dropShadowAlpha(dropShadowAlpha: number)
     {
         if (this._dropShadowAlpha !== dropShadowAlpha)
         {
@@ -287,11 +287,11 @@ export class TextStyle implements ITextStyle
      *
      * @member {number}
      */
-    get dropShadowAngle()
+    get dropShadowAngle(): number
     {
         return this._dropShadowAngle;
     }
-    set dropShadowAngle(dropShadowAngle)
+    set dropShadowAngle(dropShadowAngle: number)
     {
         if (this._dropShadowAngle !== dropShadowAngle)
         {
@@ -305,11 +305,11 @@ export class TextStyle implements ITextStyle
      *
      * @member {number}
      */
-    get dropShadowBlur()
+    get dropShadowBlur(): number
     {
         return this._dropShadowBlur;
     }
-    set dropShadowBlur(dropShadowBlur)
+    set dropShadowBlur(dropShadowBlur: number)
     {
         if (this._dropShadowBlur !== dropShadowBlur)
         {
@@ -323,11 +323,11 @@ export class TextStyle implements ITextStyle
      *
      * @member {string|number}
      */
-    get dropShadowColor()
+    get dropShadowColor(): number | string
     {
         return this._dropShadowColor;
     }
-    set dropShadowColor(dropShadowColor)
+    set dropShadowColor(dropShadowColor: number | string)
     {
         const outputColor = getColor(dropShadowColor);
         if (this._dropShadowColor !== outputColor)
@@ -342,11 +342,11 @@ export class TextStyle implements ITextStyle
      *
      * @member {number}
      */
-    get dropShadowDistance()
+    get dropShadowDistance(): number
     {
         return this._dropShadowDistance;
     }
-    set dropShadowDistance(dropShadowDistance)
+    set dropShadowDistance(dropShadowDistance: number)
     {
         if (this._dropShadowDistance !== dropShadowDistance)
         {
@@ -362,11 +362,11 @@ export class TextStyle implements ITextStyle
      *
      * @member {string|string[]|number|number[]|CanvasGradient|CanvasPattern}
      */
-    get fill()
+    get fill(): TextStyleFill
     {
         return this._fill;
     }
-    set fill(fill)
+    set fill(fill: TextStyleFill)
     {
         // TODO: Can't have different types for getter and setter. The getter shouldn't have the number type as
         //       the setter converts to string. See this thread for more details:
@@ -387,11 +387,11 @@ export class TextStyle implements ITextStyle
      *
      * @member {number}
      */
-    get fillGradientType()
+    get fillGradientType(): TEXT_GRADIENT
     {
         return this._fillGradientType;
     }
-    set fillGradientType(fillGradientType)
+    set fillGradientType(fillGradientType: TEXT_GRADIENT)
     {
         if (this._fillGradientType !== fillGradientType)
         {
@@ -406,11 +406,11 @@ export class TextStyle implements ITextStyle
      *
      * @member {number[]}
      */
-    get fillGradientStops()
+    get fillGradientStops(): number[]
     {
         return this._fillGradientStops;
     }
-    set fillGradientStops(fillGradientStops)
+    set fillGradientStops(fillGradientStops: number[])
     {
         if (!areArraysEqual(this._fillGradientStops,fillGradientStops))
         {
@@ -424,11 +424,11 @@ export class TextStyle implements ITextStyle
      *
      * @member {string|string[]}
      */
-    get fontFamily()
+    get fontFamily(): string | string[]
     {
         return this._fontFamily;
     }
-    set fontFamily(fontFamily)
+    set fontFamily(fontFamily: string | string[])
     {
         if (this.fontFamily !== fontFamily)
         {
@@ -443,11 +443,11 @@ export class TextStyle implements ITextStyle
      *
      * @member {number|string}
      */
-    get fontSize()
+    get fontSize(): number | string
     {
         return this._fontSize;
     }
-    set fontSize(fontSize)
+    set fontSize(fontSize: number | string)
     {
         if (this._fontSize !== fontSize)
         {
@@ -462,11 +462,11 @@ export class TextStyle implements ITextStyle
      *
      * @member {string}
      */
-    get fontStyle()
+    get fontStyle(): TextStyleFontStyle
     {
         return this._fontStyle;
     }
-    set fontStyle(fontStyle)
+    set fontStyle(fontStyle: TextStyleFontStyle)
     {
         if (this._fontStyle !== fontStyle)
         {
@@ -481,11 +481,11 @@ export class TextStyle implements ITextStyle
      *
      * @member {string}
      */
-    get fontVariant()
+    get fontVariant(): TextStyleFontVariant
     {
         return this._fontVariant;
     }
-    set fontVariant(fontVariant)
+    set fontVariant(fontVariant: TextStyleFontVariant)
     {
         if (this._fontVariant !== fontVariant)
         {
@@ -500,11 +500,11 @@ export class TextStyle implements ITextStyle
      *
      * @member {string}
      */
-    get fontWeight()
+    get fontWeight(): TextStyleFontWeight
     {
         return this._fontWeight;
     }
-    set fontWeight(fontWeight)
+    set fontWeight(fontWeight: TextStyleFontWeight)
     {
         if (this._fontWeight !== fontWeight)
         {
@@ -518,11 +518,11 @@ export class TextStyle implements ITextStyle
      *
      * @member {number}
      */
-    get letterSpacing()
+    get letterSpacing(): number
     {
         return this._letterSpacing;
     }
-    set letterSpacing(letterSpacing)
+    set letterSpacing(letterSpacing: number)
     {
         if (this._letterSpacing !== letterSpacing)
         {
@@ -536,11 +536,11 @@ export class TextStyle implements ITextStyle
      *
      * @member {number}
      */
-    get lineHeight()
+    get lineHeight(): number
     {
         return this._lineHeight;
     }
-    set lineHeight(lineHeight)
+    set lineHeight(lineHeight: number)
     {
         if (this._lineHeight !== lineHeight)
         {
@@ -554,11 +554,11 @@ export class TextStyle implements ITextStyle
      *
      * @member {number}
      */
-    get leading()
+    get leading(): number
     {
         return this._leading;
     }
-    set leading(leading)
+    set leading(leading: number)
     {
         if (this._leading !== leading)
         {
@@ -573,11 +573,11 @@ export class TextStyle implements ITextStyle
      *
      * @member {string}
      */
-    get lineJoin()
+    get lineJoin(): TextStyleLineJoin
     {
         return this._lineJoin;
     }
-    set lineJoin(lineJoin)
+    set lineJoin(lineJoin: TextStyleLineJoin)
     {
         if (this._lineJoin !== lineJoin)
         {
@@ -592,11 +592,11 @@ export class TextStyle implements ITextStyle
      *
      * @member {number}
      */
-    get miterLimit()
+    get miterLimit(): number
     {
         return this._miterLimit;
     }
-    set miterLimit(miterLimit)
+    set miterLimit(miterLimit: number)
     {
         if (this._miterLimit !== miterLimit)
         {
@@ -611,11 +611,11 @@ export class TextStyle implements ITextStyle
      *
      * @member {number}
      */
-    get padding()
+    get padding(): number
     {
         return this._padding;
     }
-    set padding(padding)
+    set padding(padding: number)
     {
         if (this._padding !== padding)
         {
@@ -630,11 +630,11 @@ export class TextStyle implements ITextStyle
      *
      * @member {string|number}
      */
-    get stroke()
+    get stroke(): string | number
     {
         return this._stroke;
     }
-    set stroke(stroke)
+    set stroke(stroke: string | number)
     {
         // TODO: Can't have different types for getter and setter. The getter shouldn't have the number type as
         //       the setter converts to string. See this thread for more details:
@@ -653,11 +653,11 @@ export class TextStyle implements ITextStyle
      *
      * @member {number}
      */
-    get strokeThickness()
+    get strokeThickness(): number
     {
         return this._strokeThickness;
     }
-    set strokeThickness(strokeThickness)
+    set strokeThickness(strokeThickness: number)
     {
         if (this._strokeThickness !== strokeThickness)
         {
@@ -671,11 +671,11 @@ export class TextStyle implements ITextStyle
      *
      * @member {string}
      */
-    get textBaseline()
+    get textBaseline(): TextStyleTextBaseline
     {
         return this._textBaseline;
     }
-    set textBaseline(textBaseline)
+    set textBaseline(textBaseline: TextStyleTextBaseline)
     {
         if (this._textBaseline !== textBaseline)
         {
@@ -689,11 +689,11 @@ export class TextStyle implements ITextStyle
      *
      * @member {boolean}
      */
-    get trim()
+    get trim(): boolean
     {
         return this._trim;
     }
-    set trim(trim)
+    set trim(trim: boolean)
     {
         if (this._trim !== trim)
         {
@@ -714,11 +714,11 @@ export class TextStyle implements ITextStyle
      *
      * @member {string}
      */
-    get whiteSpace()
+    get whiteSpace(): TextStyleWhiteSpace
     {
         return this._whiteSpace;
     }
-    set whiteSpace(whiteSpace)
+    set whiteSpace(whiteSpace: TextStyleWhiteSpace)
     {
         if (this._whiteSpace !== whiteSpace)
         {
@@ -732,11 +732,11 @@ export class TextStyle implements ITextStyle
      *
      * @member {boolean}
      */
-    get wordWrap()
+    get wordWrap(): boolean
     {
         return this._wordWrap;
     }
-    set wordWrap(wordWrap)
+    set wordWrap(wordWrap: boolean)
     {
         if (this._wordWrap !== wordWrap)
         {
@@ -750,11 +750,11 @@ export class TextStyle implements ITextStyle
      *
      * @member {number}
      */
-    get wordWrapWidth()
+    get wordWrapWidth(): number
     {
         return this._wordWrapWidth;
     }
-    set wordWrapWidth(wordWrapWidth)
+    set wordWrapWidth(wordWrapWidth: number)
     {
         if (this._wordWrapWidth !== wordWrapWidth)
         {

--- a/packages/ticker/src/Ticker.ts
+++ b/packages/ticker/src/Ticker.ts
@@ -549,7 +549,7 @@ export class Ticker
         return 1000 / this._maxElapsedMS;
     }
 
-    set minFPS(fps)
+    set minFPS(fps: number)
     {
         // Minimum must be below the maxFPS
         const minFPS = Math.min(this.maxFPS, fps);
@@ -580,7 +580,7 @@ export class Ticker
         return 0;
     }
 
-    set maxFPS(fps)
+    set maxFPS(fps: number)
     {
         if (fps === 0)
         {


### PR DESCRIPTION
The newer version of ESLint and TypeScript plugins enforce this rule by default. This is a preemptive change so that we can support the latest tools. Adds setter types where they were missing from the code. 