### PR TITLE
Implement render-target clear in CanvasRenderer

### DIFF
--- a/packages/canvas/canvas-renderer/src/CanvasRenderer.ts
+++ b/packages/canvas/canvas-renderer/src/CanvasRenderer.ts
@@ -196,7 +196,7 @@ export class CanvasRenderer extends AbstractRenderer
      * @param {PIXI.DisplayObject} displayObject - The object to be rendered
      * @param {PIXI.RenderTexture} [renderTexture] - A render texture to be rendered to.
      *  If unset, it will render to the root context.
-     * @param {boolean} [clear=false] - Whether to clear the canvas before drawing
+     * @param {boolean} [clear=this.clearBeforeRender] - Whether to clear the canvas before drawing
      * @param {PIXI.Matrix} [transform] - A transformation to be applied
      * @param {boolean} [skipUpdateTransform=false] - Whether to skip the update transform
      */

--- a/packages/canvas/canvas-renderer/src/CanvasRenderer.ts
+++ b/packages/canvas/canvas-renderer/src/CanvasRenderer.ts
@@ -1,5 +1,5 @@
 import { AbstractRenderer, resources } from '@pixi/core';
-import { CanvasRenderTarget, sayHello } from '@pixi/utils';
+import { CanvasRenderTarget, sayHello, rgb2hex, hex2string } from '@pixi/utils';
 import { CanvasMaskManager } from './utils/CanvasMaskManager';
 import { mapCanvasBlendModesToPixi } from './utils/mapCanvasBlendModesToPixi';
 import { RENDERER_TYPE, SCALE_MODES, BLEND_MODES } from '@pixi/constants';
@@ -278,9 +278,20 @@ export class CanvasRenderer extends AbstractRenderer
                     context.fillStyle = this._backgroundColorString;
                     context.fillRect(0, 0, this.width, this.height);
                 }
-            } // else {
-            // TODO: implement background for CanvasRenderTarget or RenderTexture?
-            // }
+            }
+            else
+            {
+                renderTexture = (renderTexture as BaseRenderTexture);
+                renderTexture._canvasRenderTarget.clear();
+
+                const clearColor = renderTexture.clearColor;
+
+                if (clearColor[0] !== 0 || clearColor[1] !== 0 || clearColor[2] !== 0 || clearColor[3] !== 0)
+                {
+                    context.fillStyle = hex2string(rgb2hex(clearColor));
+                    context.fillRect(0, 0, renderTexture.realWidth, renderTexture.realHeight);
+                }
+            }
         }
 
         // TODO RENDER TARGET STUFF HERE..

--- a/packages/canvas/canvas-renderer/src/CanvasRenderer.ts
+++ b/packages/canvas/canvas-renderer/src/CanvasRenderer.ts
@@ -286,7 +286,7 @@ export class CanvasRenderer extends AbstractRenderer
 
                 const clearColor = renderTexture.clearColor;
 
-                if (clearColor[0] !== 0 || clearColor[1] !== 0 || clearColor[2] !== 0 || clearColor[3] !== 0)
+                if (clearColor[3] > 0)
                 {
                     context.fillStyle = hex2string(rgb2hex(clearColor));
                     context.fillRect(0, 0, renderTexture.realWidth, renderTexture.realHeight);


### PR DESCRIPTION
### Description of change
Implement render-target clearing in `CanvasRenderer#render`. This was reported in #6674.

Additional fixes:
* Fix the default value of the `clear` argument in the documentation.

- [x] Lint process passed (`npm run lint`)
