### PR TITLE
Fix parameter name so string2hex has correct generated .d.ts signature

### DIFF
--- a/packages/utils/src/color/hex.ts
+++ b/packages/utils/src/color/hex.ts
@@ -44,7 +44,7 @@ export function hex2string(hex: number): string
  * PIXI.utils.string2hex("#ffffff"); // returns 0xffffff
  * @memberof PIXI.utils
  * @function string2hex
- * @param {string} - The string color (e.g., `"#ffffff"`)
+ * @param {string} string - The string color (e.g., `"#ffffff"`)
  * @return {number} Number in hexadecimal.
  */
 export function string2hex(string: string): number


### PR DESCRIPTION
##### Description of change
After testing an update from v5.2.4 to 5.3.0, I noticed an error relating to `string2hex`. After the update, it seems the generated .d.ts signature changed to accidentally not accept any arguments. This doesn't affect tests or the generated JavaScript at runtime since the actual code itself and TypeScript annotation does still correctly accept a string parameter. But when using Pixi as an external dependency in a TypeScript project, something like `PIXI.utils.string2hex('#FFFFFF')` will throw a TypeScript error.

Inspired by a similar recent PR https://github.com/pixijs/pixi.js/pull/6703 that seems to fix up some issues created from the refactor in https://github.com/pixijs/pixi.js/pull/6634, this simply adds a parameter name to the JSDoc so the generated `pixi.js.d.ts` function signature is correct.

This fix can be tested by running `npm run types` before and after applying the commit and seeing the generated signature for `string2hex` in `dist/types/pixi.js.d.ts`.

Please let me know if I missed anything!

##### Pre-Merge Checklist

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
