### PR TITLE
fix: CacheAsBitmap problem under WebGLRenderer

### DIFF
--- a/packages/mixin-cache-as-bitmap/src/index.ts
+++ b/packages/mixin-cache-as-bitmap/src/index.ts
@@ -215,10 +215,7 @@ DisplayObject.prototype._initCachedDisplayObject = function _initCachedDisplayOb
     Texture.addToCache(renderTexture, textureCacheId);
 
     // need to set //
-    const m = _tempMatrix;
-
-    m.tx = -bounds.x;
-    m.ty = -bounds.y;
+    const m = this.transform.localTransform.copyTo(_tempMatrix).invert().translate(-bounds.x, -bounds.y);
 
     // reset
     this.transform.worldTransform.identity();

--- a/packages/mixin-cache-as-bitmap/src/index.ts
+++ b/packages/mixin-cache-as-bitmap/src/index.ts
@@ -217,9 +217,6 @@ DisplayObject.prototype._initCachedDisplayObject = function _initCachedDisplayOb
     // need to set //
     const m = this.transform.localTransform.copyTo(_tempMatrix).invert().translate(-bounds.x, -bounds.y);
 
-    // reset
-    this.transform.worldTransform.identity();
-
     // set all properties to there original so we can render to a texture
     this.render = this._cacheData.originalRender;
 

--- a/packages/mixin-cache-as-bitmap/src/index.ts
+++ b/packages/mixin-cache-as-bitmap/src/index.ts
@@ -220,7 +220,7 @@ DisplayObject.prototype._initCachedDisplayObject = function _initCachedDisplayOb
     // set all properties to there original so we can render to a texture
     this.render = this._cacheData.originalRender;
 
-    renderer.render(this, renderTexture, true, m, true);
+    renderer.render(this, renderTexture, true, m, false);
 
     // now restore the state be setting the new properties
     renderer.projection.transform = cachedProjectionTransform;


### PR DESCRIPTION
fix: #6733 

It's consistent with `CanvasRenderer`

fixed: https://jsfiddle.net/JetLu/gk2o7vmb/
