### PR TITLE
fix: generateCanvasTexture generates textures twice the size

### DIFF
--- a/packages/canvas/canvas-graphics/src/Graphics.ts
+++ b/packages/canvas/canvas-graphics/src/Graphics.ts
@@ -48,8 +48,7 @@ Graphics.prototype.generateCanvasTexture = function generateCanvasTexture(scaleM
         scaleMode,
     });
 
-    texture.baseTexture.resolution = resolution;
-    texture.baseTexture.update();
+    texture.baseTexture.setResolution(resolution);
 
     return texture;
 };


### PR DESCRIPTION
fix: #6083 

bug: https://jsfiddle.net/JetLu/Lnzyx135/
fixed: https://jsfiddle.net/JetLu/3ok4n7La/
