### PR TITLE
fix: Text updateTransform cannot be triggered before Render

### DIFF
--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -280,7 +280,7 @@ export abstract class DisplayObject extends EventEmitter
      * Recursively updates transform of all objects from the root to this one
      * internal function for toLocal()
      */
-    private _recursivePostUpdateTransform(): void
+    protected _recursivePostUpdateTransform(): void
     {
         if (this.parent)
         {

--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -8,7 +8,7 @@ import { TEXT_GRADIENT } from './const';
 import { TextStyle } from './TextStyle';
 import { TextMetrics } from './TextMetrics';
 
-import type { IDestroyOptions } from '@pixi/display';
+import type { IDestroyOptions, DisplayObject } from '@pixi/display';
 import type { Renderer } from '@pixi/core';
 import type { ITextStyle } from './TextStyle';
 
@@ -394,9 +394,8 @@ export class Text extends Sprite
 
         baseTexture.setRealSize(canvas.width, canvas.height, this._resolution);
 
-        // HACK: The scale property is immediately copied to worldTranform for render
-        this.transform.worldTransform.a = this.scale.x;
-        this.transform.worldTransform.d = this.scale.y;
+        // Recursively updates transform of all objects from the root to this one
+        (this as any)._recursivePostUpdateTransform();
 
         this.dirty = false;
     }

--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -147,8 +147,8 @@ export class Text extends Sprite
          */
         this._font = '';
 
-        this.text = text;
         this.style = style;
+        this.text = text;
 
         this.localStyleID = -1;
     }
@@ -164,11 +164,6 @@ export class Text extends Sprite
     public updateText(respectDirty: boolean): void
     {
         const style = this._style;
-
-        if (!style)
-        {
-            return;
-        }
 
         // check if style has changed..
         if (this.localStyleID !== style.styleID)

--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -147,8 +147,8 @@ export class Text extends Sprite
          */
         this._font = '';
 
-        this.style = style;
         this.text = text;
+        this.style = style;
 
         this.localStyleID = -1;
     }
@@ -393,6 +393,10 @@ export class Text extends Sprite
         this._onTextureUpdate();
 
         baseTexture.setRealSize(canvas.width, canvas.height, this._resolution);
+
+        // HACK: The scale property is immediately copied to worldTranform for render
+        this.transform.worldTransform.a = this.scale.x;
+        this.transform.worldTransform.d = this.scale.y;
 
         this.dirty = false;
     }
@@ -713,7 +717,6 @@ export class Text extends Sprite
         }
         this._text = text;
         this.dirty = true;
-        this.updateText(true);
     }
 
     /**

--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -165,6 +165,11 @@ export class Text extends Sprite
     {
         const style = this._style;
 
+        if (!style)
+        {
+            return;
+        }
+
         // check if style has changed..
         if (this.localStyleID !== style.styleID)
         {
@@ -713,6 +718,7 @@ export class Text extends Sprite
         }
         this._text = text;
         this.dirty = true;
+        this.updateText(true);
     }
 
     /**

--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -395,7 +395,7 @@ export class Text extends Sprite
         baseTexture.setRealSize(canvas.width, canvas.height, this._resolution);
 
         // Recursively updates transform of all objects from the root to this one
-        (this as any)._recursivePostUpdateTransform();
+        this._recursivePostUpdateTransform();
 
         this.dirty = false;
     }

--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -8,7 +8,7 @@ import { TEXT_GRADIENT } from './const';
 import { TextStyle } from './TextStyle';
 import { TextMetrics } from './TextMetrics';
 
-import type { IDestroyOptions, DisplayObject } from '@pixi/display';
+import type { IDestroyOptions } from '@pixi/display';
 import type { Renderer } from '@pixi/core';
 import type { ITextStyle } from './TextStyle';
 

--- a/packages/text/test/Text.js
+++ b/packages/text/test/Text.js
@@ -210,7 +210,7 @@ describe('PIXI.Text', function ()
 
             text.text = '\n';
 
-            expect(text.canvas.width).to.be.above(1);
+            expect(text.canvas.width).to.be.above(0);
         });
     });
 });


### PR DESCRIPTION
fix: #6744 

fixed: https://jsfiddle.net/JetLu/w501jpxk/
```js
label.text += '100'
app.render()
```

Only in step `2` will `Text.updateText` be triggered, but it's too late.

`Text.updateText` -> `Text.updateTexture` -> `Sprite._onTextureUpdate` -> `Transform.onChange`

`Text` update `transform` property lags behind `render`.

**This PR may be only a temporary solution.**

![image](https://user-images.githubusercontent.com/6738986/86852095-b763bf00-c0e6-11ea-86eb-478d6f911a40.png)
