### PR TITLE
Update documentation for AnimatedSprite handlers

### DIFF
--- a/packages/sprite-animated/src/AnimatedSprite.ts
+++ b/packages/sprite-animated/src/AnimatedSprite.ts
@@ -123,22 +123,34 @@ export class AnimatedSprite extends Sprite
         this.updateAnchor = false;
 
         /**
-         * Function to call when an AnimatedSprite finishes playing.
+         * User-assigned function to call when an AnimatedSprite finishes playing.
          *
+         * @example
+         * animation.onComplete = function () {
+         *   // finished!
+         * };
          * @member {Function}
          */
         this.onComplete = null;
 
         /**
-         * Function to call when an AnimatedSprite changes which texture is being rendered.
+         * User-assigned function to call when an AnimatedSprite changes which texture is being rendered.
          *
+         * @example
+         * animation.onFrameChange = function () {
+         *   // updated!
+         * };
          * @member {Function}
          */
         this.onFrameChange = null;
 
         /**
-         * Function to call when `loop` is true, and an AnimatedSprite is played and loops around to start again.
+         * User-assigned function to call when `loop` is true, and an AnimatedSprite is played and loops around to start again.
          *
+         * @example
+         * animation.onLoop = function () {
+         *   // looped!
+         * };
          * @member {Function}
          */
         this.onLoop = null;

--- a/packages/sprite-animated/src/AnimatedSprite.ts
+++ b/packages/sprite-animated/src/AnimatedSprite.ts
@@ -145,7 +145,8 @@ export class AnimatedSprite extends Sprite
         this.onFrameChange = null;
 
         /**
-         * User-assigned function to call when `loop` is true, and an AnimatedSprite is played and loops around to start again.
+         * User-assigned function to call when `loop` is true, and an AnimatedSprite is played and
+         * loops around to start again.
          *
          * @example
          * animation.onLoop = function () {


### PR DESCRIPTION
Fixes #6536 

### Fixed

Adds some additional context for using `onComplete`, `onFrameChange` and `onLoop`.

### Example

https://pixijs.download/fix-6536/docs/PIXI.AnimatedSprite.html#onComplete

#### Additional Note

As a side-note, I think we should convert these handlers to events. Using handlers like this doesn't really fit with other API patterns internally that really on dispatching with EventEmitter. So this implementation is a bit of an outlier, IMO. We could certainly have both and deprecate one. That would be another PR though.