### PR TITLE
Fixes namespace on deprecation entries for interaction manager

### DIFF
--- a/bundles/pixi.js/src/useDeprecated.ts
+++ b/bundles/pixi.js/src/useDeprecated.ts
@@ -253,7 +253,7 @@ export function useDeprecated(this: any): void
         InteractionManager: {
             get(): typeof InteractionManager
             {
-                deprecation('5.3.0', 'PIXI.accessibility.InteractionManager moved to PIXI.InteractionManager');
+                deprecation('5.3.0', 'PIXI.interaction.InteractionManager moved to PIXI.InteractionManager');
 
                 return PIXI.InteractionManager;
             },
@@ -267,7 +267,7 @@ export function useDeprecated(this: any): void
         InteractionData: {
             get(): typeof InteractionData
             {
-                deprecation('5.3.0', 'PIXI.accessibility.InteractionData moved to PIXI.InteractionData');
+                deprecation('5.3.0', 'PIXI.interaction.InteractionData moved to PIXI.InteractionData');
 
                 return PIXI.InteractionData;
             },
@@ -281,7 +281,7 @@ export function useDeprecated(this: any): void
         InteractionEvent: {
             get(): typeof InteractionEvent
             {
-                deprecation('5.3.0', 'PIXI.accessibility.InteractionEvent moved to PIXI.InteractionEvent');
+                deprecation('5.3.0', 'PIXI.interaction.InteractionEvent moved to PIXI.InteractionEvent');
 
                 return PIXI.InteractionEvent;
             },


### PR DESCRIPTION
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
