### PR TITLE
Fix Mesh tint for CanvasRenderer

### DIFF
--- a/packages/canvas/canvas-mesh/src/CanvasMeshRenderer.ts
+++ b/packages/canvas/canvas-mesh/src/CanvasMeshRenderer.ts
@@ -1,4 +1,5 @@
 import { DRAW_MODES } from '@pixi/constants';
+import { canvasUtils } from '@pixi/canvas-renderer';
 
 import type { CanvasRenderer } from '@pixi/canvas-renderer';
 import type { Mesh } from '@pixi/mesh';
@@ -12,6 +13,16 @@ import type { Mesh } from '@pixi/mesh';
  */
 export class CanvasMeshRenderer
 {
+    /**
+     * Cached tint value so we can tell when the tint is changed.
+     */
+    protected _cachedTint = 0xFFFFFF;
+
+    /**
+     * Cached tinted texture.
+     */
+    protected _tintedCanvas: HTMLCanvasElement = null;
+
     public renderer: CanvasRenderer;
 
     /**
@@ -108,11 +119,21 @@ export class CanvasMeshRenderer
         {
             return;
         }
-
+        const isTinted = mesh.tint !== 0xFFFFFF;
         const base = texture.baseTexture;
-        const textureSource = base.getDrawableSource();
         const textureWidth = base.width;
         const textureHeight = base.height;
+
+        if (isTinted)
+        {
+            if (this._cachedTint !== mesh.tint)
+            {
+                this._cachedTint = mesh.tint;
+                this._tintedCanvas = canvasUtils.getTintedCanvas(mesh, mesh.tint) as HTMLCanvasElement;
+            }
+        }
+
+        const textureSource = !isTinted ? base.getDrawableSource() : this._tintedCanvas;
 
         const u0 = uvs[index0] * base.width;
         const u1 = uvs[index1] * base.width;


### PR DESCRIPTION
fix: #6759 

fixed: https://jsfiddle.net/JetLu/y3x5s9g7/

It's assigned to @GoodBoyDigital , but I want to try to fix it.

The content of the code is actually copied from [NineSlicePlane._renderCanvas](https://github.com/pixijs/pixi.js/blob/dev/packages/canvas/canvas-mesh/src/NineSlicePlane.ts#L38).