### PR TITLE
Fix Mesh tint for CanvasRenderer

### DIFF
--- a/packages/canvas/canvas-mesh/global.d.ts
+++ b/packages/canvas/canvas-mesh/global.d.ts
@@ -3,6 +3,8 @@ declare namespace GlobalMixins {
         _renderCanvas?: (renderer: import('@pixi/canvas-renderer').CanvasRenderer) => void;
         _canvasPadding: number;
         canvasPadding: number;
+        _cachedTint: number;
+        _tintedCanvas: HTMLCanvasElement;
     }
 
     interface MeshMaterial {

--- a/packages/canvas/canvas-mesh/src/CanvasMeshRenderer.ts
+++ b/packages/canvas/canvas-mesh/src/CanvasMeshRenderer.ts
@@ -13,16 +13,6 @@ import type { Mesh } from '@pixi/mesh';
  */
 export class CanvasMeshRenderer
 {
-    /**
-     * Cached tint value so we can tell when the tint is changed.
-     */
-    protected _cachedTint = 0xFFFFFF;
-
-    /**
-     * Cached tinted texture.
-     */
-    protected _tintedCanvas: HTMLCanvasElement = null;
-
     public renderer: CanvasRenderer;
 
     /**
@@ -126,14 +116,14 @@ export class CanvasMeshRenderer
 
         if (isTinted)
         {
-            if (this._cachedTint !== mesh.tint)
+            if (mesh._cachedTint !== mesh.tint)
             {
-                this._cachedTint = mesh.tint;
-                this._tintedCanvas = canvasUtils.getTintedCanvas(mesh, mesh.tint) as HTMLCanvasElement;
+                mesh._cachedTint = mesh.tint;
+                mesh._tintedCanvas = canvasUtils.getTintedCanvas(mesh, mesh.tint) as HTMLCanvasElement;
             }
         }
 
-        const textureSource = !isTinted ? base.getDrawableSource() : this._tintedCanvas;
+        const textureSource = isTinted ? mesh._tintedCanvas : base.getDrawableSource();
 
         const u0 = uvs[index0] * base.width;
         const u1 = uvs[index1] * base.width;

--- a/packages/canvas/canvas-mesh/src/Mesh.ts
+++ b/packages/canvas/canvas-mesh/src/Mesh.ts
@@ -6,6 +6,22 @@ import type { CanvasRenderer } from '@pixi/canvas-renderer';
 let warned = false;
 
 /**
+ * Cached tint value so we can tell when the tint is changed.
+ * @memberof PIXI.Mesh#
+ * @member {number} _cachedTint
+ * @protected
+ */
+Mesh.prototype._cachedTint = 0xFFFFFF;
+
+/**
+ * Cached tinted texture.
+ * @memberof PIXI.Mesh#
+ * @member {HTMLCanvasElement} _tintedCanvas
+ * @protected
+ */
+Mesh.prototype._tintedCanvas = null;
+
+/**
  * Renders the object using the Canvas renderer
  *
  * @private


### PR DESCRIPTION
fix: #6782 

fixed: https://codepen.io/jerald/pen/WNrBGvG

#6764 had a problem 😞 .

The main reason is that the cache is used on the renderer, causing all Mesh instances to share one cache.