### PR TITLE
Fix generic types of container child methods

### DIFF
--- a/types/assemble.js
+++ b/types/assemble.js
@@ -49,7 +49,7 @@ if (bundle === 'pixi.js') {
 
 // tsd-jsdoc doesn't currently support indexed generics (TChildren[0])
 buffer = buffer.replace(
-    /(addChild|removeChild)\(\.\.\.children: PIXI.DisplayObject\[\]\): PIXI\.DisplayObject;/g,
+    /(addChild|removeChild)\(\.\.\.children: PIXI\.DisplayObject\[\]\): PIXI\.DisplayObject;/g,
     '$1<TChildren extends PIXI.DisplayObject[]>(...children: TChildren): TChildren[0];'
 );
 

--- a/types/assemble.js
+++ b/types/assemble.js
@@ -49,8 +49,8 @@ if (bundle === 'pixi.js') {
 
 // tsd-jsdoc doesn't currently support indexed generics (TChildren[0])
 buffer = buffer.replace(
-    /(addChild|removeChild)\(\.\.\.child: PIXI.DisplayObject\[\]\): PIXI\.DisplayObject;/g,
-    '$1<TChildren extends PIXI.DisplayObject[]>(...child: TChildren): TChildren[0];'
+    /(addChild|removeChild)\(\.\.\.children: PIXI.DisplayObject\[\]\): PIXI\.DisplayObject;/g,
+    '$1<TChildren extends PIXI.DisplayObject[]>(...children: TChildren): TChildren[0];'
 );
 
 // tsd-jsdoc supports this case using the @template tag, but using said tag breaks documentation generation


### PR DESCRIPTION
##### Description of change
<!-- Provide a description of the change below this comment. -->
During the recent conversion of the display package to TypeScript (#6261) the function signature of `addChild` and `removeChild` got changed. Previously their parameter was called `child` but now it is `children`.

As a result the massaging of the type output via string replacement (#5941) stopped working for these methods. Since 5.3.0 the declaration files state that the return type of `addChild` and `removeChild` is `DisplayObject`.

This pull request re-adds the generic types to these container methods by adjusting the regular expression.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
