### PR TITLE
Fix for loops in BitmapFont.from to guard against Array.prototype pollution

### DIFF
--- a/packages/text-bitmap/src/BitmapFont.ts
+++ b/packages/text-bitmap/src/BitmapFont.ts
@@ -163,7 +163,7 @@ export class BitmapFont
 
         // Convert the input Texture, Textures or object
         // into a page Texture lookup by "id"
-        for (const i in data.page)
+        for (let i = 0; i < data.page.length; i++)
         {
             const { id, file } = data.page[i];
 
@@ -172,7 +172,7 @@ export class BitmapFont
         }
 
         // parse letters
-        for (const i in data.char)
+        for (let i = 0; i < data.char.length; i++)
         {
             const { id, page } = data.char[i];
             let { x, y, width, height, xoffset, yoffset, xadvance } = data.char[i];
@@ -206,7 +206,7 @@ export class BitmapFont
         }
 
         // parse kernings
-        for (const i in data.kerning)
+        for (let i = 0; i < data.kerning.length; i++)
         {
             let { first, second, amount } = data.kerning[i];
 
@@ -442,7 +442,7 @@ export class BitmapFont
             const id = metrics.text.charCodeAt(0);
 
             // Create a texture holding just the glyph
-            fontData.char[id] = {
+            fontData.char.push({
                 id,
                 page: textures.length - 1,
                 x: positionX / resolution,
@@ -454,7 +454,7 @@ export class BitmapFont
                 xadvance: Math.ceil(width
                         - (style.dropShadow ? style.dropShadowDistance : 0)
                         - (style.stroke ? style.strokeThickness : 0)),
-            };
+            });
 
             positionX += (textureGlyphWidth + (2 * padding)) * resolution;
             positionX = Math.ceil(positionX);


### PR DESCRIPTION
User on Slack (@Bouh) reported a problem where pollution on `Array.prototype` was creating issue with BitmapFont because of the type of loops being use `for...in` instead of incrementing `for` loops.

**Broken** (v5.3.2): https://jsfiddle.net/bigtimebuddy/xp9k76nj/
**Fixed** (this PR): https://jsfiddle.net/bigtimebuddy/04ysxjef/

While, in general, adding Array.prototype assignments is not best practice, it's sometimes necessary for older browser and getting ES6 features. This change actually fixes the BitmapFont data arrays to be looped consistent with the rest of Pixi (`for...in` are really only used for plain objects).
