### PR TITLE
Added missed dependency for canvas-graphics, canvas-mesh, canvas-sprite and canvas-text

### DIFF
--- a/packages/canvas/canvas-graphics/package.json
+++ b/packages/canvas/canvas-graphics/package.json
@@ -28,6 +28,7 @@
     "@pixi/constants": "5.3.2",
     "@pixi/core": "5.3.2",
     "@pixi/graphics": "5.3.2",
-    "@pixi/math": "5.3.2"
+    "@pixi/math": "5.3.2",
+    "@pixi/canvas-display": "5.3.2"
   }
 }

--- a/packages/canvas/canvas-mesh/package.json
+++ b/packages/canvas/canvas-mesh/package.json
@@ -25,6 +25,7 @@
   ],
   "dependencies": {
     "@pixi/canvas-renderer": "5.3.2",
+    "@pixi/canvas-display": "5.3.2",
     "@pixi/constants": "5.3.2",
     "@pixi/mesh": "5.3.2",
     "@pixi/mesh-extras": "5.3.2",

--- a/packages/canvas/canvas-sprite/package.json
+++ b/packages/canvas/canvas-sprite/package.json
@@ -25,6 +25,7 @@
   ],
   "dependencies": {
     "@pixi/canvas-renderer": "5.3.2",
+    "@pixi/canvas-display": "5.3.2",
     "@pixi/constants": "5.3.2",
     "@pixi/math": "5.3.2",
     "@pixi/sprite": "5.3.2",

--- a/packages/canvas/canvas-text/package.json
+++ b/packages/canvas/canvas-text/package.json
@@ -22,6 +22,7 @@
     "dist"
   ],
   "dependencies": {
+    "@pixi/canvas-sprite": "5.3.2",
     "@pixi/sprite": "5.3.2",
     "@pixi/text": "5.3.2"
   }


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
Just added missed `canvas-display` dependency to `canvas-graphics`, `canvas-mesh`, `canvas-sprite` packages and added `canvas-sprite` to `canvas-text` dependecy.

As you can see Graphics extends Container
https://github.com/pixijs/pixi.js/blob/8998367f026d2a729bc3ae8583c4b6954de42260/packages/graphics/src/Graphics.ts#L78
and CanvasRenderer execute next line
https://github.com/pixijs/pixi.js/blob/cdf9494b1a4f8ad758033683dcf101033cf8c95b/packages/canvas/canvas-renderer/src/CanvasRenderer.ts#L299
which call next method ```Container.prototype.renderCanvas``` it exist in `canvas-display` (**without this module it will throw an error that `renderCanvas` method doesn't exist in Graphics class**) package and then
 ```Container.prototype.renderCanvas``` call method `_renderCanvas`
https://github.com/pixijs/pixi.js/blob/8998367f026d2a729bc3ae8583c4b6954de42260/packages/canvas/canvas-display/src/Container.ts#L36
from `canvas-graphics`
https://github.com/pixijs/pixi.js/blob/8998367f026d2a729bc3ae8583c4b6954de42260/packages/canvas/canvas-graphics/src/Graphics.ts#L66

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
