### PR TITLE
Upgrade to Earcut v2.2.2

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@pixi/constants": "5.3.2",
     "@pixi/settings": "5.3.2",
-    "earcut": "^2.1.5",
+    "earcut": "^2.2.2",
     "eventemitter3": "^3.1.0",
     "url": "^0.11.0"
   },


### PR DESCRIPTION
##### Description of change
Upgrade to Earcut v2.2.2

##### Pre-Merge Checklist
- [x] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)

**NOTE:** I ran `npm run test`, and the functional tests seem to pass, but ran into the same issue as #5931 where running `mkdirp dist/types && jsdoc -c types/jsdoc-legacy.conf.json && node types/assemble pixi.js-legacy` throws the same error.   I tried upgrading/downgrading node from 8 <-> 13.  Uninstalled my global copy of `jsdoc`.  Pulled in the latest from https://github.com/pixijs/pixi.js/pull/6700 but didn't seem to resolve my particular issue.  I would love to be able to run tests, but I must be missing something obvious... If anyone knows, give me a hint! Thnx :)