### PR TITLE
Document resizeThrottle

### DIFF
--- a/packages/app/src/Application.ts
+++ b/packages/app/src/Application.ts
@@ -72,6 +72,7 @@ export class Application
      *  The system ticker will always run before both the shared ticker and the app ticker.
      * @param {boolean} [options.sharedLoader=false] - `true` to use PIXI.Loader.shared, `false` to create new Loader.
      * @param {Window|HTMLElement} [options.resizeTo] - Element to automatically resize stage to.
+     * @param {number} [options.resizeThrottle] - How long to throttle resizing when `resizeTo` is set. This can be useful when resizing is a slow operation.
      */
     constructor(options?: IApplicationOptions)
     {

--- a/packages/app/src/Application.ts
+++ b/packages/app/src/Application.ts
@@ -72,7 +72,8 @@ export class Application
      *  The system ticker will always run before both the shared ticker and the app ticker.
      * @param {boolean} [options.sharedLoader=false] - `true` to use PIXI.Loader.shared, `false` to create new Loader.
      * @param {Window|HTMLElement} [options.resizeTo] - Element to automatically resize stage to.
-     * @param {number} [options.resizeThrottle] - How long to throttle resizing when `resizeTo` is set. This can be useful when resizing is a slow operation.
+     * @param {number} [options.resizeThrottle] - How long to throttle resizing when `resizeTo` is set. This can be
+     *  useful when resizing is a slow operation.
      */
     constructor(options?: IApplicationOptions)
     {


### PR DESCRIPTION
##### Description of change

Documents the `resizeThrottle` of `Application`.

**Open questions:**

- Is there a default value?
- Is this actually used by `pixi.js`, or is it a remnant of when this feature was being developed? It only shows up [a single time in the source code search](https://github.com/pixijs/pixi.js/search?q=resizethrottle&unscoped_q=resizethrottle); it's not clear to me how it's being used, if it is used.

If it's not being used, then perhaps [L18](https://github.com/pixijs/pixi.js/blob/ef8f397faf8b3a877adc8b5b6a009aecc0ab7b33/packages/app/src/Application.ts#L18) needs to be deleted instead.

##### Pre-Merge Checklist

- [ ] ~~Tests and/or benchmarks are included~~
- [x] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
