### PR TITLE
Account for transform pivot when decomposing matrix

### DIFF
--- a/packages/math/src/Matrix.ts
+++ b/packages/math/src/Matrix.ts
@@ -359,6 +359,7 @@ export class Matrix
         const b = this.b;
         const c = this.c;
         const d = this.d;
+        const pivot = transform.pivot;
 
         const skewX = -Math.atan2(-c, d);
         const skewY = Math.atan2(b, a);
@@ -382,8 +383,8 @@ export class Matrix
         transform.scale.y = Math.sqrt((c * c) + (d * d));
 
         // next set position
-        transform.position.x = this.tx;
-        transform.position.y = this.ty;
+        transform.position.x = this.tx + ((pivot.x * a) + (pivot.y * c));
+        transform.position.y = this.ty + ((pivot.x * b) + (pivot.y * d));
 
         return transform;
     }

--- a/packages/math/test/Matrix.js
+++ b/packages/math/test/Matrix.js
@@ -216,4 +216,27 @@ describe('PIXI.Matrix', function ()
         expect(result.c).to.closeTo(matrix.c, 0.001);
         expect(result.d).to.closeTo(matrix.d, 0.001);
     });
+
+    describe('decompose', function ()
+    {
+        it('should be the inverse of updateLocalTransform even when pivot is set', function ()
+        {
+            const matrix = new Matrix(0.01, 0.04, 0.04, 0.1, 2, 2);
+            const transform = new Transform();
+
+            transform.pivot.set(40, 40);
+
+            matrix.decompose(transform);
+            transform.updateLocalTransform();
+
+            const localTransform = transform.localTransform;
+
+            expect(localTransform.a).to.closeTo(matrix.a, 0.001);
+            expect(localTransform.b).to.closeTo(matrix.b, 0.001);
+            expect(localTransform.c).to.closeTo(matrix.c, 0.001);
+            expect(localTransform.d).to.closeTo(matrix.d, 0.001);
+            expect(localTransform.tx).to.closeTo(matrix.tx, 0.001);
+            expect(localTransform.ty).to.closeTo(matrix.ty, 0.001);
+        });
+    });
 });


### PR DESCRIPTION
#6810

##### Description of change
This patch has been battle-tested in the [@pixi-essentials/transformer](https://github.com/SukantPal/pixi-essentials/blob/ffe467dc8da91f3ac36723fbd59395428fbd8ffd/packages/transformer/src/utils/decomposeTransform.ts#L44) package.

Basically, the `Matrix#decompose` method sets the position assuming the pivot is (0, 0). Obviously, this is not always
the case.

There are either two fixes to this: set pivot to (0, 0) always OR calculate the position so that the pivot does not have to
change. I chose the latter b/c the user does not expect the pivot to change when decomposing a matrix, because it is
not a part of the actual transform.

##### Reasoning

The reason why this will work is b/c of the way tx, ty are calculated:

https://github.com/pixijs/pixi.js/blob/8f7ed7662949ea1217b6f3b6af470e855cfe0b13/packages/math/src/Transform.ts#L201

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
