### PR TITLE
Create Native Browser Module Bundles

### DIFF
--- a/bundles/pixi.js-legacy/package.json
+++ b/bundles/pixi.js-legacy/package.json
@@ -13,6 +13,7 @@
   "main": "lib/pixi-legacy.js",
   "module": "lib/pixi-legacy.es.js",
   "bundle": "dist/pixi-legacy.js",
+  "bundleModule": "dist/pixi-legacy.mjs",
   "bundleOutput": {
     "footer": "PIXI.useDeprecated();",
     "name": "PIXI"

--- a/bundles/pixi.js/package.json
+++ b/bundles/pixi.js/package.json
@@ -13,6 +13,7 @@
   "main": "lib/pixi.js",
   "module": "lib/pixi.es.js",
   "bundle": "dist/pixi.js",
+  "bundleModule": "dist/pixi.mjs",
   "bundleOutput": {
     "footer": "PIXI.useDeprecated();",
     "name": "PIXI"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -144,7 +144,7 @@ async function main()
             }
 
             const file = path.join(basePath, bundle);
-            const moduleFile = file.replace(/\.js$/, '.mjs');
+            const moduleFile = bundleModule ? path.join(basePath, bundleModule) : '';
             const external = standalone ? null : Object.keys(namespaces);
             const globals = standalone ? null : namespaces;
             const ns = namespaces[pkg.name];
@@ -185,13 +185,13 @@ async function main()
                         footer,
                         sourcemap,
                     }, bundleOutput),
-                    {
+                    ...moduleFile ? [{
                         banner,
                         file: moduleFile,
                         format: 'esm',
                         freeze,
                         sourcemap,
-                    }
+                    }] : []
                 ],
                 treeshake: false,
                 plugins,
@@ -213,13 +213,13 @@ async function main()
                             footer,
                             sourcemap,
                         }, bundleOutput),
-                        {
+                        ...moduleFile ? [{
                             banner,
                             file: moduleFile.replace(/\.mjs$/, '.min.mjs'),
                             format: 'esm',
                             freeze,
                             sourcemap,
-                        }
+                        }] : []
                     ],
                     treeshake: false,
                     plugins: [...plugins, terser({

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -101,6 +101,7 @@ async function main()
             main,
             module,
             bundle,
+            bundleModule,
             bundleInput,
             bundleOutput,
             bundleNoExports,
@@ -143,11 +144,13 @@ async function main()
             }
 
             const file = path.join(basePath, bundle);
+            const moduleFile = file.replace(/\.js$/, '.mjs');
             const external = standalone ? null : Object.keys(namespaces);
             const globals = standalone ? null : namespaces;
             const ns = namespaces[pkg.name];
             const name = pkg.name.replace(/[^a-z]+/g, '_');
             let footer;
+            let nsBanner = banner;
 
             // Ignore self-contained packages like polyfills and unsafe-eval
             // as well as the bundles pixi.js and pixi.js-legacy
@@ -162,25 +165,34 @@ async function main()
                 {
                     const base = ns.split('.')[0];
 
-                    banner += `\nthis.${base} = this.${base} || {};`;
+                    nsBanner += `\nthis.${base} = this.${base} || {};`;
                 }
 
-                banner += `\nthis.${ns} = this.${ns} || {};`;
+                nsBanner += `\nthis.${ns} = this.${ns} || {};`;
             }
 
             results.push({
                 input,
                 external,
-                output: Object.assign({
-                    banner,
-                    file,
-                    format: 'iife',
-                    freeze,
-                    globals,
-                    name,
-                    footer,
-                    sourcemap,
-                }, bundleOutput),
+                output: [
+                    Object.assign({
+                        banner: nsBanner,
+                        file,
+                        format: 'iife',
+                        freeze,
+                        globals,
+                        name,
+                        footer,
+                        sourcemap,
+                    }, bundleOutput),
+                    {
+                        banner,
+                        file: moduleFile,
+                        format: 'esm',
+                        freeze,
+                        sourcemap,
+                    }
+                ],
                 treeshake: false,
                 plugins,
             });
@@ -190,16 +202,25 @@ async function main()
                 results.push({
                     input,
                     external,
-                    output: Object.assign({
-                        banner,
-                        file: file.replace(/\.js$/, '.min.js'),
-                        format: 'iife',
-                        freeze,
-                        globals,
-                        name,
-                        footer,
-                        sourcemap,
-                    }, bundleOutput),
+                    output: [
+                        Object.assign({
+                            banner: nsBanner,
+                            file: file.replace(/\.js$/, '.min.js'),
+                            format: 'iife',
+                            freeze,
+                            globals,
+                            name,
+                            footer,
+                            sourcemap,
+                        }, bundleOutput),
+                        {
+                            banner,
+                            file: moduleFile.replace(/\.mjs$/, '.min.mjs'),
+                            format: 'esm',
+                            freeze,
+                            sourcemap,
+                        }
+                    ],
                     treeshake: false,
                     plugins: [...plugins, terser({
                         output: {


### PR DESCRIPTION
## Overview

This adds support in the build system for exporting a native browser-based module. Currently, only esm files exported are intended for users of Webpack/Rollup/Parcel. This module export will run directly in modern browsers that support `<script type="module">` and provides a modern solution for importing directly in the browser.

Fixes #6734

### Downloads

* https://pixijs.download/dev-browser-modules/pixi.mjs
* https://pixijs.download/dev-browser-modules/pixi-legacy.mjs

### Example

Code: https://github.com/bigtimebuddy/pixi.js-browser-module-example
Preview: https://mattkarl.com/pixi.js-browser-module-example/