### PR TITLE
Fix TextureMetrics wrong cache

### DIFF
--- a/packages/text/src/TextMetrics.ts
+++ b/packages/text/src/TextMetrics.ts
@@ -206,7 +206,7 @@ export class TextMetrics
         let line = '';
         let lines = '';
 
-        const cache: CharacterWidthCache = {};
+        const cache: CharacterWidthCache = Object.create(null);
         const { letterSpacing, whiteSpace } = style;
 
         // How to handle whitespaces

--- a/packages/text/src/TextMetrics.ts
+++ b/packages/text/src/TextMetrics.ts
@@ -418,7 +418,7 @@ export class TextMetrics
     {
         let width = cache[key];
 
-        if (width === undefined)
+        if (typeof width !== 'number')
         {
             const spacing = ((key.length) * letterSpacing);
 


### PR DESCRIPTION
##### Description of change
Fix wrong result when a key is reserved name of `Object.prototype` fields, like `constructor`

https://github.com/pixijs/pixi.js/issues/6836

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
