### PR TITLE
Fix crash with "kernings" field in BitmapFont txt-based format

### DIFF
--- a/packages/text-bitmap/src/formats/TextFormat.ts
+++ b/packages/text-bitmap/src/formats/TextFormat.ts
@@ -28,6 +28,9 @@ interface IBitmapFontRawData {
         yoffset: string;
         xadvance: string;
     }[];
+    kernings?: {
+        count: number;
+    }[];
     kerning?: {
         first: string;
         second: string;
@@ -75,6 +78,7 @@ export class TextFormat
             char: [],
             chars: [],
             kerning: [],
+            kernings: [],
         };
 
         for (const i in items)

--- a/packages/text-bitmap/test/resources/bmtxt-test.txt
+++ b/packages/text-bitmap/test/resources/bmtxt-test.txt
@@ -97,3 +97,5 @@ char id=123 x=1 y=330 width=18 height=34 xoffset=1 yoffset=5 xadvance=8 page=0 c
 char id=124 x=20 y=295 width=14 height=34 xoffset=3 yoffset=5 xadvance=8 page=0 chnl=0
 char id=125 x=1 y=295 width=18 height=34 xoffset=1 yoffset=5 xadvance=8 page=0 chnl=0
 char id=126 x=28 y=487 width=22 height=16 xoffset=2 yoffset=14 xadvance=14 page=0 chnl=0
+kernings count=1
+kerning first=32 second=32 amount=-2


### PR DESCRIPTION
Fixes #6839

The text-based font format supports a `kernings` attribute, but it was missing from the parsing code. Also, updates the unit-test to make sure we are parsing kernings.