### PR TITLE
Making the rect param of the getLocalBounds methods of the Spirte and TilingSprite classes optional, using the same approach as in the DisplayObject class.

### DIFF
--- a/packages/sprite-tiling/src/TilingSprite.ts
+++ b/packages/sprite-tiling/src/TilingSprite.ts
@@ -186,16 +186,6 @@ export class TilingSprite extends Sprite
      */
     public getLocalBounds(rect?: Rectangle): Rectangle
     {
-        if (!rect)
-        {
-            if (!this._localBoundsRect)
-            {
-                this._localBoundsRect = new Rectangle();
-            }
-
-            rect = this._localBoundsRect;
-        }
-
         // we can do a fast local bounds if the sprite has no children!
         if (this.children.length === 0)
         {
@@ -203,6 +193,16 @@ export class TilingSprite extends Sprite
             this._bounds.minY = this._height * -this._anchor._y;
             this._bounds.maxX = this._width * (1 - this._anchor._x);
             this._bounds.maxY = this._height * (1 - this._anchor._y);
+
+            if (!rect)
+            {
+                if (!this._localBoundsRect)
+                {
+                    this._localBoundsRect = new Rectangle();
+                }
+
+                rect = this._localBoundsRect;
+            }
 
             return this._bounds.getRectangle(rect);
         }

--- a/packages/sprite-tiling/src/TilingSprite.ts
+++ b/packages/sprite-tiling/src/TilingSprite.ts
@@ -181,11 +181,21 @@ export class TilingSprite extends Sprite
     /**
      * Gets the local bounds of the sprite object.
      *
-     * @param {PIXI.Rectangle} rect - The output rectangle.
+     * @param {PIXI.Rectangle} [rect] - Optional output rectangle.
      * @return {PIXI.Rectangle} The bounds.
      */
-    public getLocalBounds(rect: Rectangle): Rectangle
+    public getLocalBounds(rect?: Rectangle): Rectangle
     {
+        if (!rect)
+        {
+            if (!this._localBoundsRect)
+            {
+                this._localBoundsRect = new Rectangle();
+            }
+
+            rect = this._localBoundsRect;
+        }
+
         // we can do a fast local bounds if the sprite has no children!
         if (this.children.length === 0)
         {
@@ -193,16 +203,6 @@ export class TilingSprite extends Sprite
             this._bounds.minY = this._height * -this._anchor._y;
             this._bounds.maxX = this._width * (1 - this._anchor._x);
             this._bounds.maxY = this._height * (1 - this._anchor._y);
-
-            if (!rect)
-            {
-                if (!this._localBoundsRect)
-                {
-                    this._localBoundsRect = new Rectangle();
-                }
-
-                rect = this._localBoundsRect;
-            }
 
             return this._bounds.getRectangle(rect);
         }

--- a/packages/sprite/src/Sprite.ts
+++ b/packages/sprite/src/Sprite.ts
@@ -446,18 +446,8 @@ export class Sprite extends Container
      * @param {PIXI.Rectangle} [rect] - Optional output rectangle.
      * @return {PIXI.Rectangle} The bounds.
      */
-    public getLocalBounds(rect: Rectangle): Rectangle
+    public getLocalBounds(rect?: Rectangle): Rectangle
     {
-        if (!rect)
-        {
-            if (!this._localBoundsRect)
-            {
-                this._localBoundsRect = new Rectangle();
-            }
-
-            rect = this._localBoundsRect;
-        }
-
         // we can do a fast local bounds if the sprite has no children!
         if (this.children.length === 0)
         {
@@ -465,6 +455,16 @@ export class Sprite extends Container
             this._bounds.minY = this._texture.orig.height * -this._anchor._y;
             this._bounds.maxX = this._texture.orig.width * (1 - this._anchor._x);
             this._bounds.maxY = this._texture.orig.height * (1 - this._anchor._y);
+
+            if (!rect)
+            {
+                if (!this._localBoundsRect)
+                {
+                    this._localBoundsRect = new Rectangle();
+                }
+
+                rect = this._localBoundsRect;
+            }
 
             return this._bounds.getRectangle(rect);
         }

--- a/packages/sprite/src/Sprite.ts
+++ b/packages/sprite/src/Sprite.ts
@@ -443,11 +443,21 @@ export class Sprite extends Container
     /**
      * Gets the local bounds of the sprite object.
      *
-     * @param {PIXI.Rectangle} [rect] - The output rectangle.
+     * @param {PIXI.Rectangle} [rect] - Optional output rectangle.
      * @return {PIXI.Rectangle} The bounds.
      */
     public getLocalBounds(rect: Rectangle): Rectangle
     {
+        if (!rect)
+        {
+            if (!this._localBoundsRect)
+            {
+                this._localBoundsRect = new Rectangle();
+            }
+
+            rect = this._localBoundsRect;
+        }
+
         // we can do a fast local bounds if the sprite has no children!
         if (this.children.length === 0)
         {
@@ -455,16 +465,6 @@ export class Sprite extends Container
             this._bounds.minY = this._texture.orig.height * -this._anchor._y;
             this._bounds.maxX = this._texture.orig.width * (1 - this._anchor._x);
             this._bounds.maxY = this._texture.orig.height * (1 - this._anchor._y);
-
-            if (!rect)
-            {
-                if (!this._localBoundsRect)
-                {
-                    this._localBoundsRect = new Rectangle();
-                }
-
-                rect = this._localBoundsRect;
-            }
 
             return this._bounds.getRectangle(rect);
         }

--- a/packages/sprite/test/Sprite.js
+++ b/packages/sprite/test/Sprite.js
@@ -94,6 +94,24 @@ describe('PIXI.Sprite', function ()
         });
     });
 
+    describe('getLocalBounds', function ()
+    {
+        it('must have correct value according to texture size, width, height and anchor', function ()
+        {
+            const texture = new PIXI.RenderTexture.create(20, 30);
+            const sprite = new PIXI.Sprite(texture);
+
+            sprite.anchor.set(0.5, 0.5);
+
+            const bounds = sprite.getLocalBounds();
+
+            expect(bounds.x).to.equal(-10);
+            expect(bounds.y).to.equal(-15);
+            expect(bounds.width).to.equal(20);
+            expect(bounds.height).to.equal(30);
+        });
+    });
+
     describe('containsPoint', function ()
     {
         const texture = new RenderTexture.create(20, 30);

--- a/packages/sprite/test/Sprite.js
+++ b/packages/sprite/test/Sprite.js
@@ -98,8 +98,8 @@ describe('PIXI.Sprite', function ()
     {
         it('must have correct value according to texture size, width, height and anchor', function ()
         {
-            const texture = new PIXI.RenderTexture.create(20, 30);
-            const sprite = new PIXI.Sprite(texture);
+            const texture = new RenderTexture.create(20, 30);
+            const sprite = new Sprite(texture);
 
             sprite.anchor.set(0.5, 0.5);
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
