### PR TITLE
Fix canvas rendering transform of TilingSprite

### DIFF
--- a/packages/canvas/canvas-sprite-tiling/package.json
+++ b/packages/canvas/canvas-sprite-tiling/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@pixi/canvas-renderer": "5.3.2",
     "@pixi/canvas-sprite": "5.3.2",
+    "@pixi/math": "^5.3.2",
     "@pixi/sprite-tiling": "5.3.2",
     "@pixi/utils": "5.3.2"
   }

--- a/packages/canvas/canvas-sprite-tiling/src/TilingSprite.ts
+++ b/packages/canvas/canvas-sprite-tiling/src/TilingSprite.ts
@@ -80,10 +80,17 @@ TilingSprite.prototype._renderCanvas = function _renderCanvas(renderer: CanvasRe
     tempPoints[1].set(anchorX + W, anchorY);
     tempPoints[2].set(anchorX + W, anchorY + H);
     tempPoints[3].set(anchorX, anchorY + H);
-    tempPoints.forEach((pt) => lt.applyInverse(pt, pt));
+    for (let i = 0; i < 4; i++)
+    {
+        lt.applyInverse(tempPoints[i], tempPoints[i]);
+    }
 
+    context.beginPath();
     context.moveTo(tempPoints[0].x, tempPoints[0].y);
-    tempPoints.forEach((pt, i) => i && context.lineTo(pt.x, pt.y));
+    for (let i = 1; i < 4; i++)
+    {
+        context.lineTo(tempPoints[i].x, tempPoints[i].y);
+    }
     context.closePath();
     context.fill();
 };


### PR DESCRIPTION
Fixes #6862

~~A regression has been introduced in this PR as the tiles appear smaller than they should. Maybe @ivanpopelyshev can help me here.~~

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
