### PR TITLE
Fix crash on Adreno 3xx GPU devices (e.g. vivo 1606, vivo 1610, Xiaomi Redmi Note 4G).

### DIFF
--- a/packages/graphics/src/Graphics.ts
+++ b/packages/graphics/src/Graphics.ts
@@ -1151,10 +1151,17 @@ export class Graphics extends Container
             // but may be more than one plugins for graphics
             if (!DEFAULT_SHADERS[pluginName])
             {
-                const sampleValues = new Int32Array(16);
+                const batchRenderer = renderer.plugins[this.pluginName];
+                let MAX_TEXTURES = 16;
+                
+                if (batchRenderer && typeof(batchRenderer.MAX_TEXTURES) === 'number'
+                        && batchRenderer.MAX_TEXTURES > 0) {
+                    MAX_TEXTURES = batchRenderer.MAX_TEXTURES;
+                }
 
-                for (let i = 0; i < 16; i++)
-                {
+                const sampleValues = new Int32Array(MAX_TEXTURES);
+
+                for (let i = 0; i < MAX_TEXTURES; i++) {
                     sampleValues[i] = i;
                 }
 

--- a/packages/graphics/src/Graphics.ts
+++ b/packages/graphics/src/Graphics.ts
@@ -1151,15 +1151,7 @@ export class Graphics extends Container
             // but may be more than one plugins for graphics
             if (!DEFAULT_SHADERS[pluginName])
             {
-                const batchRenderer = renderer.plugins[this.pluginName];
-                let MAX_TEXTURES = 16;
-
-                if (batchRenderer && typeof batchRenderer.MAX_TEXTURES === 'number'
-                        && batchRenderer.MAX_TEXTURES > 0)
-                {
-                    MAX_TEXTURES = batchRenderer.MAX_TEXTURES;
-                }
-
+                const MAX_TEXTURES = renderer.plugins.batch.MAX_TEXTURES;
                 const sampleValues = new Int32Array(MAX_TEXTURES);
 
                 for (let i = 0; i < MAX_TEXTURES; i++)

--- a/packages/graphics/src/Graphics.ts
+++ b/packages/graphics/src/Graphics.ts
@@ -1153,15 +1153,17 @@ export class Graphics extends Container
             {
                 const batchRenderer = renderer.plugins[this.pluginName];
                 let MAX_TEXTURES = 16;
-                
-                if (batchRenderer && typeof(batchRenderer.MAX_TEXTURES) === 'number'
-                        && batchRenderer.MAX_TEXTURES > 0) {
+
+                if (batchRenderer && typeof batchRenderer.MAX_TEXTURES === 'number'
+                        && batchRenderer.MAX_TEXTURES > 0)
+                {
                     MAX_TEXTURES = batchRenderer.MAX_TEXTURES;
                 }
 
                 const sampleValues = new Int32Array(MAX_TEXTURES);
 
-                for (let i = 0; i < MAX_TEXTURES; i++) {
+                for (let i = 0; i < MAX_TEXTURES; i++)
+                {
                     sampleValues[i] = i;
                 }
 


### PR DESCRIPTION
The sampler array should not be a hardcode value of 16 since it will be larger than what maxRecommendedTextures returns.
maxRecommendedTextures will return 4 if the android version is smaller than 7.

The crash stack is:

```
09-14 14:41:35.409 14755-14934/? A/libc: Fatal signal 6 (SIGABRT), code -6 in tid 14934 (GLThread 1122)
09-14 14:41:35.519 622-622/? A/DEBUG: *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
09-14 14:41:35.519 622-622/? A/DEBUG: Build fingerprint: 'vivo/1606/1606:6.0.1/MMB29M/compiler01052117:user/release-keys'
09-14 14:41:35.519 622-622/? A/DEBUG: Revision: '0'
09-14 14:41:35.519 622-622/? A/DEBUG: ABI: 'arm'
09-14 14:41:35.519 622-622/? A/DEBUG: pid: 14755, tid: 14934, name: GLThread 1122  >>> com.yy.demo <<<
09-14 14:41:35.519 622-622/? A/DEBUG: signal 6 (SIGABRT), code -6 (SI_TKILL), fault addr --------
09-14 14:41:35.569 622-622/? A/DEBUG: Abort message: '=================================================================
    ==14755==ERROR: AddressSanitizer: SEGV on unknown address 0x000003fc (pc 0xae5c89bc bp 0x9cc6fc00 sp 0x9d091170 T16777215)
    ==14755==The signal is caused by a READ memory access.
    ==14755==Hint: address points to the zero page.
        #0 0xae5c89b8  (/system/vendor/lib/egl/libRBGLESv2_adreno.so+0xb39b8)
        #1 0xae59b83a  (/system/vendor/lib/egl/libRBGLESv2_adreno.so+0x8683a)
        #2 0xae57fd4e  (/system/vendor/lib/egl/libRBGLESv2_
09-14 14:41:35.569 622-622/? A/DEBUG:     r0 00000000  r1 00003a56  r2 00000006  r3 9d092978
09-14 14:41:35.569 622-622/? A/DEBUG:     r4 9d092980  r5 9d092930  r6 00000019  r7 0000010c
09-14 14:41:35.569 622-622/? A/DEBUG:     r8 a32c819c  r9 b3f3f820  sl a149fc48  fp a149fc34
09-14 14:41:35.569 622-622/? A/DEBUG:     ip 00000006  sp a149f198  lr b6c972bd  pc b6c996b8  cpsr 400f0010
09-14 14:41:35.589 622-622/? A/DEBUG: backtrace:
09-14 14:41:35.589 622-622/? A/DEBUG:     #00 pc 000426b8  /system/lib/libc.so (tgkill+12)
09-14 14:41:35.589 622-622/? A/DEBUG:     #01 pc 000402b9  /system/lib/libc.so (pthread_kill+32)
09-14 14:41:35.589 622-622/? A/DEBUG:     #02 pc 0001c6f3  /system/lib/libc.so (raise+10)
09-14 14:41:35.589 622-622/? A/DEBUG:     #03 pc 00019961  /system/lib/libc.so (__libc_android_abort+34)
09-14 14:41:35.589 622-622/? A/DEBUG:     #04 pc 0001751c  /system/lib/libc.so (abort+4)
09-14 14:41:35.589 622-622/? A/DEBUG:     #05 pc 000389e0  /data/app/com.yy.demo-1/lib/arm/libclang_rt.asan-arm-android.so (offset 0x2d000)
09-14 14:41:35.589 622-622/? A/DEBUG:     #06 pc 00037754  /data/app/com.yy.demo-1/lib/arm/libclang_rt.asan-arm-android.so (offset 0x2d000)
09-14 14:41:35.589 622-622/? A/DEBUG:     #07 pc 000a15b8  /data/app/com.yy.demo-1/lib/arm/libclang_rt.asan-arm-android.so (offset 0x2d000)
09-14 14:41:35.589 622-622/? A/DEBUG:     #08 pc 000a1224  /data/app/com.yy.demo-1/lib/arm/libclang_rt.asan-arm-android.so (offset 0x2d000)
09-14 14:41:35.589 622-622/? A/DEBUG:     #09 pc 000a0788  /data/app/com.yy.demo-1/lib/arm/libclang_rt.asan-arm-android.so (offset 0x2d000)
09-14 14:41:35.589 622-622/? A/DEBUG:     #10 pc 0035ab6d  /system/lib/libart.so (_ZN3art12FaultManager11HandleFaultEiP7siginfoPv+508)
09-14 14:41:35.589 622-622/? A/DEBUG:     #11 pc 00017580  /system/lib/libc.so
09-14 14:41:36.919 622-622/? A/DEBUG: Tombstone written to: /data/tombstones/tombstone_00
```
