### PR TITLE
Fix VAO & instance array check in WebGL2.

### DIFF
--- a/packages/core/src/geometry/GeometrySystem.ts
+++ b/packages/core/src/geometry/GeometrySystem.ts
@@ -93,7 +93,7 @@ export class GeometrySystem extends System
         this.CONTEXT_UID = this.renderer.CONTEXT_UID;
 
         // webgl2
-        if (!window.WebGL2RenderingContext && !gl.createVertexArray)
+        if (context.webGLVersion !== 2)
         {
             // webgl 1!
             let nativeVaoExtension = this.renderer.context.extensions.vertexArrayObject;
@@ -128,7 +128,7 @@ export class GeometrySystem extends System
             }
         }
 
-        if (!window.WebGL2RenderingContext && !gl.vertexAttribDivisor)
+        if (context.webGLVersion !== 2)
         {
             const instanceExt = gl.getExtension('ANGLE_instanced_arrays');
 

--- a/packages/core/src/geometry/GeometrySystem.ts
+++ b/packages/core/src/geometry/GeometrySystem.ts
@@ -93,7 +93,7 @@ export class GeometrySystem extends System
         this.CONTEXT_UID = this.renderer.CONTEXT_UID;
 
         // webgl2
-        if (!gl.createVertexArray)
+        if (!window.WebGL2RenderingContext && !gl.createVertexArray)
         {
             // webgl 1!
             let nativeVaoExtension = this.renderer.context.extensions.vertexArrayObject;
@@ -128,7 +128,7 @@ export class GeometrySystem extends System
             }
         }
 
-        if (!gl.vertexAttribDivisor)
+        if (!window.WebGL2RenderingContext && !gl.vertexAttribDivisor)
         {
             const instanceExt = gl.getExtension('ANGLE_instanced_arrays');
 


### PR DESCRIPTION
gl.createVertexArray may not be null in WebGL1 context on some platforms.
Use context.webGLVersion instead.