### PR TITLE
Add property to Renderer Plugins

### DIFF
--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -507,6 +507,7 @@ export class Renderer extends AbstractRenderer
      * @property {PIXI.AccessibilityManager} accessibility Support tabbing interactive elements.
      * @property {PIXI.Extract} extract Extract image data from renderer.
      * @property {PIXI.InteractionManager} interaction Handles mouse, touch and pointer events.
+     * @property {PIXI.ParticleRenderer} Particle Renderer for Particles.
      * @property {PIXI.Prepare} prepare Pre-render display objects.
      * @property {PIXI.BatchRenderer} batch Drawing and batching sprites.
      * @property {PIXI.TilingSpriteRenderer} sprite-tiling Renderer for tile sprites.

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -507,10 +507,10 @@ export class Renderer extends AbstractRenderer
      * @property {PIXI.AccessibilityManager} accessibility Support tabbing interactive elements.
      * @property {PIXI.Extract} extract Extract image data from renderer.
      * @property {PIXI.InteractionManager} interaction Handles mouse, touch and pointer events.
-     * @property {PIXI.ParticleRenderer} Particle Renderer for Particles.
+     * @property {PIXI.ParticleRenderer} particle Renderer for ParticleContainer objects.
      * @property {PIXI.Prepare} prepare Pre-render display objects.
-     * @property {PIXI.BatchRenderer} batch Drawing and batching sprites.
-     * @property {PIXI.TilingSpriteRenderer} sprite-tiling Renderer for tile sprites.
+     * @property {PIXI.BatchRenderer} batch Batching of Sprite, Graphics and Mesh objects.
+     * @property {PIXI.TilingSpriteRenderer} tilingSprite Renderer for TilingSprite objects.
      */
     static __plugins: IRendererPlugins;
 

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -508,6 +508,8 @@ export class Renderer extends AbstractRenderer
      * @property {PIXI.Extract} extract Extract image data from renderer.
      * @property {PIXI.InteractionManager} interaction Handles mouse, touch and pointer events.
      * @property {PIXI.Prepare} prepare Pre-render display objects.
+     * @property {PIXI.BatchRenderer} batch Drawing and batching sprites.
+     * @property {PIXI.TilingSpriteRenderer} sprite-tiling Renderer for tile sprites.
      */
     static __plugins: IRendererPlugins;
 


### PR DESCRIPTION
##### Description of change
Fix #6878
Add missing properties:
-PIXI.ParticleRenderer
-PIXI.BatchRenderer
-PIXI.TilingSpriteRenderer

##### Pre-Merge Checklist
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)

First PR here 🥳