### PR TITLE
BitmapFont.from generate the kerning information

### DIFF
--- a/packages/text-bitmap/src/BitmapFont.ts
+++ b/packages/text-bitmap/src/BitmapFont.ts
@@ -384,11 +384,11 @@ export class BitmapFont
         let positionX = 0;
         let positionY = 0;
 
-        let canvas;
-        let context;
-        let baseTexture;
+        let canvas: HTMLCanvasElement;
+        let context: CanvasRenderingContext2D;
+        let baseTexture: BaseTexture;
         let maxCharHeight = 0;
-        const baseTextures = [];
+        const baseTextures: BaseTexture[] = [];
         const textures: Texture[] = [];
 
         for (let i = 0; i < charsList.length; i++)
@@ -478,6 +478,31 @@ export class BitmapFont
 
             positionX += (textureGlyphWidth + (2 * padding)) * resolution;
             positionX = Math.ceil(positionX);
+        }
+
+        // Brute-force kerning info, this can be expensive b/c it's an O(n²),
+        // but we're using measureText which is native and fast.
+        for (let i = 0, len = charsList.length; i < len; i++)
+        {
+            const first = charsList[i];
+
+            for (let j = 0; j < len; j++)
+            {
+                const second = charsList[j];
+                const c1 = context.measureText(first).width;
+                const c2 = context.measureText(second).width;
+                const total = context.measureText(first + second).width;
+                const amount = total - (c1 + c2);
+
+                if (amount)
+                {
+                    fontData.kerning.push({
+                        first: first.charCodeAt(0),
+                        second: second.charCodeAt(0),
+                        amount,
+                    });
+                }
+            }
         }
 
         const font = new BitmapFont(fontData, textures);


### PR DESCRIPTION
Attempt at partially fixing #6884

Basically, when using `BitmapFont.from` we were not making any effort to get kerning information. This would make `BitmapText` look very different from the standard `Text` object.

This PR does not solve xadvance, but gets us a little closer.

In this example `Y` + `e` and `Y` + `o` in Arial is a dramatically example.

**Before**
https://jsfiddle.net/bigtimebuddy/k8jdeczu/
![Screen Shot 2020-09-16 at 2 32 06 PM](https://user-images.githubusercontent.com/864393/93377779-79db8a80-f829-11ea-83a4-ca1c4d7eed75.png)

**After**
https://jsfiddle.net/bigtimebuddy/ufrneabt/
![Screen Shot 2020-09-16 at 2 32 25 PM](https://user-images.githubusercontent.com/864393/93377786-7c3de480-f829-11ea-9aaf-1d9bc36ee58f.png)
