### PR TITLE
Make AnimatedSprite event functions optional

### DIFF
--- a/packages/sprite-animated/src/AnimatedSprite.ts
+++ b/packages/sprite-animated/src/AnimatedSprite.ts
@@ -41,9 +41,9 @@ export class AnimatedSprite extends Sprite
     public animationSpeed: number;
     public loop: boolean;
     public updateAnchor: boolean;
-    public onComplete: () => void;
-    public onFrameChange: (currentFrame: number) => void;
-    public onLoop: () => void;
+    public onComplete?: () => void;
+    public onFrameChange?: (currentFrame: number) => void;
+    public onLoop?: () => void;
 
     private _playing: boolean;
     private _textures: Texture[];


### PR DESCRIPTION
```this.animation.onComplete = undefined;```
that line gives me an error in typescript
```Type 'undefined' is not assignable to type '(...params: any[]) => any'.ts(2322)```

Even `AnimatedSprite.destroy()` function sets these to `null`, so why can't I ?

```
public destroy(options: IDestroyOptions|boolean): void
    {
        this.stop();
        super.destroy(options);

        this.onComplete = null;
        this.onFrameChange = null;
        this.onLoop = null;
    }
```

<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
