### PR TITLE
Fix compressed texture docs

### DIFF
--- a/packages/core/src/textures/resources/CompressedTextureResource.ts
+++ b/packages/core/src/textures/resources/CompressedTextureResource.ts
@@ -58,17 +58,17 @@ export interface ICompressedTextureResourceOptions
  * // The resource backing the texture data for your textures.
  * // NOTE: You can also provide a ArrayBufferView instead of a URL. This is used when loading data from a container file
  * //   format such as KTX, DDS, or BASIS.
- * const compressedResource = new PIXI.resources.CompressedTextureResource("bunny.dxt5", {
+ * const compressedResource = new PIXI.CompressedTextureResource("bunny.dxt5", {
  *   format: PIXI.INTERNAL_FORMATS.COMPRESSED_RGBA_S3TC_DXT5_EXT,
  *   width: 256,
  *   height: 256
  * });
  *
  * // You can create a base-texture to the cache, so that future `Texture`s can be created using the `Texture.from` API.
- * const baseTexture = new BaseTexture(compressedResource, { premultiplyAlpha: false });
+ * const baseTexture = new PIXI.BaseTexture(compressedResource, { pmaMode: PIXI.ALPHA_MODES.NPM });
  *
  * // Create a Texture to add to the TextureCache
- * const texture = new Texture(baseTexture);
+ * const texture = new PIXI.Texture(baseTexture);
  *
  * // Add baseTexture & texture to the global texture cache
  * PIXI.BaseTexture.addToCache(baseTexture, "bunny.dxt5");


### PR DESCRIPTION
`premultiplyAlpha` is deprecated.

`resources` namespace is removed.