### PR TITLE
Update doc of RenderTexture

### DIFF
--- a/packages/core/src/renderTexture/RenderTexture.ts
+++ b/packages/core/src/renderTexture/RenderTexture.ts
@@ -28,7 +28,7 @@ import type { IBaseTextureOptions } from '../textures/BaseTexture';
  *
  * renderer.render(sprite, renderTexture);
  * ```
- * Note that you shouldn not create a new renderer, but reuse the same as the rest of the application.
+ * Note that you should not create a new renderer, but reuse the same one as the rest of the application.
  *
  * The Sprite in this case will be rendered using its local transform. To render this sprite at 0,0
  * you can clear the transform

--- a/packages/core/src/renderTexture/RenderTexture.ts
+++ b/packages/core/src/renderTexture/RenderTexture.ts
@@ -28,6 +28,7 @@ import type { IBaseTextureOptions } from '../textures/BaseTexture';
  *
  * renderer.render(sprite, renderTexture);
  * ```
+ * Note that you shouldn not create a new renderer, but reuse the same as the rest of the application.
  *
  * The Sprite in this case will be rendered using its local transform. To render this sprite at 0,0
  * you can clear the transform


### PR DESCRIPTION
Fixes #6519 

##### Description of change

Made clear that the creation of a new renderer is not needed to render a RenderTexture in the documentation.

##### Pre-Merge Checklist

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
