### PR TITLE
Remove duplicate destroy function in Graphics

### DIFF
--- a/packages/graphics/src/Graphics.ts
+++ b/packages/graphics/src/Graphics.ts
@@ -1366,8 +1366,6 @@ export class Graphics extends Container
      */
     public destroy(options: IDestroyOptions|boolean): void
     {
-        super.destroy(options);
-
         this._geometry.refCount--;
         if (this._geometry.refCount === 0)
         {


### PR DESCRIPTION
Fixes #6942 

Remove duplicate `super.destroy`