### PR TITLE
Fix defaults args for setTransform

### DIFF
--- a/packages/text-bitmap/src/utils/drawGlyph.ts
+++ b/packages/text-bitmap/src/utils/drawGlyph.ts
@@ -84,7 +84,7 @@ export function drawGlyph(
         context.fillText(char, tx, ty + metrics.lineHeight - fontProperties.descent);
     }
 
-    context.setTransform();
+    context.setTransform(1, 0, 0, 1, 0, 0); // defaults needed for older browsers (e.g. Opera 29)
 
     context.fillStyle = 'rgba(0, 0, 0, 0)';
 }


### PR DESCRIPTION
Fixes #6939 

I [downloaded Opera 29](https://get.geo.opera.com/pub/opera/desktop/29.0.1795.60/mac/) and verified this is an issue and the fix that @relefant suggested worked.


```html
<html>
<body>
<script src="https://pixijs.download/dev/pixi.min.js"></script>
<script>
var app = new PIXI.Application({
    backgroundColor: 0x1099bb,
    width: 500,
    height: 200
});
document.body.appendChild(app.view);
var size = 150;
var style = new PIXI.TextStyle({
    fontFamily: 'Arial',
    fontSize: size
});
var font = PIXI.BitmapFont.from("fontName", style);
var bitmapFontText = new PIXI.BitmapText('Bitmap', {
    fontName: 'fontName',
});
bitmapFontText.x = 10;
bitmapFontText.y = 10;
app.stage.addChild(bitmapFontText);
</script>
</body>
</html>
```