### PR TITLE
fix issue #6934 + add style.justify feature to bitmap texts

### DIFF
--- a/packages/text/src/TextStyle.ts
+++ b/packages/text/src/TextStyle.ts
@@ -4,7 +4,7 @@
 import { TEXT_GRADIENT } from './const';
 import { hex2string } from '@pixi/utils';
 
-export type TextStyleAlign = 'left'|'center'|'right';
+export type TextStyleAlign = 'left'|'center'|'right'|'justify';
 export type TextStyleFill = string|string[]|number|number[]|CanvasGradient|CanvasPattern;
 export type TextStyleFontStyle = 'normal'|'italic'|'oblique';
 export type TextStyleFontVariant = 'normal'|'small-caps';


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
1. fix issue #6934 
2. for bitmap texts, add a new option to style.align: 'justify'. for multi-line texts, this will even out the spaces between words, such that the text will be aligned both to the right and the left. (similar to html 'justify' text)
![justify](https://user-images.githubusercontent.com/5813568/96836851-3b4f7600-144e-11eb-9563-ac6ee77bc5bf.png)

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation is changed or added (in code only)
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
