### PR TITLE
Support text alignment 'justify' in BitmapText

### DIFF
--- a/packages/text-bitmap/src/BitmapText.ts
+++ b/packages/text-bitmap/src/BitmapText.ts
@@ -28,6 +28,7 @@ interface CharRenderData {
     line: number;
     charCode: number;
     position: Point;
+    prevSpaces: number;
 }
 
 const pageMeshDataPool: PageMeshData[] = [];
@@ -87,7 +88,7 @@ export class BitmapText extends Container
      * @param {string} style.fontName - The installed BitmapFont name.
      * @param {number} [style.fontSize] - The size of the font in pixels, e.g. 24. If undefined,
      *.     this will default to the BitmapFont size.
-     * @param {string} [style.align='left'] - Alignment for multiline text ('left', 'center' or 'right'),
+     * @param {string} [style.align='left'] - Alignment for multiline text ('left', 'center', 'right' or 'justify'),
      *      does not affect single line text.
      * @param {number} [style.tint=0xFFFFFF] - The tint color.
      * @param {number} [style.letterSpacing=0] - The amount of spacing between letters.
@@ -240,6 +241,7 @@ export class BitmapText extends Container
         const pos = new Point();
         const chars: CharRenderData[] = [];
         const lineWidths = [];
+        const lineSpaces = [];
         const text = this._text.replace(/(?:\r\n|\r)/g, '\n') || ' ';
         const textLength = text.length;
         const maxWidth = this._maxWidth * data.size / this._fontSize;
@@ -252,6 +254,7 @@ export class BitmapText extends Container
         let lastBreakWidth = 0;
         let spacesRemoved = 0;
         let maxLineHeight = 0;
+        let spaceCount = 0;
 
         for (let i = 0; i < textLength; i++)
         {
@@ -262,11 +265,13 @@ export class BitmapText extends Container
             {
                 lastBreakPos = i;
                 lastBreakWidth = lastLineWidth;
+                spaceCount++;
             }
 
             if (char === '\r' || char === '\n')
             {
                 lineWidths.push(lastLineWidth);
+                lineSpaces.push(-1);
                 maxLineWidth = Math.max(maxLineWidth, lastLineWidth);
                 ++line;
                 ++spacesRemoved;
@@ -274,6 +279,7 @@ export class BitmapText extends Container
                 pos.x = 0;
                 pos.y += data.lineHeight;
                 prevCharCode = null;
+                spaceCount = 0;
                 continue;
             }
 
@@ -293,6 +299,7 @@ export class BitmapText extends Container
                 texture: Texture.EMPTY,
                 line: 0,
                 charCode: 0,
+                prevSpaces: 0,
                 position: new Point(),
             };
 
@@ -301,6 +308,7 @@ export class BitmapText extends Container
             charRenderData.charCode = charCode;
             charRenderData.position.x = pos.x + charData.xOffset + (this._letterSpacing / 2);
             charRenderData.position.y = pos.y + charData.yOffset;
+            charRenderData.prevSpaces = this._align === 'justify' ? spaceCount : 1;
 
             chars.push(charRenderData);
 
@@ -317,12 +325,14 @@ export class BitmapText extends Container
                 lastBreakPos = -1;
 
                 lineWidths.push(lastBreakWidth);
+                lineSpaces.push(chars.length > 0 ? chars[chars.length - 1].prevSpaces : 0);
                 maxLineWidth = Math.max(maxLineWidth, lastBreakWidth);
                 line++;
 
                 pos.x = 0;
                 pos.y += data.lineHeight;
                 prevCharCode = null;
+                spaceCount = 0;
             }
         }
 
@@ -337,6 +347,7 @@ export class BitmapText extends Container
 
             lineWidths.push(lastLineWidth);
             maxLineWidth = Math.max(maxLineWidth, lastLineWidth);
+            lineSpaces.push(-1);
         }
 
         const lineAlignOffsets = [];
@@ -352,6 +363,10 @@ export class BitmapText extends Container
             else if (this._align === 'center')
             {
                 alignOffset = (maxLineWidth - lineWidths[i]) / 2;
+            }
+            else if (this._align === 'justify')
+            {
+                alignOffset = lineSpaces[i] < 0 ? 0 : (maxLineWidth - lineWidths[i]) / lineSpaces[i];
             }
 
             lineAlignOffsets.push(alignOffset);
@@ -473,7 +488,7 @@ export class BitmapText extends Container
         for (let i = 0; i < lenChars; i++)
         {
             const char = chars[i];
-            let offset = char.position.x + lineAlignOffsets[char.line];
+            let offset = char.position.x + (lineAlignOffsets[char.line] * char.prevSpaces);
 
             if (this._roundPixels)
             {

--- a/packages/text-bitmap/src/BitmapText.ts
+++ b/packages/text-bitmap/src/BitmapText.ts
@@ -308,7 +308,7 @@ export class BitmapText extends Container
             charRenderData.charCode = charCode;
             charRenderData.position.x = pos.x + charData.xOffset + (this._letterSpacing / 2);
             charRenderData.position.y = pos.y + charData.yOffset;
-            charRenderData.prevSpaces = this._align === 'justify' ? spaceCount : 1;
+            charRenderData.prevSpaces = spaceCount;
 
             chars.push(charRenderData);
 
@@ -488,7 +488,7 @@ export class BitmapText extends Container
         for (let i = 0; i < lenChars; i++)
         {
             const char = chars[i];
-            let offset = char.position.x + (lineAlignOffsets[char.line] * char.prevSpaces);
+            let offset = char.position.x + (lineAlignOffsets[char.line] * (this._align === 'justify' ? char.prevSpaces : 1));
 
             if (this._roundPixels)
             {

--- a/packages/text/src/TextStyle.ts
+++ b/packages/text/src/TextStyle.ts
@@ -4,7 +4,7 @@
 import { TEXT_GRADIENT } from './const';
 import { hex2string } from '@pixi/utils';
 
-export type TextStyleAlign = 'left'|'center'|'right';
+export type TextStyleAlign = 'left'|'center'|'right'|'justify';
 export type TextStyleFill = string|string[]|number|number[]|CanvasGradient|CanvasPattern;
 export type TextStyleFontStyle = 'normal'|'italic'|'oblique';
 export type TextStyleFontVariant = 'normal'|'small-caps';


### PR DESCRIPTION

##### Description of change
Add 'justify' feature to bitmap texts. This aligns the text both right and left using varying spaces between words
roundPixels = true, is recommended for small font sizes. 

##### Pre-Merge Checklist
- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added - only inside code
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)

![test_justify](https://user-images.githubusercontent.com/5813568/97463851-dc579880-1948-11eb-8084-0a15f439af3a.png)
[TestJustify.zip](https://github.com/pixijs/pixi.js/files/5453257/TestJustify.zip)
