### PR TITLE
Fix broken docs links in PIXI.Spritesheet

### DIFF
--- a/packages/spritesheet/src/Spritesheet.ts
+++ b/packages/spritesheet/src/Spritesheet.ts
@@ -55,8 +55,8 @@ export interface ISpritesheetData {
  * ```
  * With the `sheet.textures` you can create Sprite objects,`sheet.animations` can be used to create an AnimatedSprite.
  *
- * Sprite sheets can be packed using tools like {@link https://codeandweb.com/texturepacker|TexturePacker},
- * {@link https://renderhjs.net/shoebox/|Shoebox} or {@link https://github.com/krzysztof-o/spritesheet.js|Spritesheet.js}.
+ * Sprite sheets can be packed using tools like {@link https://codeandweb.com/texturepacker},
+ * {@link https://renderhjs.net/shoebox/} or {@link https://github.com/krzysztof-o/spritesheet.js}.
  * Default anchor points (see {@link PIXI.Texture#defaultAnchor}) and grouping of animation sprites are currently only
  * supported by TexturePacker.
  *


### PR DESCRIPTION
##### Description of change
Updating some broken links discovered in the Docs when learning about PIXI.js when making a [Halloween Game](https://github.com/BrandonKlotz/ghosts-in-the-graveyard) 😄 

##### Pre-Merge Checklist
- [x] Documentation is changed or added
