### PR TITLE
Enable scissor mask support by default

### DIFF
--- a/packages/core/src/mask/MaskSystem.ts
+++ b/packages/core/src/mask/MaskSystem.ts
@@ -53,7 +53,7 @@ export class MaskSystem extends System
          * @member {boolean}
          * @readonly
          */
-        this.enableScissor = false;
+        this.enableScissor = true;
 
         /**
          * Pool of used sprite mask filters


### PR DESCRIPTION
Fix #6938 