### PR TITLE
[4.7.x] Cherry-picking blend modes bug fix to older branches.

### DIFF
--- a/src/core/renderers/webgl/utils/mapWebGLBlendModesToPixi.js
+++ b/src/core/renderers/webgl/utils/mapWebGLBlendModesToPixi.js
@@ -15,7 +15,7 @@ export default function mapWebGLBlendModesToPixi(gl, array = [])
     // TODO - premultiply alpha would be different.
     // add a boolean for that!
     array[BLEND_MODES.NORMAL] = [gl.ONE, gl.ONE_MINUS_SRC_ALPHA];
-    array[BLEND_MODES.ADD] = [gl.ONE, gl.DST_ALPHA];
+    array[BLEND_MODES.ADD] = [gl.ONE, gl.ONE];
     array[BLEND_MODES.MULTIPLY] = [gl.DST_COLOR, gl.ONE_MINUS_SRC_ALPHA];
     array[BLEND_MODES.SCREEN] = [gl.ONE, gl.ONE_MINUS_SRC_COLOR];
     array[BLEND_MODES.OVERLAY] = [gl.ONE, gl.ONE_MINUS_SRC_ALPHA];
@@ -34,7 +34,7 @@ export default function mapWebGLBlendModesToPixi(gl, array = [])
 
     // not-premultiplied blend modes
     array[BLEND_MODES.NORMAL_NPM] = [gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA];
-    array[BLEND_MODES.ADD_NPM] = [gl.SRC_ALPHA, gl.DST_ALPHA, gl.ONE, gl.DST_ALPHA];
+    array[BLEND_MODES.ADD_NPM] = [gl.SRC_ALPHA, gl.ONE, gl.ONE, gl.ONE];
     array[BLEND_MODES.SCREEN_NPM] = [gl.SRC_ALPHA, gl.ONE_MINUS_SRC_COLOR, gl.ONE, gl.ONE_MINUS_SRC_COLOR];
 
     return array;


### PR DESCRIPTION
Cherrypicking bugfix to older pixi.js version: https://github.com/pixijs/pixi.js/commit/2d50b0526d7aee8075ec3e60eac254172ea0ca26

Discussion: https://github.com/pixijs/pixi.js/issues/6988

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)