### PR TITLE
fix some types in 5.4.0-rc.2

### DIFF
--- a/packages/canvas/canvas-renderer/src/CanvasRenderer.ts
+++ b/packages/canvas/canvas-renderer/src/CanvasRenderer.ts
@@ -360,7 +360,7 @@ export class CanvasRenderer extends AbstractRenderer
      *
      * @param {string} [clearColor] - Clear the canvas with this color, except the canvas is transparent.
      */
-    public clear(clearColor: string): void
+    public clear(clearColor?: string): void
     {
         const context = this.context;
 

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -100,7 +100,7 @@ export class Renderer extends AbstractRenderer
      * @static
      * @private
      */
-    static create(options: IRendererOptions): AbstractRenderer
+    static create(options?: IRendererOptions): AbstractRenderer
     {
         if (isWebGLSupported())
         {

--- a/packages/core/src/autoDetectRenderer.ts
+++ b/packages/core/src/autoDetectRenderer.ts
@@ -34,7 +34,7 @@ export interface IRendererOptionsAuto extends IRendererOptions
  *  for devices with dual graphics card **webgl only**
  * @return {PIXI.Renderer|PIXI.CanvasRenderer} Returns WebGL renderer if available, otherwise CanvasRenderer
  */
-export function autoDetectRenderer(options: IRendererOptionsAuto): AbstractRenderer
+export function autoDetectRenderer(options?: IRendererOptionsAuto): AbstractRenderer
 {
     return Renderer.create(options);
 }

--- a/packages/core/src/filters/FilterSystem.ts
+++ b/packages/core/src/filters/FilterSystem.ts
@@ -362,7 +362,7 @@ export class FilterSystem extends System
      * @param {PIXI.RenderTexture} output - The target to output to.
      * @param {PIXI.CLEAR_MODES} [clearMode] - Should the output be cleared before rendering to it
      */
-    applyFilter(filter: Filter, input: RenderTexture, output: RenderTexture, clearMode: CLEAR_MODES): void
+    applyFilter(filter: Filter, input: RenderTexture, output: RenderTexture, clearMode?: CLEAR_MODES): void
     {
         const renderer = this.renderer;
 

--- a/packages/core/src/framebuffer/FramebufferSystem.ts
+++ b/packages/core/src/framebuffer/FramebufferSystem.ts
@@ -111,7 +111,7 @@ export class FramebufferSystem extends System
     /**
      * Bind a framebuffer
      *
-     * @param {PIXI.Framebuffer} framebuffer
+     * @param {PIXI.Framebuffer} [framebuffer]
      * @param {PIXI.Rectangle} [frame] - frame, default is framebuffer size
      */
     bind(framebuffer?: Framebuffer, frame?: Rectangle): void

--- a/packages/core/src/geometry/Geometry.ts
+++ b/packages/core/src/geometry/Geometry.ts
@@ -98,7 +98,7 @@ export class Geometry
     * Note: `stride` and `start` should be `undefined` if you dont know them, not 0!
     *
     * @param {String} id - the name of the attribute (matching up to a shader)
-    * @param {PIXI.Buffer|number[]} [buffer] - the buffer that holds the data of the attribute . You can also provide an Array and a buffer will be created from it.
+    * @param {PIXI.Buffer|number[]} buffer - the buffer that holds the data of the attribute . You can also provide an Array and a buffer will be created from it.
     * @param {Number} [size=0] - the size of the attribute. If you have 2 floats per vertex (eg position x and y) this would be 2
     * @param {Boolean} [normalized=false] - should the data be normalized.
     * @param {Number} [type=PIXI.TYPES.FLOAT] - what type of number is the attribute. Check {PIXI.TYPES} to see the ones available

--- a/packages/core/src/renderTexture/BaseRenderTexture.ts
+++ b/packages/core/src/renderTexture/BaseRenderTexture.ts
@@ -60,7 +60,7 @@ export class BaseRenderTexture extends BaseTexture
      * @param {PIXI.SCALE_MODES} [options.scaleMode] - See {@link PIXI.SCALE_MODES} for possible values.
      * @param {number} [options.resolution=1] - The resolution / device pixel ratio of the texture being generated.
      */
-    constructor(options: IBaseTextureOptions)
+    constructor(options?: IBaseTextureOptions)
     {
         if (typeof options === 'number')
         {

--- a/packages/core/src/renderTexture/RenderTexture.ts
+++ b/packages/core/src/renderTexture/RenderTexture.ts
@@ -48,9 +48,11 @@ import type { IBaseTextureOptions } from '../textures/BaseTexture';
  */
 export class RenderTexture extends Texture
 {
+    public baseTexture: BaseRenderTexture;
     public filterFrame: Rectangle|null;
     public filterPoolKey: string|number|null;
     legacyRenderer: any;
+
     /**
      * @param {PIXI.BaseRenderTexture} baseRenderTexture - The base texture object that this texture uses
      * @param {PIXI.Rectangle} [frame] - The rectangle frame of the texture to show
@@ -119,7 +121,7 @@ export class RenderTexture extends Texture
      */
     get framebuffer(): Framebuffer
     {
-        return (this.baseTexture as BaseRenderTexture).framebuffer;
+        return this.baseTexture.framebuffer;
     }
 
     /**
@@ -142,7 +144,7 @@ export class RenderTexture extends Texture
 
         if (resizeBaseTexture)
         {
-            (this.baseTexture as BaseRenderTexture).resize(width, height);
+            this.baseTexture.resize(width, height);
         }
 
         this.updateUvs();

--- a/packages/core/src/renderTexture/RenderTexture.ts
+++ b/packages/core/src/renderTexture/RenderTexture.ts
@@ -178,7 +178,7 @@ export class RenderTexture extends Texture
      * @param {number} [options.resolution=1] - The resolution / device pixel ratio of the texture being generated
      * @return {PIXI.RenderTexture} The new render texture
      */
-    static create(options: IBaseTextureOptions): RenderTexture
+    static create(options?: IBaseTextureOptions): RenderTexture
     {
         // fallback, old-style: create(width, height, scaleMode, resolution)
         if (typeof options === 'number')

--- a/packages/core/src/renderTexture/RenderTexturePool.ts
+++ b/packages/core/src/renderTexture/RenderTexturePool.ts
@@ -115,7 +115,7 @@ export class RenderTexturePool
      *  It overrides, it does not multiply
      * @returns {PIXI.RenderTexture}
      */
-    getFilterTexture(input: RenderTexture, resolution: number): RenderTexture
+    getFilterTexture(input: RenderTexture, resolution?: number): RenderTexture
     {
         const filterTexture = this.getOptimalTexture(input.width, input.height, resolution || input.resolution);
 
@@ -150,7 +150,7 @@ export class RenderTexturePool
      *
      * @param {boolean} [destroyTextures=true] - destroy all stored textures
      */
-    clear(destroyTextures: boolean): void
+    clear(destroyTextures?: boolean): void
     {
         destroyTextures = destroyTextures !== false;
         if (destroyTextures)

--- a/packages/core/src/shader/Shader.ts
+++ b/packages/core/src/shader/Shader.ts
@@ -17,7 +17,7 @@ export class Shader
      * @param {PIXI.Program} [program] - The program the shader will use.
      * @param {object} [uniforms] - Custom uniforms to use to augment the built-in ones.
      */
-    constructor(program: Program, uniforms: Dict<any>)
+    constructor(program: Program, uniforms?: Dict<any>)
     {
         /**
          * Program that the shader uses

--- a/packages/core/src/shader/UniformGroup.ts
+++ b/packages/core/src/shader/UniformGroup.ts
@@ -68,12 +68,12 @@ export class UniformGroup
         this.dirtyId++;
     }
 
-    add(name: string, uniforms: Dict<any>, _static: boolean): void
+    add(name: string, uniforms: Dict<any>, _static?: boolean): void
     {
         this.uniforms[name] = new UniformGroup(uniforms, _static);
     }
 
-    static from(uniforms: Dict<any>, _static: boolean): UniformGroup
+    static from(uniforms: Dict<any>, _static?: boolean): UniformGroup
     {
         return new UniformGroup(uniforms, _static);
     }

--- a/packages/core/src/textures/BaseTexture.ts
+++ b/packages/core/src/textures/BaseTexture.ts
@@ -613,7 +613,7 @@ export class BaseTexture extends EventEmitter
      * @param {boolean} [strict] - Enforce strict-mode, see {@link PIXI.settings.STRICT_TEXTURE_CACHE}.
      * @returns {PIXI.BaseTexture} The new base texture.
      */
-    static from(source: ImageSource|string, options: IBaseTextureOptions,
+    static from(source: ImageSource|string, options?: IBaseTextureOptions,
         strict = settings.STRICT_TEXTURE_CACHE): BaseTexture
     {
         const isFrame = typeof source === 'string';
@@ -665,7 +665,7 @@ export class BaseTexture extends EventEmitter
      * @return {PIXI.BaseTexture} The resulting new BaseTexture
      */
     static fromBuffer(buffer: Float32Array|Uint8Array,
-        width: number, height: number, options: IBaseTextureOptions): BaseTexture
+        width: number, height: number, options?: IBaseTextureOptions): BaseTexture
     {
         buffer = buffer || new Float32Array(width * height * 4);
 

--- a/packages/core/src/textures/Texture.ts
+++ b/packages/core/src/textures/Texture.ts
@@ -434,7 +434,7 @@ export class Texture extends EventEmitter
      * @return {PIXI.Texture} The resulting new BaseTexture
      */
     static fromBuffer(buffer: Float32Array|Uint8Array,
-        width: number, height: number, options: IBaseTextureOptions): Texture
+        width: number, height: number, options?: IBaseTextureOptions): Texture
     {
         return new Texture(BaseTexture.fromBuffer(buffer, width, height, options));
     }
@@ -449,7 +449,7 @@ export class Texture extends EventEmitter
      *        specified, only `imageUrl` will be used as the cache ID.
      * @return {PIXI.Texture} Output texture
      */
-    static fromLoader(source: HTMLImageElement|HTMLCanvasElement, imageUrl: string, name: string): Texture
+    static fromLoader(source: HTMLImageElement|HTMLCanvasElement, imageUrl: string, name?: string): Texture
     {
         const resource = new ImageResource(source as any);
 

--- a/packages/core/src/textures/resources/BaseImageResource.ts
+++ b/packages/core/src/textures/resources/BaseImageResource.ts
@@ -51,7 +51,7 @@ export class BaseImageResource extends Resource
      * @param {string} url - URL to check
      * @param {boolean|string} [crossorigin=true] - Cross origin value to use
      */
-    static crossOrigin(element: HTMLImageElement|HTMLVideoElement, url: string, crossorigin: boolean|string): void
+    static crossOrigin(element: HTMLImageElement|HTMLVideoElement, url: string, crossorigin?: boolean|string): void
     {
         if (crossorigin === undefined && url.indexOf('data:') !== 0)
         {

--- a/packages/core/src/textures/resources/SVGResource.ts
+++ b/packages/core/src/textures/resources/SVGResource.ts
@@ -34,7 +34,7 @@ export class SVGResource extends BaseImageResource
     private _load: Promise<SVGResource>;
     private _crossorigin?: boolean|string;
 
-    constructor(sourceBase64: string, options: ISVGResourceOptions)
+    constructor(sourceBase64: string, options?: ISVGResourceOptions)
     {
         options = options || {};
 

--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -648,7 +648,7 @@ export abstract class DisplayObject extends EventEmitter
      * @param {boolean} [skipUpdate=false] - Should we skip the update transform
      * @return {PIXI.Point} A point object representing the position of this object
      */
-    toLocal<P extends IPointData = Point>(position: IPointData, from: DisplayObject, point?: P, skipUpdate?: boolean): P
+    toLocal<P extends IPointData = Point>(position: IPointData, from?: DisplayObject, point?: P, skipUpdate?: boolean): P
     {
         if (from)
         {

--- a/packages/filters/filter-displacement/src/DisplacementFilter.ts
+++ b/packages/filters/filter-displacement/src/DisplacementFilter.ts
@@ -34,7 +34,7 @@ export class DisplacementFilter extends Filter
      * @param {PIXI.Sprite} sprite - The sprite used for the displacement map. (make sure its added to the scene!)
      * @param {number} [scale] - The scale of the displacement
      */
-    constructor(sprite: ISpriteMaskTarget, scale: number)
+    constructor(sprite: ISpriteMaskTarget, scale?: number)
     {
         const maskMatrix = new Matrix();
 

--- a/packages/graphics/src/Graphics.ts
+++ b/packages/graphics/src/Graphics.ts
@@ -1368,7 +1368,7 @@ export class Graphics extends Container
      * @param {boolean} [options.baseTexture=false] - Only used for child Sprites if options.children is set to true
      *  Should it destroy the base texture of the child sprite
      */
-    public destroy(options: IDestroyOptions|boolean): void
+    public destroy(options?: IDestroyOptions|boolean): void
     {
         this._geometry.refCount--;
         if (this._geometry.refCount === 0)

--- a/packages/graphics/src/Graphics.ts
+++ b/packages/graphics/src/Graphics.ts
@@ -736,7 +736,7 @@ export class Graphics extends Container
      * @param {PIXI.Matrix} [options.matrix=null] - Transform matrix
      * @return {PIXI.Graphics} This Graphics object. Good for chaining method calls
      */
-    beginTextureFill(options: IFillStyleOptions): this
+    beginTextureFill(options?: IFillStyleOptions): this
     {
         // Backward compatibility with params: (texture, color, alpha, matrix)
         if (options instanceof Texture)

--- a/packages/graphics/src/utils/Star.ts
+++ b/packages/graphics/src/utils/Star.ts
@@ -16,7 +16,7 @@ import { Polygon, PI_2 } from '@pixi/math';
  */
 export class Star extends Polygon
 {
-    constructor(x: number, y: number, points: number, radius: number, innerRadius: number, rotation = 0)
+    constructor(x: number, y: number, points: number, radius: number, innerRadius?: number, rotation = 0)
     {
         innerRadius = innerRadius || radius / 2;
 

--- a/packages/interaction/src/InteractionManager.ts
+++ b/packages/interaction/src/InteractionManager.ts
@@ -99,7 +99,7 @@ export class InteractionManager extends EventEmitter
      * @param {number} [options.interactionFrequency=10] - Maximum requency (ms) at pointer over/out states will be checked.
      * @param {number} [options.useSystemTicker=true] - Whether to add {@link tickerUpdate} to {@link PIXI.Ticker.system}.
      */
-    constructor(renderer: AbstractRenderer, options: InteractionManagerOptions)
+    constructor(renderer: AbstractRenderer, options?: InteractionManagerOptions)
     {
         super();
 

--- a/packages/loaders/src/LoaderResource.ts
+++ b/packages/loaders/src/LoaderResource.ts
@@ -20,7 +20,7 @@ export interface ILoaderResource extends GlobalMixins.ILoaderResource, Resource
 }
 
 // Mix constructor and typeof Resource , otherwise we can't access to statics field
-type TLoaderResource = { new(...args: any[]): ILoaderResource } & typeof Resource;
+export type TLoaderResource = { new(...args: any[]): ILoaderResource } & typeof Resource;
 
 /**
 * Reference to **{@link https://github.com/englercj/resource-loader}**'s Resource class.

--- a/packages/mesh-extras/src/SimplePlane.ts
+++ b/packages/mesh-extras/src/SimplePlane.ts
@@ -95,7 +95,7 @@ export class SimplePlane extends Mesh
         super._render(renderer);
     }
 
-    public destroy(options: IDestroyOptions|boolean): void
+    public destroy(options?: IDestroyOptions|boolean): void
     {
         this.shader.texture.off('update', this.textureUpdated, this);
         super.destroy(options);

--- a/packages/mesh/src/Mesh.ts
+++ b/packages/mesh/src/Mesh.ts
@@ -498,7 +498,7 @@ export class Mesh extends Container
      * @param {boolean} [options.children=false] - if set to true, all the children will have
      *  their destroy method called as well. 'options' will be passed on to those calls.
      */
-    public destroy(options: IDestroyOptions|boolean): void
+    public destroy(options?: IDestroyOptions|boolean): void
     {
         super.destroy(options);
 

--- a/packages/mixin-cache-as-bitmap/src/index.ts
+++ b/packages/mixin-cache-as-bitmap/src/index.ts
@@ -433,7 +433,7 @@ DisplayObject.prototype._destroyCachedDisplayObject = function _destroyCachedDis
  *  have been set to that value.
  *  Used when destroying containers, see the Container.destroy method.
  */
-DisplayObject.prototype._cacheAsBitmapDestroy = function _cacheAsBitmapDestroy(options: IDestroyOptions|boolean): void
+DisplayObject.prototype._cacheAsBitmapDestroy = function _cacheAsBitmapDestroy(options?: IDestroyOptions|boolean): void
 {
     this.cacheAsBitmap = false;
     this.destroy(options);

--- a/packages/particles/src/ParticleContainer.ts
+++ b/packages/particles/src/ParticleContainer.ts
@@ -300,7 +300,7 @@ export class ParticleContainer extends Container
      * @param {boolean} [options.baseTexture=false] - Only used for child Sprites if options.children is set to true
      *  Should it destroy the base texture of the child sprite
      */
-    public destroy(options: IDestroyOptions|boolean): void
+    public destroy(options?: IDestroyOptions|boolean): void
     {
         super.destroy(options);
 

--- a/packages/prepare/src/BasePrepare.ts
+++ b/packages/prepare/src/BasePrepare.ts
@@ -340,7 +340,7 @@ export class BasePrepare
      *        or the callback function, if items have been added using `prepare.add`.
      * @param {Function} [done] - Optional callback when all queued uploads have completed
      */
-    upload(item: IDisplayObjectExtended | IUploadHook | IFindHook | (() => void), done: () => void): void
+    upload(item: IDisplayObjectExtended | IUploadHook | IFindHook | (() => void), done?: () => void): void
     {
         if (typeof item === 'function')
         {

--- a/packages/sprite-animated/src/AnimatedSprite.ts
+++ b/packages/sprite-animated/src/AnimatedSprite.ts
@@ -371,7 +371,7 @@ export class AnimatedSprite extends Sprite
      * @param {boolean} [options.texture=false] - Should it destroy the current texture of the sprite as well.
      * @param {boolean} [options.baseTexture=false] - Should it destroy the base texture of the sprite as well.
      */
-    public destroy(options: IDestroyOptions|boolean): void
+    public destroy(options?: IDestroyOptions|boolean): void
     {
         this.stop();
         super.destroy(options);

--- a/packages/sprite-tiling/src/TilingSprite.ts
+++ b/packages/sprite-tiling/src/TilingSprite.ts
@@ -247,7 +247,7 @@ export class TilingSprite extends Sprite
      * @param {boolean} [options.texture=false] - Should it destroy the current texture of the sprite as well
      * @param {boolean} [options.baseTexture=false] - Should it destroy the base texture of the sprite as well
      */
-    public destroy(options: IDestroyOptions|boolean): void
+    public destroy(options?: IDestroyOptions|boolean): void
     {
         super.destroy(options);
 

--- a/packages/sprite/src/Sprite.ts
+++ b/packages/sprite/src/Sprite.ts
@@ -510,7 +510,7 @@ export class Sprite extends Container
      * @param {boolean} [options.texture=false] - Should it destroy the current texture of the sprite as well
      * @param {boolean} [options.baseTexture=false] - Should it destroy the base texture of the sprite as well
      */
-    public destroy(options: IDestroyOptions|boolean): void
+    public destroy(options?: IDestroyOptions|boolean): void
     {
         super.destroy(options);
 

--- a/packages/sprite/src/Sprite.ts
+++ b/packages/sprite/src/Sprite.ts
@@ -541,7 +541,7 @@ export class Sprite extends Container
      * @param {object} [options] - See {@link PIXI.BaseTexture}'s constructor for options.
      * @return {PIXI.Sprite} The newly created sprite
      */
-    static from(source: SpriteSource, options: IBaseTextureOptions): Sprite
+    static from(source: SpriteSource, options?: IBaseTextureOptions): Sprite
     {
         const texture = (source instanceof Texture)
             ? source

--- a/packages/sprite/src/Sprite.ts
+++ b/packages/sprite/src/Sprite.ts
@@ -70,7 +70,7 @@ export class Sprite extends Container
     /**
      * @param {PIXI.Texture} [texture] - The texture for this sprite.
      */
-    constructor(texture: Texture)
+    constructor(texture?: Texture)
     {
         super();
 

--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -597,7 +597,7 @@ export class Text extends Sprite
      * @param {boolean} [options.texture=true] - Should it destroy the current texture of the sprite as well
      * @param {boolean} [options.baseTexture=true] - Should it destroy the base texture of the sprite as well
      */
-    public destroy(options: IDestroyOptions|boolean): void
+    public destroy(options?: IDestroyOptions|boolean): void
     {
         if (typeof options === 'boolean')
         {

--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -63,7 +63,7 @@ export class Text extends Sprite
      * @param {object|PIXI.TextStyle} [style] - The style parameters
      * @param {HTMLCanvasElement} [canvas] - The canvas element for drawing text
      */
-    constructor(text: string, style: Partial<ITextStyle>|TextStyle, canvas: HTMLCanvasElement)
+    constructor(text: string, style?: Partial<ITextStyle>|TextStyle, canvas?: HTMLCanvasElement)
     {
         let ownCanvas = false;
 

--- a/packages/text/src/TextMetrics.ts
+++ b/packages/text/src/TextMetrics.ts
@@ -129,7 +129,7 @@ export class TextMetrics
      * @param {HTMLCanvasElement} [canvas] - optional specification of the canvas to use for measuring.
      * @return {PIXI.TextMetrics} measured width and height of the text.
      */
-    public static measureText(text: string, style: TextStyle, wordWrap: boolean, canvas = TextMetrics._canvas): TextMetrics
+    public static measureText(text: string, style: TextStyle, wordWrap?: boolean, canvas = TextMetrics._canvas): TextMetrics
     {
         wordWrap = (wordWrap === undefined || wordWrap === null) ? style.wordWrap : wordWrap;
         const font = style.toFontString();

--- a/packages/ticker/src/Ticker.ts
+++ b/packages/ticker/src/Ticker.ts
@@ -259,7 +259,7 @@ export class Ticker
      * @param {number} [priority=PIXI.UPDATE_PRIORITY.NORMAL] - The priority for emitting
      * @returns {PIXI.Ticker} This instance of a ticker
      */
-    add<T = any>(fn: TickerCallback<T>, context: T, priority = UPDATE_PRIORITY.NORMAL): this
+    add<T = any>(fn: TickerCallback<T>, context?: T, priority = UPDATE_PRIORITY.NORMAL): this
     {
         return this._addListener(new TickerListener(fn, context, priority));
     }
@@ -272,7 +272,7 @@ export class Ticker
      * @param {number} [priority=PIXI.UPDATE_PRIORITY.NORMAL] - The priority for emitting
      * @returns {PIXI.Ticker} This instance of a ticker
      */
-    addOnce<T = any>(fn: TickerCallback<T>, context: T, priority = UPDATE_PRIORITY.NORMAL): this
+    addOnce<T = any>(fn: TickerCallback<T>, context?: T, priority = UPDATE_PRIORITY.NORMAL): this
     {
         return this._addListener(new TickerListener(fn, context, priority, true));
     }
@@ -331,7 +331,7 @@ export class Ticker
      * @param {*} [context] - The listener context to be removed
      * @returns {PIXI.Ticker} This instance of a ticker
      */
-    remove<T = any>(fn: TickerCallback<T>, context: T): this
+    remove<T = any>(fn: TickerCallback<T>, context?: T): this
     {
         let listener = this._head.next;
 

--- a/packages/utils/src/color/premultiply.ts
+++ b/packages/utils/src/color/premultiply.ts
@@ -71,8 +71,8 @@ export function correctBlendMode(blendMode: number, premultiplied: boolean): num
 export function premultiplyRgba(
     rgb: Float32Array|number[],
     alpha: number,
-    out: Float32Array,
-    premultiply: boolean
+    out?: Float32Array,
+    premultiply?: boolean
 ): Float32Array
 {
     out = out || new Float32Array(4);
@@ -134,7 +134,7 @@ export function premultiplyTint(tint: number, alpha: number): number
  * @param {boolean} [premultiply=true] - do premultiply it
  * @returns {Float32Array} vec4 rgba
  */
-export function premultiplyTintToRgba(tint: number, alpha: number, out: Float32Array, premultiply: boolean): Float32Array
+export function premultiplyTintToRgba(tint: number, alpha: number, out: Float32Array, premultiply?: boolean): Float32Array
 {
     out = out || new Float32Array(4);
     out[0] = ((tint >> 16) & 0xFF) / 255.0;

--- a/packages/utils/src/media/CanvasRenderTarget.ts
+++ b/packages/utils/src/media/CanvasRenderTarget.ts
@@ -19,7 +19,7 @@ export class CanvasRenderTarget
      * @param {number} height - the height for the newly created canvas
      * @param {number} [resolution=1] - The resolution / device pixel ratio of the canvas
      */
-    constructor(width: number, height: number, resolution: number)
+    constructor(width: number, height: number, resolution?: number)
     {
         /**
          * The Canvas object that belongs to this CanvasRenderTarget.


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
Fixes a couple of incorrect types after upgrading to to the pre-release

- `.from` function now have optional options
- export `TLoaderResource` as this is the type of `LoaderResource`
- make `context` optional in `Ticker.add`, `Ticker.remove`
- update `RenderTexture.baseTexture` to be type `BaseRenderTexture`
- make `options` optional in `destroy` functions for anything extending `DisplayObejct`