### PR TITLE
Missed Version Substitution

### DIFF
--- a/bundles/pixi.js/src/index.ts
+++ b/bundles/pixi.js/src/index.ts
@@ -58,7 +58,7 @@ Application.registerPlugin(AppLoaderPlugin);
  * @name VERSION
  * @type {string}
  */
-export const VERSION = '__VERSION__';
+export const VERSION = '$_VERSION';
 
 /**
  * @namespace PIXI


### PR DESCRIPTION
After moving to JSCC, I forgot to replace `__VERSION__` with `$_VERSION` in the pixi.js bundle. @andrewstart reported this issue with pixi-particles trying to upgrade to 5.4.0-rc.2.

```js
/**
   * String of the current PIXI version.
   *
   * @static
   * @constant
   * @memberof PIXI
   * @name VERSION
   * @type {string}
   */
  var VERSION$1 = '__VERSION__';
```
https://pixijs.download/v5.4.0-rc.2/pixi.js


```js
/**
   * String of the current PIXI version.
   *
   * @static
   * @constant
   * @memberof PIXI
   * @name VERSION
   * @type {string}
   */
  var VERSION$1 = '5.4.0-rc.2';
```
https://pixijs.download/fix-version/pixi.js