### PR TITLE
Some fixes for 5.4.0

### DIFF
--- a/packages/interaction/src/InteractionManager.ts
+++ b/packages/interaction/src/InteractionManager.ts
@@ -1050,10 +1050,13 @@ export class InteractionManager extends EventEmitter
     public setCursorMode(mode: string): void
     {
         mode = mode || 'default';
-        // offscreen canvas does not support setting styles
-        if (this.interactionDOMElement instanceof OffscreenCanvas)
+        let applyStyles = true;
+
+        // offscreen canvas does not support setting styles, but cursor modes can be functions,
+        // in order to handle pixi rendered cursors, so we can't bail
+        if (self.OffscreenCanvas && this.interactionDOMElement instanceof OffscreenCanvas)
         {
-            return;
+            applyStyles = false;
         }
         // if the mode didn't actually change, bail early
         if (this.currentCursorMode === mode)
@@ -1070,7 +1073,10 @@ export class InteractionManager extends EventEmitter
             {
                 case 'string':
                     // string styles are handled as cursor CSS
-                    this.interactionDOMElement.style.cursor = style;
+                    if (applyStyles)
+                    {
+                        this.interactionDOMElement.style.cursor = style;
+                    }
                     break;
                 case 'function':
                     // functions are just called, and passed the cursor mode
@@ -1079,11 +1085,14 @@ export class InteractionManager extends EventEmitter
                 case 'object':
                     // if it is an object, assume that it is a dictionary of CSS styles,
                     // apply it to the interactionDOMElement
-                    Object.assign(this.interactionDOMElement.style, style);
+                    if (applyStyles)
+                    {
+                        Object.assign(this.interactionDOMElement.style, style);
+                    }
                     break;
             }
         }
-        else if (typeof mode === 'string' && !Object.prototype.hasOwnProperty.call(this.cursorStyles, mode))
+        else if (applyStyles && typeof mode === 'string' && !Object.prototype.hasOwnProperty.call(this.cursorStyles, mode))
         {
             // if it mode is a string (not a Symbol) and cursorStyles doesn't have any entry
             // for the mode, then assume that the dev wants it to be CSS for the cursor.

--- a/packages/prepare/src/BasePrepare.ts
+++ b/packages/prepare/src/BasePrepare.ts
@@ -21,7 +21,7 @@ interface IFindHook {
 export interface IDisplayObjectExtended extends DisplayObject {
     _textures?: Array<Texture>;
     _texture?: Texture;
-    style?: TextStyle;
+    style?: TextStyle|Partial<TextStyle>;
 }
 
 /**


### PR DESCRIPTION
Fixes #7009 and part of #7013 (the rest of that is fixed by #7006).

For the OffscreenCanvas change, I realized that bailing early would prevent the non-style cursor functionality from working, so changed it to be a more targeted check.