### PR TITLE
Fix memory leak with BitmapText

### DIFF
--- a/packages/text-bitmap/src/BitmapText.ts
+++ b/packages/text-bitmap/src/BitmapText.ts
@@ -913,7 +913,7 @@ export class BitmapText extends Container
         }
     }
 
-    destroy(options: boolean | IDestroyOptions): void
+    destroy(options?: boolean | IDestroyOptions): void
     {
         const { _textureCache } = this;
 

--- a/packages/text-bitmap/src/BitmapText.ts
+++ b/packages/text-bitmap/src/BitmapText.ts
@@ -420,9 +420,14 @@ export class BitmapText extends Container
                 pageMeshData.vertexCount = 0;
                 pageMeshData.uvsCount = 0;
                 pageMeshData.total = 0;
-                pageMeshData.mesh.texture?.destroy();
+
                 // TODO need to get page texture here somehow..
-                pageMeshData.mesh.texture = new Texture(texture.baseTexture);
+                if (pageMeshData.mesh.texture.baseTexture !== texture.baseTexture)
+                {
+                    pageMeshData.mesh.texture.destroy();
+                    pageMeshData.mesh.texture = new Texture(texture.baseTexture);
+                }
+
                 pageMeshData.mesh.tint = this._tint;
 
                 newPagesMeshData.push(pageMeshData);

--- a/packages/text-bitmap/src/BitmapText.ts
+++ b/packages/text-bitmap/src/BitmapText.ts
@@ -33,6 +33,7 @@ interface CharRenderData {
 
 const pageMeshDataPool: PageMeshData[] = [];
 const charRenderDataPool: CharRenderData[] = [];
+const textureCache: Record<number, Texture> = {};
 
 /**
  * A BitmapText object will create a line or multiple lines of text using bitmap font.
@@ -422,11 +423,8 @@ export class BitmapText extends Container
                 pageMeshData.total = 0;
 
                 // TODO need to get page texture here somehow..
-                if (pageMeshData.mesh.texture.baseTexture !== texture.baseTexture)
-                {
-                    pageMeshData.mesh.texture.destroy();
-                    pageMeshData.mesh.texture = new Texture(texture.baseTexture);
-                }
+                textureCache[baseTextureUid] = textureCache[baseTextureUid] || new Texture(texture.baseTexture);
+                pageMeshData.mesh.texture = textureCache[baseTextureUid];
 
                 pageMeshData.mesh.tint = this._tint;
 

--- a/packages/text-bitmap/src/BitmapText.ts
+++ b/packages/text-bitmap/src/BitmapText.ts
@@ -420,6 +420,7 @@ export class BitmapText extends Container
                 pageMeshData.vertexCount = 0;
                 pageMeshData.uvsCount = 0;
                 pageMeshData.total = 0;
+                pageMeshData.mesh.texture?.destroy();
                 // TODO need to get page texture here somehow..
                 pageMeshData.mesh.texture = new Texture(texture.baseTexture);
                 pageMeshData.mesh.tint = this._tint;


### PR DESCRIPTION
Fix #7003 

DEMO: https://jsfiddle.net/JetLu/w58mbhry/

The [original demo](https://www.pixiplayground.com/#/edit/AGAuOUo9ogkEvDnM3vxqf) memory footprint will increase over time.

![image](https://user-images.githubusercontent.com/6738986/99564847-e7608e80-2a05-11eb-9396-addb53aa55bf.png)
