### PR TITLE
Fix bitmap font loader to load fonts with random placed args into <info> tag in 5.4.0-rc.2

### DIFF
--- a/packages/text-bitmap/src/formats/XMLStringFormat.ts
+++ b/packages/text-bitmap/src/formats/XMLStringFormat.ts
@@ -19,9 +19,14 @@ export class XMLStringFormat
      */
     static test(data: unknown): boolean
     {
-        const xmlStringRegExp = new RegExp(/<font>(\s+)?<info\s+face=/);
+        if (typeof data === 'string' && data.includes('<font>'))
+        {
+            const xml = new self.DOMParser().parseFromString(data, 'text/xml');
 
-        return typeof data === 'string' && xmlStringRegExp.test(data);
+            return XMLFormat.test(xml);
+        }
+
+        return false;
     }
 
     /**

--- a/packages/text-bitmap/src/formats/XMLStringFormat.ts
+++ b/packages/text-bitmap/src/formats/XMLStringFormat.ts
@@ -19,7 +19,7 @@ export class XMLStringFormat
      */
     static test(data: unknown): boolean
     {
-        if (typeof data === 'string' && data.includes('<font>'))
+        if (typeof data === 'string' && data.indexOf('<font>') > -1)
         {
             const xml = new self.DOMParser().parseFromString(data, 'text/xml');
 

--- a/packages/text-bitmap/test/BitmapFontLoader.js
+++ b/packages/text-bitmap/test/BitmapFontLoader.js
@@ -67,6 +67,7 @@ describe('PIXI.BitmapFontLoader', function ()
             loadTxt('bmtxt-test.txt'),
             loadXML('font.fnt'),
             loadTxt('font-text.fnt'),
+            loadTxt('font-random-args.fnt'),
             loadXML('font@0.5x.fnt'),
             loadImage('bmtxt-test.png'),
             loadImage('font.png'),
@@ -77,6 +78,7 @@ describe('PIXI.BitmapFontLoader', function ()
             fontTXT,
             fontXML,
             fontText,
+            fontRandomArgs,
             fontScaledXML,
             fontTXTImage,
             fontImage,
@@ -88,6 +90,7 @@ describe('PIXI.BitmapFontLoader', function ()
             this.fontTXT = fontTXT;
             this.fontXML = fontXML;
             this.fontText = fontText;
+            this.fontRandomArgs = fontRandomArgs;
             this.fontScaledXML = fontScaledXML;
             this.fontTXTImage = fontTXTImage;
             this.fontImage = fontImage;
@@ -556,6 +559,26 @@ describe('PIXI.BitmapFontLoader', function ()
         const charE = font.chars['E'.charCodeAt(0)];
 
         expect(charE).to.be.undefined;
+        done();
+    });
+
+    it('should properly register bitmap font with random placed arguments into info tag', function (done)
+    {
+        const texture = Texture.from(this.fontImage);
+        const font = BitmapFont.install(this.fontRandomArgs, texture);
+
+        expect(font).to.be.an.object;
+        expect(BitmapFont.available.font).to.equal(font);
+        expect(font).to.have.property('chars');
+        const charA = font.chars['A'.charCodeAt(0)];
+
+        expect(charA).to.exist;
+        expect(charA.texture.baseTexture.resource.source).to.equal(this.fontImage);
+        expect(charA.texture.frame.x).to.equal(2);
+        expect(charA.texture.frame.y).to.equal(2);
+        expect(charA.texture.frame.width).to.equal(19);
+        expect(charA.texture.frame.height).to.equal(20);
+
         done();
     });
 });

--- a/packages/text-bitmap/test/resources/font-random-args.fnt
+++ b/packages/text-bitmap/test/resources/font-random-args.fnt
@@ -1,0 +1,18 @@
+<font>
+  <info aa="1" size="24" smooth="1" bold="0" italic="0" charset="" unicode="" stretchH="100" padding="2,2,2,2" spacing="0,0" outline="0" face="font"/>
+  <common lineHeight="27" base="18" scaleW="64" scaleH="64" pages="1" packed="0"/>
+  <pages>
+    <page id="0" file="font.png"/>
+  </pages>
+  <chars count="4">
+    <char id="65" x="2" y="2" width="19" height="20" xoffset="0" yoffset="0" xadvance="16" page="0" chnl="15"/>
+    <char id="66" x="2" y="24" width="15" height="20" xoffset="2" yoffset="0" xadvance="16" page="0" chnl="15"/>
+    <char id="67" x="23" y="2" width="18" height="20" xoffset="1" yoffset="0" xadvance="17" page="0" chnl="15"/>
+    <char id="68" x="19" y="24" width="17" height="20" xoffset="2" yoffset="0" xadvance="17" page="0" chnl="15"/>
+    <char id="32" x="0" y="0" width="0" height="0" xoffset="2" yoffset="0" xadvance="7" page="0" chnl="15"/>
+  </chars>
+  <kernings count="2">
+    <kerning first="32" second="65" amount="-1"/>
+    <kerning first="65" second="32" amount="-1"/>
+  </kernings>
+</font>


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
Fix #7008 
- For BitmapFont text format that's XML-based check if <font> tag exist than parse as XML and check if needed tags exist
- Added test for case when args into <info> tag placed randomly

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
