### PR TITLE
Add overridable TextMetrics.isBreakingSpace for better CJK plugin support

### DIFF
--- a/packages/text/src/TextMetrics.ts
+++ b/packages/text/src/TextMetrics.ts
@@ -502,11 +502,16 @@ export class TextMetrics
     /**
      * Determines if char is a breaking whitespace.
      *
+     * It allows one to determine whether char should be a breaking whitespace
+     * For example certain characters in CJK langs or numbers.
+     * It must return a boolean.
+     *
      * @private
-     * @param  {string}  char - The character
+     * @param  {string}  char     - The character
+     * @param  {string}  [nextChar] - The next character
      * @return {boolean}  True if whitespace, False otherwise.
      */
-    private static isBreakingSpace(char: string): boolean
+    private static isBreakingSpace(char: string, _nextChar?: string): boolean
     {
         if (typeof char !== 'string')
         {

--- a/packages/text/src/TextMetrics.ts
+++ b/packages/text/src/TextMetrics.ts
@@ -506,7 +506,6 @@ export class TextMetrics
      * For example certain characters in CJK langs or numbers.
      * It must return a boolean.
      *
-     * @private
      * @param  {string}  char     - The character
      * @param  {string}  [nextChar] - The next character
      * @return {boolean}  True if whitespace, False otherwise.

--- a/packages/text/src/TextMetrics.ts
+++ b/packages/text/src/TextMetrics.ts
@@ -511,7 +511,7 @@ export class TextMetrics
      * @param  {string}  [nextChar] - The next character
      * @return {boolean}  True if whitespace, False otherwise.
      */
-    private static isBreakingSpace(char: string, _nextChar?: string): boolean
+    static isBreakingSpace(char: string, _nextChar?: string): boolean
     {
         if (typeof char !== 'string')
         {

--- a/packages/text/src/TextMetrics.ts
+++ b/packages/text/src/TextMetrics.ts
@@ -541,8 +541,9 @@ export class TextMetrics
         for (let i = 0; i < text.length; i++)
         {
             const char = text[i];
+            const nextChar = text[i + 1];
 
-            if (TextMetrics.isBreakingSpace(char) || TextMetrics.isNewline(char))
+            if (TextMetrics.isBreakingSpace(char, nextChar) || TextMetrics.isNewline(char))
             {
                 if (token !== '')
                 {

--- a/packages/text/test/TextMetrics.js
+++ b/packages/text/test/TextMetrics.js
@@ -485,6 +485,31 @@ describe('PIXI.TextMetrics', function ()
 
             expect(bool).to.equal(false);
         });
+
+        it('overridable breaking spaces', function ()
+        {
+            const reg = /[あいうえお]/;
+
+            // override breakingSpace
+            TextMetrics.isBreakingSpace = function (char, nextChar)
+            {
+                const isBreakingSpace = breakingSpaces.includes(char);
+
+                if (isBreakingSpace && nextChar)
+                {
+                    return !nextChar.match(reg);
+                }
+
+                return isBreakingSpace;
+            };
+
+            breakingSpaces.forEach((char) =>
+            {
+                const bool = TextMetrics.isBreakingSpace(char, 'あ');
+
+                expect(bool).to.equal(false);
+            });
+        });
     });
 
     describe('tokenize', function ()

--- a/packages/text/test/TextMetrics.js
+++ b/packages/text/test/TextMetrics.js
@@ -490,6 +490,8 @@ describe('PIXI.TextMetrics', function ()
         {
             const reg = /[あいうえお]/;
 
+            const original = TextMetrics.isBreakingSpace;
+
             // override breakingSpace
             TextMetrics.isBreakingSpace = function (char, nextChar)
             {
@@ -509,6 +511,9 @@ describe('PIXI.TextMetrics', function ()
 
                 expect(bool).to.equal(false);
             });
+
+            // reset the override breakingSpace
+            TextMetrics.isBreakingSpace = original;
         });
     });
 


### PR DESCRIPTION
##### Description of change
As the discussion with @themoonrat in #6975, suggest allowing the `isBreakingSpace ` to be able to receive the `nextChar ` for solving the CJK issues in adding additions.

For example, the example plugin(https://codepen.io/huang-yuwei/pen/GRqbEmm) shows how we can solve the #6975 and #4447 via an adding addition.
However, I am not 100% sure whether the CJK related issues should be solved directly in PIXI.js itself.
Therefore, suggest applying the additional parameters for other developers can change via other plugins.

##### Pre-Merge Checklist
- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
