### PR TITLE
Move constructor documentation params from class declaration

### DIFF
--- a/packages/core/src/textures/BaseTexture.ts
+++ b/packages/core/src/textures/BaseTexture.ts
@@ -41,23 +41,6 @@ export interface BaseTexture extends GlobalMixins.BaseTexture, EventEmitter {}
  * @class
  * @extends PIXI.utils.EventEmitter
  * @memberof PIXI
- * @param {PIXI.Resource|string|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement} [resource=null] -
- *        The current resource to use, for things that aren't Resource objects, will be converted
- *        into a Resource.
- * @param {Object} [options] - Collection of options
- * @param {PIXI.MIPMAP_MODES} [options.mipmap=PIXI.settings.MIPMAP_TEXTURES] - If mipmapping is enabled for texture
- * @param {number} [options.anisotropicLevel=PIXI.settings.ANISOTROPIC_LEVEL] - Anisotropic filtering level of texture
- * @param {PIXI.WRAP_MODES} [options.wrapMode=PIXI.settings.WRAP_MODE] - Wrap mode for textures
- * @param {PIXI.SCALE_MODES} [options.scaleMode=PIXI.settings.SCALE_MODE] - Default scale mode, linear, nearest
- * @param {PIXI.FORMATS} [options.format=PIXI.FORMATS.RGBA] - GL format type
- * @param {PIXI.TYPES} [options.type=PIXI.TYPES.UNSIGNED_BYTE] - GL data type
- * @param {PIXI.TARGETS} [options.target=PIXI.TARGETS.TEXTURE_2D] - GL texture target
- * @param {PIXI.ALPHA_MODES} [options.alphaMode=PIXI.ALPHA_MODES.UNPACK] - Pre multiply the image alpha
- * @param {number} [options.width=0] - Width of the texture
- * @param {number} [options.height=0] - Height of the texture
- * @param {number} [options.resolution] - Resolution of the base texture
- * @param {object} [options.resourceOptions] - Optional resource options,
- *        see {@link PIXI.autoDetectResource autoDetectResource}
  */
 export class BaseTexture extends EventEmitter
 {
@@ -89,6 +72,25 @@ export class BaseTexture extends EventEmitter
     _batchLocation: number;
     parentTextureArray: BaseTexture;
 
+    /**
+     * @param {PIXI.Resource|string|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement} [resource=null] -
+     *        The current resource to use, for things that aren't Resource objects, will be converted
+     *        into a Resource.
+     * @param {Object} [options] - Collection of options
+     * @param {PIXI.MIPMAP_MODES} [options.mipmap=PIXI.settings.MIPMAP_TEXTURES] - If mipmapping is enabled for texture
+     * @param {number} [options.anisotropicLevel=PIXI.settings.ANISOTROPIC_LEVEL] - Anisotropic filtering level of texture
+     * @param {PIXI.WRAP_MODES} [options.wrapMode=PIXI.settings.WRAP_MODE] - Wrap mode for textures
+     * @param {PIXI.SCALE_MODES} [options.scaleMode=PIXI.settings.SCALE_MODE] - Default scale mode, linear, nearest
+     * @param {PIXI.FORMATS} [options.format=PIXI.FORMATS.RGBA] - GL format type
+     * @param {PIXI.TYPES} [options.type=PIXI.TYPES.UNSIGNED_BYTE] - GL data type
+     * @param {PIXI.TARGETS} [options.target=PIXI.TARGETS.TEXTURE_2D] - GL texture target
+     * @param {PIXI.ALPHA_MODES} [options.alphaMode=PIXI.ALPHA_MODES.UNPACK] - Pre multiply the image alpha
+     * @param {number} [options.width=0] - Width of the texture
+     * @param {number} [options.height=0] - Height of the texture
+     * @param {number} [options.resolution] - Resolution of the base texture
+     * @param {object} [options.resourceOptions] - Optional resource options,
+     *        see {@link PIXI.autoDetectResource autoDetectResource}
+     */
     constructor(resource: Resource | ImageSource | string | any = null, options: IBaseTextureOptions = null)
     {
         super();

--- a/packages/core/src/textures/resources/ArrayResource.ts
+++ b/packages/core/src/textures/resources/ArrayResource.ts
@@ -13,14 +13,16 @@ import type { ISize } from '@pixi/math';
  * @class
  * @extends PIXI.Resource
  * @memberof PIXI
- * @param {number|Array<*>} source - Number of items in array or the collection
- *        of image URLs to use. Can also be resources, image elements, canvas, etc.
- * @param {object} [options] - Options to apply to {@link PIXI.autoDetectResource}
- * @param {number} [options.width] - Width of the resource
- * @param {number} [options.height] - Height of the resource
  */
 export class ArrayResource extends AbstractMultiResource
 {
+    /**
+     * @param {number|Array<*>} source - Number of items in array or the collection
+     *        of image URLs to use. Can also be resources, image elements, canvas, etc.
+     * @param {object} [options] - Options to apply to {@link PIXI.autoDetectResource}
+     * @param {number} [options.width] - Width of the resource
+     * @param {number} [options.height] - Height of the resource
+     */
     constructor(source: number|Array<any>, options?: ISize)
     {
         const { width, height } = options || {};

--- a/packages/core/src/textures/resources/CanvasResource.ts
+++ b/packages/core/src/textures/resources/CanvasResource.ts
@@ -9,10 +9,18 @@ import { BaseImageResource } from './BaseImageResource';
  * @class
  * @extends PIXI.BaseImageResource
  * @memberof PIXI
- * @param {HTMLCanvasElement} source - Canvas element to use
  */
 export class CanvasResource extends BaseImageResource
 {
+    /**
+     * @param {HTMLCanvasElement} source - Canvas element to use
+     */
+    // eslint-disable-next-line @typescript-eslint/no-useless-constructor
+    constructor(source: HTMLCanvasElement)
+    {
+        super(source);
+    }
+
     /**
      * Used to auto-detect the type of resource.
      *

--- a/packages/core/src/textures/resources/CubeResource.ts
+++ b/packages/core/src/textures/resources/CubeResource.ts
@@ -23,14 +23,6 @@ export interface ICubeResourceOptions extends ISize
  * @class
  * @extends PIXI.ArrayResource
  * @memberof PIXI
- * @param {Array<string|PIXI.Resource>} [source] - Collection of URLs or resources
- *        to use as the sides of the cube.
- * @param {object} [options] - ImageResource options
- * @param {number} [options.width] - Width of resource
- * @param {number} [options.height] - Height of resource
- * @param {number} [options.autoLoad=true] - Whether to auto-load resources
- * @param {number} [options.linkBaseTexture=true] - In case BaseTextures are supplied,
- *   whether to copy them or use
  */
 export class CubeResource extends AbstractMultiResource
 {
@@ -38,6 +30,16 @@ export class CubeResource extends AbstractMultiResource
 
     linkBaseTexture: boolean;
 
+    /**
+     * @param {Array<string|PIXI.Resource>} [source] - Collection of URLs or resources
+     *        to use as the sides of the cube.
+     * @param {object} [options] - ImageResource options
+     * @param {number} [options.width] - Width of resource
+     * @param {number} [options.height] - Height of resource
+     * @param {number} [options.autoLoad=true] - Whether to auto-load resources
+     * @param {number} [options.linkBaseTexture=true] - In case BaseTextures are supplied,
+     *   whether to copy them or use
+     */
     constructor(source?: ArrayFixed<string|Resource, 6>, options?: ICubeResourceOptions)
     {
         const { width, height, autoLoad, linkBaseTexture } = options || {};

--- a/packages/core/src/textures/resources/ImageBitmapResource.ts
+++ b/packages/core/src/textures/resources/ImageBitmapResource.ts
@@ -5,10 +5,18 @@ import { BaseImageResource } from './BaseImageResource';
  * @class
  * @extends PIXI.BaseImageResource
  * @memberof PIXI
- * @param {ImageBitmap} source - Image element to use
  */
 export class ImageBitmapResource extends BaseImageResource
 {
+    /**
+     * @param {ImageBitmap} source - Image element to use
+     */
+    // eslint-disable-next-line @typescript-eslint/no-useless-constructor
+    constructor(source: ImageBitmap)
+    {
+        super(source);
+    }
+
     /**
      * Used to auto-detect the type of resource.
      *

--- a/packages/core/src/textures/resources/SVGResource.ts
+++ b/packages/core/src/textures/resources/SVGResource.ts
@@ -17,12 +17,6 @@ export interface ISVGResourceOptions
  * @class
  * @extends PIXI.BaseImageResource
  * @memberof PIXI
- * @param {string} source - Base64 encoded SVG element or URL for SVG file.
- * @param {object} [options] - Options to use
- * @param {number} [options.scale=1] - Scale to apply to SVG. Overridden by...
- * @param {number} [options.width] - Rasterize SVG this wide. Aspect ratio preserved if height not specified.
- * @param {number} [options.height] - Rasterize SVG this high. Aspect ratio preserved if width not specified.
- * @param {boolean} [options.autoLoad=true] - Start loading right away.
  */
 export class SVGResource extends BaseImageResource
 {
@@ -34,6 +28,14 @@ export class SVGResource extends BaseImageResource
     private _load: Promise<SVGResource>;
     private _crossorigin?: boolean|string;
 
+    /**
+     * @param {string} source - Base64 encoded SVG element or URL for SVG file.
+     * @param {object} [options] - Options to use
+     * @param {number} [options.scale=1] - Scale to apply to SVG. Overridden by...
+     * @param {number} [options.width] - Rasterize SVG this wide. Aspect ratio preserved if height not specified.
+     * @param {number} [options.height] - Rasterize SVG this high. Aspect ratio preserved if width not specified.
+     * @param {boolean} [options.autoLoad=true] - Start loading right away.
+     */
     constructor(sourceBase64: string, options?: ISVGResourceOptions)
     {
         options = options || {};

--- a/packages/core/src/textures/resources/VideoResource.ts
+++ b/packages/core/src/textures/resources/VideoResource.ts
@@ -22,13 +22,6 @@ export interface IVideoResourceOptionsElement
  * @class
  * @extends PIXI.BaseImageResource
  * @memberof PIXI
- * @param {HTMLVideoElement|object|string|Array<string|object>} source - Video element to use.
- * @param {object} [options] - Options to use
- * @param {boolean} [options.autoLoad=true] - Start loading the video immediately
- * @param {boolean} [options.autoPlay=true] - Start playing video immediately
- * @param {number} [options.updateFPS=0] - How many times a second to update the texture from the video.
- * Leave at 0 to update at every render.
- * @param {boolean} [options.crossorigin=true] - Load image using cross origin
  */
 export class VideoResource extends BaseImageResource
 {
@@ -40,6 +33,15 @@ export class VideoResource extends BaseImageResource
     private _load: Promise<VideoResource>;
     private _resolve: (value?: VideoResource | PromiseLike<VideoResource>) => void;
 
+    /**
+     * @param {HTMLVideoElement|object|string|Array<string|object>} source - Video element to use.
+     * @param {object} [options] - Options to use
+     * @param {boolean} [options.autoLoad=true] - Start loading the video immediately
+     * @param {boolean} [options.autoPlay=true] - Start playing video immediately
+     * @param {number} [options.updateFPS=0] - How many times a second to update the texture from the video.
+     * Leave at 0 to update at every render.
+     * @param {boolean} [options.crossorigin=true] - Load image using cross origin
+     */
     constructor(source?: HTMLVideoElement|Array<string|IVideoResourceOptionsElement>|string, options?: IVideoResourceOptions)
     {
         options = options || {};

--- a/packages/graphics/src/utils/Star.ts
+++ b/packages/graphics/src/utils/Star.ts
@@ -6,16 +6,17 @@ import { Polygon, PI_2 } from '@pixi/math';
  * @class
  * @extends PIXI.Polygon
  * @memberof PIXI.graphicsUtils
- * @param {number} x - Center X position of the star
- * @param {number} y - Center Y position of the star
- * @param {number} points - The number of points of the star, must be > 1
- * @param {number} radius - The outer radius of the star
- * @param {number} [innerRadius] - The inner radius between points, default half `radius`
- * @param {number} [rotation=0] - The rotation of the star in radians, where 0 is vertical
- * @return {PIXI.Graphics} This Graphics object. Good for chaining method calls
  */
 export class Star extends Polygon
 {
+    /**
+     * @param {number} x - Center X position of the star
+     * @param {number} y - Center Y position of the star
+     * @param {number} points - The number of points of the star, must be > 1
+     * @param {number} radius - The outer radius of the star
+     * @param {number} [innerRadius] - The inner radius between points, default half `radius`
+     * @param {number} [rotation=0] - The rotation of the star in radians, where 0 is vertical
+     */
     constructor(x: number, y: number, points: number, radius: number, innerRadius?: number, rotation = 0)
     {
         innerRadius = innerRadius || radius / 2;

--- a/packages/loaders/src/Loader.ts
+++ b/packages/loaders/src/Loader.ts
@@ -51,8 +51,6 @@ import type { Resource } from 'resource-loader';
  *
  * @class Loader
  * @memberof PIXI
- * @param {string} [baseUrl=''] - The base url for all resources loaded by this loader.
- * @param {number} [concurrency=10] - The number of resources to load concurrently.
  */
 export class Loader extends ResourceLoader
 {
@@ -68,6 +66,10 @@ export class Loader extends ResourceLoader
     private static _shared: Loader;
     private _protected: boolean;
 
+    /**
+     * @param {string} [baseUrl=''] - The base url for all resources loaded by this loader.
+     * @param {number} [concurrency=10] - The number of resources to load concurrently.
+     */
     constructor(baseUrl?: string, concurrency?: number)
     {
         super(baseUrl, concurrency);


### PR DESCRIPTION
Fixes #7022 

Moves documentation from the class doc block to the constructor.