### PR TITLE
Fix #7035

### DIFF
--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -379,7 +379,7 @@ export class Renderer extends AbstractRenderer
      * @param displayObject - The object to be rendered.
      * @param [renderTexture] - The render texture to render to.
      * @param [clear=true] - Should the canvas be cleared before the new render.
-     * @param [transform] - A transform to apply to the render texture before rendering.
+     * @param [transform] - A transform to apply to the object before rendering.
      * @param [skipUpdateTransform=false] - Should we skip the update transform pass?
      */
     render(displayObject: DisplayObject, renderTexture?: RenderTexture,


### PR DESCRIPTION
##### Description of change

Fixes #7035.

1. The transform must not be applied in the pop phase; only in push.
2. The source frame must be transformed as well if no filter area is given, i.e., the bounds must be transformed.
3. The matrix transforms the object, not the render texture; documentation was changed.

##### Pre-Merge Checklist

- [x] Documentation is changed
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
