### PR TITLE
Fix #7038

### DIFF
--- a/packages/core/src/renderTexture/RenderTexture.ts
+++ b/packages/core/src/renderTexture/RenderTexture.ts
@@ -133,9 +133,6 @@ export class RenderTexture extends Texture
      */
     resize(width: number, height: number, resizeBaseTexture = true): void
     {
-        width = Math.ceil(width);
-        height = Math.ceil(height);
-
         // TODO - could be not required..
         this.valid = (width > 0 && height > 0);
 

--- a/packages/core/src/renderTexture/RenderTextureSystem.ts
+++ b/packages/core/src/renderTexture/RenderTextureSystem.ts
@@ -155,8 +155,8 @@ export class RenderTextureSystem extends System
 
             if (!sourceFrame)
             {
-                tempRect.width = renderer.screen.width;
-                tempRect.height = renderer.screen.height;
+                tempRect.width = renderer.view.width / renderer.resolution;
+                tempRect.height = renderer.view.height / renderer.resolution;
 
                 sourceFrame = tempRect;
             }
@@ -181,6 +181,8 @@ export class RenderTextureSystem extends System
         {
             viewportFrame.y = renderer.view.height - (viewportFrame.y + viewportFrame.height);
         }
+
+        viewportFrame.ceil();
 
         this.renderer.framebuffer.bind(framebuffer, viewportFrame);
         this.renderer.projection.update(destinationFrame, sourceFrame, resolution, !framebuffer);

--- a/packages/math/src/shapes/Rectangle.ts
+++ b/packages/math/src/shapes/Rectangle.ts
@@ -236,14 +236,16 @@ export class Rectangle
      */
     ceil(resolution = 1, eps = 0.001): this
     {
-        const x2 = Math.ceil((this.x + this.width - eps) * resolution) / resolution;
-        const y2 = Math.ceil((this.y + this.height - eps) * resolution) / resolution;
+        const x1 = Math.floor((this.x + eps) * resolution);
+        const y1 = Math.floor((this.y + eps) * resolution);
+        const x2 = Math.ceil((this.x + this.width - eps) * resolution);
+        const y2 = Math.ceil((this.y + this.height - eps) * resolution);
 
-        this.x = Math.floor((this.x + eps) * resolution) / resolution;
-        this.y = Math.floor((this.y + eps) * resolution) / resolution;
+        this.x = x1 / resolution;
+        this.y = y1 / resolution;
 
-        this.width = x2 - this.x;
-        this.height = y2 - this.y;
+        this.width = (x2 - x1) / resolution;
+        this.height = (y2 - y1) / resolution;
 
         return this;
     }


### PR DESCRIPTION
##### Description of change

Fixes #7038.

1. Changed calculations in `Rectangle.ceil()` to improve precision of width and height. This is technically not necessary if (2) is applied.
2. Ensure the viewport frame is on the grid, i.e., integer. `gl.viewport()` converts it's arguments to `GLint`/`GLsizei` as `float` would be in C. That's why tiny rounding errors have an undesirable effect. This is an another bug that has actually the opposite effect of (3), which is not visible in the pictures in #7038.

```js
gl.viewport(64.00001, 63.99999, 128.00001, 127.99999);
console.log(gl.getParameter(gl.VIEWPORT)); // => Int32Array [64, 63, 128, 127]
````
![image](https://user-images.githubusercontent.com/31905376/100956476-d1c88a00-3518-11eb-947c-9fe7c40bdce5.png)

3. Fixed a bug in `RenderTexture.resize()` that set the width/height wrong that not only caused the flop texture to double in size, but caused what is depicted in #7038.
4. The canvas source frame has now the correct dimensions in case of non-integer resolutions, because `screen` is slightly too large in that case: `view.width == Math.floor(screen.width * resolution)` and `view.height == Math.floor(screen.height * resolution)`.

##### Pre-Merge Checklist

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
