### PR TITLE
Silence harmless warning

### DIFF
--- a/packages/text-bitmap/src/utils/drawGlyph.ts
+++ b/packages/text-bitmap/src/utils/drawGlyph.ts
@@ -69,7 +69,7 @@ export function drawGlyph(
     }
     else
     {
-        context.shadowColor = '0';
+        context.shadowColor = 'black';
         context.shadowBlur = 0;
         context.shadowOffsetX = 0;
         context.shadowOffsetY = 0;

--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -251,7 +251,7 @@ export class Text extends Sprite
                 //       https://github.com/microsoft/TypeScript/issues/2521
                 context.strokeStyle = style.stroke as string;
 
-                context.shadowColor = '0';
+                context.shadowColor = 'black';
                 context.shadowBlur = 0;
                 context.shadowOffsetX = 0;
                 context.shadowOffsetY = 0;


### PR DESCRIPTION
##### Description of change
Firefox warn`Expected color but found ‘0’.` to create Text instances.
Because, run `context.shadowColor = '0'` in `updateText()`, but it should be css color, '0' is not valid css color.
I silenced it.

##### Pre-Merge Checklist

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
