### PR TITLE
Fix transform filters

### DIFF
--- a/packages/core/src/filters/FilterSystem.ts
+++ b/packages/core/src/filters/FilterSystem.ts
@@ -174,14 +174,21 @@ export class FilterSystem extends System
 
         state.target = target;
 
-        state.sourceFrame.copyFrom(target.filterArea || target.getBounds(true));
-
-        const transform = renderer.projection.transform;
-
-        if (transform)
+        if (target.filterArea)
         {
-            // TODO: use Bounds.addFrameMatrix instead
-            this.transformAABB(transform, state.sourceFrame);
+            state.sourceFrame.copyFrom(target.filterArea);
+        }
+        else
+        {
+            state.sourceFrame.copyFrom(target.getBounds(true));
+
+            const transform = renderer.projection.transform;
+
+            if (transform)
+            {
+                // TODO: use Bounds.addFrameMatrix instead
+                this.transformAABB(transform, state.sourceFrame);
+            }
         }
 
         state.sourceFrame.pad(padding);

--- a/packages/core/test/MaskSystem.js
+++ b/packages/core/test/MaskSystem.js
@@ -132,6 +132,8 @@ describe('PIXI.systems.MaskSystem', function ()
         expect(scissor.args[1]).to.eql([7.5, 12, 18, 15]);
 
         rt.destroy(true);
+        this.renderer.projection.transform = null;
+        this.renderer.resolution = 1;
     });
 
     it('should correctly calculate alpha mask area if filter is present', function ()
@@ -167,7 +169,7 @@ describe('PIXI.systems.MaskSystem', function ()
             expect(this.renderer.renderTexture.current).to.be.notnull;
 
             const filterArea = this.renderer.renderTexture.current.filterFrame;
-            const expected = maskBounds.clone();
+            const expected = maskBounds.clone().ceil();
 
             expected.fit(filteredObject.getBounds());
             expect(filterArea).to.be.notnull;


### PR DESCRIPTION
Alternative to #7039 

We'll remove new private transformAABB function in favor of `Bounds.addFrameMatrix` after we move `Bounds` to `@pixi/math`