### PR TITLE
Add strict engines support

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/package.json
+++ b/package.json
@@ -34,6 +34,11 @@
   "pre-commit": [
     "lintfix"
   ],
+  "engines": {
+    "node": ">=12",
+    "yarn": "please-use-npm",
+    "npm": ">=6"
+  },
   "devDependencies": {
     "@lerna/batch-packages": "^3.13.0",
     "@lerna/filter-packages": "^3.13.0",


### PR DESCRIPTION
This is a non-critical change to define `engines` in the root package.json. I added similar changes for v5.3.x and v5.2.x branches (those old branches explicitly require Node 10 to build docs/types) and thought it would be good to declare supported Node.js versions and npm versions more explicitly. This aligns with the GitHub Actions for testing. In the past, users trying to build have hit issues #6775, #6571, #5724, etc
