### PR TITLE
Deprecates transparent Option

### DIFF
--- a/packages/app/src/Application.ts
+++ b/packages/app/src/Application.ts
@@ -50,7 +50,7 @@ export class Application
      * @param {number} [options.width=800] - The width of the renderers view.
      * @param {number} [options.height=600] - The height of the renderers view.
      * @param {HTMLCanvasElement} [options.view] - The canvas to use as a view, optional.
-     * @param {boolean} [options.transparent=false] - If the render view is transparent.
+     * @param {boolean} [options.contextAlpha=true] - Pass-through value for canvas' context `alpha` property.
      * @param {boolean} [options.autoDensity=false] - Resizes renderer view in CSS pixels to allow for
      *   resolutions other than 1.
      * @param {boolean} [options.antialias=false] - Sets antialias
@@ -62,6 +62,7 @@ export class Application
      *   it is ignored.
      * @param {number} [options.backgroundColor=0x000000] - The background color of the rendered area
      *  (shown if not transparent).
+     * @param {number} [options.backgroundAlpha=1] - Value from 0 (fully transparent) to 1 (fully opaque).
      * @param {boolean} [options.clearBeforeRender=true] - This sets if the renderer will clear the canvas or
      *   not before the new render pass.
      * @param {string} [options.powerPreference] - Parameter passed to webgl context, set to "high-performance"

--- a/packages/canvas/canvas-renderer/src/CanvasRenderer.ts
+++ b/packages/canvas/canvas-renderer/src/CanvasRenderer.ts
@@ -79,7 +79,7 @@ export class CanvasRenderer extends AbstractRenderer
      * @param {number} [options.width=800] - the width of the screen
      * @param {number} [options.height=600] - the height of the screen
      * @param {HTMLCanvasElement} [options.view] - the canvas to use as a view, optional
-     * @param {boolean} [options.transparent=false] - If the render view is transparent, default false
+     * @param {boolean} [options.contextAlpha=true] - Pass-through value for canvas' context `alpha` property.
      * @param {boolean} [options.autoDensity=false] - Resizes renderer view in CSS pixels to allow for
      *   resolutions other than 1
      * @param {boolean} [options.antialias=false] - sets antialias
@@ -91,6 +91,7 @@ export class CanvasRenderer extends AbstractRenderer
      *      not before the new render pass.
      * @param {number} [options.backgroundColor=0x000000] - The background color of the rendered area
      *  (shown if not transparent).
+     * @param {number} [options.backgroundAlpha=1] - Value from 0 (fully transparent) to 1 (fully opaque).
      */
     constructor(options?: IRendererOptions)
     {
@@ -101,7 +102,7 @@ export class CanvasRenderer extends AbstractRenderer
          *
          * @member {CanvasRenderingContext2D}
          */
-        this.rootContext = this.view.getContext('2d', { alpha: this.transparent }) as
+        this.rootContext = this.view.getContext('2d', { alpha: this.contextAlpha }) as
             CrossPlatformCanvasRenderingContext2D;
 
         /**
@@ -268,7 +269,7 @@ export class CanvasRenderer extends AbstractRenderer
         {
             if (this.renderingToScreen)
             {
-                if (this.transparent)
+                if (this.contextAlpha)
                 {
                     context.clearRect(0, 0, this.width, this.height);
                 }
@@ -366,7 +367,7 @@ export class CanvasRenderer extends AbstractRenderer
 
         clearColor = clearColor || this._backgroundColorString;
 
-        if (!this.transparent && clearColor)
+        if (!this.contextAlpha && clearColor)
         {
             context.fillStyle = clearColor;
             context.fillRect(0, 0, this.width, this.height);

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -115,7 +115,7 @@ export class Renderer extends AbstractRenderer
      * @param {number} [options.width=800] - The width of the screen.
      * @param {number} [options.height=600] - The height of the screen.
      * @param {HTMLCanvasElement} [options.view] - The canvas to use as a view, optional.
-     * @param {boolean} [options.transparent=true] - If the render has alpha enabled on the canvas.
+     * @param {boolean} [options.contextAlpha=true] - Pass-through value for canvas' context `alpha` property.
      * @param {boolean} [options.autoDensity=false] - Resizes renderer view in CSS pixels to allow for
      *   resolutions other than 1.
      * @param {boolean} [options.antialias=false] - Sets antialias. If not available natively then FXAA
@@ -129,6 +129,7 @@ export class Renderer extends AbstractRenderer
      *  enable this if you need to call toDataUrl on the WebGL context.
      * @param {number} [options.backgroundColor=0x000000] - The background color of the rendered area
      *  (shown if not transparent).
+     * @param {number} [options.backgroundAlpha=1] - Value from 0 (fully transparent) to 1 (fully opaque).
      * @param {string} [options.powerPreference] - Parameter passed to WebGL context, set to "high-performance"
      *  for devices with dual graphics card.
      * @param {object} [options.context] - If WebGL context already exists, all parameters must be taken from it.
@@ -297,9 +298,9 @@ export class Renderer extends AbstractRenderer
         else
         {
             this.context.initFromOptions({
-                alpha: !!this.transparent,
+                alpha: !!this.contextAlpha,
                 antialias: options.antialias,
-                premultipliedAlpha: this.transparent && this.transparent !== 'notMultiplied',
+                premultipliedAlpha: this.contextAlpha && this.contextAlpha !== 'notMultiplied',
                 stencil: true,
                 preserveDrawingBuffer: options.preserveDrawingBuffer,
                 powerPreference: this.options.powerPreference,

--- a/packages/core/src/autoDetectRenderer.ts
+++ b/packages/core/src/autoDetectRenderer.ts
@@ -16,7 +16,7 @@ export interface IRendererOptionsAuto extends IRendererOptions
  * @param {number} [options.width=800] - the width of the renderers view
  * @param {number} [options.height=600] - the height of the renderers view
  * @param {HTMLCanvasElement} [options.view] - the canvas to use as a view, optional
- * @param {boolean} [options.transparent=true] - If the render has alpha enabled on the canvas.
+ * @param {boolean} [options.contextAlpha=true] - Pass-through value for canvas' context `alpha` property.
  * @param {boolean} [options.autoDensity=false] - Resizes renderer view in CSS pixels to allow for
  *   resolutions other than 1
  * @param {boolean} [options.antialias=false] - sets antialias
@@ -24,6 +24,7 @@ export interface IRendererOptionsAuto extends IRendererOptions
  *  need to call toDataUrl on the webgl context
  * @param {number} [options.backgroundColor=0x000000] - The background color of the rendered area
  *  (shown if not transparent).
+ * @param {number} [options.backgroundAlpha=1] - Value from 0 (fully transparent) to 1 (fully opaque).
  * @param {boolean} [options.clearBeforeRender=true] - This sets if the renderer will clear the canvas or
  *   not before the new render pass.
  * @param {number} [options.resolution=1] - The resolution / device pixel ratio of the renderer, retina would be 2

--- a/packages/settings/src/settings.ts
+++ b/packages/settings/src/settings.ts
@@ -6,8 +6,9 @@ export interface IRenderOptions {
     view: HTMLCanvasElement;
     antialias: boolean;
     autoDensity: boolean;
-    transparent: boolean;
     backgroundColor: number;
+    backgroundAlpha: number;
+    contextAlpha: boolean | 'notMultiplied';
     clearBeforeRender: boolean;
     preserveDrawingBuffer: boolean;
     width: number;
@@ -142,8 +143,9 @@ export const settings: ISettings = {
      * @property {number} resolution=1
      * @property {boolean} antialias=false
      * @property {boolean} autoDensity=false
-     * @property {boolean} transparent=false
+     * @property {boolean} contextAlpha=true
      * @property {number} backgroundColor=0x000000
+     * @property {number} backgroundAlpha=1
      * @property {boolean} clearBeforeRender=true
      * @property {boolean} preserveDrawingBuffer=false
      * @property {number} width=800
@@ -154,8 +156,9 @@ export const settings: ISettings = {
         view: null,
         antialias: false,
         autoDensity: false,
-        transparent: true,
         backgroundColor: 0x000000,
+        backgroundAlpha: 1,
+        contextAlpha: true,
         clearBeforeRender: true,
         preserveDrawingBuffer: false,
         width: 800,


### PR DESCRIPTION
Fixes #7066

This clears up the ambiguity of the recent transparent changes by creating two distinct options for Application and Renderer. It's easier to backward support `transparent` by not overloading it with new meaning.

* **`contextAlpha`** the readonly property for creating the `canvas.getContext`
* **`backgroundAlpha`** the amount of background alpha from 0 to 1

The option `transparent` is marked as deprecated but still supports backward compatibility by setting `contextAlpha` and `backgroundAlpha`.

**Broken**
https://pixijs.io/examples/#/demos-basic/transparent-background.js

**Fixed**
https://pixijs.io/examples/?v=dev-context-alpha#/demos-basic/transparent-background.js
