### PR TITLE
FAIL_IF_MAJOR_PERFORMANCE_CAVEAT switched to false by default

### DIFF
--- a/packages/utils/src/settings.ts
+++ b/packages/utils/src/settings.ts
@@ -14,15 +14,30 @@ settings.RETINA_PREFIX = /@([0-9\.]+)x/;
 
 /**
  * Should the `failIfMajorPerformanceCaveat` flag be enabled as a context option used in the `isWebGLSupported` function.
- * For most scenarios this should be left as true, as otherwise the user may have a poor experience.
- * However, it can be useful to disable under certain scenarios, such as headless unit tests.
+ * If set to true, a WebGL renderer can fail to be created if the browser thinks there could be performance issues when
+ * using WebGL.
+ *
+ * In PixiJS v6 this has changed from true to false by default, to allow WebGL to work in as many scenarios as possible.
+ * However, some users may have a poor experience, for example, if a user has a gpu or driver version blacklisted by the
+ * browser.
+ *
+ * If your application requires high performance rendering, you may wish to set this to false.
+ * We recommend one of two options if you decide to set this flag to false:
+ *
+ * 1: Use the `pixi.js-legacy` package, which includes a Canvas renderer as a fallback in case high performance WebGL is
+ *    not supported.
+ *
+ * 2: Call `isWebGLSupported` (which if found in the PIXI.utils package) in your code before attempting to create a PixiJS
+ *    renderer, and show an error message to the user if the function returns false, explaining that their device & browser
+ *    combination does not support high performance WebGL.
+ *    This is a much better strategy than trying to create a PixiJS renderer and finding it then fails.
  *
  * @static
  * @name FAIL_IF_MAJOR_PERFORMANCE_CAVEAT
  * @memberof PIXI.settings
  * @type {boolean}
- * @default true
+ * @default false
  */
-settings.FAIL_IF_MAJOR_PERFORMANCE_CAVEAT = true;
+settings.FAIL_IF_MAJOR_PERFORMANCE_CAVEAT = false;
 
 export { settings };


### PR DESCRIPTION
##### Description of change
After the discussions in https://github.com/pixijs/pixi.js/issues/7054 - I feel it's a better strategy by default to allow WebGL where possible, and let developers decide if they want to fail on this flag. It seems it's not always an accurate indicator on whether a device will have good performance or not.

##### Pre-Merge Checklist
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)

How docs looks after generation

![image](https://user-images.githubusercontent.com/1528426/102195393-6eded780-3eb6-11eb-9d75-0800805c3777.png)

