### PR TITLE
Fix: Clamp blur filter to inputClamp

### DIFF
--- a/packages/filters/filter-blur/src/generateBlurFragSource.ts
+++ b/packages/filters/filter-blur/src/generateBlurFragSource.ts
@@ -13,6 +13,7 @@ const GAUSSIAN_VALUES: IGAUSSIAN_VALUES = {
 const fragTemplate = [
     'varying vec2 vBlurTexCoords[%size%];',
     'uniform sampler2D uSampler;',
+    'uniform vec4 inputClamp;',
 
     'void main(void)',
     '{',
@@ -22,6 +23,11 @@ const fragTemplate = [
 
 ].join('\n');
 
+const sampleTexelTemplate = `gl_FragColor += texture2D(
+    uSampler, 
+    clamp(vBlurTexCoords[%index%], inputClamp.xy, inputClamp.zw)
+) * %value%;`;
+
 export function generateBlurFragSource(kernelSize: number): string
 {
     const kernel = GAUSSIAN_VALUES[kernelSize];
@@ -30,12 +36,11 @@ export function generateBlurFragSource(kernelSize: number): string
     let fragSource = fragTemplate;
 
     let blurLoop = '';
-    const template = 'gl_FragColor += texture2D(uSampler, vBlurTexCoords[%index%]) * %value%;';
     let value: number;
 
     for (let i = 0; i < kernelSize; i++)
     {
-        let blur = template.replace('%index%', i.toString());
+        let blur = sampleTexelTemplate.replace('%index%', i.toString());
 
         value = i;
 


### PR DESCRIPTION
Fixes #7063 

This wasn't a regression in that the offending PR was incorrect. The problem rather lied in the `BlurFilter` incorrectly assuming the filter texture outside of the filtering area on the texture was cleared.

### The Problem

In #7063, @Article19 correctly suggested that the filter texture was bleeding. The `BlurFilter` was sampling texels outside of the filtering area (even outside the padding). Since the `FilterSystem` no longer has to clear the whole texture, those texels could have garbage from previous filtering operations.

### Description of change

The blur filter's texel sampling is clamped to the `inputClamp`, i.e. the padded filtering area.

### Explanation

Technically, the blur filter shouldn't require clamping - we already apply a padding around the filter target. However, the blur filter is also applied inside the padding - which is due the limitation of the `FilterSystem`. Ideally, the filter should run only in the filter target's area.

![Blur Filter Bleeding](https://user-images.githubusercontent.com/22450567/102366295-7bcafc00-3f86-11eb-9a8b-9e748ff73bcf.png)

The above diagram shows different texels the filter calculates the output for. In each case, the filter samples all the texels in the input texture within the radius around the output texel. For any location within the yellow region (filter target's bounds), the texels have the correct values within the blurring radius (filter target inside its bounds, transparent black in filter padding). HOWEVER, for any location in the filter padding itself, the blur filter would sample pixels outside of the filter source frame. Since the blue region could contain garbage, using it in the blur manifests itself as "bleeding".

## Verification of fix

I tested that clamping the filter sampling to `inputClamp` by clearing the area outside of the filtering area with opaque red. Without this fix, you would see a red bleeding:

<img width="390" alt="Screen Shot 2020-12-16 at 9 59 32 AM" src="https://user-images.githubusercontent.com/22450567/102366997-42df5700-3f87-11eb-9f49-45b9beba9f8c.png">

And indeed, this fix works - after:

<img width="390" alt="Screen Shot 2020-12-16 at 10 14 47 AM" src="https://user-images.githubusercontent.com/22450567/102367235-86d25c00-3f87-11eb-983c-5256cb267a57.png">

## Reproduction notes

To reproduce this bug, you must ensure that multiple objects are filtered using the same filter textures. That means the next-power-of-2 filter area (bounds + filter padding) must be equal.

##### Pre-Merge Checklist
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
