### PR TITLE
Improve CLEAR_MODES docs

### DIFF
--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -329,7 +329,12 @@ export enum ALPHA_MODES {
 }
 
 /**
- * How to clear renderTextures in filter
+ * How to clear renderTextures in filter.
+ * If your filter takes samples only from used part of temporary RT,
+ * 1. it guarantees clamping of texture sampling coordinates,
+ * 2. it sets blendMode of filter to NONE
+ * then you can use AUTO mode.
+ * Otherwise, good old YES will work for you, it ensures clearing of whole temporary RT.
  *
  * @name CLEAR_MODES
  * @memberof PIXI

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -331,9 +331,8 @@ export enum ALPHA_MODES {
 /**
  * Configure whether filter textures are cleared after binding.
  *
- * Filter textures need not be cleared if the filter does not use pixel blending. Its will overwrite the
- * output texture if its {@code BLEND_MODE} is {@link BLEND_MODES.NONE}. {@link CLEAR_MODES.BLIT} will detect
- * whether this and skip clearing as an optimization.
+ * Filter textures need not be cleared if the filter does not use pixel blending. {@link CLEAR_MODES.BLIT} will detect
+ * this and skip clearing as an optimization.
  *
  * @name CLEAR_MODES
  * @memberof PIXI

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -329,20 +329,19 @@ export enum ALPHA_MODES {
 }
 
 /**
- * How to clear renderTextures in filter.
- * If your filter takes samples only from used part of temporary RT,
- * 1. it guarantees clamping of texture sampling coordinates,
- * 2. it sets blendMode of filter to NONE
- * then you can use AUTO mode.
- * Otherwise, good old YES will work for you, it ensures clearing of whole temporary RT.
+ * Configure whether filter textures are cleared after binding.
+ *
+ * Filter textures need not be cleared if the filter does not use pixel blending. Its will overwrite the
+ * output texture if its {@code BLEND_MODE} is {@link BLEND_MODES.NONE}. {@link CLEAR_MODES.BLIT} will detect
+ * whether this and skip clearing as an optimization.
  *
  * @name CLEAR_MODES
  * @memberof PIXI
  * @static
  * @enum {number}
- * @property {number} BLEND - Preserve the information in the texture, blend above
- * @property {number} CLEAR - Must use `gl.clear` operation
- * @property {number} BLIT - Clear or blit it, depends on device and level of paranoia
+ * @property {number} BLEND - Do not clear the filter texture. The filter's output will blend on top of the output texture.
+ * @property {number} CLEAR - Always clear the filter texture.
+ * @property {number} BLIT - Clear only if {@link FilterSystem.forceClear} is set or if the filter uses pixel blending.
  * @property {number} NO - Alias for BLEND, same as `false` in earlier versions
  * @property {number} YES - Alias for CLEAR, same as `true` in earlier versions
  * @property {number} AUTO - Alias for BLIT

--- a/packages/core/src/filters/FilterSystem.ts
+++ b/packages/core/src/filters/FilterSystem.ts
@@ -4,7 +4,7 @@ import { Quad } from '../utils/Quad';
 import { QuadUv } from '../utils/QuadUv';
 import { Rectangle, Matrix } from '@pixi/math';
 import { UniformGroup } from '../shader/UniformGroup';
-import { DRAW_MODES, CLEAR_MODES, BLEND_MODES } from '@pixi/constants';
+import { DRAW_MODES, CLEAR_MODES } from '@pixi/constants';
 import { FilterState } from './FilterState';
 
 import type { Filter } from './Filter';
@@ -344,7 +344,7 @@ export class FilterSystem extends System
             renderTextureSystem.bind(filterTexture);
         }
 
-        const autoClear = stateSystem.blendMode !== BLEND_MODES.NONE || this.forceClear;
+        const autoClear = (stateSystem.stateId & 1) || this.forceClear;
 
         if (clearMode === CLEAR_MODES.CLEAR
             || (clearMode === CLEAR_MODES.BLIT && autoClear))
@@ -365,6 +365,7 @@ export class FilterSystem extends System
     {
         const renderer = this.renderer;
 
+        renderer.state.set(filter.state);
         this.bindAndClear(output, clearMode);
 
         // set the uniforms..
@@ -374,8 +375,6 @@ export class FilterSystem extends System
         // TODO make it so that the order of this does not matter..
         // because it does at the moment cos of global uniforms.
         // they need to get resynced
-
-        renderer.state.set(filter.state);
         renderer.shader.bind(filter);
 
         if (filter.legacy)

--- a/packages/core/test/FilterSystem.js
+++ b/packages/core/test/FilterSystem.js
@@ -1,4 +1,4 @@
-const { CLEAR_MODES } = require('@pixi/constants');
+const { CLEAR_MODES, BLEND_MODES } = require('@pixi/constants');
 const { Rectangle, Matrix } = require('@pixi/math');
 const { Renderer, Filter } = require('../');
 
@@ -32,6 +32,8 @@ describe('PIXI.FilterSystem', function ()
         const clearSpy = sinon.spy(this.renderer.framebuffer, 'clear');
         const obj = onePixelObject();
         const filterSystem = this.renderer.filter;
+
+        this.renderer.state.setBlendMode(BLEND_MODES.NONE);
 
         let clearModeValue = CLEAR_MODES.BLEND;
 

--- a/packages/core/test/FilterSystem.js
+++ b/packages/core/test/FilterSystem.js
@@ -33,7 +33,7 @@ describe('PIXI.FilterSystem', function ()
         const obj = onePixelObject();
         const filterSystem = this.renderer.filter;
 
-        filter.blendMode = BLEND_MODES.NONE;
+        innerFilter.state.blend = false;
 
         let clearModeValue = CLEAR_MODES.BLEND;
 

--- a/packages/core/test/FilterSystem.js
+++ b/packages/core/test/FilterSystem.js
@@ -33,7 +33,7 @@ describe('PIXI.FilterSystem', function ()
         const obj = onePixelObject();
         const filterSystem = this.renderer.filter;
 
-        this.renderer.state.setBlendMode(BLEND_MODES.NONE);
+        filter.blendMode = BLEND_MODES.NONE;
 
         let clearModeValue = CLEAR_MODES.BLEND;
 


### PR DESCRIPTION
As discussed with @SukantPal , I have to clarify this once more.

Most people that write filters dont know about clamping and other tricks that are needed in case we use pow2 temporary renderTextures. Even our `BlurFilter` is affected, @GoodBoyDigital wrote this version for v5 :)

For them, we distinguish two clearing modes - one `CLEAR` that clears everything, and second `BLIT` that just overwrites new content over texture, and leaves right and bottom zone as it was.