### PR TITLE
GraphicsGeometry JSDoc function signature

### DIFF
--- a/packages/graphics/src/GraphicsGeometry.ts
+++ b/packages/graphics/src/GraphicsGeometry.ts
@@ -447,7 +447,7 @@ export class GraphicsGeometry extends BatchGeometry
      * Generates intermediate batch data. Either gets converted to drawCalls
      * or used to convert to batch objects directly by the Graphics object.
      *
-     * @param {boolean} [aloow32Indices] - Allow using 32-bit indices for preventings artefacts when more that 65535 vertices
+     * @param {boolean} [allow32Indices] - Allow using 32-bit indices for preventing artefacts when more that 65535 vertices
      */
     updateBatches(allow32Indices?: boolean): void
     {

--- a/packages/graphics/src/GraphicsGeometry.ts
+++ b/packages/graphics/src/GraphicsGeometry.ts
@@ -447,7 +447,7 @@ export class GraphicsGeometry extends BatchGeometry
      * Generates intermediate batch data. Either gets converted to drawCalls
      * or used to convert to batch objects directly by the Graphics object.
      *
-     * @param {boolean} [allow32Indices] - Allow using 32-bit indices for preventing artefacts when more that 65535 vertices
+     * @param {boolean} [allow32Indices] - Allow using 32-bit indices for preventing artifacts when more that 65535 vertices
      */
     updateBatches(allow32Indices?: boolean): void
     {


### PR DESCRIPTION
JSDoc comment doesn't match function signature: `aloow32Indices` changed to: `allow32Indices`

Also updated "_preventings_" to "_preventing_" in the comment.  

Might want to assure you actually mean "_artefacts_" instead of "_artifacts_".