### PR TITLE
Basis package jsdoc

### DIFF
--- a/packages/basis/src/BasisLoader.ts
+++ b/packages/basis/src/BasisLoader.ts
@@ -456,7 +456,7 @@ export class BasisLoader
      * });
      * ```
      *
-     * @param basisu - the initialized transcoder library
+     * @param {BasisBinding} basisLibrary - the initialized transcoder library
      * @private
      */
     static bindTranscoder(basisLibrary: BasisBinding): void

--- a/packages/basis/src/TranscoderWorkerWrapper.ts
+++ b/packages/basis/src/TranscoderWorkerWrapper.ts
@@ -74,7 +74,7 @@ declare global {
  *
  * The transcoder worker responds to two types of messages: "init" and "transcode". You must always send the first "init"
  * {@link IInitializeTranscoderMessage} message with the WebAssembly binary; if the transcoder is successfully initialized,
- * the web-worker will respond by sending anothor {@link ITranscodeResponse} message with `success: true`.
+ * the web-worker will respond by sending another {@link ITranscodeResponse} message with `success: true`.
  *
  * @ignore
  */


### PR DESCRIPTION
Perhaps this started out as Basis Universal, then became `basisLibrary`?

This library is the only [basisu keyword at npm](https://www.npmjs.com/search?q=keywords:basisu), defined in [basis package.json](https://github.com/pixijs/pixi.js/blob/dev/packages/basis/package.json)

Set JSDoc param `basisu` to type `BasisBinding` named `basisLibrary`

Minor typo (ignored from JSDoc): _anothor_ => _another_