### PR TITLE
Core package jsdoc

### DIFF
--- a/packages/core/src/batch/BatchShaderGenerator.ts
+++ b/packages/core/src/batch/BatchShaderGenerator.ts
@@ -29,7 +29,7 @@ export class BatchShaderGenerator
         this.vertexSrc = vertexSrc;
 
         /**
-         * Reference to the fragement shader template. Must contain "%count%" and "%forloop%".
+         * Reference to the fragment shader template. Must contain "%count%" and "%forloop%".
          *
          * @member {string}
          */

--- a/packages/core/src/filters/Filter.ts
+++ b/packages/core/src/filters/Filter.ts
@@ -164,7 +164,7 @@ import type { Dict } from '@pixi/utils';
  * `inputClamp.zw` is bottom-right pixel center.
  *
  * ```
- * vec4 color = texture2D(uSampler, clamp(modifigedTextureCoord, inputClamp.xy, inputClamp.zw))
+ * vec4 color = texture2D(uSampler, clamp(modifiedTextureCoord, inputClamp.xy, inputClamp.zw))
  * ```
  * OR
  * ```

--- a/packages/core/src/fragments/index.ts
+++ b/packages/core/src/fragments/index.ts
@@ -13,7 +13,7 @@ import $defaultFilterVertex from './defaultFilter.vert';
  * @member {string} defaultFilterVertex
  */
 
-// NOTE: This black magic is so that @microsoft/api-extractor does not complain! This explicity specifies the types
+// NOTE: This black magic is so that @microsoft/api-extractor does not complain! This explicitly specifies the types
 // of defaultVertex, defaultFilterVertex.
 const defaultVertex: string = $defaultVertex;
 const defaultFilterVertex: string = $defaultFilterVertex;

--- a/packages/core/src/framebuffer/Framebuffer.ts
+++ b/packages/core/src/framebuffer/Framebuffer.ts
@@ -190,7 +190,7 @@ export class Framebuffer
             const texture = this.colorTextures[i];
             const resolution = texture.resolution;
 
-            // take into acount the fact the texture may have a different resolution..
+            // take into account the fact the texture may have a different resolution..
             texture.setSize(width / resolution, height / resolution);
         }
 

--- a/packages/core/src/geometry/GeometrySystem.ts
+++ b/packages/core/src/geometry/GeometrySystem.ts
@@ -258,7 +258,7 @@ export class GeometrySystem extends System
     }
 
     /**
-     * Check compability between a geometry and a program
+     * Check compatibility between a geometry and a program
      * @protected
      * @param {PIXI.Geometry} geometry - Geometry instance
      * @param {PIXI.Program} program - Program instance

--- a/packages/core/src/shader/ShaderSystem.ts
+++ b/packages/core/src/shader/ShaderSystem.ts
@@ -12,7 +12,7 @@ import type { Dict } from '@pixi/utils';
 import type { UniformsSyncCallback } from './utils';
 
 let UID = 0;
-// defualt sync data so we don't create a new one each time!
+// default sync data so we don't create a new one each time!
 const defaultSyncData = { textureCount: 0 };
 
 /**

--- a/packages/core/src/textures/TextureGCSystem.ts
+++ b/packages/core/src/textures/TextureGCSystem.ts
@@ -62,7 +62,7 @@ export class TextureGCSystem extends System
         this.checkCountMax = settings.GC_MAX_CHECK_COUNT;
 
         /**
-         * Current garabage collection mode
+         * Current garbage collection mode
          * @member {PIXI.GC_MODES}
          * @see PIXI.settings.GC_MODE
          */


### PR DESCRIPTION
Minor typos in core package:
- _fragement_ => _fragment_
- _modifigedTextureCoord_ => _modifiedTextureCoord_
- _explicity_ => _explicitly_
- _acount_ => _account_
- _compability_ => _compatibility_
- _defualt_ => _default_
- _garabage_ => _garbage_