### PR TITLE
Graphics package jsdoc

### DIFF
--- a/packages/graphics/src/Graphics.ts
+++ b/packages/graphics/src/Graphics.ts
@@ -339,7 +339,7 @@ export class Graphics extends Container
      * @param {number} [width=0] - width of the line to draw, will update the objects stored style
      * @param {number} [color=0x0] - color of the line to draw, will update the objects stored style
      * @param {number} [alpha=1] - alpha of the line to draw, will update the objects stored style
-     * @param {number} [alignment=0.5] - alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
+     * @param {number} [alignment=0.5] - alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outer)
      * @param {boolean} [native=false] - If true the lines will be draw using LINES instead of TRIANGLE_STRIP
      * @return {PIXI.Graphics} This Graphics object. Good for chaining method calls
      */
@@ -351,7 +351,7 @@ export class Graphics extends Container
      * @param {number} [options.width=0] - width of the line to draw, will update the objects stored style
      * @param {number} [options.color=0x0] - color of the line to draw, will update the objects stored style
      * @param {number} [options.alpha=1] - alpha of the line to draw, will update the objects stored style
-     * @param {number} [options.alignment=0.5] - alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
+     * @param {number} [options.alignment=0.5] - alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outer)
      * @param {boolean} [options.native=false] - If true the lines will be draw using LINES instead of TRIANGLE_STRIP
      * @param {PIXI.LINE_CAP}[options.cap=PIXI.LINE_CAP.BUTT] - line cap style
      * @param {PIXI.LINE_JOIN}[options.join=PIXI.LINE_JOIN.MITER] - line join style
@@ -388,7 +388,7 @@ export class Graphics extends Container
      *  Default 0xFFFFFF if texture present.
      * @param {number} [options.alpha=1] - alpha of the line to draw, will update the objects stored style
      * @param {PIXI.Matrix} [options.matrix=null] - Texture matrix to transform texture
-     * @param {number} [options.alignment=0.5] - alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outter)
+     * @param {number} [options.alignment=0.5] - alignment of the line to draw, (0 = inner, 0.5 = middle, 1 = outer)
      * @param {boolean} [options.native=false] - If true the lines will be draw using LINES instead of TRIANGLE_STRIP
      * @param {PIXI.LINE_CAP}[options.cap=PIXI.LINE_CAP.BUTT] - line cap style
      * @param {PIXI.LINE_JOIN}[options.join=PIXI.LINE_JOIN.MITER] - line join style
@@ -1195,7 +1195,7 @@ export class Graphics extends Container
     }
 
     /**
-     * Recalcuate the tint by applying tin to batches using Graphics tint.
+     * Recalculate the tint by applying tint to batches using Graphics tint.
      * @protected
      */
     protected calculateTints(): void
@@ -1228,7 +1228,7 @@ export class Graphics extends Container
 
     /**
      * If there's a transform update or a change to the shape of the
-     * geometry, recaculate the vertices.
+     * geometry, recalculate the vertices.
      * @protected
      */
     protected calculateVertices(): void

--- a/packages/graphics/src/styles/FillStyle.ts
+++ b/packages/graphics/src/styles/FillStyle.ts
@@ -34,7 +34,7 @@ export class FillStyle
     public texture: Texture = Texture.WHITE;
 
     /**
-     * The transform aplpied to the texture.
+     * The transform applied to the texture.
      *
      * @member {PIXI.Matrix}
      * @default null

--- a/packages/graphics/src/utils/buildLine.ts
+++ b/packages/graphics/src/utils/buildLine.ts
@@ -321,7 +321,7 @@ function buildNonNativeLine(graphicsData: GraphicsData, graphicsGeometry: Graphi
         perp1x *= width;
         perp1y *= width;
 
-        /* d[x|y](0|1) = the component displacment between points p(0,1|1,2) */
+        /* d[x|y](0|1) = the component displacement between points p(0,1|1,2) */
         const dx0 = x1 - x0;
         const dy0 = y0 - y1;
         const dx1 = x1 - x2;


### PR DESCRIPTION
Minor typos in the graphics package:
- _outter_ -> _outer_
- _tin_ => _tint_
- _Recalcuate_ => _Recalculate_
- _recaculate_ => _recalculate_
- _aplpied_ => _applied_
- _displacment_ => _displacement_