### PR TITLE
Fix: Geometry with different shaders leaked buffers

### DIFF
--- a/packages/core/src/geometry/GeometrySystem.ts
+++ b/packages/core/src/geometry/GeometrySystem.ts
@@ -169,15 +169,17 @@ export class GeometrySystem extends System
         // Still mulling over the best way to solve this one..
         // will likely need to modify the shader attribute locations at run time!
         let vaos = geometry.glVertexArrayObjects[this.CONTEXT_UID];
+        let incRefCount = false;
 
         if (!vaos)
         {
             this.managedGeometries[geometry.id] = geometry;
             geometry.disposeRunner.add(this);
             geometry.glVertexArrayObjects[this.CONTEXT_UID] = vaos = {};
+            incRefCount = true;
         }
 
-        const vao = vaos[shader.program.id] || this.initGeometryVao(geometry, shader.program);
+        const vao = vaos[shader.program.id] || this.initGeometryVao(geometry, shader.program, incRefCount);
 
         this._activeGeometry = geometry;
 
@@ -311,8 +313,9 @@ export class GeometrySystem extends System
      * @protected
      * @param {PIXI.Geometry} geometry - Instance of geometry to to generate Vao for
      * @param {PIXI.Program} program - Instance of program
+     * @param {boolean} [incRefCount=false] - Increment refCount of all geometry buffers
      */
-    protected initGeometryVao(geometry: Geometry, program: Program): WebGLVertexArrayObject
+    protected initGeometryVao(geometry: Geometry, program: Program, incRefCount = true): WebGLVertexArrayObject
     {
         this.checkCompatibility(geometry, program);
 
@@ -400,7 +403,10 @@ export class GeometrySystem extends System
                 buffer.disposeRunner.add(this);
             }
 
-            buffer._glBuffers[CONTEXT_UID].refCount++;
+            if (incRefCount)
+            {
+                buffer._glBuffers[CONTEXT_UID].refCount++;
+            }
         }
 
         // TODO - maybe make this a data object?

--- a/packages/core/test/Geometry.js
+++ b/packages/core/test/Geometry.js
@@ -11,6 +11,16 @@ void main() {
     vUvs = aUvs;
     gl_Position = vec4((projectionMatrix * translationMatrix * vec3(aVertexPosition, 1.0)).xy, 0.0, 1.0);
 }`;
+const vert2 = `
+attribute vec2 aVertexPosition;
+uniform mat3 translationMatrix;
+uniform mat3 projectionMatrix;
+varying vec2 vUvs;
+
+void main() {
+    vUvs = aVertexPosition;
+    gl_Position = vec4((projectionMatrix * translationMatrix * vec3(aVertexPosition, 1.0)).xy, 0.0, 1.0);
+}`;
 const frag = `
 varying vec2 vUvs;
 uniform sampler2D uSampler;
@@ -48,6 +58,44 @@ describe('PIXI.Geometry', function ()
             expect(Object.keys(indices._glBuffers).length).to.equal(1);
             geometry2.destroy();
             expect(Object.keys(indices._glBuffers).length).to.equal(0);
+        }
+        finally
+        {
+            renderer.destroy();
+        }
+    });
+
+    it('should dispose buffer if geometry is used by two shaders', function ()
+    {
+        const renderer = new Renderer(1, 1);
+
+        try
+        {
+            const indices = new Buffer([0, 1, 2, 0, 2, 3], true, true);
+            const geometry = new Geometry();
+            const prog = new Program(vert, frag);
+            const prog2 = new Program(vert2, frag);
+            const shader = new Shader(prog, { uSampler: Texture.WHITE });
+            const shader2 = new Shader(prog2, { uSampler: Texture.WHITE });
+
+            geometry.addAttribute('aVertexPosition', [-100, -100, 100, -100, 100, 100, -100, 100], 2)
+                .addAttribute('aUvs', [0, 0, 1, 0, 1, 1, 0, 1], 2)
+                .addIndex(indices);
+
+            renderer.geometry.bind(geometry, shader);
+            renderer.geometry.bind(geometry, shader2);
+
+            // 2 signatures and 2 by shader-ids
+            expect(Object.keys(geometry.glVertexArrayObjects).length).to.equal(1);
+            expect(Object.keys(geometry.glVertexArrayObjects[renderer.CONTEXT_UID]).length).to.equal(4);
+            expect(Object.keys(renderer.geometry.managedGeometries).length).to.equal(1);
+            expect(Object.keys(indices._glBuffers).length).to.equal(1);
+            expect(indices._glBuffers[renderer.CONTEXT_UID].refCount).to.equal(1);
+            geometry.dispose();
+            expect(Object.keys(geometry.glVertexArrayObjects).length).to.equal(0);
+            expect(Object.keys(renderer.geometry.managedGeometries).length).to.equal(0);
+            expect(Object.keys(indices._glBuffers).length).to.equal(0);
+            geometry.destroy();
         }
         finally
         {


### PR DESCRIPTION
Added special test for it.

Exists for all v5 branches.

Recommend to backport to 5.3.x

Bug was eating memory in production application on thousands of users. Now we can move to hundred thousands :)
