### PR TITLE
Fix: TilingSprite uvRespectAnchor = false mode.

### DIFF
--- a/packages/canvas/canvas-sprite-tiling/src/TilingSprite.ts
+++ b/packages/canvas/canvas-sprite-tiling/src/TilingSprite.ts
@@ -119,8 +119,7 @@ TilingSprite.prototype._renderCanvas = function _renderCanvas(renderer: CanvasRe
     // and this matrix is used to inverse-map the local space vertices into it.
     //
     // patternMatrix = tileTransfrom x shiftTransform
-    patternMatrix.identity();
-    patternMatrix.prepend(lt);
+    patternMatrix.copyFrom(lt);
 
     // Apply shiftTransform into patternMatrix. See $1.1
     if (!this.uvRespectAnchor)

--- a/packages/canvas/canvas-sprite-tiling/src/TilingSprite.ts
+++ b/packages/canvas/canvas-sprite-tiling/src/TilingSprite.ts
@@ -5,8 +5,9 @@ import { Matrix, Point } from '@pixi/math';
 
 import type { CanvasRenderer } from '@pixi/canvas-renderer';
 
-const tempMatrix = new Matrix();
-const tempPoints = [new Point(), new Point(), new Point(), new Point()];
+const worldMatrix = new Matrix();
+const patternMatrix = new Matrix();
+const patternRect = [new Point(), new Point(), new Point(), new Point()];
 
 /**
  * Renders the object using the Canvas renderer
@@ -64,33 +65,109 @@ TilingSprite.prototype._renderCanvas = function _renderCanvas(renderer: CanvasRe
     const W = this._width;
     const H = this._height;
 
-    tempMatrix.identity();
-    tempMatrix.copyFrom(lt);
-    tempMatrix.prepend(transform);
+    /*
+     * # Implementation Notes
+     *
+     * The tiling transform is not simply a transform on the tiling sprite's local space. If that
+     * were, the bounds of the tiling sprite would change. Rather the tile transform is a transform
+     * on the "pattern" coordinates each vertex is assigned.
+     *
+     * To implement the `tileTransform`, we issue drawing commands in the pattern's own space, which
+     * is defined as:
+     *
+     * Pattern_Space = Local_Space x inverse(tileTransform)
+     *
+     * In other words,
+     * Local_Space = Pattern_Space x tileTransform
+     *
+     * We draw the pattern in pattern space, because the space we draw in defines the pattern's coordinates.
+     * In other words, the pattern will always "originate" from (0, 0) in the space we draw in.
+     *
+     * This technique is equivalent to drawing a pattern texture, and then finding a quadrilateral that becomes
+     * the tiling sprite's local bounds under the tileTransform and mapping that onto the screen.
+     *
+     * ## uvRespectAnchor
+     *
+     * The preceding paragraph discusses the case without considering `uvRespectAnchor`. The `uvRespectAnchor` flags
+     * where the origin of the pattern space is. Assuming the tileTransform includes no translation, without
+     * loss of generality: If uvRespectAnchor = true, then
+     *
+     * Local Space (0, 0) <--> Pattern Space (0, 0) (where <--> means "maps to")
+     *
+     * Here the mapping is provided by trivially by the tileTransform (note tileTransform includes no translation. That
+     * means the invariant under all other transforms are the origins)
+     *
+     * Otherwise,
+     *
+     * Local Space (-localBounds.x, -localBounds.y) <--> Pattern Space (0, 0)
+     *
+     * Here the mapping is provided by the tileTransfrom PLUS some "shift". This shift is done POST-tileTransform. The shift
+     * is equal to the position of the top-left corner of the tiling sprite in its local space.
+     *
+     * Hence,
+     *
+     * Local_Space = Pattern_Space x tileTransform x shiftTransform
+     */
 
-    renderer.setContextTransform(tempMatrix);
+    // worldMatrix is used to convert from pattern space to world space.
+    //
+    // worldMatrix = tileTransform x shiftTransform x worldTransfrom
+    //             = patternMatrix x worldTransform
+    worldMatrix.identity();
 
-    // fill the pattern!
+    // patternMatrix is used to convert from pattern space to local space. The drawing commands are issued in pattern space
+    // and this matrix is used to inverse-map the local space vertices into it.
+    //
+    // patternMatrix = tileTransfrom x shiftTransform
+    patternMatrix.identity();
+    patternMatrix.prepend(lt);
+
+    // Apply shiftTransform into patternMatrix. See $1.1
+    if (!this.uvRespectAnchor)
+    {
+        patternMatrix.translate(-this.anchor.x * W, -this.anchor.y * H);
+    }
+
+    worldMatrix.prepend(patternMatrix);
+    worldMatrix.prepend(transform);
+
+    renderer.setContextTransform(worldMatrix);
+
+    // Fill the pattern!
     context.fillStyle = this._canvasPattern;
 
-    const anchorX = this.uvRespectAnchor ? this.anchor.x * -W : 0;
-    const anchorY = this.uvRespectAnchor ? this.anchor.y * -H : 0;
+    // The position in local space we are drawing the rectangle: (lx, ly, lx + W, ly + H)
+    const lx = this.anchor.x * -W;
+    const ly = this.anchor.y * -H;
 
-    tempPoints[0].set(anchorX, anchorY);
-    tempPoints[1].set(anchorX + W, anchorY);
-    tempPoints[2].set(anchorX + W, anchorY + H);
-    tempPoints[3].set(anchorX, anchorY + H);
+    // Set pattern rect in local space first.
+    patternRect[0].set(lx, ly);
+    patternRect[1].set(lx + W, ly);
+    patternRect[2].set(lx + W, ly + H);
+    patternRect[3].set(lx, ly + H);
+
+    // Map patternRect into pattern space.
     for (let i = 0; i < 4; i++)
     {
-        lt.applyInverse(tempPoints[i], tempPoints[i]);
+        patternMatrix.applyInverse(patternRect[i], patternRect[i]);
     }
 
+    /*
+     * # Note about verification of theory
+     *
+     * As discussed in the implementation notes, you can verify that `patternRect[0]` will always be (0, 0) in case of
+     * `uvRespectAnchor` false and tileTransform having no translation. Indeed, because the pattern origin should map
+     * to the top-left corner of the tiling sprite in its local space.
+     */
+
     context.beginPath();
-    context.moveTo(tempPoints[0].x, tempPoints[0].y);
+    context.moveTo(patternRect[0].x, patternRect[0].y);
+
     for (let i = 1; i < 4; i++)
     {
-        context.lineTo(tempPoints[i].x, tempPoints[i].y);
+        context.lineTo(patternRect[i].x, patternRect[i].y);
     }
+
     context.closePath();
     context.fill();
 };

--- a/packages/sprite-tiling/src/TilingSprite.ts
+++ b/packages/sprite-tiling/src/TilingSprite.ts
@@ -11,7 +11,7 @@ const tempPoint = new Point();
 export interface TilingSprite extends GlobalMixins.TilingSprite {}
 
 /**
- * A tiling sprite is a fast way of rendering a tiling image
+ * A tiling sprite is a fast way of rendering a tiling image.
  *
  * @class
  * @extends PIXI.Sprite
@@ -72,7 +72,11 @@ export class TilingSprite extends Sprite
         this.pluginName = 'tilingSprite';
 
         /**
-         * Whether or not anchor affects uvs
+         * Flags whether the tiling pattern should originate from the origin instead of the top-left corner in
+         * local space.
+         *
+         * This will make the texture coordinates assigned to each vertex dependent on the value of the anchor. Without
+         * this, the top-left corner always gets the (0, 0) texture coordinate.
          *
          * @member {boolean}
          * @default false


### PR DESCRIPTION
Fixes #7098 

##### Description of change

Apply the "shift matrix" in case of `uvRespectAnchor` being false as described in the (newly added) implementation notes. The local space rect being drawn is now always (-anchor.x * W, -anchor.y * H, W, H) (i.e. equal to the local bounds of the tiling sprite).

Pen: https://codepen.io/sukantpal/pen/yLaPqWd?editors=1010