### PR TITLE
Fix bug with TilingSpriteRenderer reseting default UVs

### DIFF
--- a/packages/sprite-tiling/src/TilingSpriteRenderer.ts
+++ b/packages/sprite-tiling/src/TilingSpriteRenderer.ts
@@ -69,7 +69,8 @@ export class TilingSpriteRenderer extends ObjectRenderer
         vertices[2] = vertices[4] = (ts._width) * (1.0 - ts.anchor.x);
         vertices[5] = vertices[7] = ts._height * (1.0 - ts.anchor.y);
 
-        const { x: anchorX = 0, y: anchorY = 0 } = ts.uvRespectAnchor ? ts.anchor : {};
+        const anchorX = ts.uvRespectAnchor ? ts.anchor.x : 0;
+        const anchorY = ts.uvRespectAnchor ? ts.anchor.y : 0;
 
         vertices = quad.uvs;
 

--- a/packages/sprite-tiling/src/TilingSpriteRenderer.ts
+++ b/packages/sprite-tiling/src/TilingSpriteRenderer.ts
@@ -69,16 +69,15 @@ export class TilingSpriteRenderer extends ObjectRenderer
         vertices[2] = vertices[4] = (ts._width) * (1.0 - ts.anchor.x);
         vertices[5] = vertices[7] = ts._height * (1.0 - ts.anchor.y);
 
-        if (ts.uvRespectAnchor)
-        {
-            vertices = quad.uvs;
+        const { x: anchorX = 0, y: anchorY = 0 } = ts.uvRespectAnchor ? ts.anchor : {};
 
-            vertices[0] = vertices[6] = -ts.anchor.x;
-            vertices[1] = vertices[3] = -ts.anchor.y;
+        vertices = quad.uvs;
 
-            vertices[2] = vertices[4] = 1.0 - ts.anchor.x;
-            vertices[5] = vertices[7] = 1.0 - ts.anchor.y;
-        }
+        vertices[0] = vertices[6] = -anchorX;
+        vertices[1] = vertices[3] = -anchorY;
+
+        vertices[2] = vertices[4] = 1.0 - anchorX;
+        vertices[5] = vertices[7] = 1.0 - anchorY;
 
         quad.invalidate();
 


### PR DESCRIPTION
Fixes issue found here: https://github.com/pixijs/pixi.js/pull/7105#issuecomment-751520798

Thanks for the tip @ivanpopelyshev :+1: 

### 🕷️   Broken
https://jsfiddle.net/bigtimebuddy/7xeLys04/

### ✅   Fixed (this PR)
https://jsfiddle.net/bigtimebuddy/wt354zu2/