### PR TITLE
Update the banners without version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 PixiJS — The HTML5 Creation Engine
 =============
 
-![pixi.js logo](https://pixijs.download/pixijs-banner-v5.png)
+![pixi.js logo](https://pixijs.download/pixijs-banner-no-version.png)
+
 [<img src="https://img.shields.io/badge/slack/pixijs-gray.svg?logo=slack">](https://join.slack.com/t/pixijs/shared_invite/zt-dcem1map-uVuVGC7pZ0trF8SrcA2p9g)
 [![npm version](https://badge.fury.io/js/pixi.js.svg)](https://badge.fury.io/js/pixi.js)
 [![Inline docs](http://inch-ci.org/github/pixijs/pixi.js.svg?branch=dev)](http://inch-ci.org/github/pixijs/pixi.js)

--- a/bundles/pixi.js-legacy/README.md
+++ b/bundles/pixi.js-legacy/README.md
@@ -1,7 +1,7 @@
 PixiJS — The HTML5 Creation Engine
 =============
 
-![pixi.js logo](https://pixijs.download/pixijs-banner-v5.png)
+![pixi.js logo](https://pixijs.download/pixijs-banner-no-version.png)
 
 The aim of this project is to provide a fast lightweight 2D library that works
 across all devices. The PixiJS renderer allows everyone to enjoy the power of

--- a/bundles/pixi.js/README.md
+++ b/bundles/pixi.js/README.md
@@ -1,7 +1,7 @@
 PixiJS — The HTML5 Creation Engine
 =============
 
-![pixi.js logo](https://pixijs.download/pixijs-banner-v5.png)
+![pixi.js logo](https://pixijs.download/pixijs-banner-no-version.png)
 
 The aim of this project is to provide a fast lightweight 2D library that works
 across all devices. The PixiJS renderer allows everyone to enjoy the power of


### PR DESCRIPTION
In anticipation of our new major version, this removes "v5" so we can be more ever-green.