### PR TITLE
Remove Renderer casting in accessibility, clean up local variables

### DIFF
--- a/packages/accessibility/package.json
+++ b/packages/accessibility/package.json
@@ -27,9 +27,7 @@
   "dependencies": {
     "@pixi/core": "5.4.0-rc.3",
     "@pixi/display": "5.4.0-rc.3",
+    "@pixi/canvas-renderer": "5.4.0-rc.3",
     "@pixi/utils": "5.4.0-rc.3"
-  },
-  "devDependencies": {
-    "@pixi/canvas-renderer": "5.4.0-rc.3"
   }
 }

--- a/packages/accessibility/src/AccessibilityManager.ts
+++ b/packages/accessibility/src/AccessibilityManager.ts
@@ -4,7 +4,8 @@ import { accessibleTarget } from './accessibleTarget';
 
 import type { Rectangle } from '@pixi/math';
 import type { Container } from '@pixi/display';
-import type { Renderer, AbstractRenderer } from '@pixi/core';
+import type { Renderer } from '@pixi/core';
+import type { CanvasRenderer } from '@pixi/canvas-renderer';
 import type { IAccessibleHTMLElement } from './accessibleTarget';
 
 // add some extra variables to the container..
@@ -37,7 +38,7 @@ const DIV_HOOK_ZINDEX = 2;
 export class AccessibilityManager
 {
     public debug: boolean;
-    public renderer: AbstractRenderer|Renderer;
+    public renderer: CanvasRenderer|Renderer;
 
     private _isActive: boolean;
     private _isMobileAccessibility: boolean;
@@ -52,7 +53,7 @@ export class AccessibilityManager
     /**
      * @param {PIXI.CanvasRenderer|PIXI.Renderer} renderer - A reference to the current renderer
      */
-    constructor(renderer: AbstractRenderer|Renderer)
+    constructor(renderer: CanvasRenderer|Renderer)
     {
         /**
          * @type {?HTMLElement}
@@ -109,7 +110,7 @@ export class AccessibilityManager
         /**
          * The renderer this accessibility manager works for.
          *
-         * @member {PIXI.AbstractRenderer}
+         * @member {PIXI.CanvasRenderer|PIXI.Renderer}
          */
         this.renderer = renderer;
 
@@ -240,13 +241,8 @@ export class AccessibilityManager
         self.document.addEventListener('mousemove', this._onMouseMove, true);
         self.removeEventListener('keydown', this._onKeyDown, false);
 
-        // TODO: Remove casting when CanvasRenderer is converted
-        (this.renderer as AbstractRenderer).on('postrender', this.update, this);
-
-        if ((this.renderer as AbstractRenderer).view.parentNode)
-        {
-            (this.renderer as AbstractRenderer).view.parentNode.appendChild(this.div);
-        }
+        this.renderer.on('postrender', this.update, this);
+        this.renderer.view.parentNode?.appendChild(this.div);
     }
 
     /**
@@ -267,13 +263,8 @@ export class AccessibilityManager
         self.document.removeEventListener('mousemove', this._onMouseMove, true);
         self.addEventListener('keydown', this._onKeyDown, false);
 
-        // TODO: Remove casting when CanvasRenderer is converted
-        (this.renderer as AbstractRenderer).off('postrender', this.update);
-
-        if (this.div.parentNode)
-        {
-            this.div.parentNode.removeChild(this.div);
-        }
+        this.renderer.off('postrender', this.update);
+        this.div.parentNode?.removeChild(this.div);
     }
 
     /**
@@ -338,20 +329,18 @@ export class AccessibilityManager
             this.updateAccessibleObjects(this.renderer._lastObjectRendered as Container);
         }
 
-        // TODO: Remove casting when CanvasRenderer is converted
-        const rect = (this.renderer as AbstractRenderer).view.getBoundingClientRect();
+        const { left, top, width, height } = this.renderer.view.getBoundingClientRect();
+        const { width: stageWidth, height: stageHeight, resolution } = this.renderer;
 
-        const resolution = this.renderer.resolution;
-
-        const sx = (rect.width / (this.renderer as AbstractRenderer).width) * resolution;
-        const sy = (rect.height / (this.renderer as AbstractRenderer).height) * resolution;
+        const sx = (width / stageWidth) * resolution;
+        const sy = (height / stageHeight) * resolution;
 
         let div = this.div;
 
-        div.style.left = `${rect.left}px`;
-        div.style.top = `${rect.top}px`;
-        div.style.width = `${(this.renderer as AbstractRenderer).width}px`;
-        div.style.height = `${(this.renderer as AbstractRenderer).height}px`;
+        div.style.left = `${left}px`;
+        div.style.top = `${top}px`;
+        div.style.width = `${stageWidth}px`;
+        div.style.height = `${stageHeight}px`;
 
         for (let i = 0; i < this.children.length; i++)
         {
@@ -451,15 +440,16 @@ export class AccessibilityManager
             hitArea.y = 0;
         }
 
-        // TODO: Remove casting when CanvasRenderer is converted
-        if (hitArea.x + hitArea.width > (this.renderer as AbstractRenderer).width)
+        const { width: stageWidth, height: stageHeight } = this.renderer;
+
+        if (hitArea.x + hitArea.width > stageWidth)
         {
-            hitArea.width = (this.renderer as AbstractRenderer).width - hitArea.x;
+            hitArea.width = stageWidth - hitArea.x;
         }
 
-        if (hitArea.y + hitArea.height > (this.renderer as AbstractRenderer).height)
+        if (hitArea.y + hitArea.height > stageHeight)
         {
-            hitArea.height = (this.renderer as AbstractRenderer).height - hitArea.y;
+            hitArea.height = stageHeight - hitArea.y;
         }
     }
 
@@ -553,18 +543,13 @@ export class AccessibilityManager
      */
     private _onClick(e: MouseEvent): void
     {
-        // TODO: Remove casting when CanvasRenderer is converted
-        const interactionManager = (this.renderer as AbstractRenderer).plugins.interaction;
+        const interactionManager = this.renderer.plugins.interaction;
+        const { displayObject } = e.target as IAccessibleHTMLElement;
+        const { eventData } = interactionManager;
 
-        interactionManager.dispatchEvent(
-            (e.target as IAccessibleHTMLElement).displayObject, 'click', interactionManager.eventData
-        );
-        interactionManager.dispatchEvent(
-            (e.target as IAccessibleHTMLElement).displayObject, 'pointertap', interactionManager.eventData
-        );
-        interactionManager.dispatchEvent(
-            (e.target as IAccessibleHTMLElement).displayObject, 'tap', interactionManager.eventData
-        );
+        interactionManager.dispatchEvent(displayObject, 'click', eventData);
+        interactionManager.dispatchEvent(displayObject, 'pointertap', eventData);
+        interactionManager.dispatchEvent(displayObject, 'tap', eventData);
     }
 
     /**
@@ -580,12 +565,11 @@ export class AccessibilityManager
             (e.target as Element).setAttribute('aria-live', 'assertive');
         }
 
-        // TODO: Remove casting when CanvasRenderer is converted
-        const interactionManager = (this.renderer as AbstractRenderer).plugins.interaction;
+        const interactionManager = this.renderer.plugins.interaction;
+        const { displayObject } = e.target as IAccessibleHTMLElement;
+        const { eventData } = interactionManager;
 
-        interactionManager.dispatchEvent(
-            (e.target as IAccessibleHTMLElement).displayObject, 'mouseover', interactionManager.eventData
-        );
+        interactionManager.dispatchEvent(displayObject, 'mouseover', eventData);
     }
 
     /**
@@ -601,10 +585,11 @@ export class AccessibilityManager
             (e.target as Element).setAttribute('aria-live', 'polite');
         }
 
-        // TODO: Remove casting when CanvasRenderer is converted
-        const interactionManager = (this.renderer as AbstractRenderer).plugins.interaction;
+        const interactionManager = this.renderer.plugins.interaction;
+        const { displayObject } = e.target as IAccessibleHTMLElement;
+        const { eventData } = interactionManager;
 
-        interactionManager.dispatchEvent((e.target as any).displayObject, 'mouseout', interactionManager.eventData);
+        interactionManager.dispatchEvent(displayObject, 'mouseout', eventData);
     }
 
     /**

--- a/packages/accessibility/src/AccessibilityManager.ts
+++ b/packages/accessibility/src/AccessibilityManager.ts
@@ -330,17 +330,17 @@ export class AccessibilityManager
         }
 
         const { left, top, width, height } = this.renderer.view.getBoundingClientRect();
-        const { width: stageWidth, height: stageHeight, resolution } = this.renderer;
+        const { width: viewWidth, height: viewHeight, resolution } = this.renderer;
 
-        const sx = (width / stageWidth) * resolution;
-        const sy = (height / stageHeight) * resolution;
+        const sx = (width / viewWidth) * resolution;
+        const sy = (height / viewHeight) * resolution;
 
         let div = this.div;
 
         div.style.left = `${left}px`;
         div.style.top = `${top}px`;
-        div.style.width = `${stageWidth}px`;
-        div.style.height = `${stageHeight}px`;
+        div.style.width = `${viewWidth}px`;
+        div.style.height = `${viewHeight}px`;
 
         for (let i = 0; i < this.children.length; i++)
         {
@@ -440,16 +440,16 @@ export class AccessibilityManager
             hitArea.y = 0;
         }
 
-        const { width: stageWidth, height: stageHeight } = this.renderer;
+        const { width: viewWidth, height: viewHeight } = this.renderer;
 
-        if (hitArea.x + hitArea.width > stageWidth)
+        if (hitArea.x + hitArea.width > viewWidth)
         {
-            hitArea.width = stageWidth - hitArea.x;
+            hitArea.width = viewWidth - hitArea.x;
         }
 
-        if (hitArea.y + hitArea.height > stageHeight)
+        if (hitArea.y + hitArea.height > viewHeight)
         {
-            hitArea.height = stageHeight - hitArea.y;
+            hitArea.height = viewHeight - hitArea.y;
         }
     }
 


### PR DESCRIPTION
A little light, non-critical cleanup to AccessibilityManager. There were some left-over TODOs from the conversion to TypesScript that added a lot of unnecessary casting. Also, tweaked some local variables to minimize verbose variable reuse. None of these changes impact functionality.