### PR TITLE
Remove type coupling between core and extract

### DIFF
--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -24,7 +24,6 @@ import type { RenderTexture } from './renderTexture/RenderTexture';
 import type { DisplayObject } from '@pixi/display';
 import type { System } from './System';
 import type { IRenderingContext } from './IRenderingContext';
-import type { Extract } from '@pixi/extract';
 
 export interface IRendererPluginConstructor {
     new (renderer: Renderer, options?: any): IRendererPlugin;
@@ -74,7 +73,6 @@ export class Renderer extends AbstractRenderer
     public globalUniforms: UniformGroup;
     public CONTEXT_UID: number;
     public renderingToScreen: boolean;
-    public extract: Extract;
     // systems
     public mask: MaskSystem;
     public context: ContextSystem;

--- a/packages/extract/src/Extract.ts
+++ b/packages/extract/src/Extract.ts
@@ -39,14 +39,6 @@ export class Extract implements IRendererPlugin
     constructor(renderer: Renderer)
     {
         this.renderer = renderer;
-        /**
-         * Collection of methods for extracting data (image, pixels, etc.) from a display object or render texture
-         *
-         * @member {PIXI.Extract} extract
-         * @memberof PIXI.Renderer#
-         * @see PIXI.Extract
-         */
-        renderer.extract = this;
     }
 
     /**
@@ -263,7 +255,6 @@ export class Extract implements IRendererPlugin
      */
     public destroy(): void
     {
-        this.renderer.extract = null;
         this.renderer = null;
     }
 


### PR DESCRIPTION
###  Bug

This type issue happens when using `@pixi/core` without installing `@pixi/extract`.

```
node_modules/@pixi/core/index.d.ts:13:43 - error TS7016: Could not find a declaration file for module '@pixi/extract'. '/node_modules/@pixi/extract/lib/extract.js' implicitly has an 'any' type.
  Try `npm install @types/pixi__extract` if it exists or add a new declaration (.d.ts) file containing `declare module '@pixi/extract';`

13 import type { Extract as Extract_2 } from '@pixi/extract';
```

### Description

CanvasExtract was removed in #6503 as a property of CanvasRenderer. This make this change consistent with Renderer and Extract. The `extract` property is redundant with `plugins.extract` and unnecessary. It also create an undesirable dependency between core with extract.