### PR TITLE
Remove type coupling between core and display

### DIFF
--- a/packages/core/src/AbstractRenderer.ts
+++ b/packages/core/src/AbstractRenderer.ts
@@ -2,12 +2,11 @@ import { hex2string, hex2rgb, EventEmitter, deprecation } from '@pixi/utils';
 import { Matrix, Rectangle } from '@pixi/math';
 import { RENDERER_TYPE } from '@pixi/constants';
 import { settings } from '@pixi/settings';
-import { DisplayObject } from '@pixi/display';
 import { RenderTexture } from './renderTexture/RenderTexture';
 
 import type { SCALE_MODES } from '@pixi/constants';
 import type { IRenderingContext } from './IRenderingContext';
-import type { Container } from '@pixi/display';
+import type { IRenderableContainer, IRenderableObject } from './IRenderableObject';
 
 const tempMatrix = new Matrix();
 
@@ -63,7 +62,7 @@ export abstract class AbstractRenderer extends EventEmitter
     protected _backgroundColor: number;
     protected _backgroundColorString: string;
     _backgroundColorRgba: number[];
-    _lastObjectRendered: DisplayObject;
+    _lastObjectRendered: IRenderableObject;
 
     /**
      * @param system - The name of the system this renderer is for.
@@ -300,10 +299,10 @@ export abstract class AbstractRenderer extends EventEmitter
      *        if no region is specified, defaults to the local bounds of the displayObject.
      * @return A texture of the graphics object.
      */
-    generateTexture(displayObject: DisplayObject,
+    generateTexture(displayObject: IRenderableObject,
         scaleMode?: SCALE_MODES, resolution?: number, region?: Rectangle): RenderTexture
     {
-        region = region || (displayObject as Container).getLocalBounds(null, true);
+        region = region || (displayObject as IRenderableContainer).getLocalBounds(null, true);
 
         // minimum texture size is 1x1, 0x0 will throw an error
         if (region.width === 0) region.width = 1;
@@ -325,7 +324,7 @@ export abstract class AbstractRenderer extends EventEmitter
         return renderTexture;
     }
 
-    abstract render(displayObject: DisplayObject, renderTexture?: RenderTexture,
+    abstract render(displayObject: IRenderableObject, renderTexture?: RenderTexture,
                     clear?: boolean, transform?: Matrix, skipUpdateTransform?: boolean): void;
 
     /**

--- a/packages/core/src/IRenderableObject.ts
+++ b/packages/core/src/IRenderableObject.ts
@@ -1,0 +1,23 @@
+import type { Rectangle } from '@pixi/math';
+import type { Renderer } from './Renderer';
+
+/**
+ * Interface for DisplayObject to interface with Renderer.
+ * The minimum APIs needed to implement a renderable object.
+ */
+interface IRenderableObject {
+    parent: IRenderableContainer;
+    enableTempParent(): IRenderableContainer;
+    updateTransform(): void;
+    disableTempParent(parent: IRenderableContainer): void;
+    render(renderer: Renderer): void;
+}
+
+/**
+ * Interface for Container to interface with Renderer.
+ */
+interface IRenderableContainer extends IRenderableObject {
+    getLocalBounds(rect?: Rectangle, skipChildrenUpdate?: boolean): Rectangle;
+}
+
+export type { IRenderableObject, IRenderableContainer };

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -20,8 +20,8 @@ import { Matrix } from '@pixi/math';
 import { Runner } from '@pixi/runner';
 
 import type { IRendererOptions, IRendererPlugins } from './AbstractRenderer';
+import type { IRenderableObject } from './IRenderableObject';
 import type { RenderTexture } from './renderTexture/RenderTexture';
-import type { DisplayObject } from '@pixi/display';
 import type { System } from './System';
 import type { IRenderingContext } from './IRenderingContext';
 import type { Extract } from '@pixi/extract';
@@ -381,7 +381,7 @@ export class Renderer extends AbstractRenderer
      * @param [transform] - A transform to apply to the render texture before rendering.
      * @param [skipUpdateTransform=false] - Should we skip the update transform pass?
      */
-    render(displayObject: DisplayObject, renderTexture?: RenderTexture,
+    render(displayObject: IRenderableObject, renderTexture?: RenderTexture,
         clear?: boolean, transform?: Matrix, skipUpdateTransform?: boolean): void
     {
         // can be handy to know!

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ import './settings';
 export * from './textures/resources';
 export * from './systems';
 export * from './IRenderingContext';
+export * from './IRenderableObject';
 export * from './autoDetectRenderer';
 export * from './fragments';
 export * from './System';

--- a/packages/interaction/src/InteractionManager.ts
+++ b/packages/interaction/src/InteractionManager.ts
@@ -764,7 +764,7 @@ export class InteractionManager extends EventEmitter
      */
     get lastObjectRendered(): DisplayObject
     {
-        return this.renderer._lastObjectRendered || this._tempDisplayObject;
+        return (this.renderer._lastObjectRendered as DisplayObject) || this._tempDisplayObject;
     }
 
     /**


### PR DESCRIPTION
### Bug

When attempting to install `@pixi/core` without `@pixi/display`, you get this error. There was previous work to decouple runtime the core and display (#6450), but the types were still creating this unnecessary coupling.

```
node_modules/@pixi/core/index.d.ts:10:31 - error TS7016: Could not find a declaration file for module '@pixi/display'. '/node_modules/@pixi/display/lib/display.js' implicitly has an 'any' type.
  Try `npm install @types/pixi__display` if it exists or add a new declaration (.d.ts) file containing `declare module '@pixi/display';`

10 import { DisplayObject } from '@pixi/display';
```

### Description

Created two interfaces that define the surface area between the Renderer and the DisplayObject/Container. These are called IRenderableObject and IRenderableContainer. Potentially this could be a single interface since we only render Containers, in practice.
