### PR TITLE
Add optional clearMode argument type for Blur and Displacement

### DIFF
--- a/packages/filters/filter-blur/src/BlurFilter.ts
+++ b/packages/filters/filter-blur/src/BlurFilter.ts
@@ -48,9 +48,9 @@ export class BlurFilter extends Filter
      * @param {PIXI.FilterSystem} filterManager - The manager.
      * @param {PIXI.RenderTexture} input - The input target.
      * @param {PIXI.RenderTexture} output - The output target.
-     * @param {PIXI.CLEAR_MODES} clearMode - How to clear
+     * @param {PIXI.CLEAR_MODES} [clearMode] - How to clear
      */
-    apply(filterManager: FilterSystem, input: RenderTexture, output: RenderTexture, clearMode: CLEAR_MODES): void
+    apply(filterManager: FilterSystem, input: RenderTexture, output: RenderTexture, clearMode?: CLEAR_MODES): void
     {
         const xStrength = Math.abs(this.blurXFilter.strength);
         const yStrength = Math.abs(this.blurYFilter.strength);

--- a/packages/filters/filter-blur/src/BlurFilterPass.ts
+++ b/packages/filters/filter-blur/src/BlurFilterPass.ts
@@ -57,10 +57,10 @@ export class BlurFilterPass extends Filter
      * @param {PIXI.FilterSystem} filterManager - The manager.
      * @param {PIXI.RenderTexture} input - The input target.
      * @param {PIXI.RenderTexture} output - The output target.
-     * @param {PIXI.CLEAR_MODES} clearMode - How to clear
+     * @param {PIXI.CLEAR_MODES} [clearMode] - How to clear
      */
     public apply(
-        filterManager: FilterSystem, input: RenderTexture, output: RenderTexture, clearMode: CLEAR_MODES
+        filterManager: FilterSystem, input: RenderTexture, output: RenderTexture, clearMode?: CLEAR_MODES
     ): void
     {
         if (output)

--- a/packages/filters/filter-displacement/src/DisplacementFilter.ts
+++ b/packages/filters/filter-displacement/src/DisplacementFilter.ts
@@ -68,10 +68,10 @@ export class DisplacementFilter extends Filter
      * @param {PIXI.FilterSystem} filterManager - The manager.
      * @param {PIXI.RenderTexture} input - The input target.
      * @param {PIXI.RenderTexture} output - The output target.
-     * @param {PIXI.CLEAR_MODES} clearMode - clearMode.
+     * @param {PIXI.CLEAR_MODES} [clearMode] - clearMode.
      */
     public apply(
-        filterManager: FilterSystem, input: RenderTexture, output: RenderTexture, clearMode: CLEAR_MODES
+        filterManager: FilterSystem, input: RenderTexture, output: RenderTexture, clearMode?: CLEAR_MODES
     ): void
     {
         // fill maskMatrix with _normalized sprite texture coords_


### PR DESCRIPTION
Follow-up to #7116

With the `apply` override, the `clearMode` should support being optional.