### PR TITLE
Optional arguments to getGlobalPosition

### DIFF
--- a/packages/mixin-get-global-position/global.d.ts
+++ b/packages/mixin-get-global-position/global.d.ts
@@ -2,6 +2,6 @@ declare namespace GlobalMixins
 {
     interface DisplayObject
     {
-        getGlobalPosition?: (point: import('@pixi/math').Point, skipUpdate: boolean) => import('@pixi/math').Point;
+        getGlobalPosition?: (point?: import('@pixi/math').Point, skipUpdate?: boolean) => import('@pixi/math').Point;
     }
 }


### PR DESCRIPTION
Parameters of `getGlobalPosition` should be optional.