### PR TITLE
Cleanup docs and types for upcoming release

### DIFF
--- a/packages/app/src/Application.ts
+++ b/packages/app/src/Application.ts
@@ -50,7 +50,9 @@ export class Application
      * @param {number} [options.width=800] - The width of the renderers view.
      * @param {number} [options.height=600] - The height of the renderers view.
      * @param {HTMLCanvasElement} [options.view] - The canvas to use as a view, optional.
-     * @param {boolean} [options.contextAlpha=true] - Pass-through value for canvas' context `alpha` property.
+     * @param {boolean} [options.useContextAlpha=true] - Pass-through value for canvas' context `alpha` property.
+     *   If you want to set transparency, please use `backgroundAlpha`. This option is for cases where the
+     *   canvas needs to be opaque, possibly for performance reasons on some older devices.
      * @param {boolean} [options.autoDensity=false] - Resizes renderer view in CSS pixels to allow for
      *   resolutions other than 1.
      * @param {boolean} [options.antialias=false] - Sets antialias

--- a/packages/canvas/canvas-renderer/src/CanvasRenderer.ts
+++ b/packages/canvas/canvas-renderer/src/CanvasRenderer.ts
@@ -79,7 +79,9 @@ export class CanvasRenderer extends AbstractRenderer
      * @param {number} [options.width=800] - the width of the screen
      * @param {number} [options.height=600] - the height of the screen
      * @param {HTMLCanvasElement} [options.view] - the canvas to use as a view, optional
-     * @param {boolean} [options.contextAlpha=true] - Pass-through value for canvas' context `alpha` property.
+     * @param {boolean} [options.useContextAlpha=true] - Pass-through value for canvas' context `alpha` property.
+     *   If you want to set transparency, please use `backgroundAlpha`. This option is for cases where the
+     *   canvas needs to be opaque, possibly for performance reasons on some older devices.
      * @param {boolean} [options.autoDensity=false] - Resizes renderer view in CSS pixels to allow for
      *   resolutions other than 1
      * @param {boolean} [options.antialias=false] - sets antialias
@@ -102,7 +104,7 @@ export class CanvasRenderer extends AbstractRenderer
          *
          * @member {CanvasRenderingContext2D}
          */
-        this.rootContext = this.view.getContext('2d', { alpha: this.contextAlpha }) as
+        this.rootContext = this.view.getContext('2d', { alpha: this.useContextAlpha }) as
             CrossPlatformCanvasRenderingContext2D;
 
         /**
@@ -273,7 +275,7 @@ export class CanvasRenderer extends AbstractRenderer
 
                 if (this.backgroundAlpha > 0)
                 {
-                    context.globalAlpha = this.contextAlpha ? this.backgroundAlpha : 1;
+                    context.globalAlpha = this.useContextAlpha ? this.backgroundAlpha : 1;
                     context.fillStyle = this._backgroundColorString;
                     context.fillRect(0, 0, this.width, this.height);
                     context.globalAlpha = 1;
@@ -288,7 +290,7 @@ export class CanvasRenderer extends AbstractRenderer
 
                 if (clearColor[3] > 0)
                 {
-                    context.globalAlpha = this.contextAlpha ? clearColor[3] : 1;
+                    context.globalAlpha = this.useContextAlpha ? clearColor[3] : 1;
                     context.fillStyle = hex2string(rgb2hex(clearColor));
                     context.fillRect(0, 0, renderTexture.realWidth, renderTexture.realHeight);
                     context.globalAlpha = 1;
@@ -372,7 +374,7 @@ export class CanvasRenderer extends AbstractRenderer
 
         if (clearColor)
         {
-            context.globalAlpha = this.contextAlpha ? alpha : 1;
+            context.globalAlpha = this.useContextAlpha ? alpha : 1;
             context.fillStyle = clearColor;
             context.fillRect(0, 0, this.width, this.height);
             context.globalAlpha = 1;

--- a/packages/compressed-textures/src/resources/BlobResource.ts
+++ b/packages/compressed-textures/src/resources/BlobResource.ts
@@ -11,8 +11,8 @@ interface IBlobOptions
  * Resource that fetches texture data over the network and stores it in a buffer.
  *
  * @class
- * @extends PIXI.resources.Resource
- * @memberof PIXI.resources
+ * @extends PIXI.Resource
+ * @memberof PIXI
  */
 export abstract class BlobResource extends BufferResource
 {

--- a/packages/core/src/AbstractRenderer.ts
+++ b/packages/core/src/AbstractRenderer.ts
@@ -15,9 +15,9 @@ export interface IRendererOptions extends GlobalMixins.IRendererOptions
     width?: number;
     height?: number;
     view?: HTMLCanvasElement;
-    contextAlpha?: boolean | 'notMultiplied';
+    useContextAlpha?: boolean | 'notMultiplied';
     /**
-     * Use `contextAlpha` and `backgroundAlpha` instead.
+     * Use `backgroundAlpha` instead.
      * @deprecated
      */
     transparent?: boolean;
@@ -55,7 +55,7 @@ export abstract class AbstractRenderer extends EventEmitter
     public readonly screen: Rectangle;
     public readonly view: HTMLCanvasElement;
     public readonly plugins: IRendererPlugins;
-    public readonly contextAlpha: boolean | 'notMultiplied';
+    public readonly useContextAlpha: boolean | 'notMultiplied';
     public readonly autoDensity: boolean;
     public readonly preserveDrawingBuffer: boolean;
 
@@ -70,7 +70,9 @@ export abstract class AbstractRenderer extends EventEmitter
      * @param {number} [options.width=800] - The width of the screen.
      * @param {number} [options.height=600] - The height of the screen.
      * @param {HTMLCanvasElement} [options.view] - The canvas to use as a view, optional.
-     * @param {boolean} [options.contextAlpha=true] - Pass-through value for canvas' context `alpha` property.
+     * @param {boolean} [options.useContextAlpha=true] - Pass-through value for canvas' context `alpha` property.
+     *   If you want to set transparency, please use `backgroundAlpha`. This option is for cases where the
+     *   canvas needs to be opaque, possibly for performance reasons on some older devices.
      * @param {boolean} [options.autoDensity=false] - Resizes renderer view in CSS pixels to allow for
      *   resolutions other than 1.
      * @param {boolean} [options.antialias=false] - Sets antialias
@@ -133,11 +135,12 @@ export abstract class AbstractRenderer extends EventEmitter
         this.resolution = options.resolution || settings.RESOLUTION;
 
         /**
-         * Whether the render view is transparent.
+         * Pass-thru setting for the the canvas' context `alpha` property. This is typically
+         * not something you need to fiddle with. If you want transparency, use `backgroundAlpha`.
          *
          * @member {boolean}
          */
-        this.contextAlpha = options.contextAlpha;
+        this.useContextAlpha = options.useContextAlpha;
 
         /**
          * Whether CSS dimensions of canvas view should be resized to screen dimensions automatically.
@@ -197,9 +200,9 @@ export abstract class AbstractRenderer extends EventEmitter
         if (options.transparent !== undefined)
         {
             // #if _DEBUG
-            deprecation('6.0.0', 'Option transparent is deprecated, please use contextAlpha or backgroundAlpha instead.');
+            deprecation('6.0.0', 'Option transparent is deprecated, please use backgroundAlpha instead.');
             // #endif
-            this.contextAlpha = options.transparent;
+            this.useContextAlpha = options.transparent;
             this.backgroundAlpha = options.transparent ? 0 : 1;
         }
 

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -113,7 +113,9 @@ export class Renderer extends AbstractRenderer
      * @param {number} [options.width=800] - The width of the screen.
      * @param {number} [options.height=600] - The height of the screen.
      * @param {HTMLCanvasElement} [options.view] - The canvas to use as a view, optional.
-     * @param {boolean} [options.contextAlpha=true] - Pass-through value for canvas' context `alpha` property.
+     * @param {boolean} [options.useContextAlpha=true] - Pass-through value for canvas' context `alpha` property.
+     *   If you want to set transparency, please use `backgroundAlpha`. This option is for cases where the
+     *   canvas needs to be opaque, possibly for performance reasons on some older devices.
      * @param {boolean} [options.autoDensity=false] - Resizes renderer view in CSS pixels to allow for
      *   resolutions other than 1.
      * @param {boolean} [options.antialias=false] - Sets antialias. If not available natively then FXAA
@@ -296,9 +298,9 @@ export class Renderer extends AbstractRenderer
         else
         {
             this.context.initFromOptions({
-                alpha: !!this.contextAlpha,
+                alpha: !!this.useContextAlpha,
                 antialias: options.antialias,
-                premultipliedAlpha: this.contextAlpha && this.contextAlpha !== 'notMultiplied',
+                premultipliedAlpha: this.useContextAlpha && this.useContextAlpha !== 'notMultiplied',
                 stencil: true,
                 preserveDrawingBuffer: options.preserveDrawingBuffer,
                 powerPreference: this.options.powerPreference,

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -1,5 +1,5 @@
 import { AbstractRenderer } from './AbstractRenderer';
-import { sayHello, isWebGLSupported } from '@pixi/utils';
+import { sayHello, isWebGLSupported, deprecation } from '@pixi/utils';
 import { MaskSystem } from './mask/MaskSystem';
 import { StencilSystem } from './mask/StencilSystem';
 import { ScissorSystem } from './mask/ScissorSystem';
@@ -492,6 +492,21 @@ export class Renderer extends AbstractRenderer
 
         // TODO nullify all the managers..
         this.gl = null;
+    }
+
+    /**
+     * Please use `plugins.extract` instead.
+     * @member {PIXI.Extract} extract
+     * @deprecated since 6.0.0
+     * @readonly
+     */
+    public get extract(): any
+    {
+        // #if _DEBUG
+        deprecation('6.0.0', 'Renderer#extract has been deprecated, please use Renderer#plugins.extract instead.');
+        // #endif
+
+        return this.plugins.extract;
     }
 
     /**

--- a/packages/core/src/autoDetectRenderer.ts
+++ b/packages/core/src/autoDetectRenderer.ts
@@ -16,7 +16,9 @@ export interface IRendererOptionsAuto extends IRendererOptions
  * @param {number} [options.width=800] - the width of the renderers view
  * @param {number} [options.height=600] - the height of the renderers view
  * @param {HTMLCanvasElement} [options.view] - the canvas to use as a view, optional
- * @param {boolean} [options.contextAlpha=true] - Pass-through value for canvas' context `alpha` property.
+ * @param {boolean} [options.useContextAlpha=true] - Pass-through value for canvas' context `alpha` property.
+ *   If you want to set transparency, please use `backgroundAlpha`. This option is for cases where the
+ *   canvas needs to be opaque, possibly for performance reasons on some older devices.
  * @param {boolean} [options.autoDensity=false] - Resizes renderer view in CSS pixels to allow for
  *   resolutions other than 1
  * @param {boolean} [options.antialias=false] - sets antialias

--- a/packages/core/src/deprecations.ts
+++ b/packages/core/src/deprecations.ts
@@ -16,7 +16,7 @@ for (const name in _resources)
         {
             get()
             {
-                deprecation('6.0.0', `@pixi/core.systems.${name} has moved to @pixi/core.${name}`);
+                deprecation('6.0.0', `PIXI.systems.${name} has moved to PIXI.${name}`);
 
                 return (_resources as any)[name];
             },
@@ -37,7 +37,7 @@ for (const name in _systems)
         {
             get()
             {
-                deprecation('6.0.0', `@pixi/core.resources.${name} has moved to $pixi/core.${name}`);
+                deprecation('6.0.0', `PIXI.resources.${name} has moved to PIXI.${name}`);
 
                 return (_systems as any)[name];
             },

--- a/packages/core/src/renderTexture/RenderTexture.ts
+++ b/packages/core/src/renderTexture/RenderTexture.ts
@@ -4,6 +4,8 @@ import { Texture } from '../textures/Texture';
 import type { Rectangle } from '@pixi/math';
 import type { Framebuffer } from '../framebuffer/Framebuffer';
 import type { IBaseTextureOptions } from '../textures/BaseTexture';
+import { SCALE_MODES } from '@pixi/constants/src';
+import { deprecation } from '@pixi/utils/src';
 
 /**
  * A RenderTexture is a special texture that allows any PixiJS display object to be rendered to it.
@@ -37,7 +39,7 @@ import type { IBaseTextureOptions } from '../textures/BaseTexture';
  *
  * sprite.setTransform()
  *
- * let renderTexture = new PIXI.RenderTexture.create(100, 100);
+ * let renderTexture = new PIXI.RenderTexture.create({ width: 100, height: 100 });
  *
  * renderer.render(sprite, renderTexture);  // Renders to center of RenderTexture
  * ```
@@ -51,7 +53,6 @@ export class RenderTexture extends Texture
     public baseTexture: BaseRenderTexture;
     public filterFrame: Rectangle|null;
     public filterPoolKey: string|number|null;
-    legacyRenderer: any;
 
     /**
      * @param {PIXI.BaseRenderTexture} baseRenderTexture - The base texture object that this texture uses
@@ -59,34 +60,7 @@ export class RenderTexture extends Texture
      */
     constructor(baseRenderTexture: BaseRenderTexture, frame?: Rectangle)
     {
-        // support for legacy..
-        let _legacyRenderer = null;
-
-        if (!(baseRenderTexture instanceof BaseRenderTexture))
-        {
-            /* eslint-disable prefer-rest-params, no-console */
-            const width = arguments[1];
-            const height = arguments[2];
-            const scaleMode = arguments[3];
-            const resolution = arguments[4];
-
-            // we have an old render texture..
-            console.warn(`Please use RenderTexture.create(${width}, ${height}) instead of the ctor directly.`);
-            _legacyRenderer = arguments[0];
-            /* eslint-enable prefer-rest-params, no-console */
-
-            frame = null;
-            baseRenderTexture = new BaseRenderTexture({
-                width,
-                height,
-                scaleMode,
-                resolution,
-            });
-        }
-
         super(baseRenderTexture, frame);
-
-        this.legacyRenderer = _legacyRenderer;
 
         /**
          * This will let the renderer know if the texture is valid. If it's not then it cannot be rendered.
@@ -169,8 +143,21 @@ export class RenderTexture extends Texture
     }
 
     /**
+     * Use the object-based construction instead.
+     *
+     * @method
+     * @deprecated since 6.0.0
+     * @param {number} [width]
+     * @param {number} [height]
+     * @param {PIXI.SCALE_MODES} [scaleMode=PIXI.settings.SCALE_MODE]
+     * @param {number} [resolution=1]
+     */
+    static create(width: number, height: number, scaleMode?: SCALE_MODES, resolution?: number): RenderTexture;
+
+    /**
      * A short hand way of creating a render texture.
      *
+     * @method
      * @param {object} [options] - Options
      * @param {number} [options.width=100] - The width of the render texture
      * @param {number} [options.height=100] - The height of the render texture
@@ -178,17 +165,22 @@ export class RenderTexture extends Texture
      * @param {number} [options.resolution=1] - The resolution / device pixel ratio of the texture being generated
      * @return {PIXI.RenderTexture} The new render texture
      */
-    static create(options?: IBaseTextureOptions): RenderTexture
+    static create(options?: IBaseTextureOptions): RenderTexture;
+    static create(options?: IBaseTextureOptions | number, ...rest: any[]): RenderTexture
     {
-        // fallback, old-style: create(width, height, scaleMode, resolution)
+        // @deprecated fallback, old-style: create(width, height, scaleMode, resolution)
         if (typeof options === 'number')
         {
+            // #if _DEBUG
+            deprecation('6.0.0', 'Arguments (width, height, scaleMode, resolution) have been deprecated.');
+            // #endif
+
             /* eslint-disable prefer-rest-params */
             options = {
                 width: options,
-                height: arguments[1],
-                scaleMode: arguments[2],
-                resolution: arguments[3],
+                height: rest[0],
+                scaleMode: rest[1],
+                resolution: rest[2],
             };
             /* eslint-enable prefer-rest-params */
         }

--- a/packages/core/src/renderTexture/RenderTexture.ts
+++ b/packages/core/src/renderTexture/RenderTexture.ts
@@ -4,8 +4,8 @@ import { Texture } from '../textures/Texture';
 import type { Rectangle } from '@pixi/math';
 import type { Framebuffer } from '../framebuffer/Framebuffer';
 import type { IBaseTextureOptions } from '../textures/BaseTexture';
-import { SCALE_MODES } from '@pixi/constants/src';
-import { deprecation } from '@pixi/utils/src';
+import type { SCALE_MODES } from '@pixi/constants';
+import { deprecation } from '@pixi/utils';
 
 /**
  * A RenderTexture is a special texture that allows any PixiJS display object to be rendered to it.

--- a/packages/settings/src/settings.ts
+++ b/packages/settings/src/settings.ts
@@ -8,7 +8,7 @@ export interface IRenderOptions {
     autoDensity: boolean;
     backgroundColor: number;
     backgroundAlpha: number;
-    contextAlpha: boolean | 'notMultiplied';
+    useContextAlpha: boolean | 'notMultiplied';
     clearBeforeRender: boolean;
     preserveDrawingBuffer: boolean;
     width: number;
@@ -143,7 +143,7 @@ export const settings: ISettings = {
      * @property {number} resolution=1
      * @property {boolean} antialias=false
      * @property {boolean} autoDensity=false
-     * @property {boolean} contextAlpha=true
+     * @property {boolean} useContextAlpha=true
      * @property {number} backgroundColor=0x000000
      * @property {number} backgroundAlpha=1
      * @property {boolean} clearBeforeRender=true
@@ -158,7 +158,7 @@ export const settings: ISettings = {
         autoDensity: false,
         backgroundColor: 0x000000,
         backgroundAlpha: 1,
-        contextAlpha: true,
+        useContextAlpha: true,
         clearBeforeRender: true,
         preserveDrawingBuffer: false,
         width: 800,


### PR DESCRIPTION
These were notes from @themoonrat on Slack.

- [x] Add proper Renderer.extract deprecation
- [x] Improve docs for `backgroundAlpha` & `contextAlpha` (rename to `useContextAlpha`)
- [x] Remove package names from deprecation warnings for resources
- [x] Fix BlobResource namespace in documentation
- [x] Add proper `RenderTexture.create` deprecation for `(width, height, scaleMode, resolution)`
