### PR TITLE
Add missing dependency to fix type errors on mixin-cache-as-bitmap

### DIFF
--- a/packages/mixin-cache-as-bitmap/package.json
+++ b/packages/mixin-cache-as-bitmap/package.json
@@ -26,6 +26,7 @@
     "*.d.ts"
   ],
   "dependencies": {
+    "@pixi/canvas-renderer": "6.0.0-rc",
     "@pixi/core": "6.0.0-rc",
     "@pixi/display": "6.0.0-rc",
     "@pixi/math": "6.0.0-rc",

--- a/packages/mixin-cache-as-bitmap/src/index.ts
+++ b/packages/mixin-cache-as-bitmap/src/index.ts
@@ -4,7 +4,7 @@ import { Container, DisplayObject, IDestroyOptions } from '@pixi/display';
 import { IPointData, Matrix, Rectangle } from '@pixi/math';
 import { uid } from '@pixi/utils';
 import { settings } from '@pixi/settings';
-import { CanvasRenderer } from '@pixi/canvas-renderer';
+import type { CanvasRenderer } from '@pixi/canvas-renderer';
 
 const _tempMatrix = new Matrix();
 


### PR DESCRIPTION
Reported on Slack when installing cache-as-bitmap, there's a missing CanvasRenderer reference in the types.