### PR TITLE
Fix AnimatedSprite.textures type annotation

### DIFF
--- a/packages/sprite-animated/src/AnimatedSprite.ts
+++ b/packages/sprite-animated/src/AnimatedSprite.ts
@@ -435,7 +435,7 @@ export class AnimatedSprite extends Sprite
     /**
      * The array of textures used for this AnimatedSprite.
      *
-     * @member {PIXI.Texture[]}
+     * @member {PIXI.Texture[]|PIXI.AnimatedSprite.FrameObject[]}
      */
     get textures(): Texture[]|FrameObject[]
     {


### PR DESCRIPTION
##### Description of change

I met an incorrect type definition for `PIXI.AnimatedSprite`'s `textures` setter. on 5.3.x.
I realized annotation is different from a real `.ts` code, so I just adjusted.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)

I don't know which base branch is better to be merged.
but I expect this PR will be merged into 5.3.x and release as 5.3.8 or later.

btw, I read CONTRIBUTING.md but there is no `master` branch anymore. Is it (a little bit) outdated?