### PR TITLE
Add GlobalMixin types for Application plugins

### DIFF
--- a/packages/app/global.d.ts
+++ b/packages/app/global.d.ts
@@ -1,0 +1,15 @@
+declare namespace GlobalMixins
+{
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface Application
+    {
+        resizeTo: Window|HTMLElement;
+        resize(): void;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface IApplicationOptions
+    {
+        resizeTo: Window|HTMLElement;
+    }
+}

--- a/packages/app/src/Application.ts
+++ b/packages/app/src/Application.ts
@@ -14,7 +14,7 @@ export interface IApplicationPlugin {
 export interface IApplicationOptions extends IRendererOptionsAuto, GlobalMixins.IApplicationOptions {}
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface Application extends GlobalMixins.DisplayObject {}
+export interface Application extends GlobalMixins.Application {}
 
 /**
  * Convenience class to create a new PIXI application.

--- a/packages/app/src/Application.ts
+++ b/packages/app/src/Application.ts
@@ -10,12 +10,11 @@ export interface IApplicationPlugin {
     destroy: (...params: any[]) => any;
 }
 
-export interface IApplicationOptions extends IRendererOptionsAuto {
-    autoStart?: boolean;
-    sharedTicker?: boolean;
-    sharedLoader?: boolean;
-    resizeTo?: Window | HTMLElement;
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface IApplicationOptions extends IRendererOptionsAuto, GlobalMixins.IApplicationOptions {}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface Application extends GlobalMixins.DisplayObject {}
 
 /**
  * Convenience class to create a new PIXI application.

--- a/packages/loaders/global.d.ts
+++ b/packages/loaders/global.d.ts
@@ -10,4 +10,14 @@ declare namespace GlobalMixins
     {
 
     }
+
+    interface Application
+    {
+        loader: import('@pixi/loaders').Loader;
+    }
+
+    interface IApplicationOptions
+    {
+        sharedLoader: boolean;
+    }
 }

--- a/packages/ticker/global.d.ts
+++ b/packages/ticker/global.d.ts
@@ -1,0 +1,15 @@
+declare namespace GlobalMixins
+{
+    interface Application
+    {
+        ticker: import('@pixi/ticker').Ticker;
+        stop(): void;
+        start(): void;
+    }
+
+    interface IApplicationOptions
+    {
+        autoStart: boolean;
+        sharedTicker: boolean;
+    }
+}


### PR DESCRIPTION
Partially fixes #7141 by adding types for Application plugins. Will support types for `loader`, `resizeTo` and `ticker`.