### PR TITLE
Fix types for missing optional options and param

### DIFF
--- a/packages/app/global.d.ts
+++ b/packages/app/global.d.ts
@@ -10,6 +10,6 @@ declare namespace GlobalMixins
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
     interface IApplicationOptions
     {
-        resizeTo: Window|HTMLElement;
+        resizeTo?: Window|HTMLElement;
     }
 }

--- a/packages/loaders/global.d.ts
+++ b/packages/loaders/global.d.ts
@@ -18,6 +18,6 @@ declare namespace GlobalMixins
 
     interface IApplicationOptions
     {
-        sharedLoader: boolean;
+        sharedLoader?: boolean;
     }
 }

--- a/packages/text/src/TextStyle.ts
+++ b/packages/text/src/TextStyle.ts
@@ -178,7 +178,7 @@ export class TextStyle implements ITextStyle
      * @param {boolean} [style.wordWrap=false] - Indicates if word wrap should be used
      * @param {number} [style.wordWrapWidth=100] - The width at which text will wrap, it needs wordWrap to be set to true
      */
-    constructor(style: Partial<ITextStyle>)
+    constructor(style?: Partial<ITextStyle>)
     {
         this.styleID = 0;
 

--- a/packages/ticker/global.d.ts
+++ b/packages/ticker/global.d.ts
@@ -9,7 +9,7 @@ declare namespace GlobalMixins
 
     interface IApplicationOptions
     {
-        autoStart: boolean;
-        sharedTicker: boolean;
+        autoStart?: boolean;
+        sharedTicker?: boolean;
     }
 }


### PR DESCRIPTION
Issues reported by users on Slack in 6.0.0-rc.2

* TextStyle constructor arg is optional
* Application plugin options are optional

cc
@miltoncandelero 
@tomasfreres