### PR TITLE
Feature: stroke alignment support in CanvasRenderer

### DIFF
--- a/packages/canvas/canvas-display/src/Container.ts
+++ b/packages/canvas/canvas-display/src/Container.ts
@@ -28,15 +28,22 @@ Container.prototype.renderCanvas = function renderCanvas(renderer: CanvasRendere
         return;
     }
 
+    // This newly forged CanvasRenderer will provide a secondary RenderingContext for
+    //   certain drawing operations (i.e. strokes); this temporary RenderingContext is
+    //   off-screen and _only_ used for rendering strokes with certain alignments
+    //   (i.e. other than 0.5) - otherwise drawing is done directly onto the main
+    //   RenderingContext, thus ensuring optimal performance.
+    const _renderer = renderer.forge();
+
     if (this._mask)
     {
         renderer.maskManager.pushMask(this._mask as MaskData);
     }
 
-    this._renderCanvas(renderer);
+    this._renderCanvas(_renderer);
     for (let i = 0, j = this.children.length; i < j; ++i)
     {
-        this.children[i].renderCanvas(renderer);
+        this.children[i].renderCanvas(_renderer);
     }
 
     if (this._mask)

--- a/packages/canvas/canvas-graphics/src/CanvasGraphicsRenderer.ts
+++ b/packages/canvas/canvas-graphics/src/CanvasGraphicsRenderer.ts
@@ -1,7 +1,7 @@
 import { Texture } from '@pixi/core';
 import { SHAPES, Matrix } from '@pixi/math';
 import { canvasUtils } from '@pixi/canvas-renderer';
-import { BLEND_MODES } from '@pixi/constants';
+import { ALIGNMENT, BLEND_MODES } from '@pixi/constants';
 
 import type { CanvasRenderer } from '@pixi/canvas-renderer';
 import type { FillStyle, Graphics } from '@pixi/graphics';
@@ -140,7 +140,7 @@ export class CanvasGraphicsRenderer
 
             // If the stroke has to be drawn and its either not in the middle or the fill must
             //   also be drawn, then rendering shall be performed a secondary RenderingContext
-            if (strokeVisible)
+            if (strokeVisible && (alignment != ALIGNMENT.MIDDLE || fillVisible))
             {
                 // Obtain the secondary RenderingContext, along with the functions for the final
                 //   drawing and erasing, respectively
@@ -173,7 +173,9 @@ export class CanvasGraphicsRenderer
 
                 if (strokeVisible)
                 {
-                    context.lineWidth = lineWidth;
+                    const middle = alignment == ALIGNMENT.MIDDLE;
+
+                    context.lineWidth = middle ? lineWidth : lineWidth * 2;
                     context.lineCap = lineStyle.cap;
                     context.lineJoin = lineStyle.join;
                     context.miterLimit = lineStyle.miterLimit;
@@ -181,6 +183,12 @@ export class CanvasGraphicsRenderer
                     context.globalAlpha = lineStyle.alpha * worldAlpha;
                     context.strokeStyle = contextStrokeStyle;
                     context.stroke();
+
+                    if (!middle) {
+                        context.globalAlpha = 1;
+                        context.globalCompositeOperation = blendModes[ALIGNMENT[alignment]];
+                        context.fill();
+                    }
 
                     if (fillVisible) {
                         // The fill shall be drawn last, beneath the stroke

--- a/packages/canvas/canvas-graphics/src/CanvasGraphicsRenderer.ts
+++ b/packages/canvas/canvas-graphics/src/CanvasGraphicsRenderer.ts
@@ -1,6 +1,7 @@
 import { Texture } from '@pixi/core';
 import { SHAPES, Matrix } from '@pixi/math';
 import { canvasUtils } from '@pixi/canvas-renderer';
+import { BLEND_MODES } from '@pixi/constants';
 
 import type { CanvasRenderer } from '@pixi/canvas-renderer';
 import type { FillStyle, Graphics } from '@pixi/graphics';
@@ -81,17 +82,14 @@ export class CanvasGraphicsRenderer
     public render(graphics: Graphics): void
     {
         const renderer = this.renderer;
-        const context = renderer.context;
+        const { blendModes } = renderer;
         const worldAlpha = graphics.worldAlpha;
-        const transform = graphics.transform.worldTransform;
+        const { worldTransform } = graphics.transform;
 
-        renderer.setContextTransform(transform);
+        const transform = renderer.newContextTransform(worldTransform);
         renderer.setBlendMode(graphics.blendMode);
 
         const graphicsData = graphics.geometry.graphicsData;
-
-        let contextFillStyle;
-        let contextStrokeStyle;
 
         const tintR = ((graphics.tint >> 16) & 0xFF) / 255;
         const tintG = ((graphics.tint >> 8) & 0xFF) / 255;
@@ -104,16 +102,12 @@ export class CanvasGraphicsRenderer
             const fillStyle = data.fillStyle;
             const lineStyle = data.lineStyle;
 
-            const fillColor = data.fillStyle.color | 0;
-            const lineColor = data.lineStyle.color | 0;
-
-            if (data.matrix)
-            {
-                renderer.setContextTransform(transform.copyTo(this._tempMatrix).append(data.matrix));
-            }
+            let contextFillStyle;
+            let contextStrokeStyle;
 
             if (fillStyle.visible)
             {
+                const fillColor = fillStyle.color | 0;
                 const fillTint = (
                     (((fillColor >> 16) & 0xFF) / 255 * tintR * 255 << 16)
                     + (((fillColor >> 8) & 0xFF) / 255 * tintG * 255 << 8)
@@ -124,6 +118,7 @@ export class CanvasGraphicsRenderer
             }
             if (lineStyle.visible)
             {
+                const lineColor = lineStyle.color | 0;
                 const lineTint = (
                     (((lineColor >> 16) & 0xFF) / 255 * tintR * 255 << 16)
                     + (((lineColor >> 8) & 0xFF) / 255 * tintG * 255 << 8)
@@ -133,10 +128,80 @@ export class CanvasGraphicsRenderer
                 contextStrokeStyle = this._calcCanvasStyle(lineStyle, lineTint);
             }
 
-            context.lineWidth = lineStyle.width;
-            context.lineCap = lineStyle.cap;
-            context.lineJoin = lineStyle.join;
-            context.miterLimit = lineStyle.miterLimit;
+            const { width: lineWidth, alignment } = lineStyle;
+
+            const strokeVisible = contextStrokeStyle != null && lineWidth > 0;
+            const fillVisible = contextFillStyle != null;
+            const visible = fillVisible || strokeVisible;
+
+            if (!visible) continue; // nothing needs drawing
+
+            let context: CanvasRenderingContext2D, finalize: Function, erase: Function;
+
+            // If the stroke has to be drawn and its either not in the middle or the fill must
+            //   also be drawn, then rendering shall be performed a secondary RenderingContext
+            if (strokeVisible)
+            {
+                // Obtain the secondary RenderingContext, along with the functions for the final
+                //   drawing and erasing, respectively
+                [context, finalize, erase] = renderer.forgeContext();
+            }
+
+            if (!context) {
+                // No secondary RenderingContext, so the stroke cannot be drawn - disable it
+                strokeVisible = false;
+
+                // Revert to main RenderingContext
+                context = renderer.context;
+
+                // If no fill is to be drawn, simply move on
+                if (!fillVisible) continue;
+            }
+
+            if (data.matrix)
+            {
+                transform = renderer.newContextTransform(worldTransform.copyTo(this._tempMatrix).append(data.matrix));
+            }
+            renderer.applyTransform(transform, context);
+
+            const draw = (rect?: Rectangle) =>
+            {
+                if (rect)
+                {
+                    context.rect(rect.x, rect.y, rect.width, rect.height);
+                }
+
+                if (strokeVisible)
+                {
+                    context.lineWidth = lineWidth;
+                    context.lineCap = lineStyle.cap;
+                    context.lineJoin = lineStyle.join;
+                    context.miterLimit = lineStyle.miterLimit;
+
+                    context.globalAlpha = lineStyle.alpha * worldAlpha;
+                    context.strokeStyle = contextStrokeStyle;
+                    context.stroke();
+
+                    if (fillVisible) {
+                        // The fill shall be drawn last, beneath the stroke
+                        context.globalCompositeOperation = blendModes[BLEND_MODES.DST_OVER];
+                    }
+                }
+                if (fillVisible)
+                {
+                    context.globalAlpha = fillStyle.alpha * worldAlpha;
+                    context.fillStyle = contextFillStyle;
+
+                    // The actual fill is drawn
+                    context.fill();
+                }
+
+                if (finalize)
+                {
+                    finalize();
+                    erase();
+                }
+            }
 
             if (data.type === SHAPES.POLY)
             {
@@ -217,36 +282,11 @@ export class CanvasGraphicsRenderer
                     }
                 }
 
-                if (fillStyle.visible)
-                {
-                    context.globalAlpha = fillStyle.alpha * worldAlpha;
-                    context.fillStyle = contextFillStyle;
-                    context.fill();
-                }
-
-                if (lineStyle.visible)
-                {
-                    context.globalAlpha = lineStyle.alpha * worldAlpha;
-                    context.strokeStyle = contextStrokeStyle;
-                    context.stroke();
-                }
+                draw();
             }
             else if (data.type === SHAPES.RECT)
             {
-                const tempShape = shape as Rectangle;
-
-                if (fillStyle.visible)
-                {
-                    context.globalAlpha = fillStyle.alpha * worldAlpha;
-                    context.fillStyle = contextFillStyle;
-                    context.fillRect(tempShape.x, tempShape.y, tempShape.width, tempShape.height);
-                }
-                if (lineStyle.visible)
-                {
-                    context.globalAlpha = lineStyle.alpha * worldAlpha;
-                    context.strokeStyle = contextStrokeStyle;
-                    context.strokeRect(tempShape.x, tempShape.y, tempShape.width, tempShape.height);
-                }
+                draw(shape as Rectangle);
             }
             else if (data.type === SHAPES.CIRC)
             {
@@ -257,19 +297,7 @@ export class CanvasGraphicsRenderer
                 context.arc(tempShape.x, tempShape.y, tempShape.radius, 0, 2 * Math.PI);
                 context.closePath();
 
-                if (fillStyle.visible)
-                {
-                    context.globalAlpha = fillStyle.alpha * worldAlpha;
-                    context.fillStyle = contextFillStyle;
-                    context.fill();
-                }
-
-                if (lineStyle.visible)
-                {
-                    context.globalAlpha = lineStyle.alpha * worldAlpha;
-                    context.strokeStyle = contextStrokeStyle;
-                    context.stroke();
-                }
+                draw();
             }
             else if (data.type === SHAPES.ELIP)
             {
@@ -301,18 +329,7 @@ export class CanvasGraphicsRenderer
 
                 context.closePath();
 
-                if (fillStyle.visible)
-                {
-                    context.globalAlpha = fillStyle.alpha * worldAlpha;
-                    context.fillStyle = contextFillStyle;
-                    context.fill();
-                }
-                if (lineStyle.visible)
-                {
-                    context.globalAlpha = lineStyle.alpha * worldAlpha;
-                    context.strokeStyle = contextStrokeStyle;
-                    context.stroke();
-                }
+                draw();
             }
             else if (data.type === SHAPES.RREC)
             {
@@ -340,18 +357,7 @@ export class CanvasGraphicsRenderer
                 context.quadraticCurveTo(rx, ry, rx, ry + radius);
                 context.closePath();
 
-                if (fillStyle.visible)
-                {
-                    context.globalAlpha = fillStyle.alpha * worldAlpha;
-                    context.fillStyle = contextFillStyle;
-                    context.fill();
-                }
-                if (lineStyle.visible)
-                {
-                    context.globalAlpha = lineStyle.alpha * worldAlpha;
-                    context.strokeStyle = contextStrokeStyle;
-                    context.stroke();
-                }
+                draw();
             }
         }
     }

--- a/packages/canvas/canvas-graphics/src/Graphics.ts
+++ b/packages/canvas/canvas-graphics/src/Graphics.ts
@@ -71,5 +71,6 @@ Graphics.prototype._renderCanvas = function _renderCanvas(renderer: CanvasRender
     }
 
     this.finishPoly();
-    renderer.plugins.graphics.render(this);
+
+    renderer.getPlugin('graphics').render(this);
 };

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -436,3 +436,23 @@ export enum MSAA_QUALITY {
     MEDIUM = 4,
     HIGH = 8
 }
+
+/**
+ * Constants that specify blend modes associated to specific stroke alignment values.
+ *
+ * @name ALIGNMENT
+ * @memberof PIXI
+ * @constant
+ * @static
+ * @enum {number}
+ * @property {number} 0=BLEND_MODES.DST_IN
+ * @property {number} 1=BLEND_MODES.DST_OUT
+ * @property {number} MIDDLE=0.5
+ */
+export const ALIGNMENT =
+[
+    BLEND_MODES.DST_IN,
+    BLEND_MODES.DST_OUT,
+];
+
+ALIGNMENT.MIDDLE = 0.5;

--- a/packages/core/src/canvas.ts
+++ b/packages/core/src/canvas.ts
@@ -1,0 +1,33 @@
+/**
+ * Assigns the width property to given target canvas from given srcCanvas.AAGUID
+ *
+ * @param {HTMLCanvasElement} canvas - The target Canvas instance
+ * @param {HTMLCanvasElement} srcCanvas - The source Canvas instance
+ * @return {HTMLCanvasElement} The given target canvas
+ */
+export function setWidth(canvas: HTMLCanvasElement, srcCanvas: HTMLCanvasElement): HTMLCanvasElement
+{
+    if (canvas == null) return canvas;
+    if (srcCanvas == null) return canvas;
+
+    canvas.width = srcCanvas.width;
+
+    return canvas;
+}
+
+/**
+ * Assigns the height property to given target canvas from given srcCanvas.AAGUID
+ *
+ * @param {HTMLCanvasElement} canvas - The target Canvas instance
+ * @param {HTMLCanvasElement} srcCanvas - The source Canvas instance
+ * @return {HTMLCanvasElement} The given target canvas
+ */
+export function setHeight(canvas: HTMLCanvasElement, srcCanvas: HTMLCanvasElement): HTMLCanvasElement
+{
+    if (canvas == null) return canvas;
+    if (srcCanvas == null) return canvas;
+
+    canvas.height = srcCanvas.height;
+
+    return canvas;
+}

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -1,0 +1,58 @@
+import { setWidth, setHeight } from './canvas';
+
+/**
+ * Creates a new RenderingContext instance based on given src.
+ * Facilitates off-screen rendering for e.g. double-buffering.
+ *
+ * @param {RenderingContext|string} src - The source RenderingContext or context type (i.e. '2d' etc.)
+ * @return {RenderingContext} The newly created RenderingContext
+ */
+export function OffscreenContext(src?: RenderingContext|string): RenderingContext
+{
+    if (src == null) return src as RenderingContext;
+
+    const canvas = document.createElement('canvas') as HTMLCanvasElement;
+    let type: string;
+
+    if (typeof src === 'object')
+    {
+        const srcCanvas = src.canvas;
+
+        setWidth(canvas, srcCanvas);
+        setHeight(canvas, srcCanvas);
+
+        type = getContextType(src);
+    }
+    else if (typeof src === 'string')
+    {
+        type = src;
+    }
+
+    if (type)
+    {
+        return canvas.getContext(type) as RenderingContext;
+    }
+}
+
+/**
+ * Returns the context type of given context (e.g. '2d').
+ *
+ * @param {RenderingContext} context - The context to inspect
+ * @return {string} The type of given context
+ */
+export function getContextType(context: RenderingContext): string
+{
+    if (context == null) return context as string;
+    if (isContext2D(context)) return '2d';
+}
+
+/**
+ * Determines whether given context is a CanvasRenderingContext2D instance.context
+ *
+ * @param {object} context - The object to inspect
+ * @return {boolean}
+ */
+export function isContext2D(context: object): boolean
+{
+    return context instanceof CanvasRenderingContext2D;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,6 +45,9 @@ export * from './geometry/Buffer';
 export * from './geometry/Geometry';
 export * from './geometry/ViewableBuffer';
 
+export * from './canvas';
+export * from './context';
+
 // #if _DEBUG
 export * from './deprecations';
 // #endif


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Enable drawing strokes with different alignment values on **Canvas**.

The `CanvasGraphicsRenderer` now performs the actual drawing onto a secondary off-screen `RenderingContext`; the stroke is drawn by compositing drawing operations according to specified `strokeStyle.alignment`. The result then is finally drawn onto the main `RenderingContext`.

**Performance**:
 - a _shared_ secondary `RenderingContext` is acquired whenever possible - i.e. prior to rendering multiple objects;
 - drawing resorts to the secondary `RenderingContext` _only_ when actually necessary - i.e. when the **stroke** is _visible_ and _either_ the _alignment_ is non-**middle** _or_ the **fill** is also _visible_.

[**DEMO**](https://jsfiddle.net/y2jh9uap/)

![DEMO result](https://user-images.githubusercontent.com/8561801/104322905-271b9200-54ee-11eb-98fd-8c687e430097.png)

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)

Further details available [here](https://github.com/denim2x/pixi.js/releases/tag/v6.0.0-rc.2)
