### PR TITLE
Feature: stroke alignment support for CanvasRenderer

### DIFF
--- a/packages/canvas/canvas-display/src/Container.ts
+++ b/packages/canvas/canvas-display/src/Container.ts
@@ -28,12 +28,13 @@ Container.prototype.renderCanvas = function renderCanvas(renderer: CanvasRendere
         return;
     }
 
-    // This newly forged CanvasRenderer will provide a secondary RenderingContext for
-    //   certain drawing operations (i.e. strokes); this temporary RenderingContext is
-    //   off-screen and _only_ used for rendering strokes with certain alignments
-    //   (i.e. other than 0.5) - otherwise drawing is done directly onto the main
-    //   RenderingContext, thus ensuring optimal performance.
-    const _renderer = renderer.forge();
+    let _renderer = renderer;
+
+    if (renderer)
+    {
+        // The forged CanvasRenderer performs accurate rendering via (shared) secondary off-screen RenderingContext
+        _renderer = renderer.forge();
+    }
 
     if (this._mask)
     {

--- a/packages/canvas/canvas-display/src/Container.ts
+++ b/packages/canvas/canvas-display/src/Container.ts
@@ -28,15 +28,22 @@ Container.prototype.renderCanvas = function renderCanvas(renderer: CanvasRendere
         return;
     }
 
+    // This newly forged CanvasRenderer will provide a secondary RenderingContext for
+    //   certain drawing operations (i.e. strokes); this temporary RenderingContext is
+    //   off-screen and _only_ used for rendering strokes with certain alignments
+    //   (i.e. other than 0.5) - otherwise drawing is done directly onto the main
+    //   RenderingContext, thus ensuring optimal performance.
+    const _renderer = renderer.forge();
+
     if (this._mask)
     {
         renderer.maskManager.pushMask(this._mask as MaskData);
     }
 
-    this._renderCanvas(renderer);
+    this._renderCanvas(_renderer);
     for (let i = 0, j = this.children.length; i < j; ++i)
     {
-        this.children[i].renderCanvas(renderer);
+        this.children[i].renderCanvas(_renderer);
     }
 
     if (this._mask)

--- a/packages/canvas/canvas-graphics/src/Graphics.ts
+++ b/packages/canvas/canvas-graphics/src/Graphics.ts
@@ -3,6 +3,7 @@ import { CanvasRenderer } from '@pixi/canvas-renderer';
 import { RenderTexture, Texture } from '@pixi/core';
 import { Matrix } from '@pixi/math';
 
+import type { CanvasGraphicsRenderer } from '@pixi/canvas-graphics';
 import type { SCALE_MODES } from '@pixi/constants';
 import type { BaseRenderTexture } from '@pixi/core';
 
@@ -72,5 +73,7 @@ Graphics.prototype._renderCanvas = function _renderCanvas(renderer: CanvasRender
 
     this.finishPoly();
 
-    renderer.getPlugin('graphics').render(this);
+    const graphics = renderer.getPlugin('graphics') as CanvasGraphicsRenderer;
+
+    graphics.render(this);
 };

--- a/packages/canvas/canvas-graphics/src/Graphics.ts
+++ b/packages/canvas/canvas-graphics/src/Graphics.ts
@@ -71,5 +71,6 @@ Graphics.prototype._renderCanvas = function _renderCanvas(renderer: CanvasRender
     }
 
     this.finishPoly();
-    renderer.plugins.graphics.render(this);
+
+    renderer.getPlugin('graphics').render(this);
 };

--- a/packages/canvas/canvas-renderer/src/CanvasRenderer.ts
+++ b/packages/canvas/canvas-renderer/src/CanvasRenderer.ts
@@ -1,4 +1,4 @@
-import { AbstractRenderer, CanvasResource } from '@pixi/core';
+import { AbstractRenderer, CanvasResource, OffscreenContext } from '@pixi/core';
 import { CanvasRenderTarget, sayHello, rgb2hex, hex2string } from '@pixi/utils';
 import { CanvasMaskManager } from './utils/CanvasMaskManager';
 import { mapCanvasBlendModesToPixi } from './utils/mapCanvasBlendModesToPixi';
@@ -16,7 +16,40 @@ import type {
 
 const tempMatrix = new Matrix();
 
-export interface ICanvasRendererPluginConstructor {
+/**
+ * Performs final drawing onto main RenderingContext with contents from secondary RenderingContext.
+ */
+const DRAW = function(): void
+{
+    this.context.drawImage(this.$canvas, 0, 0);
+
+    if (this._willDispose)
+    {
+        this._willDispose = false;
+        this.$context = null;
+    }
+    else
+    {
+        this.applyTransform(Matrix.IDENTITY, this.$context);
+        this._resetContext(this.$context);
+    }
+};
+
+/**
+ * Clears the secondary RenderingContext, (optionally) according to given coordinates.
+ *
+ * @param {number} [x]
+ * @param {number} [y]
+ * @param {number} [w]
+ * @param {number} [h]
+ */
+const ERASE = function(x = 0, y = 0, w = Infinity, h = Infinity): void
+{
+    this.$context.clearRect(x, y, Math.min(w, this.width), Math.min(h, this.height));
+};
+
+export interface ICanvasRendererPluginConstructor
+{
     new (renderer: CanvasRenderer, options?: any): IRendererPlugin;
 }
 
@@ -69,8 +102,13 @@ export class CanvasRenderer extends AbstractRenderer
     public readonly blendModes: string[];
     public renderingToScreen: boolean;
 
+    private $context: CanvasRenderingContext2D;
+    private _finalize: Function;
+    private _erase: Function;
+
     private _activeBlendMode: BLEND_MODES;
     private _projTransform: Matrix;
+    private _willDispose: boolean;
 
     _outerBlend: boolean;
 
@@ -194,6 +232,106 @@ export class CanvasRenderer extends AbstractRenderer
         this.resize(this.options.width, this.options.height);
     }
 
+    getPlugin(name: string): IRendererPlugin {
+        const plugin = this.plugins[name];
+
+        if (!plugin) return plugin;
+        if (!this.$context) return plugin;
+
+        return Object.create(
+            plugin,
+            {
+                renderer:
+                {
+                    value: this,
+                    enumerable: true,
+                    writable: false,
+                    configurable: true,
+                }
+            }
+        );
+    }
+
+    /**
+     * Creates an enhanced CanvasRenderer based on this instance.
+     * Facilitates further off-screen operations via new secondary RenderingContext.
+     *
+     * @return {PIXI.CanvasRenderer} The newly enhanced CanvasRenderer
+     */
+    public forge(): CanvasRenderer {
+        if (!this.view || this.$context) return this;
+
+        try
+        {
+            return Object.create(
+                this,
+                {
+                    $context:
+                    {
+                        value: this._forgeContext(),
+                        enumerable: false,
+                        writable: false,
+                        configurable: true,
+                    }
+                }
+            ) as CanvasRenderer;
+        }
+        catch (err)
+        {
+            console.warn('No OffscreenContext() was created:', err.message || err);
+            return this;
+        }
+    }
+
+    /**
+     * Returns (or creates) the secondary RenderingContext, based on the main RenderingContext.
+     *
+     * @return {[CanvasRenderingContext2D, Function, Function]} The (newly created) secondary RenderingContext; the final drawing function; the erasing function
+     */
+    forgeContext(): [CanvasRenderingContext2D, Function, Function]
+    {
+        if (!this.$context) {
+            try
+            {
+                this.$context = this._forgeContext();
+                this._willDispose = true;
+            }
+            catch (err)
+            {
+                console.warn('No OffscreenContext() was created:', err.message || err);
+                return [];
+            }
+        }
+
+        this._resetContext(this.$context);
+
+        // Create the functions bound to this CanvasRenderer instance, which has the
+        //  `$context` (possibly from a previous `forge()` call)
+        const draw = DRAW.bind(this);
+        const erase = ERASE.bind(this);
+
+        return [this.$context, draw, erase];
+    }
+
+    private _forgeContext(): CanvasRenderingContext2D
+    {
+        return OffscreenContext(this.context) as CanvasRenderingContext2D;
+    }
+
+    private _resetContext(context: CanvasRenderingContext2D, blendMode = BLEND_MODES.NORMAL): void
+    {
+        context.globalCompositeOperation = this.blendModes[blendMode];
+    }
+
+    /**
+     * Returns the Canvas instance associated with the current $context instance.
+     *
+     * @return {HTMLCanvasElement}
+     */
+    private get $canvas(): HTMLCanvasElement {
+        return this.$context && this.$context.canvas;
+    }
+
     /**
      * Renders the object to this canvas view
      *
@@ -302,7 +440,7 @@ export class CanvasRenderer extends AbstractRenderer
         const tempContext = this.context;
 
         this.context = context;
-        displayObject.renderCanvas(this);
+        displayObject.renderCanvas(this.forge());
         this.context = tempContext;
 
         context.restore();
@@ -314,15 +452,14 @@ export class CanvasRenderer extends AbstractRenderer
     }
 
     /**
-     * sets matrix of context
-     * called only from render() methods
-     * takes care about resolution
+     * Creates new Matrix for context transform.
+     * Resolution is handled appropriately.
+     *
      * @param {PIXI.Matrix} transform - world matrix of current element
      * @param {boolean} [roundPixels] - whether to round (tx,ty) coords
      * @param {number} [localResolution] - If specified, used instead of `renderer.resolution` for local scaling
      */
-    setContextTransform(transform: Matrix, roundPixels?: boolean, localResolution?: number): void
-    {
+    newContextTransform(transform: Matrix, roundPixels?: boolean, localResolution?: number): Matrix {
         let mat = transform;
         const proj = this._projTransform;
         const resolution = this.resolution;
@@ -338,30 +475,62 @@ export class CanvasRenderer extends AbstractRenderer
 
         if (roundPixels)
         {
-            this.context.setTransform(
+            return new Matrix(
                 mat.a * localResolution,
                 mat.b * localResolution,
                 mat.c * localResolution,
                 mat.d * localResolution,
                 (mat.tx * resolution) | 0,
-                (mat.ty * resolution) | 0
+                (mat.ty * resolution) | 0,
             );
         }
-        else
-        {
-            this.context.setTransform(
-                mat.a * localResolution,
-                mat.b * localResolution,
-                mat.c * localResolution,
-                mat.d * localResolution,
-                mat.tx * resolution,
-                mat.ty * resolution
-            );
-        }
+
+        return new Matrix(
+            mat.a * localResolution,
+            mat.b * localResolution,
+            mat.c * localResolution,
+            mat.d * localResolution,
+            mat.tx * resolution,
+            mat.ty * resolution,
+        );
     }
 
     /**
-     * Clear the canvas of renderer.
+     * Updates current context with given transform Matrix.
+     * Resolution is handled appropriately.
+     * Only called only from render() methods.
+     *
+     * @param {PIXI.Matrix} transform - world matrix of current element
+     * @param {boolean} [roundPixels] - whether to round (tx,ty) coords
+     * @param {number} [localResolution] - If specified, used instead of `renderer.resolution` for local scaling
+     */
+    setContextTransform(transform: Matrix, roundPixels?: boolean, localResolution?: number): void
+    {
+        const mat = this.newContextTransform(transform, roundPixels, localResolution);
+
+        this.applyTransform(mat);
+    }
+
+    /**
+     * Applies given transform upon the main RenderingContext - or the given context, if specified.
+     *
+     * @param {PIXI.Matrix} transform - The transformation to apply
+     * @param {CanvasRenderingContext2D} [context] - The context to apply transformation to
+     */
+    applyTransform(transform: Matrix, context?: CanvasRenderingContext2D): void
+    {
+        if (context == null)
+        {
+            context = this.context;
+        }
+
+        const { a, b, c, d, tx, ty } = transform;
+
+        context.setTransform(a, b, c, d, tx, ty);
+    }
+
+    /**
+     * Clears current canvas.
      *
      * @param {string} [clearColor] - Clear the canvas with this color, except the canvas is transparent.
      * @param {number} [alpha] - Alpha to apply to the background fill color.

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -436,3 +436,18 @@ export enum MSAA_QUALITY {
     MEDIUM = 4,
     HIGH = 8
 }
+
+/**
+ * Constants for stroke alignments.
+ *
+ * @see PIXI.StrokeStyle#aslignment
+ *
+ * @name ALIGNMENT
+ * @memberof PIXI
+ * @static
+ * @enum {number}
+ * @property {number} MIDDLE=0.5
+ */
+export enum ALIGNMENT {
+    MIDDLE = 0.5,
+}

--- a/packages/core/src/canvas.ts
+++ b/packages/core/src/canvas.ts
@@ -1,0 +1,33 @@
+/**
+ * Assigns the width property to given target canvas from given srcCanvas.AAGUID
+ *
+ * @param {HTMLCanvasElement} canvas - The target Canvas instance
+ * @param {HTMLCanvasElement} srcCanvas - The source Canvas instance
+ * @return {HTMLCanvasElement} The given target canvas
+ */
+export function setWidth(canvas: HTMLCanvasElement, srcCanvas: HTMLCanvasElement): HTMLCanvasElement
+{
+    if (canvas == null) return canvas;
+    if (srcCanvas == null) return canvas;
+
+    canvas.width = srcCanvas.width;
+
+    return canvas;
+}
+
+/**
+ * Assigns the height property to given target canvas from given srcCanvas.AAGUID
+ *
+ * @param {HTMLCanvasElement} canvas - The target Canvas instance
+ * @param {HTMLCanvasElement} srcCanvas - The source Canvas instance
+ * @return {HTMLCanvasElement} The given target canvas
+ */
+export function setHeight(canvas: HTMLCanvasElement, srcCanvas: HTMLCanvasElement): HTMLCanvasElement
+{
+    if (canvas == null) return canvas;
+    if (srcCanvas == null) return canvas;
+
+    canvas.height = srcCanvas.height;
+
+    return canvas;
+}

--- a/packages/core/src/canvas.ts
+++ b/packages/core/src/canvas.ts
@@ -1,14 +1,16 @@
+export type Canvas = HTMLCanvasElement | OffscreenCanvas;
+
 /**
- * Assigns the width property to given target canvas from given srcCanvas.AAGUID
+ * Assigns the width property to given target canvas from given srcCanvas.
  *
- * @param {HTMLCanvasElement} canvas - The target Canvas instance
- * @param {HTMLCanvasElement} srcCanvas - The source Canvas instance
- * @return {HTMLCanvasElement} The given target canvas
+ * @param {Canvas} canvas - The target Canvas instance
+ * @param {Canvas} srcCanvas - The source Canvas instance
+ * @return {Canvas} The given target canvas
  */
-export function setWidth(canvas: HTMLCanvasElement, srcCanvas: HTMLCanvasElement): HTMLCanvasElement
+export function setWidth(canvas: Canvas, srcCanvas: Canvas): Canvas
 {
-    if (canvas == null) return canvas;
-    if (srcCanvas == null) return canvas;
+    if (!canvas) return canvas;
+    if (!srcCanvas) return canvas;
 
     canvas.width = srcCanvas.width;
 
@@ -16,16 +18,16 @@ export function setWidth(canvas: HTMLCanvasElement, srcCanvas: HTMLCanvasElement
 }
 
 /**
- * Assigns the height property to given target canvas from given srcCanvas.AAGUID
+ * Assigns the height property to given target canvas from given srcCanvas.
  *
- * @param {HTMLCanvasElement} canvas - The target Canvas instance
- * @param {HTMLCanvasElement} srcCanvas - The source Canvas instance
- * @return {HTMLCanvasElement} The given target canvas
+ * @param {Canvas} canvas - The target Canvas instance
+ * @param {Canvas} srcCanvas - The source Canvas instance
+ * @return {Canvas} The given target canvas
  */
-export function setHeight(canvas: HTMLCanvasElement, srcCanvas: HTMLCanvasElement): HTMLCanvasElement
+export function setHeight(canvas: Canvas, srcCanvas: Canvas): Canvas
 {
-    if (canvas == null) return canvas;
-    if (srcCanvas == null) return canvas;
+    if (!canvas) return canvas;
+    if (!srcCanvas) return canvas;
 
     canvas.height = srcCanvas.height;
 

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -1,6 +1,30 @@
 import { setWidth, setHeight } from './canvas';
 
 /**
+ * Determines whether given context is a CanvasRenderingContext2D instance.context
+ *
+ * @param {object} context - The object to inspect
+ * @return {boolean}
+ */
+export function isContext2D(context: unknown): boolean
+{
+    return context instanceof CanvasRenderingContext2D;
+}
+
+/**
+ * Returns the context type of given context (e.g. '2d').
+ *
+ * @param {RenderingContext} context - The context to inspect
+ * @return {string} The type of given context
+ */
+export function getContextType(context: RenderingContext): string
+{
+    if (isContext2D(context)) return '2d';
+
+    return undefined;
+}
+
+/**
  * Creates a new RenderingContext instance based on given src.
  * Facilitates off-screen rendering for e.g. double-buffering.
  *
@@ -9,14 +33,14 @@ import { setWidth, setHeight } from './canvas';
  */
 export function OffscreenContext(src?: RenderingContext|string): RenderingContext
 {
-    if (src == null) return src as RenderingContext;
+    if (!src) return src as RenderingContext;
 
     const canvas = document.createElement('canvas') as HTMLCanvasElement;
     let type: string;
 
     if (typeof src === 'object')
     {
-        const srcCanvas = src.canvas;
+        const srcCanvas = (src as RenderingContext).canvas;
 
         setWidth(canvas, srcCanvas);
         setHeight(canvas, srcCanvas);
@@ -28,31 +52,7 @@ export function OffscreenContext(src?: RenderingContext|string): RenderingContex
         type = src;
     }
 
-    if (type)
-    {
-        return canvas.getContext(type) as RenderingContext;
-    }
-}
+    if (type) return canvas.getContext(type) as RenderingContext;
 
-/**
- * Returns the context type of given context (e.g. '2d').
- *
- * @param {RenderingContext} context - The context to inspect
- * @return {string} The type of given context
- */
-export function getContextType(context: RenderingContext): string
-{
-    if (context == null) return context as string;
-    if (isContext2D(context)) return '2d';
-}
-
-/**
- * Determines whether given context is a CanvasRenderingContext2D instance.context
- *
- * @param {object} context - The object to inspect
- * @return {boolean}
- */
-export function isContext2D(context: object): boolean
-{
-    return context instanceof CanvasRenderingContext2D;
+    return undefined;
 }

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -1,0 +1,58 @@
+import { setWidth, setHeight } from './canvas';
+
+/**
+ * Creates a new RenderingContext instance based on given src.
+ * Facilitates off-screen rendering for e.g. double-buffering.
+ *
+ * @param {RenderingContext|string} src - The source RenderingContext or context type (i.e. '2d' etc.)
+ * @return {RenderingContext} The newly created RenderingContext
+ */
+export function OffscreenContext(src?: RenderingContext|string): RenderingContext
+{
+    if (src == null) return src as RenderingContext;
+
+    const canvas = document.createElement('canvas') as HTMLCanvasElement;
+    let type: string;
+
+    if (typeof src === 'object')
+    {
+        const srcCanvas = src.canvas;
+
+        setWidth(canvas, srcCanvas);
+        setHeight(canvas, srcCanvas);
+
+        type = getContextType(src);
+    }
+    else if (typeof src === 'string')
+    {
+        type = src;
+    }
+
+    if (type)
+    {
+        return canvas.getContext(type) as RenderingContext;
+    }
+}
+
+/**
+ * Returns the context type of given context (e.g. '2d').
+ *
+ * @param {RenderingContext} context - The context to inspect
+ * @return {string} The type of given context
+ */
+export function getContextType(context: RenderingContext): string
+{
+    if (context == null) return context as string;
+    if (isContext2D(context)) return '2d';
+}
+
+/**
+ * Determines whether given context is a CanvasRenderingContext2D instance.context
+ *
+ * @param {object} context - The object to inspect
+ * @return {boolean}
+ */
+export function isContext2D(context: object): boolean
+{
+    return context instanceof CanvasRenderingContext2D;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,6 +45,9 @@ export * from './geometry/Buffer';
 export * from './geometry/Geometry';
 export * from './geometry/ViewableBuffer';
 
+export * from './canvas';
+export * from './context';
+
 // #if _DEBUG
 export * from './deprecations';
 // #endif


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Enable drawing strokes with different alignment values (0 - 1) for **Canvas**.

The `CanvasGraphicsRenderer` now performs the actual drawing onto a secondary off-screen `RenderingContext`; the stroke is drawn by compositing drawing operations according to specified `strokeStyle.alignment`. The result then is finally drawn onto the main `RenderingContext`.

**Performance**:
 - a _shared_ secondary `RenderingContext` is acquired whenever possible - i.e. prior to rendering multiple objects;
 - drawing resorts to the secondary `RenderingContext` _only_ when actually necessary - i.e. when the **stroke** is _visible_ and _either_ the _alignment_ is non-**middle** _or_ the **fill** is also _visible_.

[**DEMO**](https://jsfiddle.net/6wfnm5o1/)

![DEMO result](https://user-images.githubusercontent.com/8561801/104768216-f2217080-5775-11eb-8ec2-0c974c117ba9.png)

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
