### PR TITLE
Improve deprecations strategy for core

### DIFF
--- a/packages/core/src/deprecations.ts
+++ b/packages/core/src/deprecations.ts
@@ -16,7 +16,9 @@ for (const name in _resources)
         {
             get()
             {
+                // #if _DEBUG
                 deprecation('6.0.0', `PIXI.systems.${name} has moved to PIXI.${name}`);
+                // #endif
 
                 return (_resources as any)[name];
             },
@@ -37,7 +39,9 @@ for (const name in _systems)
         {
             get()
             {
+                // #if _DEBUG
                 deprecation('6.0.0', `PIXI.resources.${name} has moved to PIXI.${name}`);
+                // #endif
 
                 return (_systems as any)[name];
             },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,7 +44,4 @@ export * from './geometry/Attribute';
 export * from './geometry/Buffer';
 export * from './geometry/Geometry';
 export * from './geometry/ViewableBuffer';
-
-// #if _DEBUG
 export * from './deprecations';
-// #endif


### PR DESCRIPTION
Upon further investigation, this deprecation strategy needed a little refining.

Deprecations should work runtime even for production builds (minus the console warnings). My first attempt at this meant that runtime didn't work. In this case, trying to use `PIXI.resources.ImageResource` would fail in production builds but work in development builds.