### PR TITLE
Fix for animated sprite not stopping

### DIFF
--- a/packages/sprite-animated/src/AnimatedSprite.ts
+++ b/packages/sprite-animated/src/AnimatedSprite.ts
@@ -260,6 +260,11 @@ export class AnimatedSprite extends Sprite
      */
     update(deltaTime: number): void
     {
+		if (!this._playing)
+        {
+            return;
+        }
+		
         const elapsed = this.animationSpeed * deltaTime;
         const previousFrame = this.currentFrame;
 

--- a/packages/sprite-animated/src/AnimatedSprite.ts
+++ b/packages/sprite-animated/src/AnimatedSprite.ts
@@ -260,7 +260,7 @@ export class AnimatedSprite extends Sprite
      */
     update(deltaTime: number): void
     {
-		if (!this._playing)
+        if (!this._playing)
         {
             return;
         }

--- a/packages/sprite-animated/src/AnimatedSprite.ts
+++ b/packages/sprite-animated/src/AnimatedSprite.ts
@@ -264,7 +264,7 @@ export class AnimatedSprite extends Sprite
         {
             return;
         }
-		
+
         const elapsed = this.animationSpeed * deltaTime;
         const previousFrame = this.currentFrame;
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
Fixes issue where animated sprite continues to play even when `_playing = false`

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
