### PR TITLE
Upgrade to @webdoc/cli 1.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2135,39 +2135,6 @@
 				"write-file-atomic": "^2.3.0"
 			}
 		},
-		"@material-ui/icons": {
-			"version": "4.11.2",
-			"resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.11.2.tgz",
-			"integrity": "sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.4.4"
-			}
-		},
-		"@material-ui/lab": {
-			"version": "4.0.0-alpha.57",
-			"resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.57.tgz",
-			"integrity": "sha512-qo/IuIQOmEKtzmRD2E4Aa6DB4A87kmY6h0uYhjUmrrgmEAgbbw9etXpWPVXuRK6AGIQCjFzV6WO2i21m1R4FCw==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.4.4",
-				"@material-ui/utils": "^4.11.2",
-				"clsx": "^1.0.4",
-				"prop-types": "^15.7.2",
-				"react-is": "^16.8.0 || ^17.0.0"
-			}
-		},
-		"@material-ui/utils": {
-			"version": "4.11.2",
-			"resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.2.tgz",
-			"integrity": "sha512-Uul8w38u+PICe2Fg2pDKCaIG7kOyhowZ9vjiC1FsVwPABTW8vPPKfF6OvxRq3IiBaI1faOJmgdvMG7rMJARBhA==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.4.4",
-				"prop-types": "^15.7.2",
-				"react-is": "^16.8.0 || ^17.0.0"
-			}
-		},
 		"@microsoft/api-extractor": {
 			"version": "7.9.11",
 			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.9.11.tgz",
@@ -3320,19 +3287,19 @@
 			}
 		},
 		"@webdoc/cli": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@webdoc/cli/-/cli-1.1.5.tgz",
-			"integrity": "sha512-bNC128rSRPZ6WP2sxMk2aEz0nuN7deTkAUnt+PN/pUS6F1/2LbZp3FEPx3t5rhzUjti8yx4U+9qqkETHbF6QdQ==",
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@webdoc/cli/-/cli-1.1.6.tgz",
+			"integrity": "sha512-29zGcq1OvAIZQL1HKELm+txJ1x770lrw+C+YSuz2b+a01iCmhnE5T/ciO7wHzBEwtChCg6auWuUChi04kJlgDA==",
 			"dev": true,
 			"requires": {
-				"@webdoc/default-template": "^1.1.5",
-				"@webdoc/externalize": "^1.1.5",
-				"@webdoc/legacy-template": "^1.1.5",
-				"@webdoc/model": "^1.1.5",
-				"@webdoc/parser": "^1.1.5",
-				"@webdoc/plugin-markdown": "^1.1.5",
-				"@webdoc/template-library": "^1.1.5",
-				"@webdoc/types": "^1.1.5",
+				"@webdoc/default-template": "^1.1.6",
+				"@webdoc/externalize": "^1.1.6",
+				"@webdoc/legacy-template": "^1.1.6",
+				"@webdoc/model": "^1.1.6",
+				"@webdoc/parser": "^1.1.6",
+				"@webdoc/plugin-markdown": "^1.1.6",
+				"@webdoc/template-library": "^1.1.6",
+				"@webdoc/types": "^1.1.6",
 				"array.prototype.flatmap": "~1.2.3",
 				"fs-extra": "^9.0.1",
 				"globby": "11.0.0",
@@ -3354,38 +3321,38 @@
 					"dev": true
 				},
 				"@webdoc/model": {
-					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/@webdoc/model/-/model-1.1.5.tgz",
-					"integrity": "sha512-YE76hx23vqnzjKL96xc2zBghug1FtL5BLt2fCuYPJZexNdhK2JKnV6yJ2hmVrcKiqVjjqZi4TISiHhuFG7dchA==",
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/@webdoc/model/-/model-1.1.6.tgz",
+					"integrity": "sha512-GYUelaVLVc0WqP54OfF/zsI8V34z7c2LzSVG2Ejs1zE1RDAVU3113Vdbgs3kHoPXsbJw7h7A8E1MQsfGxrfmpg==",
 					"dev": true,
 					"requires": {
-						"@webdoc/types": "^1.1.5",
+						"@webdoc/types": "^1.1.6",
 						"catharsis": "0.8.11",
 						"nanoid": "~3.1.16",
 						"taffydb": "2.7.3"
 					}
 				},
 				"@webdoc/template-library": {
-					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/@webdoc/template-library/-/template-library-1.1.5.tgz",
-					"integrity": "sha512-RAPXUL55rOoEIibUlouu0qUppa6f0Wc9J4bzTx9DcRTP7dIO+yIFMiKK6CwqoM8bl45wQjoa4ONhA1HHKCkW8g==",
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/@webdoc/template-library/-/template-library-1.1.6.tgz",
+					"integrity": "sha512-NRDm4sVDkbeh/utjs2JsNsKzaKBlC9y9Ckfpi4NOCBSQfTcc+52Zu3koHJbSXGYvR9WSekZG22jj6QU4yNa9CQ==",
 					"dev": true,
 					"requires": {
-						"@webdoc/model": "^1.1.5",
-						"@webdoc/types": "^1.1.5",
+						"@webdoc/model": "^1.1.6",
+						"@webdoc/types": "^1.1.6",
 						"catharsis": "0.8.11",
 						"fs-extra": "^9.0.1",
 						"git-branch": "2.0.1",
-						"lodash": "^4.17.15",
+						"lodash": "^4.17.20",
 						"missionlog": "1.6.0",
 						"nanoid": "~3.1.16",
 						"parse-github-url": "1.0.2"
 					}
 				},
 				"@webdoc/types": {
-					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/@webdoc/types/-/types-1.1.5.tgz",
-					"integrity": "sha512-MSM0S3NvUvbM4Nr7msKRtwMkh0o8urBN1myM8XU2oMKmx+LDD89itVuyYDRIH/yX6h/W/pM/afRp7GSpecx5ow==",
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/@webdoc/types/-/types-1.1.6.tgz",
+					"integrity": "sha512-uyi4oip3XJqyJMg76eoSwkAu2XXmJW5nY9AZ8thgXYQ3dDh/s6mDZcHg0za23neGjSSe8cGEFrikfjn7G55Ikg==",
 					"dev": true
 				},
 				"ansi-regex": {
@@ -3493,15 +3460,15 @@
 					}
 				},
 				"fs-extra": {
-					"version": "9.0.1",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-					"integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+					"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
 					"dev": true,
 					"requires": {
 						"at-least-node": "^1.0.0",
 						"graceful-fs": "^4.2.0",
 						"jsonfile": "^6.0.1",
-						"universalify": "^1.0.0"
+						"universalify": "^2.0.0"
 					}
 				},
 				"get-caller-file": {
@@ -3574,14 +3541,6 @@
 					"requires": {
 						"graceful-fs": "^4.1.6",
 						"universalify": "^2.0.0"
-					},
-					"dependencies": {
-						"universalify": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-							"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-							"dev": true
-						}
 					}
 				},
 				"locate-path": {
@@ -3640,9 +3599,9 @@
 					"dev": true
 				},
 				"parse-json": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
-					"integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+					"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
@@ -3730,9 +3689,9 @@
 					}
 				},
 				"universalify": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-					"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
 					"dev": true
 				},
 				"wrap-ansi": {
@@ -3776,17 +3735,15 @@
 			}
 		},
 		"@webdoc/default-template": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@webdoc/default-template/-/default-template-1.1.5.tgz",
-			"integrity": "sha512-rkIlZQafsqX03cxXcbCktQHMiEh0dwDSftFD81Y811oW5dvBmZuOFRhQu+V+JT0BWcYdvjOMaAixwDeODANdWw==",
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@webdoc/default-template/-/default-template-1.1.6.tgz",
+			"integrity": "sha512-jSc61Awdeg6zDCf8goNERsdanUX8EvxaK8EvFUEmuKGkPTtqSyVH2o+2ENHR1G3yG5Nkxzi2zjPwogykZFxfMw==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.9.0",
 				"@babel/preset-react": "^7.10.1",
-				"@material-ui/icons": "^4.9.1",
-				"@material-ui/lab": "^4.0.0-alpha.56",
-				"@webdoc/model": "^1.1.5",
-				"@webdoc/template-library": "^1.1.5",
+				"@webdoc/model": "^1.1.6",
+				"@webdoc/template-library": "^1.1.6",
 				"code-prettify": "^0.1.0",
 				"fs-extra": "^9.0.1",
 				"markdown-it": "^11.0.0",
@@ -3794,50 +3751,50 @@
 			},
 			"dependencies": {
 				"@webdoc/model": {
-					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/@webdoc/model/-/model-1.1.5.tgz",
-					"integrity": "sha512-YE76hx23vqnzjKL96xc2zBghug1FtL5BLt2fCuYPJZexNdhK2JKnV6yJ2hmVrcKiqVjjqZi4TISiHhuFG7dchA==",
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/@webdoc/model/-/model-1.1.6.tgz",
+					"integrity": "sha512-GYUelaVLVc0WqP54OfF/zsI8V34z7c2LzSVG2Ejs1zE1RDAVU3113Vdbgs3kHoPXsbJw7h7A8E1MQsfGxrfmpg==",
 					"dev": true,
 					"requires": {
-						"@webdoc/types": "^1.1.5",
+						"@webdoc/types": "^1.1.6",
 						"catharsis": "0.8.11",
 						"nanoid": "~3.1.16",
 						"taffydb": "2.7.3"
 					}
 				},
 				"@webdoc/template-library": {
-					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/@webdoc/template-library/-/template-library-1.1.5.tgz",
-					"integrity": "sha512-RAPXUL55rOoEIibUlouu0qUppa6f0Wc9J4bzTx9DcRTP7dIO+yIFMiKK6CwqoM8bl45wQjoa4ONhA1HHKCkW8g==",
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/@webdoc/template-library/-/template-library-1.1.6.tgz",
+					"integrity": "sha512-NRDm4sVDkbeh/utjs2JsNsKzaKBlC9y9Ckfpi4NOCBSQfTcc+52Zu3koHJbSXGYvR9WSekZG22jj6QU4yNa9CQ==",
 					"dev": true,
 					"requires": {
-						"@webdoc/model": "^1.1.5",
-						"@webdoc/types": "^1.1.5",
+						"@webdoc/model": "^1.1.6",
+						"@webdoc/types": "^1.1.6",
 						"catharsis": "0.8.11",
 						"fs-extra": "^9.0.1",
 						"git-branch": "2.0.1",
-						"lodash": "^4.17.15",
+						"lodash": "^4.17.20",
 						"missionlog": "1.6.0",
 						"nanoid": "~3.1.16",
 						"parse-github-url": "1.0.2"
 					}
 				},
 				"@webdoc/types": {
-					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/@webdoc/types/-/types-1.1.5.tgz",
-					"integrity": "sha512-MSM0S3NvUvbM4Nr7msKRtwMkh0o8urBN1myM8XU2oMKmx+LDD89itVuyYDRIH/yX6h/W/pM/afRp7GSpecx5ow==",
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/@webdoc/types/-/types-1.1.6.tgz",
+					"integrity": "sha512-uyi4oip3XJqyJMg76eoSwkAu2XXmJW5nY9AZ8thgXYQ3dDh/s6mDZcHg0za23neGjSSe8cGEFrikfjn7G55Ikg==",
 					"dev": true
 				},
 				"fs-extra": {
-					"version": "9.0.1",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-					"integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+					"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
 					"dev": true,
 					"requires": {
 						"at-least-node": "^1.0.0",
 						"graceful-fs": "^4.2.0",
 						"jsonfile": "^6.0.1",
-						"universalify": "^1.0.0"
+						"universalify": "^2.0.0"
 					}
 				},
 				"graceful-fs": {
@@ -3854,14 +3811,6 @@
 					"requires": {
 						"graceful-fs": "^4.1.6",
 						"universalify": "^2.0.0"
-					},
-					"dependencies": {
-						"universalify": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-							"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-							"dev": true
-						}
 					}
 				},
 				"lodash": {
@@ -3871,52 +3820,52 @@
 					"dev": true
 				},
 				"universalify": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-					"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
 					"dev": true
 				}
 			}
 		},
 		"@webdoc/externalize": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@webdoc/externalize/-/externalize-1.1.5.tgz",
-			"integrity": "sha512-LlsjRTMDOU3EcJ7ptEl2jif7Pm6RQnwyi9cLh2xbePGRw1U+/MPGWEQT6WJ1YODlkxrj3HeKzKFVp9FeSnZqTQ==",
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@webdoc/externalize/-/externalize-1.1.6.tgz",
+			"integrity": "sha512-5FKszLTCXZfTiWzFT6scuDaTTS4H28qof58Rk5WX67RQhy+/4YvSotgnkLBjBQw9qE/csdcE6a0ZYv1nuoa60A==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.9.0",
-				"@webdoc/model": "^1.1.5",
-				"@webdoc/types": "^1.1.5"
+				"@webdoc/model": "^1.1.6",
+				"@webdoc/types": "^1.1.6"
 			},
 			"dependencies": {
 				"@webdoc/model": {
-					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/@webdoc/model/-/model-1.1.5.tgz",
-					"integrity": "sha512-YE76hx23vqnzjKL96xc2zBghug1FtL5BLt2fCuYPJZexNdhK2JKnV6yJ2hmVrcKiqVjjqZi4TISiHhuFG7dchA==",
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/@webdoc/model/-/model-1.1.6.tgz",
+					"integrity": "sha512-GYUelaVLVc0WqP54OfF/zsI8V34z7c2LzSVG2Ejs1zE1RDAVU3113Vdbgs3kHoPXsbJw7h7A8E1MQsfGxrfmpg==",
 					"dev": true,
 					"requires": {
-						"@webdoc/types": "^1.1.5",
+						"@webdoc/types": "^1.1.6",
 						"catharsis": "0.8.11",
 						"nanoid": "~3.1.16",
 						"taffydb": "2.7.3"
 					}
 				},
 				"@webdoc/types": {
-					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/@webdoc/types/-/types-1.1.5.tgz",
-					"integrity": "sha512-MSM0S3NvUvbM4Nr7msKRtwMkh0o8urBN1myM8XU2oMKmx+LDD89itVuyYDRIH/yX6h/W/pM/afRp7GSpecx5ow==",
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/@webdoc/types/-/types-1.1.6.tgz",
+					"integrity": "sha512-uyi4oip3XJqyJMg76eoSwkAu2XXmJW5nY9AZ8thgXYQ3dDh/s6mDZcHg0za23neGjSSe8cGEFrikfjn7G55Ikg==",
 					"dev": true
 				}
 			}
 		},
 		"@webdoc/legacy-template": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@webdoc/legacy-template/-/legacy-template-1.1.5.tgz",
-			"integrity": "sha512-Kw7aT6pTzoIswRe6pcF6wciNhP9RA3nPmDKGIRZZd9Jdhrd7poL6zfgmetko+8HP3y2CT2QaJ7jjkgsHqnywlA==",
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@webdoc/legacy-template/-/legacy-template-1.1.6.tgz",
+			"integrity": "sha512-I4913r917sMB2PSpT7O9rYHylFl2OWkEi6REg/Mtmkk7A5qaRjlHEq391X/gjcDaT0AZTLK5m8Y/dDMSZW/VHg==",
 			"dev": true,
 			"requires": {
-				"@webdoc/model": "^1.1.5",
-				"@webdoc/template-library": "^1.1.5",
+				"@webdoc/model": "^1.1.6",
+				"@webdoc/template-library": "^1.1.6",
 				"bluebird": "^3.7.2",
 				"code-prettify": "^0.1.0",
 				"color-themes-for-google-code-prettify": "^2.0.4",
@@ -3924,7 +3873,7 @@
 				"escape-string-regexp": "^3.0.0",
 				"fs-extra": "^9.0.1",
 				"klaw-sync": "6.0.0",
-				"lodash": "^4.17.15",
+				"lodash": "^4.17.20",
 				"markdown-it": "^11.0.0",
 				"markdown-it-highlightjs": "^3.1.0",
 				"marked": "^0.8.2",
@@ -3933,38 +3882,38 @@
 			},
 			"dependencies": {
 				"@webdoc/model": {
-					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/@webdoc/model/-/model-1.1.5.tgz",
-					"integrity": "sha512-YE76hx23vqnzjKL96xc2zBghug1FtL5BLt2fCuYPJZexNdhK2JKnV6yJ2hmVrcKiqVjjqZi4TISiHhuFG7dchA==",
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/@webdoc/model/-/model-1.1.6.tgz",
+					"integrity": "sha512-GYUelaVLVc0WqP54OfF/zsI8V34z7c2LzSVG2Ejs1zE1RDAVU3113Vdbgs3kHoPXsbJw7h7A8E1MQsfGxrfmpg==",
 					"dev": true,
 					"requires": {
-						"@webdoc/types": "^1.1.5",
+						"@webdoc/types": "^1.1.6",
 						"catharsis": "0.8.11",
 						"nanoid": "~3.1.16",
 						"taffydb": "2.7.3"
 					}
 				},
 				"@webdoc/template-library": {
-					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/@webdoc/template-library/-/template-library-1.1.5.tgz",
-					"integrity": "sha512-RAPXUL55rOoEIibUlouu0qUppa6f0Wc9J4bzTx9DcRTP7dIO+yIFMiKK6CwqoM8bl45wQjoa4ONhA1HHKCkW8g==",
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/@webdoc/template-library/-/template-library-1.1.6.tgz",
+					"integrity": "sha512-NRDm4sVDkbeh/utjs2JsNsKzaKBlC9y9Ckfpi4NOCBSQfTcc+52Zu3koHJbSXGYvR9WSekZG22jj6QU4yNa9CQ==",
 					"dev": true,
 					"requires": {
-						"@webdoc/model": "^1.1.5",
-						"@webdoc/types": "^1.1.5",
+						"@webdoc/model": "^1.1.6",
+						"@webdoc/types": "^1.1.6",
 						"catharsis": "0.8.11",
 						"fs-extra": "^9.0.1",
 						"git-branch": "2.0.1",
-						"lodash": "^4.17.15",
+						"lodash": "^4.17.20",
 						"missionlog": "1.6.0",
 						"nanoid": "~3.1.16",
 						"parse-github-url": "1.0.2"
 					}
 				},
 				"@webdoc/types": {
-					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/@webdoc/types/-/types-1.1.5.tgz",
-					"integrity": "sha512-MSM0S3NvUvbM4Nr7msKRtwMkh0o8urBN1myM8XU2oMKmx+LDD89itVuyYDRIH/yX6h/W/pM/afRp7GSpecx5ow==",
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/@webdoc/types/-/types-1.1.6.tgz",
+					"integrity": "sha512-uyi4oip3XJqyJMg76eoSwkAu2XXmJW5nY9AZ8thgXYQ3dDh/s6mDZcHg0za23neGjSSe8cGEFrikfjn7G55Ikg==",
 					"dev": true
 				},
 				"bluebird": {
@@ -3980,15 +3929,15 @@
 					"dev": true
 				},
 				"fs-extra": {
-					"version": "9.0.1",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-					"integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+					"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
 					"dev": true,
 					"requires": {
 						"at-least-node": "^1.0.0",
 						"graceful-fs": "^4.2.0",
 						"jsonfile": "^6.0.1",
-						"universalify": "^1.0.0"
+						"universalify": "^2.0.0"
 					}
 				},
 				"graceful-fs": {
@@ -4005,14 +3954,6 @@
 					"requires": {
 						"graceful-fs": "^4.1.6",
 						"universalify": "^2.0.0"
-					},
-					"dependencies": {
-						"universalify": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-							"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-							"dev": true
-						}
 					}
 				},
 				"lodash": {
@@ -4022,9 +3963,9 @@
 					"dev": true
 				},
 				"universalify": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-					"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
 					"dev": true
 				}
 			}
@@ -4042,17 +3983,17 @@
 			}
 		},
 		"@webdoc/parser": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@webdoc/parser/-/parser-1.1.5.tgz",
-			"integrity": "sha512-jyGxTXtzQZVrEqATihrMiOJekgS6zARzBH1eXxPqGHfLYT2bbsXUy2lsU5JeaLeF2816r0mG0asS1Od9/W4bXQ==",
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@webdoc/parser/-/parser-1.1.6.tgz",
+			"integrity": "sha512-mg3LHXcze1zuc8DqdEUGhnSgksHJgKeG4dJg6d8LvLbxQUzcnKQcfhIocOJD/kn+wujGEvztXfI7d4wQYN8YFw==",
 			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.9.4",
 				"@babel/traverse": "7.9.5",
 				"@babel/types": "7.9.5",
-				"@webdoc/model": "^1.1.5",
-				"@webdoc/types": "^1.1.5",
-				"lodash": "^4.17.15",
+				"@webdoc/model": "^1.1.6",
+				"@webdoc/types": "^1.1.6",
+				"lodash": "^4.17.20",
 				"missionlog": "1.6.0",
 				"nanoid": "~3.1.16"
 			},
@@ -4228,21 +4169,21 @@
 					}
 				},
 				"@webdoc/model": {
-					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/@webdoc/model/-/model-1.1.5.tgz",
-					"integrity": "sha512-YE76hx23vqnzjKL96xc2zBghug1FtL5BLt2fCuYPJZexNdhK2JKnV6yJ2hmVrcKiqVjjqZi4TISiHhuFG7dchA==",
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/@webdoc/model/-/model-1.1.6.tgz",
+					"integrity": "sha512-GYUelaVLVc0WqP54OfF/zsI8V34z7c2LzSVG2Ejs1zE1RDAVU3113Vdbgs3kHoPXsbJw7h7A8E1MQsfGxrfmpg==",
 					"dev": true,
 					"requires": {
-						"@webdoc/types": "^1.1.5",
+						"@webdoc/types": "^1.1.6",
 						"catharsis": "0.8.11",
 						"nanoid": "~3.1.16",
 						"taffydb": "2.7.3"
 					}
 				},
 				"@webdoc/types": {
-					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/@webdoc/types/-/types-1.1.5.tgz",
-					"integrity": "sha512-MSM0S3NvUvbM4Nr7msKRtwMkh0o8urBN1myM8XU2oMKmx+LDD89itVuyYDRIH/yX6h/W/pM/afRp7GSpecx5ow==",
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/@webdoc/types/-/types-1.1.6.tgz",
+					"integrity": "sha512-uyi4oip3XJqyJMg76eoSwkAu2XXmJW5nY9AZ8thgXYQ3dDh/s6mDZcHg0za23neGjSSe8cGEFrikfjn7G55Ikg==",
 					"dev": true
 				},
 				"debug": {
@@ -4281,9 +4222,9 @@
 			}
 		},
 		"@webdoc/plugin-markdown": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@webdoc/plugin-markdown/-/plugin-markdown-1.1.5.tgz",
-			"integrity": "sha512-sSATovBaigubwehRjJT2ShhazmZS4d3M/rc4/keBClhUGY4ZFtK2B8CMJ0A7f7LzBAiudHEzQfcObTEIrQ+QbQ==",
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@webdoc/plugin-markdown/-/plugin-markdown-1.1.6.tgz",
+			"integrity": "sha512-fB+1bOrJmjImsvLEbgRoa4HGVFimGcDJuAOsFZFpyfarqUuAzScdcvwHNACgE/HMTInj5bD1c6hCJC5tJYhGDA==",
 			"dev": true,
 			"requires": {
 				"markdown-it": "^11.0.0",
@@ -4559,23 +4500,25 @@
 			},
 			"dependencies": {
 				"es-abstract": {
-					"version": "1.18.0-next.1",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+					"version": "1.18.0-next.2",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.2.tgz",
+					"integrity": "sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==",
 					"dev": true,
 					"requires": {
+						"call-bind": "^1.0.2",
 						"es-to-primitive": "^1.2.1",
 						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.0.2",
 						"has": "^1.0.3",
 						"has-symbols": "^1.0.1",
 						"is-callable": "^1.2.2",
-						"is-negative-zero": "^2.0.0",
+						"is-negative-zero": "^2.0.1",
 						"is-regex": "^1.1.1",
-						"object-inspect": "^1.8.0",
+						"object-inspect": "^1.9.0",
 						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.1",
-						"string.prototype.trimend": "^1.0.1",
-						"string.prototype.trimstart": "^1.0.1"
+						"object.assign": "^4.1.2",
+						"string.prototype.trimend": "^1.0.3",
+						"string.prototype.trimstart": "^1.0.3"
 					}
 				},
 				"es-to-primitive": {
@@ -4596,17 +4539,18 @@
 					"dev": true
 				},
 				"is-callable": {
-					"version": "1.2.2",
-					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
-					"integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+					"version": "1.2.3",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
 					"dev": true
 				},
 				"is-regex": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
-					"integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
 					"dev": true,
 					"requires": {
+						"call-bind": "^1.0.2",
 						"has-symbols": "^1.0.1"
 					}
 				},
@@ -5250,12 +5194,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
 			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-			"dev": true
-		},
-		"clsx": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
-			"integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
 			"dev": true
 		},
 		"cmd-shim": {
@@ -8199,9 +8137,9 @@
 			"dev": true
 		},
 		"get-intrinsic": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
-			"integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.0.tgz",
+			"integrity": "sha512-M11rgtQp5GZMZzDL7jLTNxbDfurpzuau5uqRWDPvlHjfvg3TdScAZo96GLvhMjImrmR8uAt0FS2RLoMrfWGKlg==",
 			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1",
@@ -9594,9 +9532,9 @@
 			"dev": true
 		},
 		"json5": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-			"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+			"integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
 			"dev": true,
 			"requires": {
 				"minimist": "^1.2.5"
@@ -9925,15 +9863,6 @@
 			"integrity": "sha512-BYxIEXiVq5lGIXeVHnsFzqa1TxN5acnKnPCdlZSpzm8viNEOhiigupA4vTQ9HEFQ6nLTQ9wQOgBknJgzUYQ9Aw==",
 			"dev": true
 		},
-		"loose-envify": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"dev": true,
-			"requires": {
-				"js-tokens": "^3.0.0 || ^4.0.0"
-			}
-		},
 		"loud-rejection": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
@@ -10059,9 +9988,9 @@
 			}
 		},
 		"markdown-it-highlightjs": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/markdown-it-highlightjs/-/markdown-it-highlightjs-3.3.1.tgz",
-			"integrity": "sha512-T9L+37CC+H/aQWHbHCpmo6FvSH2imqXYjZj/Tj064UmPn0aCne/bAtSORo6W5x7BdLIWwbTR20xrdlKDAq0M6w==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/markdown-it-highlightjs/-/markdown-it-highlightjs-3.4.0.tgz",
+			"integrity": "sha512-JES5P8ll3Vpf6a4C0FlsaO1opOaH53Rbvphj2IAON29v33cHNUiwXBSaC+bThUiLp6m3UEZ4vv579CHSElWSdw==",
 			"dev": true,
 			"requires": {
 				"highlight.js": "^10.2.0",
@@ -11021,23 +10950,25 @@
 			},
 			"dependencies": {
 				"es-abstract": {
-					"version": "1.18.0-next.1",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+					"version": "1.18.0-next.2",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.2.tgz",
+					"integrity": "sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==",
 					"dev": true,
 					"requires": {
+						"call-bind": "^1.0.2",
 						"es-to-primitive": "^1.2.1",
 						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.0.2",
 						"has": "^1.0.3",
 						"has-symbols": "^1.0.1",
 						"is-callable": "^1.2.2",
-						"is-negative-zero": "^2.0.0",
+						"is-negative-zero": "^2.0.1",
 						"is-regex": "^1.1.1",
-						"object-inspect": "^1.8.0",
+						"object-inspect": "^1.9.0",
 						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.1",
-						"string.prototype.trimend": "^1.0.1",
-						"string.prototype.trimstart": "^1.0.1"
+						"object.assign": "^4.1.2",
+						"string.prototype.trimend": "^1.0.3",
+						"string.prototype.trimstart": "^1.0.3"
 					}
 				},
 				"es-to-primitive": {
@@ -11058,17 +10989,18 @@
 					"dev": true
 				},
 				"is-callable": {
-					"version": "1.2.2",
-					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
-					"integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+					"version": "1.2.3",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
 					"dev": true
 				},
 				"is-regex": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
-					"integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+					"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
 					"dev": true,
 					"requires": {
+						"call-bind": "^1.0.2",
 						"has-symbols": "^1.0.1"
 					}
 				},
@@ -11867,25 +11799,6 @@
 				"read": "1"
 			}
 		},
-		"prop-types": {
-			"version": "15.7.2",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-			"dev": true,
-			"requires": {
-				"loose-envify": "^1.4.0",
-				"object-assign": "^4.1.1",
-				"react-is": "^16.8.1"
-			},
-			"dependencies": {
-				"react-is": {
-					"version": "16.13.1",
-					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-					"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-					"dev": true
-				}
-			}
-		},
 		"proto-list": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -11987,12 +11900,6 @@
 				"minimist": "^1.2.0",
 				"strip-json-comments": "~2.0.1"
 			}
-		},
-		"react-is": {
-			"version": "17.0.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
-			"integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
-			"dev": true
 		},
 		"read": {
 			"version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
     "@rollup/plugin-typescript": "^6.0.0",
-    "@webdoc/cli": "^1.1.5",
+    "@webdoc/cli": "^1.1.6",
     "chai": "~3.5.0",
     "copyfiles": "^2.1.0",
     "cross-env": "^5.2.0",

--- a/webdoc.conf.json
+++ b/webdoc.conf.json
@@ -3,7 +3,7 @@
         "allowUnknownTags": false
     },
     "source": {
-        "includePattern": [
+        "include": [
             "packages/*/src/**/*.ts",
             "bundles/pixi.js/src/*.ts",
             "packages/filters/*/src/**/*.(ts)",


### PR DESCRIPTION
## webdoc upgrade 🎉 

[webdoc 1.1.6](https://github.com/webdoc-labs/webdoc/releases/tag/1.1.6) has a little breaking change - the config now matches what JSDoc's options provided - include/includePattern/excludePattern/exclude. The includePattern(s) must be regex(s) and not glob paths, which should be input(s).

## Description of change
* Install webdoc 1.1.6
* Change includePattern to include in webdoc.conf.json