### PR TITLE
fix instances of '.to.be.notnull' in tests

### DIFF
--- a/packages/core/test/MaskSystem.js
+++ b/packages/core/test/MaskSystem.js
@@ -65,7 +65,7 @@ describe('PIXI.MaskSystem', function ()
 
         const maskData = this.renderer.mask.maskDataPool[0];
 
-        expect(maskData).to.be.notnull;
+        expect(maskData).to.exist;
         expect(maskData._scissorCounter).to.equal(1);
     });
 
@@ -166,13 +166,13 @@ describe('PIXI.MaskSystem', function ()
             maskSystem.push(filteredObject, maskObject);
             expect(maskSystem.maskStack.length).to.equal(1);
             expect(maskSystem.maskStack[0].type).to.equal(MASK_TYPES.SPRITE);
-            expect(this.renderer.renderTexture.current).to.be.notnull;
+            expect(this.renderer.renderTexture.current).to.exist;
 
             const filterArea = this.renderer.renderTexture.current.filterFrame;
             const expected = maskBounds.clone().ceil();
 
             expected.fit(filteredObject.getBounds());
-            expect(filterArea).to.be.notnull;
+            expect(filterArea).to.exist;
             expect(filterArea.x).to.equal(expected.x);
             expect(filterArea.y).to.equal(expected.y);
             expect(filterArea.width).to.equal(expected.width);

--- a/packages/core/test/TextureSystem.js
+++ b/packages/core/test/TextureSystem.js
@@ -35,7 +35,7 @@ describe('PIXI.TextureSystem', function ()
 
         const glTex = baseTex._glTextures[this.renderer.CONTEXT_UID];
 
-        expect(glTex).to.be.notnull;
+        expect(glTex).to.exist;
         expect(glTex.wrapMode).to.equal(WRAP_MODES.REPEAT);
     });
 
@@ -49,7 +49,7 @@ describe('PIXI.TextureSystem', function ()
 
         const glTex = baseTex._glTextures[this.renderer.CONTEXT_UID];
 
-        expect(glTex).to.be.notnull;
+        expect(glTex).to.exist;
         expect(glTex.wrapMode).to.equal(WRAP_MODES.CLAMP);
     });
 });

--- a/packages/prepare/test/Prepare.js
+++ b/packages/prepare/test/Prepare.js
@@ -35,7 +35,7 @@ describe('PIXI.Prepare', function ()
 
             expect(Object.keys(texture.baseTexture._glTextures)).to.eql([`${CONTEXT_UID}`]);
             expect(graphics.geometry.batches.length).to.equal(2);
-            expect(vaos[CONTEXT_UID]).to.be.notnull;
+            expect(vaos[CONTEXT_UID]).to.exist;
             expect(Object.keys(vaos[CONTEXT_UID]).length).to.equal(2); // [shader_id] and [signature]
         }
         finally


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

A few tests use the construction `.to.be.notnull`. I could be missing something but I don't think `notnull` is defined or does anything. (Unfortunately, chai's cute "you don't need to put parentheses at the end!" use of properties means that this wont trigger an error. 🤷‍♂️)

I've replaced them with `.to.exist`.

##### Pre-Merge Checklist
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
