### PR TITLE
Fixes render textures being destroyed on unload plugin

### DIFF
--- a/packages/core/src/textures/TextureGCSystem.ts
+++ b/packages/core/src/textures/TextureGCSystem.ts
@@ -149,7 +149,7 @@ export class TextureGCSystem extends System
         // only destroy non generated textures
         if (texture && !texture.framebuffer)
         {
-            tm.destroyTexture(displayObject._texture);
+            tm.destroyTexture(texture);
         }
 
         for (let i = displayObject.children.length - 1; i >= 0; i--)

--- a/packages/core/src/textures/TextureGCSystem.ts
+++ b/packages/core/src/textures/TextureGCSystem.ts
@@ -144,9 +144,10 @@ export class TextureGCSystem extends System
     unload(displayObject: IUnloadableTexture): void
     {
         const tm = this.renderer.texture;
+        const texture = displayObject._texture as RenderTexture;
 
         // only destroy non generated textures
-        if ((displayObject._texture as RenderTexture)?.framebuffer)
+        if (texture && !texture.framebuffer)
         {
             tm.destroyTexture(displayObject._texture);
         }


### PR DESCRIPTION
##### Description of change
https://github.com/pixijs/pixi.js/issues/7201

Copies the same logic for not destroying render textures as the 'run' function has - ie. must have a _texture, but can't have a framebuffer property, as only render textures have that

##### Pre-Merge Checklist
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)

Use https://pixijs.download/bugfix/render-texture-unload/pixi.js as url in https://www.pixiplayground.com/#/edit/CdtIblFjYmf47uNXMIWap to see the fix works (for some reason, custom url isn't saved on pixi-playground