### PR TITLE
updates to ubo

### DIFF
--- a/packages/core/src/geometry/BufferSystem.ts
+++ b/packages/core/src/geometry/BufferSystem.ts
@@ -78,9 +78,31 @@ export class BufferSystem extends System
 
         if (this.boundBufferBases[index] !== buffer)
         {
+            const glBuffer = buffer._glBuffers[CONTEXT_UID] || this.createGLBuffer(buffer);
+
             this.boundBufferBases[index] = buffer;
-            gl.bindBufferBase(gl.UNIFORM_BUFFER, index, buffer._glBuffers[CONTEXT_UID].buffer);
+
+            gl.bindBufferBase(gl.UNIFORM_BUFFER, index, glBuffer.buffer);
         }
+    }
+
+    /**
+     * Binds a buffer whilst also binding its range.
+     * This will make the buffer start from the offset supplied rather than 0 when it is read.
+     *
+     * @param buffer - the buffer to bind
+     * @param offset - the offset to bind at (this is blocks of 256). 0 = 0, 1 = 256, 2 = 512 etc
+     * @param index - the base index to bind at, defaults to 0
+     */
+    bindBufferRange(buffer:Buffer, offset?:number, index?:number):void
+    {
+        const { gl, CONTEXT_UID } = this;
+
+        offset = offset || 0;
+
+        const glBuffer = buffer._glBuffers[CONTEXT_UID] || this.createGLBuffer(buffer);
+
+        gl.bindBufferRange(gl.UNIFORM_BUFFER, index || 0, glBuffer.buffer, offset * 256, 256);
     }
 
     /**

--- a/packages/core/src/shader/GLProgram.ts
+++ b/packages/core/src/shader/GLProgram.ts
@@ -18,6 +18,19 @@ export class GLProgram
     public uniformData: Dict<any>;
     public uniformGroups: Dict<any>;
     /**
+     * a hash that stores where ubs are bound to on the program
+     */
+    public uniformBufferBindings: Dict<any>;
+    /**
+     * a hash for upload functions, we only generates new ones if they don't already exist
+     */
+    public uniformSync: Dict<any>;
+    /**
+     * a place where dirty ticks are stored for groups
+     */
+    public uniformDirtyGroups: Dict<any>;
+
+    /**
      * Makes a new Pixi program
      *
      * @param {WebGLProgram} program - webgl program
@@ -45,6 +58,10 @@ export class GLProgram
          * @member {Object}
          */
         this.uniformGroups = {};
+
+        this.uniformDirtyGroups = {};
+
+        this.uniformBufferBindings = {};
     }
 
     /**
@@ -54,6 +71,7 @@ export class GLProgram
     {
         this.uniformData = null;
         this.uniformGroups = null;
+        this.uniformBufferBindings = null;
         this.program = null;
     }
 }

--- a/packages/core/src/shader/UniformGroup.ts
+++ b/packages/core/src/shader/UniformGroup.ts
@@ -144,7 +144,7 @@ export class UniformGroup<LAYOUT = Dict<any>>
     {
         if (!this.ubo)
         {
-            this.uniforms[name] = new UniformGroup(uniforms, _static);
+            (this.uniforms as any)[name] = new UniformGroup(uniforms, _static);
         }
         else
         {

--- a/packages/core/src/shader/UniformGroup.ts
+++ b/packages/core/src/shader/UniformGroup.ts
@@ -49,9 +49,9 @@ let UID = 0;
  * @class
  * @memberof PIXI
  */
-export class UniformGroup
+export class UniformGroup<LAYOUT = Dict<any>>
 {
-    public readonly uniforms: Dict<any>;
+    public readonly uniforms: LAYOUT;
     public readonly group: boolean;
     public id: number;
     syncUniforms: Dict<UniformsSyncCallback>;
@@ -66,7 +66,7 @@ export class UniformGroup
      * @param {boolean} [_static] - Uniforms wont be changed after creation
      * @param {boolean} [_ubo] - if true, will treat this uniform group as a uniform buffer object
      */
-    constructor(uniforms: Dict<any> | Buffer, _static?: boolean, _ubo?:boolean)
+    constructor(uniforms: LAYOUT | Buffer, _static?: boolean, _ubo?:boolean)
     {
         /**
          * Its a group and not a single uniforms
@@ -133,6 +133,11 @@ export class UniformGroup
     update(): void
     {
         this.dirtyId++;
+
+        if (!this.autoManage && this.buffer)
+        {
+            this.buffer.update();
+        }
     }
 
     add(name: string, uniforms: Dict<any>, _static?: boolean): void

--- a/packages/core/src/shader/utils/generateUniformsSync.ts
+++ b/packages/core/src/shader/utils/generateUniformsSync.ts
@@ -115,7 +115,7 @@ export function generateUniformsSync(group: UniformGroup, uniformData: Dict<any>
                 if (group.uniforms[i].ubo)
                 {
                     funcFragments.push(`
-                        renderer.shader.syncUniformBufferGroup(uv.${i}, '${i}', syncData);
+                        renderer.shader.syncUniformBufferGroup(uv.${i}, '${i}');
                     `);
                 }
                 else

--- a/packages/core/src/shader/utils/uniformParsers.ts
+++ b/packages/core/src/shader/utils/uniformParsers.ts
@@ -30,10 +30,10 @@ export const uniformParsers: IUniformParser[] = [
             data.type === 'float' && data.size === 1,
         code: (name: string): string =>
             `
-            if(uv["${name}"] !== ud["${name}"].value)
+            if(uv.${name} !== ud.${name}.value)
             {
-                ud["${name}"].value = uv["${name}"]
-                gl.uniform1f(ud["${name}"].location, uv["${name}"])
+                ud.${name}.value = uv.${name}
+                gl.uniform1f(ud.${name}.location, uv.${name})
             }
             `,
     },
@@ -44,12 +44,12 @@ export const uniformParsers: IUniformParser[] = [
             (data.type === 'sampler2D' || data.type === 'samplerCube' || data.type === 'sampler2DArray') && data.size === 1 && !data.isArray,
         code: (name: string): string => `t = syncData.textureCount++;
 
-            renderer.texture.bind(uv["${name}"], t);
+            renderer.texture.bind(uv.${name}, t);
 
-            if(ud["${name}"].value !== t)
+            if(ud.${name}.value !== t)
             {
-                ud["${name}"].value = t;
-                gl.uniform1i(ud["${name}"].location, t);\n; // eslint-disable-line max-len
+                ud.${name}.value = t;
+                gl.uniform1i(ud.${name}.location, t);\n; // eslint-disable-line max-len
             }`,
     },
     // uploading pixi matrix object to mat3
@@ -60,7 +60,7 @@ export const uniformParsers: IUniformParser[] = [
 
             // TODO and some smart caching dirty ids here!
             `
-            gl.uniformMatrix3fv(ud["${name}"].location, false, uv["${name}"].toArray(true));
+            gl.uniformMatrix3fv(ud.${name}.location, false, uv.${name}.toArray(true));
             `,
         codeUbo: (name: string): string =>
             `
@@ -80,14 +80,14 @@ export const uniformParsers: IUniformParser[] = [
             data.type === 'vec2' && data.size === 1 && uniform.x !== undefined,
         code: (name: string): string =>
             `
-                cv = ud["${name}"].value;
-                v = uv["${name}"];
+                cv = ud.${name}.value;
+                v = uv.${name};
 
                 if(cv[0] !== v.x || cv[1] !== v.y)
                 {
                     cv[0] = v.x;
                     cv[1] = v.y;
-                    gl.uniform2f(ud["${name}"].location, v.x, v.y);
+                    gl.uniform2f(ud.${name}.location, v.x, v.y);
                 }`,
         codeUbo: (name:string): string =>
             `
@@ -103,14 +103,14 @@ export const uniformParsers: IUniformParser[] = [
             data.type === 'vec2' && data.size === 1,
         code: (name: string): string =>
             `
-                cv = ud["${name}"].value;
-                v = uv["${name}"];
+                cv = ud.${name}.value;
+                v = uv.${name};
 
                 if(cv[0] !== v[0] || cv[1] !== v[1])
                 {
                     cv[0] = v[0];
                     cv[1] = v[1];
-                    gl.uniform2f(ud["${name}"].location, v[0], v[1]);
+                    gl.uniform2f(ud.${name}.location, v[0], v[1]);
                 }
             `,
     },
@@ -121,8 +121,8 @@ export const uniformParsers: IUniformParser[] = [
 
         code: (name: string): string =>
             `
-                cv = ud["${name}"].value;
-                v = uv["${name}"];
+                cv = ud.${name}.value;
+                v = uv.${name};
 
                 if(cv[0] !== v.x || cv[1] !== v.y || cv[2] !== v.width || cv[3] !== v.height)
                 {
@@ -130,7 +130,7 @@ export const uniformParsers: IUniformParser[] = [
                     cv[1] = v.y;
                     cv[2] = v.width;
                     cv[3] = v.height;
-                    gl.uniform4f(ud["${name}"].location, v.x, v.y, v.width, v.height)
+                    gl.uniform4f(ud.${name}.location, v.x, v.y, v.width, v.height)
                 }`,
         codeUbo: (name:string): string =>
             `
@@ -148,8 +148,8 @@ export const uniformParsers: IUniformParser[] = [
             data.type === 'vec4' && data.size === 1,
         code: (name: string): string =>
             `
-                cv = ud["${name}"].value;
-                v = uv["${name}"];
+                cv = ud.${name}.value;
+                v = uv.${name};
 
                 if(cv[0] !== v[0] || cv[1] !== v[1] || cv[2] !== v[2] || cv[3] !== v[3])
                 {
@@ -158,7 +158,7 @@ export const uniformParsers: IUniformParser[] = [
                     cv[2] = v[2];
                     cv[3] = v[3];
 
-                    gl.uniform4f(ud["${name}"].location, v[0], v[1], v[2], v[3])
+                    gl.uniform4f(ud.${name}.location, v[0], v[1], v[2], v[3])
                 }`,
     },
 ];

--- a/packages/core/src/shader/utils/uniformParsers.ts
+++ b/packages/core/src/shader/utils/uniformParsers.ts
@@ -30,10 +30,10 @@ export const uniformParsers: IUniformParser[] = [
             data.type === 'float' && data.size === 1,
         code: (name: string): string =>
             `
-            if(uv.${name} !== ud.${name}.value)
+            if(uv["${name}"] !== ud["${name}"].value)
             {
-                ud.${name}.value = uv.${name}
-                gl.uniform1f(ud.${name}.location, uv.${name})
+                ud["${name}"].value = uv["${name}"]
+                gl.uniform1f(ud["${name}"].location, uv["${name}"])
             }
             `,
     },
@@ -44,12 +44,12 @@ export const uniformParsers: IUniformParser[] = [
             (data.type === 'sampler2D' || data.type === 'samplerCube' || data.type === 'sampler2DArray') && data.size === 1 && !data.isArray,
         code: (name: string): string => `t = syncData.textureCount++;
 
-            renderer.texture.bind(uv.${name}, t);
+            renderer.texture.bind(uv["${name}"], t);
 
-            if(ud.${name}.value !== t)
+            if(ud["${name}"].value !== t)
             {
-                ud.${name}.value = t;
-                gl.uniform1i(ud.${name}.location, t);\n; // eslint-disable-line max-len
+                ud["${name}"].value = t;
+                gl.uniform1i(ud["${name}"].location, t);\n; // eslint-disable-line max-len
             }`,
     },
     // uploading pixi matrix object to mat3
@@ -60,7 +60,7 @@ export const uniformParsers: IUniformParser[] = [
 
             // TODO and some smart caching dirty ids here!
             `
-            gl.uniformMatrix3fv(ud.${name}.location, false, uv.${name}.toArray(true));
+            gl.uniformMatrix3fv(ud["${name}"].location, false, uv["${name}"].toArray(true));
             `,
         codeUbo: (name: string): string =>
             `
@@ -80,14 +80,14 @@ export const uniformParsers: IUniformParser[] = [
             data.type === 'vec2' && data.size === 1 && uniform.x !== undefined,
         code: (name: string): string =>
             `
-                cv = ud.${name}.value;
-                v = uv.${name};
+                cv = ud["${name}"].value;
+                v = uv["${name}"];
 
                 if(cv[0] !== v.x || cv[1] !== v.y)
                 {
                     cv[0] = v.x;
                     cv[1] = v.y;
-                    gl.uniform2f(ud.${name}.location, v.x, v.y);
+                    gl.uniform2f(ud["${name}"].location, v.x, v.y);
                 }`,
         codeUbo: (name:string): string =>
             `
@@ -103,14 +103,14 @@ export const uniformParsers: IUniformParser[] = [
             data.type === 'vec2' && data.size === 1,
         code: (name: string): string =>
             `
-                cv = ud.${name}.value;
-                v = uv.${name};
+                cv = ud["${name}"].value;
+                v = uv["${name}"];
 
                 if(cv[0] !== v[0] || cv[1] !== v[1])
                 {
                     cv[0] = v[0];
                     cv[1] = v[1];
-                    gl.uniform2f(ud.${name}.location, v[0], v[1]);
+                    gl.uniform2f(ud["${name}"].location, v[0], v[1]);
                 }
             `,
     },
@@ -121,8 +121,8 @@ export const uniformParsers: IUniformParser[] = [
 
         code: (name: string): string =>
             `
-                cv = ud.${name}.value;
-                v = uv.${name};
+                cv = ud["${name}"].value;
+                v = uv["${name}"];
 
                 if(cv[0] !== v.x || cv[1] !== v.y || cv[2] !== v.width || cv[3] !== v.height)
                 {
@@ -130,7 +130,7 @@ export const uniformParsers: IUniformParser[] = [
                     cv[1] = v.y;
                     cv[2] = v.width;
                     cv[3] = v.height;
-                    gl.uniform4f(ud.${name}.location, v.x, v.y, v.width, v.height)
+                    gl.uniform4f(ud["${name}"].location, v.x, v.y, v.width, v.height)
                 }`,
         codeUbo: (name:string): string =>
             `
@@ -148,8 +148,8 @@ export const uniformParsers: IUniformParser[] = [
             data.type === 'vec4' && data.size === 1,
         code: (name: string): string =>
             `
-                cv = ud.${name}.value;
-                v = uv.${name};
+                cv = ud["${name}"].value;
+                v = uv["${name}"];
 
                 if(cv[0] !== v[0] || cv[1] !== v[1] || cv[2] !== v[2] || cv[3] !== v[3])
                 {
@@ -158,7 +158,7 @@ export const uniformParsers: IUniformParser[] = [
                     cv[2] = v[2];
                     cv[3] = v[3];
 
-                    gl.uniform4f(ud.${name}.location, v[0], v[1], v[2], v[3])
+                    gl.uniform4f(ud["${name}"].location, v[0], v[1], v[2], v[3])
                 }`,
     },
 ];

--- a/packages/core/test/shader/UniformBuffer.js
+++ b/packages/core/test/shader/UniformBuffer.js
@@ -124,27 +124,23 @@ describe('generateUniformBufferSync', function ()
                     data: { name: 'uFloat', index: 1, type: 'float', size: 1, isArray: false, value: 0 },
                     offset: 0,
                     dataLen: 4,
-                    chunkLen: 4,
                     dirty: 0
                 },
                 {
                     data: { name: 'uBool', index: 2, type: 'bool', size: 1, isArray: false, value: false },
                     offset: 4,
                     dataLen: 4,
-                    chunkLen: 4,
                     dirty: 0
                 },
                 {
                     data: { name: 'uInt', index: 3, type: 'int', size: 1, isArray: false, value: 0 },
                     offset: 8,
                     dataLen: 4,
-                    chunkLen: 4,
                     dirty: 0 },
                 {
                     data: { name: 'uUInt', index: 4, type: 'uint', size: 1, isArray: false, value: 0 },
                     offset: 12,
                     dataLen: 4,
-                    chunkLen: 4,
                     dirty: 0
                 }
             ],
@@ -395,6 +391,44 @@ describe('generateUniformBufferSync', function ()
                 ])
 
             },
+            {
+                uboSrc: ` uniform uboTest {
+                    vec3 uLightColor;
+                    float uLightDistance;
+                };`,
+                groupData: {
+                    uLightColor: [1, 2, 3],
+                    uLightDistance: 4
+                },
+                expectedBuffer: new Float32Array([
+                    1, 2, 3, 4,
+                ])
+
+            },
+            {
+                debug: true,
+                uboSrc: ` uniform uboTest {
+                    vec3 uLightColor;
+                    vec3 uLightPosition;
+                    float uLightDistance;
+                    vec2 uLimit;
+                    vec3 uGlobalAmbient;
+                };`,
+                groupData: {
+                    uLightColor: [1, 1, 1],
+                    uLightPosition: [2, 2, 2],
+                    uLightDistance: 3,
+                    uLimit: [4, 4],
+                    uGlobalAmbient: [5, 5, 5],
+                },
+                expectedBuffer: new Float32Array([
+                    1, 1, 1, 0,
+                    2, 2, 2, 3,
+                    4, 4, 0, 0,
+                    5, 5, 5, 0,
+                ])
+
+            },
 
         ].forEach((toTest) =>
         {
@@ -419,7 +453,12 @@ describe('generateUniformBufferSync', function ()
 
             const buffer = group.buffer;
 
-            f(shader.program.uniformData, group.uniforms, stubRenderer, {}, buffer);
+            if (buffer.data.length === 1)
+            {
+                buffer.data = new Float32Array(f.size / 4);
+            }
+
+            f.syncFunc(shader.program.uniformData, group.uniforms, stubRenderer, {}, buffer);
 
             chai.expect(buffer.data).to.deep.equal(toTest.expectedBuffer);
         });


### PR DESCRIPTION
Final pass on ubo functionality

- added `bindBufferRange`
- optimised uniform reading in generateSync
- fixed up a few binding issues with ubos

- [X] Documentation is changed or added
- [X] Lint process passed (`npm run lint`)
- [X] Tests passed (`npm run test`)
