### PR TITLE
Add Generics to Texture, BaseTexture for Resource types

### DIFF
--- a/packages/canvas/canvas-mesh/src/CanvasMeshRenderer.ts
+++ b/packages/canvas/canvas-mesh/src/CanvasMeshRenderer.ts
@@ -1,4 +1,4 @@
-import { Texture } from '@pixi/core/src';
+import { Texture } from '@pixi/core';
 import { DRAW_MODES } from '@pixi/constants';
 import { canvasUtils } from '@pixi/canvas-renderer';
 

--- a/packages/core/src/textures/BaseTexture.ts
+++ b/packages/core/src/textures/BaseTexture.ts
@@ -16,7 +16,7 @@ const defaultBufferOptions = {
 
 export type ImageSource = HTMLImageElement|HTMLCanvasElement|HTMLVideoElement|ImageBitmap;
 
-export interface IBaseTextureOptions<T = any> {
+export interface IBaseTextureOptions<RO = any> {
     alphaMode?: ALPHA_MODES;
     mipmap?: MIPMAP_MODES;
     anisotropicLevel?: number;
@@ -28,7 +28,7 @@ export interface IBaseTextureOptions<T = any> {
     type?: TYPES;
     target?: TARGETS;
     resolution?: number;
-    resourceOptions?: T;
+    resourceOptions?: RO;
     pixiIdPrefix?: string;
 }
 
@@ -42,8 +42,10 @@ export interface BaseTexture extends GlobalMixins.BaseTexture, EventEmitter {}
  * @class
  * @extends PIXI.utils.EventEmitter
  * @memberof PIXI
+ * @typeParam R - The BaseTexture's Resource type.
+ * @typeParam RO - The options for constructing resource.
  */
-export class BaseTexture<T extends Resource = Resource, U = IAutoDetectOptions> extends EventEmitter
+export class BaseTexture<R extends Resource = Resource, RO = IAutoDetectOptions> extends EventEmitter
 {
     public width: number;
     public height: number;
@@ -68,7 +70,7 @@ export class BaseTexture<T extends Resource = Resource, U = IAutoDetectOptions> 
     public valid: boolean;
     textureCacheIds: Array<string>;
     public destroyed: boolean;
-    public resource: T;
+    public resource: R;
     _batchEnabled: number;
     _batchLocation: number;
     parentTextureArray: BaseTexture;
@@ -92,7 +94,7 @@ export class BaseTexture<T extends Resource = Resource, U = IAutoDetectOptions> 
      * @param {object} [options.resourceOptions] - Optional resource options,
      *        see {@link PIXI.autoDetectResource autoDetectResource}
      */
-    constructor(resource: T | ImageSource | string | any = null, options: IBaseTextureOptions<U> = null)
+    constructor(resource: R | ImageSource | string | any = null, options: IBaseTextureOptions<RO> = null)
     {
         super();
 
@@ -104,7 +106,7 @@ export class BaseTexture<T extends Resource = Resource, U = IAutoDetectOptions> 
         // Convert the resource to a Resource object
         if (resource && !(resource instanceof Resource))
         {
-            resource = autoDetectResource<T, U>(resource, resourceOptions);
+            resource = autoDetectResource<R, RO>(resource, resourceOptions);
             resource.internal = true;
         }
 
@@ -489,7 +491,7 @@ export class BaseTexture<T extends Resource = Resource, U = IAutoDetectOptions> 
      * @param {PIXI.Resource} resource - that is managing this BaseTexture
      * @returns {PIXI.BaseTexture} this
      */
-    setResource(resource: T): this
+    setResource(resource: R): this
     {
         if (this.resource === resource)
         {
@@ -610,8 +612,8 @@ export class BaseTexture<T extends Resource = Resource, U = IAutoDetectOptions> 
      * @param {boolean} [strict] - Enforce strict-mode, see {@link PIXI.settings.STRICT_TEXTURE_CACHE}.
      * @returns {PIXI.BaseTexture} The new base texture.
      */
-    static from<T extends Resource = Resource, U = IAutoDetectOptions>(source: ImageSource|string,
-        options?: IBaseTextureOptions<U>, strict = settings.STRICT_TEXTURE_CACHE): BaseTexture<T>
+    static from<R extends Resource = Resource, RO = IAutoDetectOptions>(source: ImageSource|string,
+        options?: IBaseTextureOptions<RO>, strict = settings.STRICT_TEXTURE_CACHE): BaseTexture<R>
     {
         const isFrame = typeof source === 'string';
         let cacheId = null;
@@ -632,7 +634,7 @@ export class BaseTexture<T extends Resource = Resource, U = IAutoDetectOptions> 
             cacheId = (source as any)._pixiId;
         }
 
-        let baseTexture = BaseTextureCache[cacheId] as BaseTexture<T>;
+        let baseTexture = BaseTextureCache[cacheId] as BaseTexture<R>;
 
         // Strict-mode rejects invalid cacheIds
         if (isFrame && strict && !baseTexture)
@@ -642,7 +644,7 @@ export class BaseTexture<T extends Resource = Resource, U = IAutoDetectOptions> 
 
         if (!baseTexture)
         {
-            baseTexture = new BaseTexture<T>(source, options);
+            baseTexture = new BaseTexture<R>(source, options);
             baseTexture.cacheId = cacheId;
             BaseTexture.addToCache(baseTexture, cacheId);
         }

--- a/packages/core/src/textures/Texture.ts
+++ b/packages/core/src/textures/Texture.ts
@@ -47,10 +47,11 @@ export interface Texture extends GlobalMixins.Texture, EventEmitter {}
  * @class
  * @extends PIXI.utils.EventEmitter
  * @memberof PIXI
+ * @typeParam R - The BaseTexture's Resource type.
  */
-export class Texture<T extends Resource = Resource> extends EventEmitter
+export class Texture<R extends Resource = Resource> extends EventEmitter
 {
-    public baseTexture: BaseTexture<T>;
+    public baseTexture: BaseTexture<R>;
     public orig: Rectangle;
     public trim: Rectangle;
     public valid: boolean;
@@ -71,7 +72,7 @@ export class Texture<T extends Resource = Resource> extends EventEmitter
      * @param {number} [rotate] - indicates how the texture was rotated by texture packer. See {@link PIXI.groupD8}
      * @param {PIXI.IPointData} [anchor] - Default anchor point used for sprite placement / rotation
      */
-    constructor(baseTexture: BaseTexture<T>, frame?: Rectangle,
+    constructor(baseTexture: BaseTexture<R>, frame?: Rectangle,
         orig?: Rectangle, trim?: Rectangle, rotate?: number, anchor?: IPointData)
     {
         super();
@@ -352,8 +353,8 @@ export class Texture<T extends Resource = Resource> extends EventEmitter
      * @param {boolean} [strict] - Enforce strict-mode, see {@link PIXI.settings.STRICT_TEXTURE_CACHE}.
      * @return {PIXI.Texture} The newly created texture
      */
-    static from<T extends Resource = Resource, U = any>(source: TextureSource, options: IBaseTextureOptions<U> = {},
-        strict = settings.STRICT_TEXTURE_CACHE): Texture<T>
+    static from<R extends Resource = Resource, RO = any>(source: TextureSource, options: IBaseTextureOptions<RO> = {},
+        strict = settings.STRICT_TEXTURE_CACHE): Texture<R>
     {
         const isFrame = typeof source === 'string';
         let cacheId = null;
@@ -374,7 +375,7 @@ export class Texture<T extends Resource = Resource> extends EventEmitter
             cacheId = (source as any)._pixiId;
         }
 
-        let texture = TextureCache[cacheId] as Texture<T>;
+        let texture = TextureCache[cacheId] as Texture<R>;
 
         // Strict-mode rejects invalid cacheIds
         if (isFrame && strict && !texture)
@@ -389,7 +390,7 @@ export class Texture<T extends Resource = Resource> extends EventEmitter
                 options.resolution = getResolutionOfUrl(source as string);
             }
 
-            texture = new Texture<T>(new BaseTexture<T>(source, options));
+            texture = new Texture<R>(new BaseTexture<R>(source, options));
             texture.baseTexture.cacheId = cacheId;
 
             BaseTexture.addToCache(texture.baseTexture, cacheId);
@@ -408,11 +409,11 @@ export class Texture<T extends Resource = Resource> extends EventEmitter
      * @param {object} [options] - Optional options to include
      * @return {Promise<PIXI.Texture>} A Promise that resolves to a Texture.
      */
-    static fromURL<T extends Resource = Resource, U = any>(
-        url: string, options?: IBaseTextureOptions<U>): Promise<Texture<T>>
+    static fromURL<R extends Resource = Resource, RO = any>(
+        url: string, options?: IBaseTextureOptions<RO>): Promise<Texture<R>>
     {
         const resourceOptions = Object.assign({ autoLoad: false }, options?.resourceOptions);
-        const texture = Texture.from<T>(url, Object.assign({ resourceOptions }, options), false);
+        const texture = Texture.from<R>(url, Object.assign({ resourceOptions }, options), false);
         const resource = texture.baseTexture.resource;
 
         // The texture was already loaded
@@ -452,10 +453,10 @@ export class Texture<T extends Resource = Resource> extends EventEmitter
      *        specified, only `imageUrl` will be used as the cache ID.
      * @return {PIXI.Texture} Output texture
      */
-    static fromLoader<T extends Resource = Resource>(source: HTMLImageElement|HTMLCanvasElement|string,
-        imageUrl: string, name?: string, options?: IBaseTextureOptions): Promise<Texture<T>>
+    static fromLoader<R extends Resource = Resource>(source: HTMLImageElement|HTMLCanvasElement|string,
+        imageUrl: string, name?: string, options?: IBaseTextureOptions): Promise<Texture<R>>
     {
-        const baseTexture = new BaseTexture<T>(source, Object.assign({
+        const baseTexture = new BaseTexture<R>(source, Object.assign({
             scaleMode: settings.SCALE_MODE,
             resolution: getResolutionOfUrl(imageUrl),
         }, options));
@@ -467,7 +468,7 @@ export class Texture<T extends Resource = Resource> extends EventEmitter
             resource.url = imageUrl;
         }
 
-        const texture = new Texture<T>(baseTexture);
+        const texture = new Texture<R>(baseTexture);
 
         // No name, use imageUrl instead
         if (!name)

--- a/packages/core/src/textures/Texture.ts
+++ b/packages/core/src/textures/Texture.ts
@@ -677,11 +677,11 @@ export class Texture<T extends Resource = Resource> extends EventEmitter
         return this.baseTexture;
     }
 
-    static readonly EMPTY: Texture;
-    static readonly WHITE: Texture;
+    static readonly EMPTY: Texture<CanvasResource>;
+    static readonly WHITE: Texture<CanvasResource>;
 }
 
-function createWhiteTexture(): Texture
+function createWhiteTexture(): Texture<CanvasResource>
 {
     const canvas = document.createElement('canvas');
 

--- a/packages/core/src/textures/Texture.ts
+++ b/packages/core/src/textures/Texture.ts
@@ -8,7 +8,7 @@ import { uid, TextureCache, getResolutionOfUrl, EventEmitter } from '@pixi/utils
 
 import type { Resource } from './resources/Resource';
 import type { BufferResource } from './resources/BufferResource';
-import type { IPointData } from '@pixi/math';
+import type { IPointData, ISize } from '@pixi/math';
 import type { IBaseTextureOptions, ImageSource } from './BaseTexture';
 import type { TextureMatrix } from './TextureMatrix';
 
@@ -279,7 +279,7 @@ export class Texture<T extends Resource = Resource> extends EventEmitter
         {
             if (destroyBase)
             {
-                const resource = this.baseTexture as any;
+                const { resource } = this.baseTexture as unknown as BaseTexture<ImageResource>;
 
                 // delete the texture if it exists in the texture cache..
                 // this only needs to be removed if the base texture is actually destroyed too..
@@ -352,7 +352,7 @@ export class Texture<T extends Resource = Resource> extends EventEmitter
      * @param {boolean} [strict] - Enforce strict-mode, see {@link PIXI.settings.STRICT_TEXTURE_CACHE}.
      * @return {PIXI.Texture} The newly created texture
      */
-    static from<T extends Resource = Resource>(source: TextureSource, options: IBaseTextureOptions = {},
+    static from<T extends Resource = Resource, U = any>(source: TextureSource, options: IBaseTextureOptions<U> = {},
         strict = settings.STRICT_TEXTURE_CACHE): Texture<T>
     {
         const isFrame = typeof source === 'string';
@@ -408,10 +408,11 @@ export class Texture<T extends Resource = Resource> extends EventEmitter
      * @param {object} [options] - Optional options to include
      * @return {Promise<PIXI.Texture>} A Promise that resolves to a Texture.
      */
-    static fromURL(url: string, options?: IBaseTextureOptions): Promise<Texture<ImageResource>>
+    static fromURL<T extends Resource = Resource, U = any>(
+        url: string, options?: IBaseTextureOptions<U>): Promise<Texture<T>>
     {
         const resourceOptions = Object.assign({ autoLoad: false }, options?.resourceOptions);
-        const texture = Texture.from<ImageResource>(url, Object.assign({ resourceOptions }, options), false);
+        const texture = Texture.from<T>(url, Object.assign({ resourceOptions }, options), false);
         const resource = texture.baseTexture.resource;
 
         // The texture was already loaded
@@ -436,7 +437,7 @@ export class Texture<T extends Resource = Resource> extends EventEmitter
      * @return {PIXI.Texture} The resulting new BaseTexture
      */
     static fromBuffer(buffer: Float32Array|Uint8Array,
-        width: number, height: number, options?: IBaseTextureOptions): Texture<BufferResource>
+        width: number, height: number, options?: IBaseTextureOptions<ISize>): Texture<BufferResource>
     {
         return new Texture(BaseTexture.fromBuffer(buffer, width, height, options));
     }

--- a/packages/core/src/textures/resources/autoDetectResource.ts
+++ b/packages/core/src/textures/resources/autoDetectResource.ts
@@ -1,10 +1,10 @@
 import { Resource } from './Resource';
 
 import type { IImageResourceOptions } from './ImageResource';
-import type{ ISize } from '@pixi/math';
-import type{ ICubeResourceOptions } from './CubeResource';
-import type{ ISVGResourceOptions } from './SVGResource';
-import type{ IVideoResourceOptions } from './VideoResource';
+import type { ISize } from '@pixi/math';
+import type { ICubeResourceOptions } from './CubeResource';
+import type { ISVGResourceOptions } from './SVGResource';
+import type { IVideoResourceOptions } from './VideoResource';
 
 /*
  * Allow flexible options for resource plugins
@@ -26,10 +26,10 @@ export type IAutoDetectOptions = ISize
  *
  * @memberof PIXI
  */
-export interface IResourcePlugin
+export interface IResourcePlugin<T, U>
 {
     test(source: unknown, extension: string): boolean;
-    new (source: any, options?: any): Resource;
+    new (source: any, options?: U): T;
 }
 
 /**
@@ -58,7 +58,7 @@ export interface IResourcePlugin
  * @static
  * @readonly
  */
-export const INSTALLED: Array<IResourcePlugin> = [];
+export const INSTALLED: Array<IResourcePlugin<any, any>> = [];
 
 /**
  * Create a resource element from a single source element. This
@@ -90,7 +90,7 @@ export const INSTALLED: Array<IResourcePlugin> = [];
  *        texture should be updated from the video. Leave at 0 to update at every render
  * @return {PIXI.Resource} The created resource.
  */
-export function autoDetectResource(source: unknown, options?: IAutoDetectOptions): Resource
+export function autoDetectResource<T extends Resource, U>(source: unknown, options?: U): T
 {
     if (!source)
     {
@@ -112,7 +112,7 @@ export function autoDetectResource(source: unknown, options?: IAutoDetectOptions
 
     for (let i = INSTALLED.length - 1; i >= 0; --i)
     {
-        const ResourcePlugin = INSTALLED[i];
+        const ResourcePlugin = INSTALLED[i] as IResourcePlugin<T, U>;
 
         if (ResourcePlugin.test && ResourcePlugin.test(source, extension))
         {

--- a/packages/core/src/textures/resources/autoDetectResource.ts
+++ b/packages/core/src/textures/resources/autoDetectResource.ts
@@ -26,10 +26,10 @@ export type IAutoDetectOptions = ISize
  *
  * @memberof PIXI
  */
-export interface IResourcePlugin<T, U>
+export interface IResourcePlugin<R, RO>
 {
     test(source: unknown, extension: string): boolean;
-    new (source: any, options?: U): T;
+    new (source: any, options?: RO): R;
 }
 
 /**
@@ -90,7 +90,7 @@ export const INSTALLED: Array<IResourcePlugin<any, any>> = [];
  *        texture should be updated from the video. Leave at 0 to update at every render
  * @return {PIXI.Resource} The created resource.
  */
-export function autoDetectResource<T extends Resource, U>(source: unknown, options?: U): T
+export function autoDetectResource<R extends Resource, RO>(source: unknown, options?: RO): R
 {
     if (!source)
     {
@@ -112,7 +112,7 @@ export function autoDetectResource<T extends Resource, U>(source: unknown, optio
 
     for (let i = INSTALLED.length - 1; i >= 0; --i)
     {
-        const ResourcePlugin = INSTALLED[i] as IResourcePlugin<T, U>;
+        const ResourcePlugin = INSTALLED[i] as IResourcePlugin<R, RO>;
 
         if (ResourcePlugin.test && ResourcePlugin.test(source, extension))
         {

--- a/packages/mesh-extras/src/SimpleMesh.ts
+++ b/packages/mesh-extras/src/SimpleMesh.ts
@@ -24,7 +24,7 @@ export class SimpleMesh extends Mesh
      * @param {number} [drawMode] - the drawMode, can be any of the Mesh.DRAW_MODES consts
      */
     constructor(
-        texture = Texture.EMPTY,
+        texture: Texture = Texture.EMPTY,
         vertices?: IArrayBuffer,
         uvs?: IArrayBuffer,
         indices?: IArrayBuffer,


### PR DESCRIPTION
This adds an opt-in stricter type for Texture and BaseTexture using Generics.

Here are some uses cases:


### Better Return Values Using `from`
```js
// current
const texture = Texture.from('path/to/image.png');
const url = (texture.baseTexture.resource as ImageResource).url;

// new!
const texture = Texture.from<ImageResource>('path/to/image.png');
const url = texture.baseTexture.resource.url;
```

### More Casting Flexibility
```js
// current
const url = (sprite.texture.baseTexture.resource as ImageResource).url;

// new!
const texture = sprite.texture as Texture<ImageResource>;
const url = texture.baseTexture.resource.url;
```

### Stricter Resource Option Types

```js
// current
const base = BaseTexture.from("path/to/image.svg", {
  resourceOptions: { anything: 'goes' } // <-- NO TYPE CHECKING HERE
});

// new!
const base = BaseTexture.from<SVGResource, ISVGResourceOptions>("path/to/image.svg", {
  resourceOptions: { } // <-- ONLY VALID ISVGResourceOptions
});
```