### PR TITLE
Fixed Parent type for Container

### DIFF
--- a/packages/display/src/Container.ts
+++ b/packages/display/src/Container.ts
@@ -60,6 +60,7 @@ export class Container extends DisplayObject
     public readonly children: DisplayObject[];
     public sortableChildren: boolean;
     public sortDirty: boolean;
+    public parent: Container;
     public containerUpdateTransform: () => void;
 
     protected _width: number;


### PR DESCRIPTION
pixi.js@6.0.0-rc.2

TypeScript:
```ts
class A extends PIXI.Container {
  constructor() {
    super()
    // There is no `addChild` method because it is `DisplayObject`
    this.parent.addChild
  }
}
```