### PR TITLE
Remove utils dependency to Node types

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -34,7 +34,6 @@
     "url": "^0.11.0"
   },
   "devDependencies": {
-    "@types/node": "^12.0.0",
     "css-color-names": "^1.0.1"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -29,12 +29,12 @@
     "@pixi/constants": "6.0.0",
     "@pixi/settings": "6.0.0",
     "@types/earcut": "^2.1.0",
-    "@types/node": "^12.0.0",
     "earcut": "^2.2.2",
     "eventemitter3": "^3.1.0",
     "url": "^0.11.0"
   },
   "devDependencies": {
+    "@types/node": "^12.0.0",
     "css-color-names": "^1.0.1"
   }
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -74,7 +74,7 @@ export { EventEmitter };
  */
 export { default as earcut } from 'earcut';
 
-import { parse, format, resolve } from 'url';
+import { parse, format, resolve } from './url';
 
 /**
  * Node.js compatible URL utilities.

--- a/packages/utils/src/network/determineCrossOrigin.ts
+++ b/packages/utils/src/network/determineCrossOrigin.ts
@@ -1,4 +1,4 @@
-import * as _url from 'url';
+import * as _url from '../url';
 
 let tempAnchor: HTMLAnchorElement|undefined;
 

--- a/packages/utils/src/url.ts
+++ b/packages/utils/src/url.ts
@@ -1,0 +1,76 @@
+/**
+ * This file contains redeclared types for Node `url` and `querystring` modules. These modules
+ * don't provide their own typings but instead are a part of the full Node typings. The purpose of
+ * this file is to redeclare the required types to avoid having the whole Node types as a
+ * dependency.
+ */
+
+import { parse as _parse, format as _format, resolve as _resolve } from 'url';
+
+export interface ParsedUrlQuery {
+    [key: string]: string | string[];
+}
+
+export interface ParsedUrlQueryInput {
+    [key: string]: unknown;
+}
+
+export interface UrlObjectCommon {
+    auth?: string;
+    hash?: string;
+    host?: string;
+    hostname?: string;
+    href?: string;
+    path?: string;
+    pathname?: string;
+    protocol?: string;
+    search?: string;
+    slashes?: boolean;
+}
+
+// Input to `url.format`
+export interface UrlObject extends UrlObjectCommon {
+    port?: string | number;
+    query?: string | null | ParsedUrlQueryInput;
+}
+
+// Output of `url.parse`
+export interface Url extends UrlObjectCommon {
+    port?: string;
+    query?: string | null | ParsedUrlQuery;
+}
+
+export interface UrlWithParsedQuery extends Url {
+    query: ParsedUrlQuery;
+}
+
+export interface UrlWithStringQuery extends Url {
+    query: string | null;
+}
+
+export interface URLFormatOptions {
+    auth?: boolean;
+    fragment?: boolean;
+    search?: boolean;
+    unicode?: boolean;
+}
+
+export type ParseFunction = {
+    (urlStr: string): UrlWithStringQuery;
+    (urlStr: string, parseQueryString: false | undefined, slashesDenoteHost?: boolean): UrlWithStringQuery;
+    (urlStr: string, parseQueryString: true, slashesDenoteHost?: boolean): UrlWithParsedQuery;
+    (urlStr: string, parseQueryString: boolean, slashesDenoteHost?: boolean): Url;
+};
+
+export type FormatFunction = {
+    (URL: URL, options?: URLFormatOptions): string;
+    (urlObject: UrlObject | string): string;
+};
+
+export type ResolveFunction = {
+    (from: string, to: string): string;
+};
+
+export const parse: ParseFunction = _parse;
+export const format: FormatFunction = _format;
+export const resolve: ResolveFunction = _resolve;


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
Moved the `utils` Node types dependency to a dev dependency. Had to redeclare types for Node `url` and `querystring` packages for the `utils.url` export.

Fixes #7283

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
