### PR TITLE
Workaround webdoc parsing crash

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,8 @@
 {
   "extends": [
     "@pixi/eslint-config"
-  ]
+  ],
+  "rules": {
+    "@typescript-eslint/no-parameter-properties": 1
+  }
 }

--- a/packages/core/src/batch/BatchSystem.ts
+++ b/packages/core/src/batch/BatchSystem.ts
@@ -15,12 +15,15 @@ export class BatchSystem implements ISystem
 {
     public readonly emptyRenderer: ObjectRenderer;
     public currentRenderer: ObjectRenderer;
+    private renderer: Renderer;
 
     /**
      * @param {PIXI.Renderer} renderer - The renderer this System works for.
      */
-    constructor(private renderer: Renderer)
+    constructor(renderer: Renderer)
     {
+        this.renderer = renderer;
+
         /**
          * An empty renderer.
          *

--- a/packages/core/src/context/ContextSystem.ts
+++ b/packages/core/src/context/ContextSystem.ts
@@ -28,12 +28,15 @@ export class ContextSystem implements ISystem
     protected gl: IRenderingContext;
 
     public extensions: WebGLExtensions;
+    private renderer: Renderer;
 
     /**
      * @param {PIXI.Renderer} renderer - The renderer this System works for.
      */
-    constructor(private renderer: Renderer)
+    constructor(renderer: Renderer)
     {
+        this.renderer = renderer;
+
         /**
          * Either 1 or 2 to reflect the WebGL version being used
          * @member {number}

--- a/packages/core/src/filters/FilterSystem.ts
+++ b/packages/core/src/filters/FilterSystem.ts
@@ -56,12 +56,15 @@ export class FilterSystem implements ISystem
     protected activeState: FilterState;
     protected globalUniforms: UniformGroup;
     private tempRect: Rectangle;
+    public renderer: Renderer;
 
     /**
      * @param {PIXI.Renderer} renderer - The renderer this System works for.
      */
-    constructor(public renderer: Renderer)
+    constructor(renderer: Renderer)
     {
+        this.renderer = renderer;
+
         /**
          * List of filters for the FilterSystem
          * @member {Object[]}

--- a/packages/core/src/framebuffer/FramebufferSystem.ts
+++ b/packages/core/src/framebuffer/FramebufferSystem.ts
@@ -28,12 +28,15 @@ export class FramebufferSystem implements ISystem
     protected gl: IRenderingContext;
     protected unknownFramebuffer: Framebuffer;
     protected msaaSamples: Array<number>;
+    public renderer: Renderer;
 
     /**
      * @param {PIXI.Renderer} renderer - The renderer this System works for.
      */
-    constructor(public renderer: Renderer)
+    constructor(renderer: Renderer)
     {
+        this.renderer = renderer;
+
         /**
          * A list of managed framebuffers
          * @member {PIXI.Framebuffer[]}

--- a/packages/core/src/geometry/GeometrySystem.ts
+++ b/packages/core/src/geometry/GeometrySystem.ts
@@ -33,12 +33,14 @@ export class GeometrySystem implements ISystem
     protected _boundBuffer: GLBuffer;
     readonly managedGeometries: {[key: number]: Geometry};
     readonly managedBuffers: {[key: number]: Buffer};
+    private renderer: Renderer;
 
     /**
      * @param {PIXI.Renderer} renderer - The renderer this System works for.
      */
-    constructor(private renderer: Renderer)
+    constructor(renderer: Renderer)
     {
+        this.renderer = renderer;
         this._activeGeometry = null;
         this._activeVao = null;
 

--- a/packages/core/src/mask/AbstractMaskSystem.ts
+++ b/packages/core/src/mask/AbstractMaskSystem.ts
@@ -13,11 +13,15 @@ export class AbstractMaskSystem implements ISystem
 {
     protected maskStack: Array<MaskData>;
     protected glConst: number;
+    protected renderer: Renderer;
+
     /**
      * @param {PIXI.Renderer} renderer - The renderer this System works for.
      */
-    constructor(protected renderer: Renderer)
+    constructor(renderer: Renderer)
     {
+        this.renderer = renderer;
+
         /**
          * The mask stack
          * @member {PIXI.MaskData[]}

--- a/packages/core/src/mask/MaskSystem.ts
+++ b/packages/core/src/mask/MaskSystem.ts
@@ -39,12 +39,15 @@ export class MaskSystem implements ISystem
     protected alphaMaskIndex: number;
     private readonly maskDataPool: Array<MaskData>;
     private maskStack: Array<MaskData>;
+    private renderer: Renderer;
 
     /**
      * @param {PIXI.Renderer} renderer - The renderer this System works for.
      */
-    constructor(private renderer: Renderer)
+    constructor(renderer: Renderer)
     {
+        this.renderer = renderer;
+
         /**
          * Enable scissor masking.
          *

--- a/packages/core/src/projection/ProjectionSystem.ts
+++ b/packages/core/src/projection/ProjectionSystem.ts
@@ -21,12 +21,15 @@ export class ProjectionSystem implements ISystem
     public defaultFrame: Rectangle;
     public projectionMatrix: Matrix;
     public transform: Matrix;
+    private renderer: Renderer;
 
     /**
      * @param {PIXI.Renderer} renderer - The renderer this System works for.
      */
-    constructor(private renderer: Renderer)
+    constructor(renderer: Renderer)
     {
+        this.renderer = renderer;
+
         /**
          * The destination frame used to calculate the current projection matrix.
          *

--- a/packages/core/src/renderTexture/RenderTextureSystem.ts
+++ b/packages/core/src/renderTexture/RenderTextureSystem.ts
@@ -45,12 +45,15 @@ export class RenderTextureSystem implements ISystem
     public readonly sourceFrame: Rectangle;
     public readonly destinationFrame: Rectangle;
     public readonly viewportFrame: Rectangle;
+    private renderer: Renderer;
 
     /**
      * @param {PIXI.Renderer} renderer - The renderer this System works for.
      */
-    constructor(private renderer: Renderer)
+    constructor(renderer: Renderer)
     {
+        this.renderer = renderer;
+
         /**
          * The clear background color as rgba
          * @member {number[]}

--- a/packages/core/src/shader/ShaderSystem.ts
+++ b/packages/core/src/shader/ShaderSystem.ts
@@ -30,11 +30,15 @@ export class ShaderSystem implements ISystem
     public id: number;
     public destroyed = false;
     private cache: Dict<UniformsSyncCallback>;
+    private renderer: Renderer;
+
     /**
      * @param {PIXI.Renderer} renderer - The renderer this System works for.
      */
-    constructor(private renderer: Renderer)
+    constructor(renderer: Renderer)
     {
+        this.renderer = renderer;
+
         // Validation check that this environment support `new Function`
         this.systemCheck();
 

--- a/packages/core/src/state/StateSystem.ts
+++ b/packages/core/src/state/StateSystem.ts
@@ -30,9 +30,6 @@ export class StateSystem implements ISystem
     protected readonly map: Array<(value: boolean) => void>;
     protected readonly checks: Array<(system: this, state: State) => void>;
     protected defaultState: State;
-    /**
-     * @param {PIXI.Renderer} renderer - The renderer this System works for.
-     */
     constructor()
     {
         /**

--- a/packages/core/src/textures/TextureGCSystem.ts
+++ b/packages/core/src/textures/TextureGCSystem.ts
@@ -26,11 +26,15 @@ export class TextureGCSystem implements ISystem
     public maxIdle: number;
     public checkCountMax: number;
     public mode: number;
+    private renderer: Renderer;
+
     /**
      * @param {PIXI.Renderer} renderer - The renderer this System works for.
      */
-    constructor(private renderer: Renderer)
+    constructor(renderer: Renderer)
     {
+        this.renderer = renderer;
+
         /**
          * Count
          * @member {number}

--- a/packages/core/src/textures/TextureSystem.ts
+++ b/packages/core/src/textures/TextureSystem.ts
@@ -26,12 +26,15 @@ export class TextureSystem implements ISystem
     protected _unknownBoundTextures: boolean;
     currentLocation: number;
     emptyTextures: {[key: number]: GLTexture};
+    private renderer: Renderer;
 
     /**
      * @param {PIXI.Renderer} renderer - The renderer this System works for.
      */
-    constructor(private renderer: Renderer)
+    constructor(renderer: Renderer)
     {
+        this.renderer = renderer;
+
         // TODO set to max textures...
         /**
          * Bound textures


### PR DESCRIPTION
Fixes #7276 

Unfortunately, parameter properties aren't quite ready for Webdoc [related](https://github.com/webdoc-labs/webdoc/issues/98). This is an easier to fix to unblock the current broken docs.