### PR TITLE
Remove spritesheet dependency from loader, fix resources type

### DIFF
--- a/packages/loaders/src/Loader.ts
+++ b/packages/loaders/src/Loader.ts
@@ -2,6 +2,7 @@ import { Loader as ResourceLoader, middleware } from 'resource-loader';
 import { TextureLoader } from './TextureLoader';
 
 import type { Resource } from 'resource-loader';
+import type { ILoaderResource } from './LoaderResource';
 
 /**
  * The new loader, extends Resource Loader by Chad Engler: https://github.com/englercj/resource-loader
@@ -65,6 +66,9 @@ export class Loader extends ResourceLoader
     private static _plugins: Array<ILoaderPlugin> = [];
     private static _shared: Loader;
     private _protected: boolean;
+
+    /** All the resources for this loader by name. */
+    public readonly resources: {[name: string]: ILoaderResource};
 
     /**
      * @param {string} [baseUrl=''] - The base url for all resources loaded by this loader.

--- a/packages/loaders/src/LoaderResource.ts
+++ b/packages/loaders/src/LoaderResource.ts
@@ -1,21 +1,39 @@
 import { Resource } from 'resource-loader';
 
-import type { Spritesheet } from '@pixi/spritesheet';
 import type { IBaseTextureOptions, Texture } from '@pixi/core';
-import type { Dict } from '@pixi/utils';
 
+/**
+ * Resource metadata, can be used to pass BaseTexture options.
+ * @memberof PIXI
+ * @extends PIXI.IBaseTextureOptions
+ */
 export interface IResourceMetadata extends GlobalMixins.IResourceMetadata, Resource.IMetadata, IBaseTextureOptions {
-    imageMetadata?: any;
+    /**
+     * Used by BitmapFonts, Spritesheet and CompressedTextures as the options to used for
+     * metadata when loading the child image.
+     * @type {object}
+     */
+    imageMetadata?: IResourceMetadata;
 }
+
+/**
+ * PixiJS' base Loader resource type. This is a superset of the resource-loader's Resource class
+ * and contains any mixins for extending.
+ * @memberof PIXI
+ * @extends resource-loader.Resource
+ */
 export interface ILoaderResource extends GlobalMixins.ILoaderResource, Resource
 {
+    /**
+     * Texture reference for loading images and other textures.
+     * @type {PIXI.Texture}
+     */
     texture?: Texture;
-    spritesheet?: Spritesheet;
 
-    // required for Spritesheet
-    textures?: Dict<Texture>;
-
-    // required specific type for Spritesheet
+    /**
+     * Data that can be added for loading resources.
+     * @type {IResourceMetadata}
+     */
     metadata: IResourceMetadata;
 }
 

--- a/packages/loaders/src/LoaderResource.ts
+++ b/packages/loaders/src/LoaderResource.ts
@@ -11,7 +11,7 @@ export interface IResourceMetadata extends GlobalMixins.IResourceMetadata, Resou
     /**
      * Used by BitmapFonts, Spritesheet and CompressedTextures as the options to used for
      * metadata when loading the child image.
-     * @type {object}
+     * @type {PIXI.IResourceMetadata}
      */
     imageMetadata?: IResourceMetadata;
 }
@@ -32,7 +32,7 @@ export interface ILoaderResource extends GlobalMixins.ILoaderResource, Resource
 
     /**
      * Data that can be added for loading resources.
-     * @type {IResourceMetadata}
+     * @type {PIXI.IResourceMetadata}
      */
     metadata: IResourceMetadata;
 }

--- a/packages/spritesheet/global.d.ts
+++ b/packages/spritesheet/global.d.ts
@@ -1,0 +1,11 @@
+declare namespace GlobalMixins
+{
+    interface ILoaderResource
+    {
+        /** Reference to Spritesheet object created. */
+        spritesheet?: import('@pixi/spritesheet').Spritesheet;
+
+        /** Dictionary of textures from Spritesheet. */
+        textures?: {[name: string]: Texture};
+    }
+}

--- a/packages/spritesheet/src/Spritesheet.ts
+++ b/packages/spritesheet/src/Spritesheet.ts
@@ -387,3 +387,17 @@ export class Spritesheet
         this.baseTexture = null;
     }
 }
+
+/**
+ * Reference to Spritesheet object created.
+ * @member {PIXI.Spritesheet} spritesheet
+ * @memberof PIXI.ILoaderResource
+ * @instance
+ */
+
+/**
+ * Dictionary of textures from Spritesheet.
+ * @member {object<string, PIXI.Texture>} textures
+ * @memberof PIXI.ILoaderResource
+ * @instance
+ */


### PR DESCRIPTION
Replaces #7295

* Remove the `@pixi/spritesheet` dependency from `@pixi/loaders`
* Fix the `resources` type for Loader to be more strict (e.g., contains `texture`) credit: @AdrienLemaire
* Added some additional documentation for Loader interfaces