### PR TITLE
Remove deprecation warnings in tests

### DIFF
--- a/packages/mesh-extras/test/SimplePlane.js
+++ b/packages/mesh-extras/test/SimplePlane.js
@@ -37,7 +37,7 @@ describe('PIXI.SimplePlane', function ()
         it('should return true when point inside', function ()
         {
             const point = new Point(10, 10);
-            const texture = new RenderTexture.create(20, 30);
+            const texture = new RenderTexture.create({ width: 20, height: 30 });
             const plane = new SimplePlane(texture, 100, 100);
 
             expect(plane.containsPoint(point)).to.be.true;
@@ -46,7 +46,7 @@ describe('PIXI.SimplePlane', function ()
         it('should return false when point outside', function ()
         {
             const point = new Point(100, 100);
-            const texture = new RenderTexture.create(20, 30);
+            const texture = new RenderTexture.create({ width: 20, height: 30 });
             const plane = new SimplePlane(texture, 100, 100);
 
             expect(plane.containsPoint(point)).to.be.false;

--- a/packages/sprite/test/Sprite.js
+++ b/packages/sprite/test/Sprite.js
@@ -72,7 +72,7 @@ describe('PIXI.Sprite', function ()
         it('must have correct value according to texture size, width, height and anchor', function ()
         {
             const parent = new Container();
-            const texture = new RenderTexture.create(20, 30);
+            const texture = new RenderTexture.create({ width: 20, height: 30 });
             const sprite = new Sprite(texture);
 
             sprite.width = 200;
@@ -98,7 +98,7 @@ describe('PIXI.Sprite', function ()
     {
         it('must have correct value according to texture size, width, height and anchor', function ()
         {
-            const texture = new RenderTexture.create(20, 30);
+            const texture = new RenderTexture.create({ width: 20, height: 30 });
             const sprite = new Sprite(texture);
 
             sprite.anchor.set(0.5, 0.5);
@@ -114,7 +114,7 @@ describe('PIXI.Sprite', function ()
 
     describe('containsPoint', function ()
     {
-        const texture = new RenderTexture.create(20, 30);
+        const texture = new RenderTexture.create({ width: 20, height: 30 });
         const sprite = new Sprite(texture);
 
         it('should return true when point inside', function ()


### PR DESCRIPTION
This tests are using the old deprecated syntax for RenderTexture.create. Updated tests to use the new API.