### PR TITLE
Support running GitHub Actions on Forks and other workflow cleanup (take 2)

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,19 +12,17 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [ 12.x ]
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 12.x
     - name: Install Dependencies
       run: npm ci
     - name: Install Code Coverage Dependency
+      if: ${{ env.CODECOV_TOKEN }}
       run: npm install codecov -g
     - name: Run Unit Tests
       uses: GabrielBB/xvfb-action@v1.0
@@ -34,6 +32,7 @@ jobs:
         NODE_ENV: production
 
     - name: Report Code Coverage
+      if: ${{ env.CODECOV_TOKEN }}
       run: codecov
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -58,7 +57,7 @@ jobs:
     # 3) branch A pushed directly to git
     - name: Deploy Non-Tag Branches
       uses: jakejarvis/s3-sync-action@master
-      if: github.event_name == 'push' && matrix.node-version == '12.x' && !contains(github.ref, 'refs/tags')
+      if: github.event_name == 'push' && !contains(github.ref, 'refs/tags') && ${{ env.AWS_ACCESS_KEY_ID }}
       with:
         args: --acl public-read --follow-symlinks --delete --cache-control "max-age=60"
       env:
@@ -72,7 +71,7 @@ jobs:
     # Release is published and deployed into s3://bucket-name/v5.22/
     - name: Deploy Released Branches
       uses: jakejarvis/s3-sync-action@master
-      if: (github.event_name == 'release' || contains(github.ref, 'refs/tags')) && matrix.node-version == '12.x'
+      if: (github.event_name == 'release' || contains(github.ref, 'refs/tags')) && ${{ env.AWS_ACCESS_KEY_ID }}
       with:
         args: --acl public-read --follow-symlinks --delete --cache-control "max-age=2592000"
       env:
@@ -86,7 +85,7 @@ jobs:
     # Same release from previous deployed into s3://bucket-name/release/
     - name: Deploy Latest Release
       uses: jakejarvis/s3-sync-action@master
-      if: (github.event_name == 'release' || contains(github.ref, 'refs/tags')) && matrix.node-version == '12.x'
+      if: (github.event_name == 'release' || contains(github.ref, 'refs/tags')) && ${{ env.AWS_ACCESS_KEY_ID }}
       with:
         args: --acl public-read --follow-symlinks --delete --cache-control "max-age=1209600"
       env:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-      AWS_REGION: 'eu-west-1'
+      AWS_REGION: ${{ secrets.AWS_REGION }}
       SOURCE_DIR: 'dist'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install Dependencies
       run: npm ci
     - name: Install Code Coverage Dependency
-      if: env.CODECOV_TOKEN != null
+      if: ${{ env.CODECOV_TOKEN }}
       run: npm install codecov -g
     - name: Run Unit Tests
       uses: GabrielBB/xvfb-action@v1.0
@@ -39,7 +39,7 @@ jobs:
         NODE_ENV: production
 
     - name: Report Code Coverage
-      if: env.CODECOV_TOKEN != null
+      if: ${{ env.CODECOV_TOKEN }}
       run: codecov
 
     # All the below are deploy-related steps
@@ -62,7 +62,7 @@ jobs:
     # 3) branch A pushed directly to git
     - name: Deploy Non-Tag Branches
       uses: jakejarvis/s3-sync-action@master
-      if: github.event_name == 'push' && !contains(github.ref, 'refs/tags') && env.AWS_ACCESS_KEY_ID != null
+      if: github.event_name == 'push' && !contains(github.ref, 'refs/tags') && ${{ env.AWS_ACCESS_KEY_ID }}
       with:
         args: --acl public-read --follow-symlinks --delete --cache-control "max-age=60"
       env:
@@ -71,7 +71,7 @@ jobs:
     # Release is published and deployed into s3://bucket-name/v5.22/
     - name: Deploy Released Branches
       uses: jakejarvis/s3-sync-action@master
-      if: (github.event_name == 'release' || contains(github.ref, 'refs/tags')) && env.AWS_ACCESS_KEY_ID != null
+      if: (github.event_name == 'release' || contains(github.ref, 'refs/tags')) && ${{ env.AWS_ACCESS_KEY_ID }}
       with:
         args: --acl public-read --follow-symlinks --delete --cache-control "max-age=2592000"
       env:
@@ -80,7 +80,7 @@ jobs:
     # Same release from previous deployed into s3://bucket-name/release/
     - name: Deploy Latest Release
       uses: jakejarvis/s3-sync-action@master
-      if: (github.event_name == 'release' || contains(github.ref, 'refs/tags')) && env.AWS_ACCESS_KEY_ID != null
+      if: (github.event_name == 'release' || contains(github.ref, 'refs/tags')) && ${{ env.AWS_ACCESS_KEY_ID }}
       with:
         args: --acl public-read --follow-symlinks --delete --cache-control "max-age=1209600"
       env:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,6 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+
     - name: Checkout
       uses: actions/checkout@v2
     - name: Use Node.js

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,9 +16,10 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+      AWS_REGION: 'eu-west-1'
+      SOURCE_DIR: 'dist'
     runs-on: ubuntu-latest
     steps:
-
     - name: Checkout
       uses: actions/checkout@v2
     - name: Use Node.js
@@ -65,8 +66,6 @@ jobs:
       with:
         args: --acl public-read --follow-symlinks --delete --cache-control "max-age=60"
       env:
-        AWS_REGION: 'eu-west-1'
-        SOURCE_DIR: 'dist'
         DEST_DIR: ${{ steps.branch_name.outputs.BRANCH_NAME }}
 
     # Release is published and deployed into s3://bucket-name/v5.22/
@@ -76,8 +75,6 @@ jobs:
       with:
         args: --acl public-read --follow-symlinks --delete --cache-control "max-age=2592000"
       env:
-        AWS_REGION: 'eu-west-1'
-        SOURCE_DIR: 'dist'
         DEST_DIR: ${{ steps.tag_name.outputs.TAG_NAME }}
 
     # Same release from previous deployed into s3://bucket-name/release/
@@ -87,6 +84,4 @@ jobs:
       with:
         args: --acl public-read --follow-symlinks --delete --cache-control "max-age=1209600"
       env:
-        AWS_REGION: 'eu-west-1'
-        SOURCE_DIR: 'dist'
         DEST_DIR: 'release'

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,6 +11,11 @@ on:
 
 jobs:
   build:
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
     runs-on: ubuntu-latest
     steps:
 
@@ -23,7 +28,7 @@ jobs:
     - name: Install Dependencies
       run: npm ci
     - name: Install Code Coverage Dependency
-      if: ${{ secrets.CODECOV_TOKEN }}
+      if: env.CODECOV_TOKEN != null
       run: npm install codecov -g
     - name: Run Unit Tests
       uses: GabrielBB/xvfb-action@v1.0
@@ -33,10 +38,8 @@ jobs:
         NODE_ENV: production
 
     - name: Report Code Coverage
-      if: ${{ secrets.CODECOV_TOKEN }}
+      if: env.CODECOV_TOKEN != null
       run: codecov
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     # All the below are deploy-related steps
     - name: Extract Branch Name
@@ -58,13 +61,10 @@ jobs:
     # 3) branch A pushed directly to git
     - name: Deploy Non-Tag Branches
       uses: jakejarvis/s3-sync-action@master
-      if: github.event_name == 'push' && !contains(github.ref, 'refs/tags') && ${{ secrets.AWS_ACCESS_KEY_ID }}
+      if: github.event_name == 'push' && !contains(github.ref, 'refs/tags') && env.AWS_ACCESS_KEY_ID != null
       with:
         args: --acl public-read --follow-symlinks --delete --cache-control "max-age=60"
       env:
-        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET || 'pixi.js' }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_REGION: 'eu-west-1'
         SOURCE_DIR: 'dist'
         DEST_DIR: ${{ steps.branch_name.outputs.BRANCH_NAME }}
@@ -72,13 +72,10 @@ jobs:
     # Release is published and deployed into s3://bucket-name/v5.22/
     - name: Deploy Released Branches
       uses: jakejarvis/s3-sync-action@master
-      if: (github.event_name == 'release' || contains(github.ref, 'refs/tags')) && ${{ secrets.AWS_ACCESS_KEY_ID }}
+      if: (github.event_name == 'release' || contains(github.ref, 'refs/tags')) && env.AWS_ACCESS_KEY_ID != null
       with:
         args: --acl public-read --follow-symlinks --delete --cache-control "max-age=2592000"
       env:
-        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET || 'pixi.js' }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_REGION: 'eu-west-1'
         SOURCE_DIR: 'dist'
         DEST_DIR: ${{ steps.tag_name.outputs.TAG_NAME }}
@@ -86,13 +83,10 @@ jobs:
     # Same release from previous deployed into s3://bucket-name/release/
     - name: Deploy Latest Release
       uses: jakejarvis/s3-sync-action@master
-      if: (github.event_name == 'release' || contains(github.ref, 'refs/tags')) && ${{ secrets.AWS_ACCESS_KEY_ID }}
+      if: (github.event_name == 'release' || contains(github.ref, 'refs/tags')) && env.AWS_ACCESS_KEY_ID != null
       with:
         args: --acl public-read --follow-symlinks --delete --cache-control "max-age=1209600"
       env:
-        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET || 'pixi.js' }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_REGION: 'eu-west-1'
         SOURCE_DIR: 'dist'
         DEST_DIR: 'release'

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install Dependencies
       run: npm ci
     - name: Install Code Coverage Dependency
-      if: ${{ env.CODECOV_TOKEN }}
+      if: ${{ secrets.CODECOV_TOKEN }}
       run: npm install codecov -g
     - name: Run Unit Tests
       uses: GabrielBB/xvfb-action@v1.0
@@ -33,7 +33,7 @@ jobs:
         NODE_ENV: production
 
     - name: Report Code Coverage
-      if: ${{ env.CODECOV_TOKEN }}
+      if: ${{ secrets.CODECOV_TOKEN }}
       run: codecov
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -58,7 +58,7 @@ jobs:
     # 3) branch A pushed directly to git
     - name: Deploy Non-Tag Branches
       uses: jakejarvis/s3-sync-action@master
-      if: github.event_name == 'push' && !contains(github.ref, 'refs/tags') && ${{ env.AWS_ACCESS_KEY_ID }}
+      if: github.event_name == 'push' && !contains(github.ref, 'refs/tags') && ${{ secrets.AWS_ACCESS_KEY_ID }}
       with:
         args: --acl public-read --follow-symlinks --delete --cache-control "max-age=60"
       env:
@@ -72,7 +72,7 @@ jobs:
     # Release is published and deployed into s3://bucket-name/v5.22/
     - name: Deploy Released Branches
       uses: jakejarvis/s3-sync-action@master
-      if: (github.event_name == 'release' || contains(github.ref, 'refs/tags')) && ${{ env.AWS_ACCESS_KEY_ID }}
+      if: (github.event_name == 'release' || contains(github.ref, 'refs/tags')) && ${{ secrets.AWS_ACCESS_KEY_ID }}
       with:
         args: --acl public-read --follow-symlinks --delete --cache-control "max-age=2592000"
       env:
@@ -86,7 +86,7 @@ jobs:
     # Same release from previous deployed into s3://bucket-name/release/
     - name: Deploy Latest Release
       uses: jakejarvis/s3-sync-action@master
-      if: (github.event_name == 'release' || contains(github.ref, 'refs/tags')) && ${{ env.AWS_ACCESS_KEY_ID }}
+      if: (github.event_name == 'release' || contains(github.ref, 'refs/tags')) && ${{ secrets.AWS_ACCESS_KEY_ID }}
       with:
         args: --acl public-read --follow-symlinks --delete --cache-control "max-age=1209600"
       env:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,8 +12,8 @@ on:
 jobs:
   build:
     env:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN || '' }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID || '' }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
@@ -29,7 +29,7 @@ jobs:
     - name: Install Dependencies
       run: npm ci
     - name: Install Code Coverage Dependency
-      if: ${{ env.CODECOV_TOKEN }}
+      if: env.CODECOV_TOKEN != ''
       run: npm install codecov -g
     - name: Run Unit Tests
       uses: GabrielBB/xvfb-action@v1.0
@@ -39,7 +39,7 @@ jobs:
         NODE_ENV: production
 
     - name: Report Code Coverage
-      if: ${{ env.CODECOV_TOKEN }}
+      if: env.CODECOV_TOKEN != ''
       run: codecov
 
     # All the below are deploy-related steps
@@ -62,7 +62,7 @@ jobs:
     # 3) branch A pushed directly to git
     - name: Deploy Non-Tag Branches
       uses: jakejarvis/s3-sync-action@master
-      if: github.event_name == 'push' && !contains(github.ref, 'refs/tags') && ${{ env.AWS_ACCESS_KEY_ID }}
+      if: github.event_name == 'push' && !contains(github.ref, 'refs/tags') && env.AWS_ACCESS_KEY_ID != ''
       with:
         args: --acl public-read --follow-symlinks --delete --cache-control "max-age=60"
       env:
@@ -71,7 +71,7 @@ jobs:
     # Release is published and deployed into s3://bucket-name/v5.22/
     - name: Deploy Released Branches
       uses: jakejarvis/s3-sync-action@master
-      if: (github.event_name == 'release' || contains(github.ref, 'refs/tags')) && ${{ env.AWS_ACCESS_KEY_ID }}
+      if: (github.event_name == 'release' || contains(github.ref, 'refs/tags')) && env.AWS_ACCESS_KEY_ID != ''
       with:
         args: --acl public-read --follow-symlinks --delete --cache-control "max-age=2592000"
       env:
@@ -80,7 +80,7 @@ jobs:
     # Same release from previous deployed into s3://bucket-name/release/
     - name: Deploy Latest Release
       uses: jakejarvis/s3-sync-action@master
-      if: (github.event_name == 'release' || contains(github.ref, 'refs/tags')) && ${{ env.AWS_ACCESS_KEY_ID }}
+      if: (github.event_name == 'release' || contains(github.ref, 'refs/tags')) && env.AWS_ACCESS_KEY_ID != ''
       with:
         args: --acl public-read --follow-symlinks --delete --cache-control "max-age=1209600"
       env:


### PR DESCRIPTION
## Overview

Made these changes to the workflow so I could iterate more freely on some of the tooling related to unit-tests and I thought it would be valuable for other users too. 

### Changed

* Allows running GitHub Actions on forks by checking for and excluding steps that require secrets (e.g., codecov, s3 deployment)
* Cleaned up common env variables to be at the top of the workflow
* Externalize AWS_REGION in case someone wants to implement their own deployment on a fork
* Removes Node.js matrix, as we only really need to practically test on a single Node version


### Example

* [Fork Actions](https://github.com/bigtimebuddy/pixi.js/runs/2148901897?check_suite_focus=true) (ignores Codecov & S3)
* [Branch Actions](https://github.com/pixijs/pixi.js/runs/2148997163?check_suite_focus=true) (runs Codecov & S3)