### PR TITLE
feat(DisplayObject): Add `destroyed` event

### DIFF
--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -444,6 +444,13 @@ export abstract class DisplayObject extends EventEmitter
      */
 
     /**
+     * Fired when this DisplayObject is destroyed.
+     *
+     * @instance
+     * @event destroyed
+     */
+
+    /**
      * Recalculates the bounds of the display object.
      */
     abstract calculateBounds(): void;
@@ -738,6 +745,7 @@ export abstract class DisplayObject extends EventEmitter
         {
             this.parent.removeChild(this);
         }
+        this.emit('destroyed');
         this.removeAllListeners();
         this.transform = null;
 

--- a/packages/display/test/DisplayObject.js
+++ b/packages/display/test/DisplayObject.js
@@ -146,7 +146,7 @@ describe('PIXI.DisplayObject', function ()
 
     describe('destroy', function ()
     {
-        it('should trigger removed listeners', function ()
+        it('should trigger removed and destroyed listeners', function ()
         {
             const child = new DisplayObject();
             const container = new Container();
@@ -154,11 +154,22 @@ describe('PIXI.DisplayObject', function ()
             container.addChild(child);
 
             let removedListenerWasCalled = false;
+            let destroyedListenerWasCalled = false;
 
             child.on('removed', () => { removedListenerWasCalled = true; });
+            child.on('destroyed', () => { destroyedListenerWasCalled = true; });
+
+            container.removeChild(child);
+
+            expect(removedListenerWasCalled).to.be.true;
+            expect(destroyedListenerWasCalled).to.be.false;
+
+            removedListenerWasCalled = false;
+            container.addChild(child);
             child.destroy();
 
             expect(removedListenerWasCalled).to.be.true;
+            expect(destroyedListenerWasCalled).to.be.true;
         });
     });
 });

--- a/packages/display/test/DisplayObject.js
+++ b/packages/display/test/DisplayObject.js
@@ -144,32 +144,47 @@ describe('PIXI.DisplayObject', function ()
         });
     });
 
-    describe('destroy', function ()
+    describe('remove', function ()
     {
-        it('should trigger removed and destroyed listeners', function ()
+        it('should trigger removed listeners', function ()
         {
+            const listener = sinon.spy();
             const child = new DisplayObject();
             const container = new Container();
 
+            child.on('removed', listener);
+
             container.addChild(child);
-
-            let removedListenerWasCalled = false;
-            let destroyedListenerWasCalled = false;
-
-            child.on('removed', () => { removedListenerWasCalled = true; });
-            child.on('destroyed', () => { destroyedListenerWasCalled = true; });
-
             container.removeChild(child);
 
-            expect(removedListenerWasCalled).to.be.true;
-            expect(destroyedListenerWasCalled).to.be.false;
+            expect(listener.calledOnce).to.be.true;
 
-            removedListenerWasCalled = false;
             container.addChild(child);
             child.destroy();
 
-            expect(removedListenerWasCalled).to.be.true;
-            expect(destroyedListenerWasCalled).to.be.true;
+            expect(listener.calledTwice).to.be.true;
+        });
+    });
+
+    describe('destroy', function ()
+    {
+        it('should trigger destroyed listeners', function ()
+        {
+            const listener = sinon.spy();
+            const child = new DisplayObject();
+            const container = new Container();
+
+            child.on('destroyed', listener);
+
+            container.addChild(child);
+            container.removeChild(child);
+
+            expect(listener.notCalled).to.be.true;
+
+            container.addChild(child);
+            child.destroy();
+
+            expect(listener.calledOnce).to.be.true;
         });
     });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

Add `destroyed` event to `DisplayObject.destroy()`.
I need it sometimes.
(`removed` event is almost insufficient.)

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
