### PR TITLE
Fix BitmapFont destroying respects external Textures

### DIFF
--- a/packages/text-bitmap/src/BitmapFont.ts
+++ b/packages/text-bitmap/src/BitmapFont.ts
@@ -107,15 +107,15 @@ export class BitmapFont
     public readonly lineHeight: number;
     public readonly chars: Dict<IBitmapFontCharacter>;
     public readonly pageTextures: Dict<Texture>;
-    private _manageTextures: boolean;
+    private _ownsTextures: boolean;
 
     /**
      * @param {PIXI.BitmapFontData} data
      * @param {PIXI.Texture[]|Object.<string, PIXI.Texture>} textures
-     * @param {boolean} manageTextures - Setting to `true` will destroy page textures
+     * @param {boolean} ownsTextures - Setting to `true` will destroy page textures
      *        when the font is uninstalled.
      */
-    constructor(data: BitmapFontData, textures: Texture[]|Dict<Texture>, manageTextures?: boolean)
+    constructor(data: BitmapFontData, textures: Texture[]|Dict<Texture>, ownsTextures?: boolean)
     {
         const [info] = data.info;
         const [common] = data.common;
@@ -123,7 +123,7 @@ export class BitmapFont
         const res = getResolutionOfUrl(page.file);
         const pageTextures: Dict<Texture> = {};
 
-        this._manageTextures = manageTextures;
+        this._ownsTextures = ownsTextures;
 
         /**
          * The name of the font face.
@@ -239,7 +239,7 @@ export class BitmapFont
 
         for (const id in this.pageTextures)
         {
-            if (this._manageTextures)
+            if (this._ownsTextures)
             {
                 this.pageTextures[id].destroy(true);
             }
@@ -269,7 +269,7 @@ export class BitmapFont
     public static install(
         data: string|XMLDocument|BitmapFontData,
         textures: Texture|Texture[]|Dict<Texture>,
-        manageTextures?: boolean
+        ownsTextures?: boolean
     ): BitmapFont
     {
         let fontData;
@@ -296,7 +296,7 @@ export class BitmapFont
             textures = [textures];
         }
 
-        const font = new BitmapFont(fontData, textures, manageTextures);
+        const font = new BitmapFont(fontData, textures, ownsTextures);
 
         BitmapFont.available[font.font] = font;
 

--- a/packages/text-bitmap/src/BitmapFontLoader.ts
+++ b/packages/text-bitmap/src/BitmapFontLoader.ts
@@ -55,7 +55,7 @@ export class BitmapFontLoader
 
             if (Object.keys(textures).length === data.page.length)
             {
-                resource.bitmapFont = BitmapFont.install(data, textures);
+                resource.bitmapFont = BitmapFont.install(data, textures, true);
                 next();
             }
         };

--- a/packages/text-bitmap/test/BitmapFontLoader.js
+++ b/packages/text-bitmap/test/BitmapFontLoader.js
@@ -1,10 +1,11 @@
 const path = require('path');
 const fs = require('fs');
 const { Loader } = require('@pixi/loaders');
-const { BaseTextureCache, TextureCache } = require('@pixi/utils');
+const { BaseTextureCache, TextureCache, destroyTextureCache } = require('@pixi/utils');
 const { Texture, BaseTexture } = require('@pixi/core');
 const { Spritesheet } = require('@pixi/spritesheet');
 const { BitmapFont, BitmapFontLoader } = require('../');
+const { expect } = require('chai');
 
 describe('PIXI.BitmapFontLoader', function ()
 {
@@ -512,6 +513,48 @@ describe('PIXI.BitmapFontLoader', function ()
             expect(loader.resources.image.url).to.equal(imagePath);
             expect(loader.resources.font.url).to.equal(fontPath);
 
+            done();
+        });
+    });
+
+    it('should load and uninstall font cleanly, remove all textures', function (done)
+    {
+        const loader = new Loader();
+        const fontPath = path.join(this.resources, 'font.fnt');
+        const textureCount = Object.keys(TextureCache).length;
+
+        expect(BitmapFont.available.font).to.be.undefined;
+
+        loader.use(BitmapFontLoader.use);
+        loader.add('font', fontPath);
+        loader.load(() =>
+        {
+            expect(BitmapFont.available.font).to.not.be.undefined;
+            BitmapFont.uninstall('font');
+            expect(BitmapFont.available.font).to.be.undefined;
+            expect(Object.keys(TextureCache).length - textureCount).equals(0);
+
+            done();
+        });
+    });
+
+    it('should load and uninstall font cleanly, preserve textures', function (done)
+    {
+        const loader = new Loader();
+        const fontPath = path.join(this.resources, 'font.fnt');
+        const textureCount = Object.keys(TextureCache).length;
+
+        expect(BitmapFont.available.font).to.be.undefined;
+
+        loader.use(BitmapFontLoader.use);
+        loader.add('font', fontPath);
+        loader.load(() =>
+        {
+            expect(BitmapFont.available.font).to.not.be.undefined;
+            BitmapFont.uninstall('font', true);
+            expect(BitmapFont.available.font).to.be.undefined;
+            expect(Object.keys(TextureCache).length - textureCount).equals(1);
+            destroyTextureCache();
             done();
         });
     });

--- a/packages/text-bitmap/test/BitmapFontLoader.js
+++ b/packages/text-bitmap/test/BitmapFontLoader.js
@@ -538,25 +538,20 @@ describe('PIXI.BitmapFontLoader', function ()
         });
     });
 
-    it('should load and uninstall font cleanly, preserve textures', function (done)
+    it('should load and uninstall font cleanly, preserve textures', function ()
     {
-        const loader = new Loader();
-        const fontPath = path.join(this.resources, 'font.fnt');
         const textureCount = Object.keys(TextureCache).length;
+        const texture = Texture.from(this.fontImage);
+        const fontText = BitmapFont.install(this.fontText, texture);
 
-        expect(BitmapFont.available.font).to.be.undefined;
+        expect(BitmapFont.available.fontText).equals(fontText);
 
-        loader.use(BitmapFontLoader.use);
-        loader.add('font', fontPath);
-        loader.load(() =>
-        {
-            expect(BitmapFont.available.font).to.not.be.undefined;
-            BitmapFont.uninstall('font', true);
-            expect(BitmapFont.available.font).to.be.undefined;
-            expect(Object.keys(TextureCache).length - textureCount).equals(1);
-            destroyTextureCache();
-            done();
-        });
+        BitmapFont.uninstall('fontText');
+
+        expect(BitmapFont.available.fontText).to.be.undefined;
+        expect(Object.keys(TextureCache).length - textureCount).equals(1);
+
+        texture.destroy(true);
     });
 
     it('should properly register bitmap font based on text format', function (done)


### PR DESCRIPTION
Fixes #7323

Unchanged behavior: BitmapFont page Textures are automatically destroyed when:
* ... loaded with `BitmapFontLoader`
* ... created with `BitmapFont.from`

New behavior: BitmapFont page Textures are _preserved_ when:
* ... manually created with `BitmapFont.install(fontData, texture)`

This is consistent with how PixiJS respects objects that are passed externally versus generated internally. Another example of this is Graphic and GraphicsGeometry. If passed to the constructor, Graphics will ignore destroying its geometry.