### PR TITLE
Fix wheel events not getting a nativeEvent

### DIFF
--- a/packages/events/src/EventSystem.ts
+++ b/packages/events/src/EventSystem.ts
@@ -597,6 +597,7 @@ export class EventSystem
         event.global.copyFrom(event.screen);
         event.offset.copyFrom(event.screen);
 
+        event.nativeEvent = nativeEvent;
         event.type = nativeEvent.type;
 
         return event;


### PR DESCRIPTION
Small bug I found while I was making [this](https://pixijs.io/examples/#/events/slider.js) example earlier today. 