### PR TITLE
Fix deprecation for System class

### DIFF
--- a/packages/core/src/ISystem.ts
+++ b/packages/core/src/ISystem.ts
@@ -1,7 +1,9 @@
 import type { Renderer } from './Renderer';
+import { deprecation } from '@pixi/utils';
 
 /**
  * Interface for systems used by the {@link PIXI.Renderer}.
+ * @memberof PIXI
  */
 export interface ISystem
 {
@@ -19,4 +21,33 @@ export interface ISystem
 export interface ISystemConstructor<R = Renderer>
 {
     new (renderer: R): ISystem;
+}
+
+/**
+ * Use the ISystem interface instead.
+ * @deprecated since 6.1.0
+ * @memberof PIXI
+ */
+export class System implements ISystem
+{
+    /** Reference to the main renderer */
+    public renderer: Renderer;
+
+    /**
+     * @param renderer - Reference to Renderer
+     */
+    constructor(renderer: Renderer)
+    {
+        // #if _DEBUG
+        deprecation('6.1.0', 'System class is deprecated, implemement ISystem interface instead.');
+        // #endif
+
+        this.renderer = renderer;
+    }
+
+    /** Destroy and don't use after this. */
+    destroy(): void
+    {
+        this.renderer = null;
+    }
 }


### PR DESCRIPTION
Follow up to #7269

This properly deprecates System to support 3rd-party custom Renderer systems. @SukantPal pointed this out, he has a few plugins that do this path.
