### PR TITLE
Populate the Loader resource with Texture objects for basis and compressed-textures

### DIFF
--- a/packages/basis/src/BasisLoader.ts
+++ b/packages/basis/src/BasisLoader.ts
@@ -160,8 +160,9 @@ export class BasisLoader
         // Should be a valid TYPES, FORMATS for uncompressed basis formats
         const type: TYPES = BASIS_FORMAT_TO_TYPE[resources.basisFormat];
         const format: FORMATS = resources.basisFormat !== BASIS_FORMATS.cTFRGBA32 ? FORMATS.RGB : FORMATS.RGBA;
+        const resourceList = resources as Array<CompressedTextureResource | BufferResource>;
 
-        const textures = resources.map((resource: CompressedTextureResource | BufferResource) =>
+        const textures = resourceList.map((resource) =>
             (
                 new Texture(new BaseTexture(resource, Object.assign({
                     mipmap: resource instanceof CompressedTextureResource && resource.levels > 1
@@ -173,7 +174,7 @@ export class BasisLoader
                 }, metadata)))
             ));
 
-        textures.forEach((texture, i) =>
+        textures.forEach((texture: Texture, i: number) =>
         {
             const { baseTexture } = texture;
             const cacheID = `${url}-${i + 1}`;

--- a/packages/basis/src/BasisLoader.ts
+++ b/packages/basis/src/BasisLoader.ts
@@ -11,12 +11,20 @@ import {
     BASIS_FORMAT_TO_TYPE
 } from './Basis';
 import { TranscoderWorker } from './TranscoderWorker';
-import { ILoaderResource, LoaderResource } from '@pixi/loaders';
+import { LoaderResource } from '@pixi/loaders';
+
+import type { ILoaderResource, IResourceMetadata } from '@pixi/loaders';
 import type { CompressedLevelBuffer } from '@pixi/compressed-textures';
 
 type TranscodedResourcesArray = (Array<CompressedTextureResource> | Array<BufferResource>) & {
     basisFormat: BASIS_FORMATS
 };
+
+/**
+ * Result when calling registerCompressedTextures.
+ * @ignore
+ */
+ type BasisTexturesResult = Pick<ILoaderResource, 'textures' | 'texture'>;
 
 LoaderResource.setExtensionXhrType('basis', LoaderResource.XHR_RESPONSE_TYPE.BUFFER);
 
@@ -100,20 +108,32 @@ export class BasisLoader
      */
     private static async transcode(resource: ILoaderResource, next: (...args: any[]) => void): Promise<void>
     {
-        const data = resource.data;
-
-        let resources: TranscodedResourcesArray;
-
-        if (typeof Worker !== 'undefined' && BasisLoader.TranscoderWorker.wasmSource)
+        try
         {
-            resources = await BasisLoader.transcodeAsync(data as ArrayBuffer);
-        }
-        else
-        {
-            resources = BasisLoader.transcodeSync(data as ArrayBuffer);
-        }
+            const data: ArrayBuffer = resource.data;
+            let resources: TranscodedResourcesArray;
 
-        BasisLoader.registerTextures(resource.url, resources);
+            if (typeof Worker !== 'undefined' && BasisLoader.TranscoderWorker.wasmSource)
+            {
+                resources = await BasisLoader.transcodeAsync(data);
+            }
+            else
+            {
+                resources = BasisLoader.transcodeSync(data);
+            }
+
+            Object.assign(resource, BasisLoader.registerTextures(
+                resource.url,
+                resources,
+                resource.metadata
+            ));
+        }
+        catch (err)
+        {
+            next(err);
+
+            return;
+        }
 
         next();
     }
@@ -123,38 +143,55 @@ export class BasisLoader
      * @param {TranscodedResourcesArray} resources
      * @private
      */
-    private static registerTextures(url: string, resources: TranscodedResourcesArray): void
+    private static registerTextures(url: string,
+        resources: TranscodedResourcesArray,
+        metadata: IResourceMetadata): BasisTexturesResult
     {
+        const result: BasisTexturesResult = {
+            textures: {},
+            texture: null,
+        };
+
         if (!resources)
         {
-            return;
+            return result;
         }
 
         // Should be a valid TYPES, FORMATS for uncompressed basis formats
         const type: TYPES = BASIS_FORMAT_TO_TYPE[resources.basisFormat];
         const format: FORMATS = resources.basisFormat !== BASIS_FORMATS.cTFRGBA32 ? FORMATS.RGB : FORMATS.RGBA;
 
-        resources.forEach((resource: CompressedTextureResource | BufferResource, i) =>
+        const textures = resources.map((resource: CompressedTextureResource | BufferResource) =>
+            (
+                new Texture(new BaseTexture(resource, Object.assign({
+                    mipmap: resource instanceof CompressedTextureResource && resource.levels > 1
+                        ? MIPMAP_MODES.ON_MANUAL
+                        : MIPMAP_MODES.OFF,
+                    alphaMode: ALPHA_MODES.NO_PREMULTIPLIED_ALPHA,
+                    type,
+                    format
+                }, metadata)))
+            ));
+
+        textures.forEach((texture, i) =>
         {
-            const baseTexture = new BaseTexture(resource, {
-                mipmap: resource instanceof CompressedTextureResource && resource.levels > 1
-                    ? MIPMAP_MODES.ON_MANUAL
-                    : MIPMAP_MODES.OFF,
-                alphaMode: ALPHA_MODES.NO_PREMULTIPLIED_ALPHA,
-                type,
-                format
-            });
+            const { baseTexture } = texture;
             const cacheID = `${url}-${i + 1}`;
 
             BaseTexture.addToCache(baseTexture, cacheID);
-            Texture.addToCache(new Texture(baseTexture), cacheID);
+            Texture.addToCache(texture, cacheID);
 
             if (i === 0)
             {
                 BaseTexture.addToCache(baseTexture, url);
-                Texture.addToCache(new Texture(baseTexture), url);
+                Texture.addToCache(texture, url);
+                result.texture = texture;
             }
+
+            result.textures[cacheID] = texture;
         });
+
+        return result;
     }
 
     /**
@@ -261,7 +298,9 @@ export class BasisLoader
 
         if (!basisFile.startTranscoding())
         {
+            // #if _DEBUG
             console.error(`Basis failed to start transcoding!`);
+            // #endif
 
             basisFile.close();
             basisFile.delete();
@@ -300,7 +339,9 @@ export class BasisLoader
                 {
                     if (fallbackMode)
                     {
+                        // #if _DEBUG
                         console.error(`Basis failed to transcode image ${i}, level ${0}!`);
+                        // #endif
                         break;
                     }
                     else
@@ -310,8 +351,10 @@ export class BasisLoader
                         i = -1;
                         fallbackMode = true;
 
+                        // #if _DEBUG
                         /* eslint-disable-next-line max-len */
                         console.warn(`Basis failed to transcode image ${i}, level ${0} to a compressed texture format. Retrying to an uncompressed fallback format!`);
+                        // #endif
                         continue;
                     }
                 }

--- a/packages/compressed-textures/src/loaders/DDSLoader.ts
+++ b/packages/compressed-textures/src/loaders/DDSLoader.ts
@@ -262,7 +262,20 @@ export class DDSLoader
     {
         if (resource.extension === 'dds' && resource.data)
         {
-            registerCompressedTextures(resource.name || resource.url, DDSLoader.parse(resource.data));
+            try
+            {
+                Object.assign(resource, registerCompressedTextures(
+                    resource.name || resource.url,
+                    DDSLoader.parse(resource.data),
+                    resource.metadata,
+                ));
+            }
+            catch (err)
+            {
+                next(err);
+
+                return;
+            }
         }
 
         next();

--- a/packages/compressed-textures/src/loaders/registerCompressedTextures.ts
+++ b/packages/compressed-textures/src/loaders/registerCompressedTextures.ts
@@ -1,7 +1,14 @@
 import { MIPMAP_MODES, ALPHA_MODES } from '@pixi/constants';
 import { BaseTexture, Texture } from '@pixi/core';
 
+import type { ILoaderResource, IResourceMetadata } from '@pixi/loaders';
 import type { CompressedTextureResource } from '../resources/CompressedTextureResource';
+
+/**
+ * Result when calling registerCompressedTextures.
+ * @ignore
+ */
+type CompressedTexturesResult = Pick<ILoaderResource, 'textures' | 'texture'>;
 
 /**
  * Creates base-textures and textures for each compressed-texture resource and adds them into the global
@@ -12,28 +19,45 @@ import type { CompressedTextureResource } from '../resources/CompressedTextureRe
  * @param resources - the resources backing texture data
  * @ignore
  */
-export function registerCompressedTextures(url: string, resources: CompressedTextureResource[]): void
+export function registerCompressedTextures(url: string,
+    resources: CompressedTextureResource[],
+    metadata: IResourceMetadata): CompressedTexturesResult
 {
+    const result: CompressedTexturesResult = {
+        textures: {},
+        texture: null,
+    };
+
     if (!resources)
     {
-        return;
+        return result;
     }
 
-    resources.forEach((resource, i) =>
+    const textures = resources.map((resource) =>
+        (
+            new Texture(new BaseTexture(resource, Object.assign({
+                mipmap: MIPMAP_MODES.OFF,
+                alphaMode: ALPHA_MODES.NO_PREMULTIPLIED_ALPHA
+            }, metadata)))
+        ));
+
+    textures.forEach((texture, i) =>
     {
-        const baseTexture = new BaseTexture(resource, {
-            mipmap: MIPMAP_MODES.OFF,
-            alphaMode: ALPHA_MODES.NO_PREMULTIPLIED_ALPHA
-        });
+        const { baseTexture } = texture;
         const cacheID = `${url}-${i + 1}`;
 
         BaseTexture.addToCache(baseTexture, cacheID);
-        Texture.addToCache(new Texture(baseTexture), cacheID);
+        Texture.addToCache(texture, cacheID);
 
         if (i === 0)
         {
             BaseTexture.addToCache(baseTexture, url);
-            Texture.addToCache(new Texture(baseTexture), url);
+            Texture.addToCache(texture, url);
+            result.texture = texture;
         }
+
+        result.textures[cacheID] = texture;
     });
+
+    return result;
 }


### PR DESCRIPTION
Partially fixes #7329

### Changes

* The Loader's resource was not getting populated with the Texture being created, the only way to fetch this was by using the TextureCache.
* Fixes an issue where the first compressed texture resource was creating two Textures
* Properly handle errors internally and passed them to the loader instead of throwing globally
* Supports passing options to the BaseTexture constructor using LoaderResource's metadata
* Fixes baseUrl or path for loading manifest of compressed textures