### PR TITLE
Fix framebuffer mipmap round

### DIFF
--- a/packages/core/src/framebuffer/FramebufferSystem.ts
+++ b/packages/core/src/framebuffer/FramebufferSystem.ts
@@ -169,6 +169,7 @@ export class FramebufferSystem implements ISystem
                 this.renderer.texture.unbind(framebuffer.depthTexture);
             }
 
+            //TODO: might be different for non pow2
             const mipWidth = (framebuffer.width >> mipLevel);
             const mipHeight = (framebuffer.height >> mipLevel);
 
@@ -177,10 +178,10 @@ export class FramebufferSystem implements ISystem
                 const scale = mipWidth / framebuffer.width;
 
                 this.setViewport(
-                    (frame.x * scale) | 0,
-                    (frame.y * scale) | 0,
-                    mipWidth,
-                    mipHeight
+                    Math.round(frame.x * scale),
+                    Math.round(frame.y * scale),
+                    Math.round(frame.width * scale),
+                    Math.round(frame.height * scale),
                 );
             }
             else

--- a/packages/core/src/framebuffer/FramebufferSystem.ts
+++ b/packages/core/src/framebuffer/FramebufferSystem.ts
@@ -169,7 +169,7 @@ export class FramebufferSystem implements ISystem
                 this.renderer.texture.unbind(framebuffer.depthTexture);
             }
 
-            //TODO: might be different for non pow2
+            // TODO: might be different for non pow2
             const mipWidth = (framebuffer.width >> mipLevel);
             const mipHeight = (framebuffer.height >> mipLevel);
 


### PR DESCRIPTION
Fixes #7374 

Demo: https://pixijs.io/examples/?v=fix-framebuffer-mipmap-round#/filters-basic/blur.js

1. reverted some changes 
2. added scale, like in previous PR
3. added rounding like in dev's PR.