### PR TITLE
Fix EventBoundary crashing when the pointerupoutside, pointerout target is unmounted from the scene graph.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18539,6 +18539,7 @@
       }
     },
     "packages/accessibility": {
+      "name": "@pixi/accessibility",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18549,6 +18550,7 @@
       }
     },
     "packages/app": {
+      "name": "@pixi/app",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18561,6 +18563,7 @@
       }
     },
     "packages/basis": {
+      "name": "@pixi/basis",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18572,6 +18575,7 @@
       }
     },
     "packages/canvas/canvas-display": {
+      "name": "@pixi/canvas-display",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18579,6 +18583,7 @@
       }
     },
     "packages/canvas/canvas-extract": {
+      "name": "@pixi/canvas-extract",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18590,6 +18595,7 @@
       }
     },
     "packages/canvas/canvas-graphics": {
+      "name": "@pixi/canvas-graphics",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18602,6 +18608,7 @@
       }
     },
     "packages/canvas/canvas-mesh": {
+      "name": "@pixi/canvas-mesh",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18618,6 +18625,7 @@
       }
     },
     "packages/canvas/canvas-particles": {
+      "name": "@pixi/canvas-particles",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18625,6 +18633,7 @@
       }
     },
     "packages/canvas/canvas-prepare": {
+      "name": "@pixi/canvas-prepare",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18634,6 +18643,7 @@
       }
     },
     "packages/canvas/canvas-renderer": {
+      "name": "@pixi/canvas-renderer",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18650,6 +18660,7 @@
       }
     },
     "packages/canvas/canvas-sprite": {
+      "name": "@pixi/canvas-sprite",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18662,6 +18673,7 @@
       }
     },
     "packages/canvas/canvas-sprite-tiling": {
+      "name": "@pixi/canvas-sprite-tiling",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18673,6 +18685,7 @@
       }
     },
     "packages/canvas/canvas-text": {
+      "name": "@pixi/canvas-text",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18682,6 +18695,7 @@
       }
     },
     "packages/compressed-textures": {
+      "name": "@pixi/compressed-textures",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18691,10 +18705,12 @@
       }
     },
     "packages/constants": {
+      "name": "@pixi/constants",
       "version": "6.0.1",
       "license": "MIT"
     },
     "packages/core": {
+      "name": "@pixi/core",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18711,6 +18727,7 @@
       }
     },
     "packages/display": {
+      "name": "@pixi/display",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18720,6 +18737,7 @@
       }
     },
     "packages/events": {
+      "name": "@pixi/events",
       "version": "6.0.0-rc.3",
       "license": "MIT",
       "dependencies": {
@@ -18729,6 +18747,7 @@
       }
     },
     "packages/extract": {
+      "name": "@pixi/extract",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18738,6 +18757,7 @@
       }
     },
     "packages/filters/filter-alpha": {
+      "name": "@pixi/filter-alpha",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18745,6 +18765,7 @@
       }
     },
     "packages/filters/filter-blur": {
+      "name": "@pixi/filter-blur",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18753,6 +18774,7 @@
       }
     },
     "packages/filters/filter-color-matrix": {
+      "name": "@pixi/filter-color-matrix",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18760,6 +18782,7 @@
       }
     },
     "packages/filters/filter-displacement": {
+      "name": "@pixi/filter-displacement",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18768,6 +18791,7 @@
       }
     },
     "packages/filters/filter-fxaa": {
+      "name": "@pixi/filter-fxaa",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18775,6 +18799,7 @@
       }
     },
     "packages/filters/filter-noise": {
+      "name": "@pixi/filter-noise",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18782,6 +18807,7 @@
       }
     },
     "packages/graphics": {
+      "name": "@pixi/graphics",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18794,6 +18820,7 @@
       }
     },
     "packages/graphics-extras": {
+      "name": "@pixi/graphics-extras",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18802,6 +18829,7 @@
       }
     },
     "packages/interaction": {
+      "name": "@pixi/interaction",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18821,6 +18849,7 @@
       }
     },
     "packages/loaders": {
+      "name": "@pixi/loaders",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18834,10 +18863,12 @@
       }
     },
     "packages/math": {
+      "name": "@pixi/math",
       "version": "6.0.1",
       "license": "MIT"
     },
     "packages/mesh": {
+      "name": "@pixi/mesh",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18850,6 +18881,7 @@
       }
     },
     "packages/mesh-extras": {
+      "name": "@pixi/mesh-extras",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18864,6 +18896,7 @@
       }
     },
     "packages/mixin-cache-as-bitmap": {
+      "name": "@pixi/mixin-cache-as-bitmap",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18877,6 +18910,7 @@
       }
     },
     "packages/mixin-get-child-by-name": {
+      "name": "@pixi/mixin-get-child-by-name",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18884,6 +18918,7 @@
       }
     },
     "packages/mixin-get-global-position": {
+      "name": "@pixi/mixin-get-global-position",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18892,6 +18927,7 @@
       }
     },
     "packages/particles": {
+      "name": "@pixi/particles",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18903,6 +18939,7 @@
       }
     },
     "packages/polyfill": {
+      "name": "@pixi/polyfill",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18915,6 +18952,7 @@
       }
     },
     "packages/prepare": {
+      "name": "@pixi/prepare",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18927,10 +18965,12 @@
       }
     },
     "packages/runner": {
+      "name": "@pixi/runner",
       "version": "6.0.1",
       "license": "MIT"
     },
     "packages/settings": {
+      "name": "@pixi/settings",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18938,6 +18978,7 @@
       }
     },
     "packages/sprite": {
+      "name": "@pixi/sprite",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18950,6 +18991,7 @@
       }
     },
     "packages/sprite-animated": {
+      "name": "@pixi/sprite-animated",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18959,6 +19001,7 @@
       }
     },
     "packages/sprite-tiling": {
+      "name": "@pixi/sprite-tiling",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18971,6 +19014,7 @@
       }
     },
     "packages/spritesheet": {
+      "name": "@pixi/spritesheet",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18981,6 +19025,7 @@
       }
     },
     "packages/text": {
+      "name": "@pixi/text",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -18997,6 +19042,7 @@
       }
     },
     "packages/text-bitmap": {
+      "name": "@pixi/text-bitmap",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -19014,6 +19060,7 @@
       }
     },
     "packages/ticker": {
+      "name": "@pixi/ticker",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -19021,6 +19068,7 @@
       }
     },
     "packages/unsafe-eval": {
+      "name": "@pixi/unsafe-eval",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -19028,6 +19076,7 @@
       }
     },
     "packages/utils": {
+      "name": "@pixi/utils",
       "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
@@ -19043,6 +19092,7 @@
       }
     },
     "tools/integration-tests": {
+      "name": "@internal/integration-tests",
       "version": "6.0.1",
       "devDependencies": {
         "@pixi/canvas-display": "6.0.1",

--- a/packages/events/src/EventBoundary.ts
+++ b/packages/events/src/EventBoundary.ts
@@ -28,7 +28,7 @@ const tempLocalMapping = new Point();
  *         timeStamp: number;
  *     }
  * };
- * overTarget: FederatedEventTarget;
+ * overTargets: FederatedEventTarget[];
  * ```
  *
  * @typedef {object} TrackingData

--- a/packages/events/src/EventSystem.ts
+++ b/packages/events/src/EventSystem.ts
@@ -1,10 +1,10 @@
 import { EventBoundary } from './EventBoundary';
+import { FederatedMouseEvent } from './FederatedMouseEvent';
 import { FederatedPointerEvent } from './FederatedPointerEvent';
 import { FederatedWheelEvent } from './FederatedWheelEvent';
 
 import type { DisplayObject } from '@pixi/display';
 import type { IPointData } from '@pixi/math';
-import { FederatedMouseEvent } from './FederatedMouseEvent';
 
 const MOUSE_POINTER_ID = 1;
 const TOUCH_TO_POINTER: Record<string, string> = {

--- a/packages/events/src/FederatedPointerEvent.ts
+++ b/packages/events/src/FederatedPointerEvent.ts
@@ -85,4 +85,21 @@ export class FederatedPointerEvent extends FederatedMouseEvent implements Pointe
      * This is the number of clicks that occurs in 200ms/click of each other.
      */
     public detail: number;
+
+    // Only included for completeness for now
+    getCoalescedEvents(): PointerEvent[]
+    {
+        if (this.type === 'pointermove' || this.type === 'mousemove' || this.type === 'touchmove')
+        {
+            return [this];
+        }
+
+        return [];
+    }
+
+    // Only included for completeness for now
+    getPredictedEvents(): PointerEvent[]
+    {
+        throw new Error('getPredictedEvents is not supported!');
+    }
 }

--- a/packages/events/test/EventBoundary.js
+++ b/packages/events/test/EventBoundary.js
@@ -3,7 +3,7 @@ const { FederatedPointerEvent, EventBoundary } = require('../');
 const { Graphics } = require('../../graphics');
 const { expect } = require('chai');
 
-describe.only('PIXI.EventBoundary', function ()
+describe('PIXI.EventBoundary', function ()
 {
     it('should fire capture, bubble events on the correct target', function ()
     {


### PR DESCRIPTION
##### Description of change

In this [example](https://pixijs.io/examples/#/events/hit-testing-with-spatial-hash.js) (before this PR is merged!), errors are thrown in the `pointerout` event dispatch because I remove each character on click. This is fixed by finding the most specific ancestor of the original target **that is still mounted**.

---
**Additional change**: Add `getCoalescedEvents` and `getPredictedEvents` to `FederatedPointerEvent` as they're new APIs and are needed to correctly implemented `PointerEvent` (was getting type errors).

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
