### PR TITLE
Declare _renderCanvas, _generateCanvasTexture as a methods not function properties

### DIFF
--- a/packages/canvas/canvas-display/global.d.ts
+++ b/packages/canvas/canvas-display/global.d.ts
@@ -1,5 +1,5 @@
 declare namespace GlobalMixins {
     interface Container {
-        _renderCanvas?: (renderer: import('@pixi/canvas-renderer').CanvasRenderer) => void;
+        _renderCanvas?(renderer: import('@pixi/canvas-renderer').CanvasRenderer): void;
     }
 }

--- a/packages/canvas/canvas-graphics/global.d.ts
+++ b/packages/canvas/canvas-graphics/global.d.ts
@@ -1,7 +1,7 @@
 declare namespace GlobalMixins {
     interface Graphics {
-        _renderCanvas?: (renderer: import('@pixi/canvas-renderer').CanvasRenderer) => void;
-        generateCanvasTexture: (scaleMode: import('@pixi/constants').SCALE_MODES, resolution?: number) => Texture;
+        _renderCanvas?(renderer: import('@pixi/canvas-renderer').CanvasRenderer): void;
+        generateCanvasTexture(scaleMode: import('@pixi/constants').SCALE_MODES, resolution?: number): Texture;
         cachedGraphicsData: import('@pixi/graphics').GraphicsData[];
     }
 }

--- a/packages/canvas/canvas-mesh/global.d.ts
+++ b/packages/canvas/canvas-mesh/global.d.ts
@@ -1,6 +1,6 @@
 declare namespace GlobalMixins {
     interface Mesh {
-        _renderCanvas?: (renderer: import('@pixi/canvas-renderer').CanvasRenderer) => void;
+        _renderCanvas?(renderer: import('@pixi/canvas-renderer').CanvasRenderer): void;
         _canvasPadding: number;
         canvasPadding: number;
         _cachedTint: number;
@@ -9,7 +9,7 @@ declare namespace GlobalMixins {
     }
 
     interface MeshMaterial {
-        _renderCanvas: (renderer: import('@pixi/canvas-renderer').CanvasRenderer, mesh: import('@pixi/mesh').Mesh) => void;
+        _renderCanvas(renderer: import('@pixi/canvas-renderer').CanvasRenderer, mesh: import('@pixi/mesh').Mesh): void;
     }
 
     interface NineSlicePlane {

--- a/packages/canvas/canvas-sprite/global.d.ts
+++ b/packages/canvas/canvas-sprite/global.d.ts
@@ -1,6 +1,6 @@
 declare namespace GlobalMixins {
     interface Sprite {
         _tintedCanvas?: HTMLCanvasElement|HTMLImageElement;
-        _renderCanvas?: (renderer: import('@pixi/canvas-renderer').CanvasRenderer) => void;
+        _renderCanvas?(renderer: import('@pixi/canvas-renderer').CanvasRenderer): void;
     }
 }


### PR DESCRIPTION
This seems to be a problem when trying build external packages against latest PixiJS in their CI.