### PR TITLE
Don't import BUFFER_TYPES from @pixi/constants/src (exclude src)

### DIFF
--- a/packages/core/src/geometry/Buffer.ts
+++ b/packages/core/src/geometry/Buffer.ts
@@ -1,4 +1,4 @@
-import { BUFFER_TYPE } from '@pixi/constants/src';
+import { BUFFER_TYPE } from '@pixi/constants';
 import { Runner } from '@pixi/runner';
 
 import type { GLBuffer } from './GLBuffer';

--- a/packages/core/src/shader/UniformGroup.ts
+++ b/packages/core/src/shader/UniformGroup.ts
@@ -1,4 +1,4 @@
-import { BUFFER_TYPE } from '@pixi/constants/src';
+import { BUFFER_TYPE } from '@pixi/constants';
 import type { Dict } from '@pixi/utils';
 import { Buffer } from '../geometry/Buffer';
 import type { UniformsSyncCallback } from './utils';


### PR DESCRIPTION
This was failing @pixi/tilemap's build against latest PixiJS. Can we get this merged ASAP so that the CI can pass there?

https://github.com/pixijs/tilemap/pull/117/checks?check_run_id=2265403059