### PR TITLE
typings fix for LoaderResource texture

### DIFF
--- a/packages/spritesheet/global.d.ts
+++ b/packages/spritesheet/global.d.ts
@@ -6,6 +6,6 @@ declare namespace GlobalMixins
         spritesheet?: import('@pixi/spritesheet').Spritesheet;
 
         /** Dictionary of textures from Spritesheet. */
-        textures?: {[name: string]: Texture};
+        textures?: {[name: string]: import('@pixi/core').Texture};
     }
 }


### PR DESCRIPTION
The interface `Texture` in GLobalMixins is mostly empty, its for mixins, so we cant really pass that interface to actual methods

Currently this fails:

```ts
new Sprite(resources['atlas'].textures['apple.png']);
```

Test: https://codesandbox.io/s/pixitilemap-typings-test-m5pb8?file=/src/index.ts 

Uncomment line 16, get an error