### PR TITLE
Allow supplying arrays to Buffer.update()

### DIFF
--- a/packages/core/src/geometry/Buffer.ts
+++ b/packages/core/src/geometry/Buffer.ts
@@ -89,10 +89,14 @@ export class Buffer
     // TODO could explore flagging only a partial upload?
     /**
      * flags this buffer as requiring an upload to the GPU
-     * @param {ArrayBuffer|SharedArrayBuffer|ArrayBufferView} [data] - the data to update in the buffer.
+     * @param {ArrayBuffer|SharedArrayBuffer|ArrayBufferView|number[]} [data] - the data to update in the buffer.
      */
-    update(data?: IArrayBuffer): void
+    update(data?: IArrayBuffer | Array<number>): void
     {
+        if (data instanceof Array)
+        {
+            data = new Float32Array(data);
+        }
         this.data = (data as ITypedArray) || this.data;
         this._updateID++;
     }


### PR DESCRIPTION

<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

`const geom = new Geometry().addAttribute('aVertexPosition', [/* blah */]);` supports normal arrays.
However, `geom.getBuffer('aVertexPosition').update([/* blah */])` does not.

This addition will make the API more uniform and less surprising.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
