### PR TITLE
Remove application dependency on loader

### DIFF
--- a/packages/loaders/src/AppLoaderPlugin.ts
+++ b/packages/loaders/src/AppLoaderPlugin.ts
@@ -19,7 +19,7 @@ export class AppLoaderPlugin
      * @param {object} options
      * @private
      */
-    static init(options?: { sharedLoader: boolean }): void
+    static init(options?: GlobalMixins.IApplicationOptions): void
     {
         options = Object.assign({
             sharedLoader: false,

--- a/packages/loaders/src/AppLoaderPlugin.ts
+++ b/packages/loaders/src/AppLoaderPlugin.ts
@@ -1,7 +1,5 @@
 import { Loader } from './Loader';
 
-import type { IApplicationOptions } from '@pixi/app';
-
 /**
  * Application plugin for supporting loader option. Installing the LoaderPlugin
  * is not necessary if using **pixi.js** or **pixi.js-legacy**.
@@ -21,7 +19,7 @@ export class AppLoaderPlugin
      * @param {object} options
      * @private
      */
-    static init(options?: IApplicationOptions): void
+    static init(options?: { sharedLoader: boolean }): void
     {
         options = Object.assign({
             sharedLoader: false,


### PR DESCRIPTION
Found a small bug when trying to do a minimal install with core, loaders, ticker and utils. There was a dangling app reference in loaders that threw an error. This decouples these types.