### PR TITLE
package-lock.json not updated on version bumping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,44 +57,44 @@
       }
     },
     "bundles/pixi.js": {
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/accessibility": "6.0.1",
-        "@pixi/app": "6.0.1",
-        "@pixi/compressed-textures": "6.0.1",
-        "@pixi/constants": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/display": "6.0.1",
-        "@pixi/extract": "6.0.1",
-        "@pixi/filter-alpha": "6.0.1",
-        "@pixi/filter-blur": "6.0.1",
-        "@pixi/filter-color-matrix": "6.0.1",
-        "@pixi/filter-displacement": "6.0.1",
-        "@pixi/filter-fxaa": "6.0.1",
-        "@pixi/filter-noise": "6.0.1",
-        "@pixi/graphics": "6.0.1",
-        "@pixi/interaction": "6.0.1",
-        "@pixi/loaders": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/mesh": "6.0.1",
-        "@pixi/mesh-extras": "6.0.1",
-        "@pixi/mixin-cache-as-bitmap": "6.0.1",
-        "@pixi/mixin-get-child-by-name": "6.0.1",
-        "@pixi/mixin-get-global-position": "6.0.1",
-        "@pixi/particles": "6.0.1",
-        "@pixi/polyfill": "6.0.1",
-        "@pixi/prepare": "6.0.1",
-        "@pixi/runner": "6.0.1",
-        "@pixi/settings": "6.0.1",
-        "@pixi/sprite": "6.0.1",
-        "@pixi/sprite-animated": "6.0.1",
-        "@pixi/sprite-tiling": "6.0.1",
-        "@pixi/spritesheet": "6.0.1",
-        "@pixi/text": "6.0.1",
-        "@pixi/text-bitmap": "6.0.1",
-        "@pixi/ticker": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/accessibility": "6.0.2",
+        "@pixi/app": "6.0.2",
+        "@pixi/compressed-textures": "6.0.2",
+        "@pixi/constants": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/display": "6.0.2",
+        "@pixi/extract": "6.0.2",
+        "@pixi/filter-alpha": "6.0.2",
+        "@pixi/filter-blur": "6.0.2",
+        "@pixi/filter-color-matrix": "6.0.2",
+        "@pixi/filter-displacement": "6.0.2",
+        "@pixi/filter-fxaa": "6.0.2",
+        "@pixi/filter-noise": "6.0.2",
+        "@pixi/graphics": "6.0.2",
+        "@pixi/interaction": "6.0.2",
+        "@pixi/loaders": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/mesh": "6.0.2",
+        "@pixi/mesh-extras": "6.0.2",
+        "@pixi/mixin-cache-as-bitmap": "6.0.2",
+        "@pixi/mixin-get-child-by-name": "6.0.2",
+        "@pixi/mixin-get-global-position": "6.0.2",
+        "@pixi/particles": "6.0.2",
+        "@pixi/polyfill": "6.0.2",
+        "@pixi/prepare": "6.0.2",
+        "@pixi/runner": "6.0.2",
+        "@pixi/settings": "6.0.2",
+        "@pixi/sprite": "6.0.2",
+        "@pixi/sprite-animated": "6.0.2",
+        "@pixi/sprite-tiling": "6.0.2",
+        "@pixi/spritesheet": "6.0.2",
+        "@pixi/text": "6.0.2",
+        "@pixi/text-bitmap": "6.0.2",
+        "@pixi/ticker": "6.0.2",
+        "@pixi/utils": "6.0.2"
       },
       "funding": {
         "type": "opencollective",
@@ -102,20 +102,20 @@
       }
     },
     "bundles/pixi.js-legacy": {
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/canvas-display": "6.0.1",
-        "@pixi/canvas-extract": "6.0.1",
-        "@pixi/canvas-graphics": "6.0.1",
-        "@pixi/canvas-mesh": "6.0.1",
-        "@pixi/canvas-particles": "6.0.1",
-        "@pixi/canvas-prepare": "6.0.1",
-        "@pixi/canvas-renderer": "6.0.1",
-        "@pixi/canvas-sprite": "6.0.1",
-        "@pixi/canvas-sprite-tiling": "6.0.1",
-        "@pixi/canvas-text": "6.0.1",
-        "pixi.js": "6.0.1"
+        "@pixi/canvas-display": "6.0.2",
+        "@pixi/canvas-extract": "6.0.2",
+        "@pixi/canvas-graphics": "6.0.2",
+        "@pixi/canvas-mesh": "6.0.2",
+        "@pixi/canvas-particles": "6.0.2",
+        "@pixi/canvas-prepare": "6.0.2",
+        "@pixi/canvas-renderer": "6.0.2",
+        "@pixi/canvas-sprite": "6.0.2",
+        "@pixi/canvas-sprite-tiling": "6.0.2",
+        "@pixi/canvas-text": "6.0.2",
+        "pixi.js": "6.0.2"
       },
       "funding": {
         "type": "opencollective",
@@ -18540,186 +18540,186 @@
     },
     "packages/accessibility": {
       "name": "@pixi/accessibility",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/canvas-renderer": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/display": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/canvas-renderer": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/display": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "packages/app": {
       "name": "@pixi/app",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/core": "6.0.1",
-        "@pixi/display": "6.0.1"
+        "@pixi/core": "6.0.2",
+        "@pixi/display": "6.0.2"
       },
       "devDependencies": {
-        "@pixi/canvas-renderer": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/canvas-renderer": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "packages/basis": {
       "name": "@pixi/basis",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/compressed-textures": "6.0.1",
-        "@pixi/constants": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/loaders": "6.0.1",
-        "@pixi/runner": "6.0.1"
+        "@pixi/compressed-textures": "6.0.2",
+        "@pixi/constants": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/loaders": "6.0.2",
+        "@pixi/runner": "6.0.2"
       }
     },
     "packages/canvas/canvas-display": {
       "name": "@pixi/canvas-display",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/display": "6.0.1"
+        "@pixi/display": "6.0.2"
       }
     },
     "packages/canvas/canvas-extract": {
       "name": "@pixi/canvas-extract",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/canvas-renderer": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/display": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/canvas-renderer": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/display": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "packages/canvas/canvas-graphics": {
       "name": "@pixi/canvas-graphics",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/canvas-display": "6.0.1",
-        "@pixi/canvas-renderer": "6.0.1",
-        "@pixi/constants": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/graphics": "6.0.1",
-        "@pixi/math": "6.0.1"
+        "@pixi/canvas-display": "6.0.2",
+        "@pixi/canvas-renderer": "6.0.2",
+        "@pixi/constants": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/graphics": "6.0.2",
+        "@pixi/math": "6.0.2"
       }
     },
     "packages/canvas/canvas-mesh": {
       "name": "@pixi/canvas-mesh",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/canvas-display": "6.0.1",
-        "@pixi/canvas-renderer": "6.0.1",
-        "@pixi/constants": "6.0.1",
-        "@pixi/mesh": "6.0.1",
-        "@pixi/mesh-extras": "6.0.1",
-        "@pixi/settings": "6.0.1"
+        "@pixi/canvas-display": "6.0.2",
+        "@pixi/canvas-renderer": "6.0.2",
+        "@pixi/constants": "6.0.2",
+        "@pixi/mesh": "6.0.2",
+        "@pixi/mesh-extras": "6.0.2",
+        "@pixi/settings": "6.0.2"
       },
       "devDependencies": {
-        "@pixi/core": "6.0.1",
-        "@pixi/sprite": "6.0.1"
+        "@pixi/core": "6.0.2",
+        "@pixi/sprite": "6.0.2"
       }
     },
     "packages/canvas/canvas-particles": {
       "name": "@pixi/canvas-particles",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/particles": "6.0.1"
+        "@pixi/particles": "6.0.2"
       }
     },
     "packages/canvas/canvas-prepare": {
       "name": "@pixi/canvas-prepare",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/canvas-renderer": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/prepare": "6.0.1"
+        "@pixi/canvas-renderer": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/prepare": "6.0.2"
       }
     },
     "packages/canvas/canvas-renderer": {
       "name": "@pixi/canvas-renderer",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/constants": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/settings": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/constants": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/settings": "6.0.2",
+        "@pixi/utils": "6.0.2"
       },
       "devDependencies": {
-        "@pixi/display": "6.0.1",
-        "@pixi/graphics": "6.0.1",
-        "@pixi/sprite": "6.0.1"
+        "@pixi/display": "6.0.2",
+        "@pixi/graphics": "6.0.2",
+        "@pixi/sprite": "6.0.2"
       }
     },
     "packages/canvas/canvas-sprite": {
       "name": "@pixi/canvas-sprite",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/canvas-display": "6.0.1",
-        "@pixi/canvas-renderer": "6.0.1",
-        "@pixi/constants": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/sprite": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/canvas-display": "6.0.2",
+        "@pixi/canvas-renderer": "6.0.2",
+        "@pixi/constants": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/sprite": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "packages/canvas/canvas-sprite-tiling": {
       "name": "@pixi/canvas-sprite-tiling",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/canvas-renderer": "6.0.1",
-        "@pixi/canvas-sprite": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/sprite-tiling": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/canvas-renderer": "6.0.2",
+        "@pixi/canvas-sprite": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/sprite-tiling": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "packages/canvas/canvas-text": {
       "name": "@pixi/canvas-text",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/canvas-sprite": "6.0.1",
-        "@pixi/sprite": "6.0.1",
-        "@pixi/text": "6.0.1"
+        "@pixi/canvas-sprite": "6.0.2",
+        "@pixi/sprite": "6.0.2",
+        "@pixi/text": "6.0.2"
       }
     },
     "packages/compressed-textures": {
       "name": "@pixi/compressed-textures",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/constants": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/loaders": "6.0.1"
+        "@pixi/constants": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/loaders": "6.0.2"
       }
     },
     "packages/constants": {
       "name": "@pixi/constants",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT"
     },
     "packages/core": {
       "name": "@pixi/core",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/constants": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/runner": "6.0.1",
-        "@pixi/settings": "6.0.1",
-        "@pixi/ticker": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/constants": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/runner": "6.0.2",
+        "@pixi/settings": "6.0.2",
+        "@pixi/ticker": "6.0.2",
+        "@pixi/utils": "6.0.2"
       },
       "funding": {
         "type": "opencollective",
@@ -18728,12 +18728,12 @@
     },
     "packages/display": {
       "name": "@pixi/display",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/math": "6.0.1",
-        "@pixi/settings": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/math": "6.0.2",
+        "@pixi/settings": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "packages/events": {
@@ -18748,114 +18748,114 @@
     },
     "packages/extract": {
       "name": "@pixi/extract",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/core": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/core": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "packages/filters/filter-alpha": {
       "name": "@pixi/filter-alpha",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/core": "6.0.1"
+        "@pixi/core": "6.0.2"
       }
     },
     "packages/filters/filter-blur": {
       "name": "@pixi/filter-blur",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/core": "6.0.1",
-        "@pixi/settings": "6.0.1"
+        "@pixi/core": "6.0.2",
+        "@pixi/settings": "6.0.2"
       }
     },
     "packages/filters/filter-color-matrix": {
       "name": "@pixi/filter-color-matrix",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/core": "6.0.1"
+        "@pixi/core": "6.0.2"
       }
     },
     "packages/filters/filter-displacement": {
       "name": "@pixi/filter-displacement",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/core": "6.0.1",
-        "@pixi/math": "6.0.1"
+        "@pixi/core": "6.0.2",
+        "@pixi/math": "6.0.2"
       }
     },
     "packages/filters/filter-fxaa": {
       "name": "@pixi/filter-fxaa",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/core": "6.0.1"
+        "@pixi/core": "6.0.2"
       }
     },
     "packages/filters/filter-noise": {
       "name": "@pixi/filter-noise",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/core": "6.0.1"
+        "@pixi/core": "6.0.2"
       }
     },
     "packages/graphics": {
       "name": "@pixi/graphics",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/constants": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/display": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/sprite": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/constants": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/display": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/sprite": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "packages/graphics-extras": {
       "name": "@pixi/graphics-extras",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/graphics": "6.0.1",
-        "@pixi/math": "6.0.1"
+        "@pixi/graphics": "6.0.2",
+        "@pixi/math": "6.0.2"
       }
     },
     "packages/interaction": {
       "name": "@pixi/interaction",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/core": "6.0.1",
-        "@pixi/display": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/ticker": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/core": "6.0.2",
+        "@pixi/display": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/ticker": "6.0.2",
+        "@pixi/utils": "6.0.2"
       },
       "devDependencies": {
-        "@pixi/canvas-display": "6.0.1",
-        "@pixi/canvas-graphics": "6.0.1",
-        "@pixi/canvas-renderer": "6.0.1",
-        "@pixi/canvas-sprite": "6.0.1",
-        "@pixi/graphics": "6.0.1",
-        "@pixi/sprite": "6.0.1"
+        "@pixi/canvas-display": "6.0.2",
+        "@pixi/canvas-graphics": "6.0.2",
+        "@pixi/canvas-renderer": "6.0.2",
+        "@pixi/canvas-sprite": "6.0.2",
+        "@pixi/graphics": "6.0.2",
+        "@pixi/sprite": "6.0.2"
       }
     },
     "packages/loaders": {
       "name": "@pixi/loaders",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/constants": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/utils": "6.0.1",
+        "@pixi/constants": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/utils": "6.0.2",
         "resource-loader": "^3.0.1"
       },
       "devDependencies": {
@@ -18864,83 +18864,83 @@
     },
     "packages/math": {
       "name": "@pixi/math",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT"
     },
     "packages/mesh": {
       "name": "@pixi/mesh",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/constants": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/display": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/settings": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/constants": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/display": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/settings": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "packages/mesh-extras": {
       "name": "@pixi/mesh-extras",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/constants": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/mesh": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/constants": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/mesh": "6.0.2",
+        "@pixi/utils": "6.0.2"
       },
       "devDependencies": {
-        "@pixi/loaders": "6.0.1"
+        "@pixi/loaders": "6.0.2"
       }
     },
     "packages/mixin-cache-as-bitmap": {
       "name": "@pixi/mixin-cache-as-bitmap",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/canvas-renderer": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/display": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/settings": "6.0.1",
-        "@pixi/sprite": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/canvas-renderer": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/display": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/settings": "6.0.2",
+        "@pixi/sprite": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "packages/mixin-get-child-by-name": {
       "name": "@pixi/mixin-get-child-by-name",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/display": "6.0.1"
+        "@pixi/display": "6.0.2"
       }
     },
     "packages/mixin-get-global-position": {
       "name": "@pixi/mixin-get-global-position",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/display": "6.0.1",
-        "@pixi/math": "6.0.1"
+        "@pixi/display": "6.0.2",
+        "@pixi/math": "6.0.2"
       }
     },
     "packages/particles": {
       "name": "@pixi/particles",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/constants": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/display": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/constants": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/display": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "packages/polyfill": {
       "name": "@pixi/polyfill",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
         "object-assign": "^4.1.1",
@@ -18953,25 +18953,25 @@
     },
     "packages/prepare": {
       "name": "@pixi/prepare",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/core": "6.0.1",
-        "@pixi/display": "6.0.1",
-        "@pixi/graphics": "6.0.1",
-        "@pixi/settings": "6.0.1",
-        "@pixi/text": "6.0.1",
-        "@pixi/ticker": "6.0.1"
+        "@pixi/core": "6.0.2",
+        "@pixi/display": "6.0.2",
+        "@pixi/graphics": "6.0.2",
+        "@pixi/settings": "6.0.2",
+        "@pixi/text": "6.0.2",
+        "@pixi/ticker": "6.0.2"
       }
     },
     "packages/runner": {
       "name": "@pixi/runner",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT"
     },
     "packages/settings": {
       "name": "@pixi/settings",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
         "ismobilejs": "^1.1.0"
@@ -18979,109 +18979,109 @@
     },
     "packages/sprite": {
       "name": "@pixi/sprite",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/constants": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/display": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/settings": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/constants": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/display": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/settings": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "packages/sprite-animated": {
       "name": "@pixi/sprite-animated",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/core": "6.0.1",
-        "@pixi/sprite": "6.0.1",
-        "@pixi/ticker": "6.0.1"
+        "@pixi/core": "6.0.2",
+        "@pixi/sprite": "6.0.2",
+        "@pixi/ticker": "6.0.2"
       }
     },
     "packages/sprite-tiling": {
       "name": "@pixi/sprite-tiling",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/constants": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/display": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/sprite": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/constants": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/display": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/sprite": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "packages/spritesheet": {
       "name": "@pixi/spritesheet",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/core": "6.0.1",
-        "@pixi/loaders": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/core": "6.0.2",
+        "@pixi/loaders": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "packages/text": {
       "name": "@pixi/text",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/core": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/settings": "6.0.1",
-        "@pixi/sprite": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/core": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/settings": "6.0.2",
+        "@pixi/sprite": "6.0.2",
+        "@pixi/utils": "6.0.2"
       },
       "devDependencies": {
-        "@pixi/canvas-display": "6.0.1",
-        "@pixi/canvas-renderer": "6.0.1",
-        "@pixi/canvas-sprite": "6.0.1"
+        "@pixi/canvas-display": "6.0.2",
+        "@pixi/canvas-renderer": "6.0.2",
+        "@pixi/canvas-sprite": "6.0.2"
       }
     },
     "packages/text-bitmap": {
       "name": "@pixi/text-bitmap",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/core": "6.0.1",
-        "@pixi/display": "6.0.1",
-        "@pixi/loaders": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/mesh": "6.0.1",
-        "@pixi/settings": "6.0.1",
-        "@pixi/text": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/core": "6.0.2",
+        "@pixi/display": "6.0.2",
+        "@pixi/loaders": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/mesh": "6.0.2",
+        "@pixi/settings": "6.0.2",
+        "@pixi/text": "6.0.2",
+        "@pixi/utils": "6.0.2"
       },
       "devDependencies": {
-        "@pixi/spritesheet": "6.0.1"
+        "@pixi/spritesheet": "6.0.2"
       }
     },
     "packages/ticker": {
       "name": "@pixi/ticker",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/settings": "6.0.1"
+        "@pixi/settings": "6.0.2"
       }
     },
     "packages/unsafe-eval": {
       "name": "@pixi/unsafe-eval",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/core": "6.0.1"
+        "@pixi/core": "6.0.2"
       }
     },
     "packages/utils": {
       "name": "@pixi/utils",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "@pixi/constants": "6.0.1",
-        "@pixi/settings": "6.0.1",
+        "@pixi/constants": "6.0.2",
+        "@pixi/settings": "6.0.2",
         "@types/earcut": "^2.1.0",
         "earcut": "^2.2.2",
         "eventemitter3": "^3.1.0",
@@ -19093,23 +19093,23 @@
     },
     "tools/integration-tests": {
       "name": "@internal/integration-tests",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "devDependencies": {
-        "@pixi/canvas-display": "6.0.1",
-        "@pixi/canvas-graphics": "6.0.1",
-        "@pixi/canvas-mesh": "6.0.1",
-        "@pixi/canvas-renderer": "6.0.1",
-        "@pixi/canvas-sprite": "6.0.1",
-        "@pixi/canvas-text": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/display": "6.0.1",
-        "@pixi/graphics": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/mesh": "6.0.1",
-        "@pixi/mesh-extras": "6.0.1",
-        "@pixi/sprite": "6.0.1",
-        "@pixi/text": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/canvas-display": "6.0.2",
+        "@pixi/canvas-graphics": "6.0.2",
+        "@pixi/canvas-mesh": "6.0.2",
+        "@pixi/canvas-renderer": "6.0.2",
+        "@pixi/canvas-sprite": "6.0.2",
+        "@pixi/canvas-text": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/display": "6.0.2",
+        "@pixi/graphics": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/mesh": "6.0.2",
+        "@pixi/mesh-extras": "6.0.2",
+        "@pixi/sprite": "6.0.2",
+        "@pixi/text": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     }
   },
@@ -20170,21 +20170,21 @@
     "@internal/integration-tests": {
       "version": "file:tools/integration-tests",
       "requires": {
-        "@pixi/canvas-display": "6.0.1",
-        "@pixi/canvas-graphics": "6.0.1",
-        "@pixi/canvas-mesh": "6.0.1",
-        "@pixi/canvas-renderer": "6.0.1",
-        "@pixi/canvas-sprite": "6.0.1",
-        "@pixi/canvas-text": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/display": "6.0.1",
-        "@pixi/graphics": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/mesh": "6.0.1",
-        "@pixi/mesh-extras": "6.0.1",
-        "@pixi/sprite": "6.0.1",
-        "@pixi/text": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/canvas-display": "6.0.2",
+        "@pixi/canvas-graphics": "6.0.2",
+        "@pixi/canvas-mesh": "6.0.2",
+        "@pixi/canvas-renderer": "6.0.2",
+        "@pixi/canvas-sprite": "6.0.2",
+        "@pixi/canvas-text": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/display": "6.0.2",
+        "@pixi/graphics": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/mesh": "6.0.2",
+        "@pixi/mesh-extras": "6.0.2",
+        "@pixi/sprite": "6.0.2",
+        "@pixi/text": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "@jsbits/escape-regex-str": {
@@ -21626,133 +21626,133 @@
     "@pixi/accessibility": {
       "version": "file:packages/accessibility",
       "requires": {
-        "@pixi/canvas-renderer": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/display": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/canvas-renderer": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/display": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "@pixi/app": {
       "version": "file:packages/app",
       "requires": {
-        "@pixi/canvas-renderer": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/display": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/canvas-renderer": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/display": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "@pixi/basis": {
       "version": "file:packages/basis",
       "requires": {
-        "@pixi/compressed-textures": "6.0.1",
-        "@pixi/constants": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/loaders": "6.0.1",
-        "@pixi/runner": "6.0.1"
+        "@pixi/compressed-textures": "6.0.2",
+        "@pixi/constants": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/loaders": "6.0.2",
+        "@pixi/runner": "6.0.2"
       }
     },
     "@pixi/canvas-display": {
       "version": "file:packages/canvas/canvas-display",
       "requires": {
-        "@pixi/display": "6.0.1"
+        "@pixi/display": "6.0.2"
       }
     },
     "@pixi/canvas-extract": {
       "version": "file:packages/canvas/canvas-extract",
       "requires": {
-        "@pixi/canvas-renderer": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/display": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/canvas-renderer": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/display": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "@pixi/canvas-graphics": {
       "version": "file:packages/canvas/canvas-graphics",
       "requires": {
-        "@pixi/canvas-display": "6.0.1",
-        "@pixi/canvas-renderer": "6.0.1",
-        "@pixi/constants": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/graphics": "6.0.1",
-        "@pixi/math": "6.0.1"
+        "@pixi/canvas-display": "6.0.2",
+        "@pixi/canvas-renderer": "6.0.2",
+        "@pixi/constants": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/graphics": "6.0.2",
+        "@pixi/math": "6.0.2"
       }
     },
     "@pixi/canvas-mesh": {
       "version": "file:packages/canvas/canvas-mesh",
       "requires": {
-        "@pixi/canvas-display": "6.0.1",
-        "@pixi/canvas-renderer": "6.0.1",
-        "@pixi/constants": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/mesh": "6.0.1",
-        "@pixi/mesh-extras": "6.0.1",
-        "@pixi/settings": "6.0.1",
-        "@pixi/sprite": "6.0.1"
+        "@pixi/canvas-display": "6.0.2",
+        "@pixi/canvas-renderer": "6.0.2",
+        "@pixi/constants": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/mesh": "6.0.2",
+        "@pixi/mesh-extras": "6.0.2",
+        "@pixi/settings": "6.0.2",
+        "@pixi/sprite": "6.0.2"
       }
     },
     "@pixi/canvas-particles": {
       "version": "file:packages/canvas/canvas-particles",
       "requires": {
-        "@pixi/particles": "6.0.1"
+        "@pixi/particles": "6.0.2"
       }
     },
     "@pixi/canvas-prepare": {
       "version": "file:packages/canvas/canvas-prepare",
       "requires": {
-        "@pixi/canvas-renderer": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/prepare": "6.0.1"
+        "@pixi/canvas-renderer": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/prepare": "6.0.2"
       }
     },
     "@pixi/canvas-renderer": {
       "version": "file:packages/canvas/canvas-renderer",
       "requires": {
-        "@pixi/constants": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/display": "6.0.1",
-        "@pixi/graphics": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/settings": "6.0.1",
-        "@pixi/sprite": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/constants": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/display": "6.0.2",
+        "@pixi/graphics": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/settings": "6.0.2",
+        "@pixi/sprite": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "@pixi/canvas-sprite": {
       "version": "file:packages/canvas/canvas-sprite",
       "requires": {
-        "@pixi/canvas-display": "6.0.1",
-        "@pixi/canvas-renderer": "6.0.1",
-        "@pixi/constants": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/sprite": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/canvas-display": "6.0.2",
+        "@pixi/canvas-renderer": "6.0.2",
+        "@pixi/constants": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/sprite": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "@pixi/canvas-sprite-tiling": {
       "version": "file:packages/canvas/canvas-sprite-tiling",
       "requires": {
-        "@pixi/canvas-renderer": "6.0.1",
-        "@pixi/canvas-sprite": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/sprite-tiling": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/canvas-renderer": "6.0.2",
+        "@pixi/canvas-sprite": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/sprite-tiling": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "@pixi/canvas-text": {
       "version": "file:packages/canvas/canvas-text",
       "requires": {
-        "@pixi/canvas-sprite": "6.0.1",
-        "@pixi/sprite": "6.0.1",
-        "@pixi/text": "6.0.1"
+        "@pixi/canvas-sprite": "6.0.2",
+        "@pixi/sprite": "6.0.2",
+        "@pixi/text": "6.0.2"
       }
     },
     "@pixi/compressed-textures": {
       "version": "file:packages/compressed-textures",
       "requires": {
-        "@pixi/constants": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/loaders": "6.0.1"
+        "@pixi/constants": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/loaders": "6.0.2"
       }
     },
     "@pixi/constants": {
@@ -21761,20 +21761,20 @@
     "@pixi/core": {
       "version": "file:packages/core",
       "requires": {
-        "@pixi/constants": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/runner": "6.0.1",
-        "@pixi/settings": "6.0.1",
-        "@pixi/ticker": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/constants": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/runner": "6.0.2",
+        "@pixi/settings": "6.0.2",
+        "@pixi/ticker": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "@pixi/display": {
       "version": "file:packages/display",
       "requires": {
-        "@pixi/math": "6.0.1",
-        "@pixi/settings": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/math": "6.0.2",
+        "@pixi/settings": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "@pixi/eslint-config": {
@@ -21798,89 +21798,89 @@
     "@pixi/extract": {
       "version": "file:packages/extract",
       "requires": {
-        "@pixi/core": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/core": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "@pixi/filter-alpha": {
       "version": "file:packages/filters/filter-alpha",
       "requires": {
-        "@pixi/core": "6.0.1"
+        "@pixi/core": "6.0.2"
       }
     },
     "@pixi/filter-blur": {
       "version": "file:packages/filters/filter-blur",
       "requires": {
-        "@pixi/core": "6.0.1",
-        "@pixi/settings": "6.0.1"
+        "@pixi/core": "6.0.2",
+        "@pixi/settings": "6.0.2"
       }
     },
     "@pixi/filter-color-matrix": {
       "version": "file:packages/filters/filter-color-matrix",
       "requires": {
-        "@pixi/core": "6.0.1"
+        "@pixi/core": "6.0.2"
       }
     },
     "@pixi/filter-displacement": {
       "version": "file:packages/filters/filter-displacement",
       "requires": {
-        "@pixi/core": "6.0.1",
-        "@pixi/math": "6.0.1"
+        "@pixi/core": "6.0.2",
+        "@pixi/math": "6.0.2"
       }
     },
     "@pixi/filter-fxaa": {
       "version": "file:packages/filters/filter-fxaa",
       "requires": {
-        "@pixi/core": "6.0.1"
+        "@pixi/core": "6.0.2"
       }
     },
     "@pixi/filter-noise": {
       "version": "file:packages/filters/filter-noise",
       "requires": {
-        "@pixi/core": "6.0.1"
+        "@pixi/core": "6.0.2"
       }
     },
     "@pixi/graphics": {
       "version": "file:packages/graphics",
       "requires": {
-        "@pixi/constants": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/display": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/sprite": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/constants": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/display": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/sprite": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "@pixi/graphics-extras": {
       "version": "file:packages/graphics-extras",
       "requires": {
-        "@pixi/graphics": "6.0.1",
-        "@pixi/math": "6.0.1"
+        "@pixi/graphics": "6.0.2",
+        "@pixi/math": "6.0.2"
       }
     },
     "@pixi/interaction": {
       "version": "file:packages/interaction",
       "requires": {
-        "@pixi/canvas-display": "6.0.1",
-        "@pixi/canvas-graphics": "6.0.1",
-        "@pixi/canvas-renderer": "6.0.1",
-        "@pixi/canvas-sprite": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/display": "6.0.1",
-        "@pixi/graphics": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/sprite": "6.0.1",
-        "@pixi/ticker": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/canvas-display": "6.0.2",
+        "@pixi/canvas-graphics": "6.0.2",
+        "@pixi/canvas-renderer": "6.0.2",
+        "@pixi/canvas-sprite": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/display": "6.0.2",
+        "@pixi/graphics": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/sprite": "6.0.2",
+        "@pixi/ticker": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "@pixi/loaders": {
       "version": "file:packages/loaders",
       "requires": {
-        "@pixi/constants": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/utils": "6.0.1",
+        "@pixi/constants": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/utils": "6.0.2",
         "resource-loader": "^3.0.1"
       }
     },
@@ -21890,58 +21890,58 @@
     "@pixi/mesh": {
       "version": "file:packages/mesh",
       "requires": {
-        "@pixi/constants": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/display": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/settings": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/constants": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/display": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/settings": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "@pixi/mesh-extras": {
       "version": "file:packages/mesh-extras",
       "requires": {
-        "@pixi/constants": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/loaders": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/mesh": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/constants": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/loaders": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/mesh": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "@pixi/mixin-cache-as-bitmap": {
       "version": "file:packages/mixin-cache-as-bitmap",
       "requires": {
-        "@pixi/canvas-renderer": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/display": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/settings": "6.0.1",
-        "@pixi/sprite": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/canvas-renderer": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/display": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/settings": "6.0.2",
+        "@pixi/sprite": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "@pixi/mixin-get-child-by-name": {
       "version": "file:packages/mixin-get-child-by-name",
       "requires": {
-        "@pixi/display": "6.0.1"
+        "@pixi/display": "6.0.2"
       }
     },
     "@pixi/mixin-get-global-position": {
       "version": "file:packages/mixin-get-global-position",
       "requires": {
-        "@pixi/display": "6.0.1",
-        "@pixi/math": "6.0.1"
+        "@pixi/display": "6.0.2",
+        "@pixi/math": "6.0.2"
       }
     },
     "@pixi/particles": {
       "version": "file:packages/particles",
       "requires": {
-        "@pixi/constants": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/display": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/constants": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/display": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "@pixi/polyfill": {
@@ -21956,12 +21956,12 @@
     "@pixi/prepare": {
       "version": "file:packages/prepare",
       "requires": {
-        "@pixi/core": "6.0.1",
-        "@pixi/display": "6.0.1",
-        "@pixi/graphics": "6.0.1",
-        "@pixi/settings": "6.0.1",
-        "@pixi/text": "6.0.1",
-        "@pixi/ticker": "6.0.1"
+        "@pixi/core": "6.0.2",
+        "@pixi/display": "6.0.2",
+        "@pixi/graphics": "6.0.2",
+        "@pixi/settings": "6.0.2",
+        "@pixi/text": "6.0.2",
+        "@pixi/ticker": "6.0.2"
       }
     },
     "@pixi/runner": {
@@ -21976,86 +21976,86 @@
     "@pixi/sprite": {
       "version": "file:packages/sprite",
       "requires": {
-        "@pixi/constants": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/display": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/settings": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/constants": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/display": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/settings": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "@pixi/sprite-animated": {
       "version": "file:packages/sprite-animated",
       "requires": {
-        "@pixi/core": "6.0.1",
-        "@pixi/sprite": "6.0.1",
-        "@pixi/ticker": "6.0.1"
+        "@pixi/core": "6.0.2",
+        "@pixi/sprite": "6.0.2",
+        "@pixi/ticker": "6.0.2"
       }
     },
     "@pixi/sprite-tiling": {
       "version": "file:packages/sprite-tiling",
       "requires": {
-        "@pixi/constants": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/display": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/sprite": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/constants": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/display": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/sprite": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "@pixi/spritesheet": {
       "version": "file:packages/spritesheet",
       "requires": {
-        "@pixi/core": "6.0.1",
-        "@pixi/loaders": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/core": "6.0.2",
+        "@pixi/loaders": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "@pixi/text": {
       "version": "file:packages/text",
       "requires": {
-        "@pixi/canvas-display": "6.0.1",
-        "@pixi/canvas-renderer": "6.0.1",
-        "@pixi/canvas-sprite": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/settings": "6.0.1",
-        "@pixi/sprite": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/canvas-display": "6.0.2",
+        "@pixi/canvas-renderer": "6.0.2",
+        "@pixi/canvas-sprite": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/settings": "6.0.2",
+        "@pixi/sprite": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "@pixi/text-bitmap": {
       "version": "file:packages/text-bitmap",
       "requires": {
-        "@pixi/core": "6.0.1",
-        "@pixi/display": "6.0.1",
-        "@pixi/loaders": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/mesh": "6.0.1",
-        "@pixi/settings": "6.0.1",
-        "@pixi/spritesheet": "6.0.1",
-        "@pixi/text": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/core": "6.0.2",
+        "@pixi/display": "6.0.2",
+        "@pixi/loaders": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/mesh": "6.0.2",
+        "@pixi/settings": "6.0.2",
+        "@pixi/spritesheet": "6.0.2",
+        "@pixi/text": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "@pixi/ticker": {
       "version": "file:packages/ticker",
       "requires": {
-        "@pixi/settings": "6.0.1"
+        "@pixi/settings": "6.0.2"
       }
     },
     "@pixi/unsafe-eval": {
       "version": "file:packages/unsafe-eval",
       "requires": {
-        "@pixi/core": "6.0.1"
+        "@pixi/core": "6.0.2"
       }
     },
     "@pixi/utils": {
       "version": "file:packages/utils",
       "requires": {
-        "@pixi/constants": "6.0.1",
-        "@pixi/settings": "6.0.1",
+        "@pixi/constants": "6.0.2",
+        "@pixi/settings": "6.0.2",
         "@types/earcut": "^2.1.0",
         "css-color-names": "^1.0.1",
         "earcut": "^2.2.2",
@@ -31809,57 +31809,57 @@
     "pixi.js": {
       "version": "file:bundles/pixi.js",
       "requires": {
-        "@pixi/accessibility": "6.0.1",
-        "@pixi/app": "6.0.1",
-        "@pixi/compressed-textures": "6.0.1",
-        "@pixi/constants": "6.0.1",
-        "@pixi/core": "6.0.1",
-        "@pixi/display": "6.0.1",
-        "@pixi/extract": "6.0.1",
-        "@pixi/filter-alpha": "6.0.1",
-        "@pixi/filter-blur": "6.0.1",
-        "@pixi/filter-color-matrix": "6.0.1",
-        "@pixi/filter-displacement": "6.0.1",
-        "@pixi/filter-fxaa": "6.0.1",
-        "@pixi/filter-noise": "6.0.1",
-        "@pixi/graphics": "6.0.1",
-        "@pixi/interaction": "6.0.1",
-        "@pixi/loaders": "6.0.1",
-        "@pixi/math": "6.0.1",
-        "@pixi/mesh": "6.0.1",
-        "@pixi/mesh-extras": "6.0.1",
-        "@pixi/mixin-cache-as-bitmap": "6.0.1",
-        "@pixi/mixin-get-child-by-name": "6.0.1",
-        "@pixi/mixin-get-global-position": "6.0.1",
-        "@pixi/particles": "6.0.1",
-        "@pixi/polyfill": "6.0.1",
-        "@pixi/prepare": "6.0.1",
-        "@pixi/runner": "6.0.1",
-        "@pixi/settings": "6.0.1",
-        "@pixi/sprite": "6.0.1",
-        "@pixi/sprite-animated": "6.0.1",
-        "@pixi/sprite-tiling": "6.0.1",
-        "@pixi/spritesheet": "6.0.1",
-        "@pixi/text": "6.0.1",
-        "@pixi/text-bitmap": "6.0.1",
-        "@pixi/ticker": "6.0.1",
-        "@pixi/utils": "6.0.1"
+        "@pixi/accessibility": "6.0.2",
+        "@pixi/app": "6.0.2",
+        "@pixi/compressed-textures": "6.0.2",
+        "@pixi/constants": "6.0.2",
+        "@pixi/core": "6.0.2",
+        "@pixi/display": "6.0.2",
+        "@pixi/extract": "6.0.2",
+        "@pixi/filter-alpha": "6.0.2",
+        "@pixi/filter-blur": "6.0.2",
+        "@pixi/filter-color-matrix": "6.0.2",
+        "@pixi/filter-displacement": "6.0.2",
+        "@pixi/filter-fxaa": "6.0.2",
+        "@pixi/filter-noise": "6.0.2",
+        "@pixi/graphics": "6.0.2",
+        "@pixi/interaction": "6.0.2",
+        "@pixi/loaders": "6.0.2",
+        "@pixi/math": "6.0.2",
+        "@pixi/mesh": "6.0.2",
+        "@pixi/mesh-extras": "6.0.2",
+        "@pixi/mixin-cache-as-bitmap": "6.0.2",
+        "@pixi/mixin-get-child-by-name": "6.0.2",
+        "@pixi/mixin-get-global-position": "6.0.2",
+        "@pixi/particles": "6.0.2",
+        "@pixi/polyfill": "6.0.2",
+        "@pixi/prepare": "6.0.2",
+        "@pixi/runner": "6.0.2",
+        "@pixi/settings": "6.0.2",
+        "@pixi/sprite": "6.0.2",
+        "@pixi/sprite-animated": "6.0.2",
+        "@pixi/sprite-tiling": "6.0.2",
+        "@pixi/spritesheet": "6.0.2",
+        "@pixi/text": "6.0.2",
+        "@pixi/text-bitmap": "6.0.2",
+        "@pixi/ticker": "6.0.2",
+        "@pixi/utils": "6.0.2"
       }
     },
     "pixi.js-legacy": {
       "version": "file:bundles/pixi.js-legacy",
       "requires": {
-        "@pixi/canvas-display": "6.0.1",
-        "@pixi/canvas-extract": "6.0.1",
-        "@pixi/canvas-graphics": "6.0.1",
-        "@pixi/canvas-mesh": "6.0.1",
-        "@pixi/canvas-particles": "6.0.1",
-        "@pixi/canvas-prepare": "6.0.1",
-        "@pixi/canvas-renderer": "6.0.1",
-        "@pixi/canvas-sprite": "6.0.1",
-        "@pixi/canvas-sprite-tiling": "6.0.1",
-        "@pixi/canvas-text": "6.0.1",
-        "pixi.js": "6.0.1"
+        "@pixi/canvas-display": "6.0.2",
+        "@pixi/canvas-extract": "6.0.2",
+        "@pixi/canvas-graphics": "6.0.2",
+        "@pixi/canvas-mesh": "6.0.2",
+        "@pixi/canvas-particles": "6.0.2",
+        "@pixi/canvas-prepare": "6.0.2",
+        "@pixi/canvas-renderer": "6.0.2",
+        "@pixi/canvas-sprite": "6.0.2",
+        "@pixi/canvas-sprite-tiling": "6.0.2",
+        "@pixi/canvas-text": "6.0.2",
+        "pixi.js": "6.0.2"
       }
     },
     "pkg-dir": {


### PR DESCRIPTION
Seems that the package-lock is not updated when Lerna does a bump. Need to find a better solution, but this is an update of the file. Might report to Lerna or do a postversion npm install.

Edit: Probably related to this bug https://github.com/lerna/lerna/issues/2832