### PR TITLE
Add the export namespace to the declaration file

### DIFF
--- a/scripts/injectGlobalMixins.ts
+++ b/scripts/injectGlobalMixins.ts
@@ -33,18 +33,13 @@ async function getSortedPackages(): Promise<SimplePackageJson[]>
 function writeToIndex(basePath: string, dataToWrite: string): void
 {
     const indexDtsPath = path.resolve(basePath, './index.d.ts');
-    const file = fs.readFileSync(indexDtsPath, { encoding: 'utf8' }).toString().split('\n');
+    const file = fs.readFileSync(indexDtsPath, { encoding: 'utf8' })
+        .toString()
+        .replace('export { }', 'export as namespace PIXI;')
+        .split('\n');
 
     file.unshift(dataToWrite);
     fs.writeFileSync(indexDtsPath, file.join('\n'));
-}
-
-function writeNamespace(basePath: string)
-{
-    const indexDtsPath = path.resolve(basePath, './index.d.ts');
-    const file = fs.readFileSync(indexDtsPath, { encoding: 'utf8' }).replace('export { }', 'export as namespace PIXI;');
-
-    fs.writeFileSync(indexDtsPath, file);
 }
 
 /**
@@ -99,17 +94,18 @@ async function start(): Promise<void>
 
             writeToIndex(basePath, packageTypeData);
         }
+        else
+        {
+            writeToIndex(basePath, '');
+        }
     });
 
     // write the total types to the main packages
     let basePath = path.relative(process.cwd(), pixiLocation);
 
     writeToIndex(basePath, pixiGlobalMixins);
-    writeNamespace(basePath);
-
     basePath = path.relative(process.cwd(), pixiLegacyLocation);
     writeToIndex(basePath, pixiLegacyGlobalMixins);
-    writeNamespace(basePath);
 }
 
 start();

--- a/scripts/injectGlobalMixins.ts
+++ b/scripts/injectGlobalMixins.ts
@@ -39,6 +39,14 @@ function writeToIndex(basePath: string, dataToWrite: string): void
     fs.writeFileSync(indexDtsPath, file.join('\n'));
 }
 
+function writeNamespace(basePath: string)
+{
+    const indexDtsPath = path.resolve(basePath, './index.d.ts');
+    const file = fs.readFileSync(indexDtsPath, { encoding: 'utf8' }).replace('export { }', 'export as namespace PIXI;');
+
+    fs.writeFileSync(indexDtsPath, file);
+}
+
 /**
  * This is a workaround for https://github.com/pixijs/pixi.js/issues/6993
  *
@@ -97,8 +105,11 @@ async function start(): Promise<void>
     let basePath = path.relative(process.cwd(), pixiLocation);
 
     writeToIndex(basePath, pixiGlobalMixins);
+    writeNamespace(basePath);
+
     basePath = path.relative(process.cwd(), pixiLegacyLocation);
     writeToIndex(basePath, pixiLegacyGlobalMixins);
+    writeNamespace(basePath);
 }
 
 start();


### PR DESCRIPTION
Want to have a namespace called `PIXI` just like `v5`. It's easy to do some custom configuration in `vscode`.

Now: 
https://unpkg.com/browse/pixi.js@6.0.2/index.d.ts

```ts
export {}
```

This PR will replace it with:

```ts
export as namespace PIXI;
```

