### PR TITLE
add support for RGB Float

### DIFF
--- a/packages/core/src/textures/TextureSystem.ts
+++ b/packages/core/src/textures/TextureSystem.ts
@@ -15,6 +15,7 @@ import type { Renderer } from '../Renderer';
  * @extends PIXI.System
  * @memberof PIXI
  */
+
 export class TextureSystem implements ISystem
 {
     public boundTextures: BaseTexture[];
@@ -159,6 +160,7 @@ export class TextureSystem implements ISystem
                         this.currentLocation = location;
                         gl.activeTexture(gl.TEXTURE0 + location);
                     }
+
                     gl.bindTexture(texture.target, glTexture.texture);
                 }
 
@@ -303,17 +305,23 @@ export class TextureSystem implements ISystem
         {
             return;
         }
+
         const gl = this.renderer.gl;
 
-        if (texture.type === gl.FLOAT
-            && texture.format === gl.RGBA)
+        if (texture.type === gl.FLOAT)
         {
-            glTexture.internalFormat = gl.RGBA32F;
-        }
-        if (texture.type === gl.FLOAT
-            && texture.format === gl.RED)
-        {
-            glTexture.internalFormat = gl.R32F;
+            if (texture.format === gl.RGBA)
+            {
+                glTexture.internalFormat = gl.RGBA32F;
+            }
+            else if (texture.format === gl.RGB)
+            {
+                glTexture.internalFormat = gl.RGB32F;
+            }
+            else if (texture.format === gl.RED)
+            {
+                glTexture.internalFormat = gl.R32F;
+            }
         }
 
         // that's WebGL1 HALF_FLOAT_OES
@@ -322,10 +330,17 @@ export class TextureSystem implements ISystem
         {
             glTexture.type = gl.HALF_FLOAT;
         }
-        if (glTexture.type === gl.HALF_FLOAT
-            && texture.format === gl.RGBA)
+
+        if (glTexture.type === gl.HALF_FLOAT)
         {
-            glTexture.internalFormat = gl.RGBA16F;
+            if (texture.format === gl.RGBA)
+            {
+                glTexture.internalFormat = gl.RGBA16F;
+            }
+            else if (texture.format === gl.RGB)
+            {
+                glTexture.internalFormat = gl.RGB16F;
+            }
         }
     }
 

--- a/packages/core/test/TextureSystem.js
+++ b/packages/core/test/TextureSystem.js
@@ -77,6 +77,18 @@ describe('PIXI.TextureSystem', function ()
         expect(glTex.internalFormat).to.equal(this.renderer.gl.R32F);
     });
 
+    it('should set internalFormat correctly for RGB FLOAT textures', function ()
+    {
+        const baseTex = createTempTexture({ type: TYPES.FLOAT, format: FORMATS.RGB });
+
+        this.renderer.texture.bind(baseTex);
+
+        const glTex = baseTex._glTextures[this.renderer.CONTEXT_UID];
+
+        expect(glTex).to.be.notnull;
+        expect(glTex.internalFormat).to.equal(this.renderer.gl.RGB32F);
+    });
+
     function createIntegerTexture()
     {
         const baseTexture = BaseTexture.fromBuffer(new Uint32Array([0, 0, 0, 0]), 1, 1);


### PR DESCRIPTION
Little tweak to support the RGB Float format.

Number of if statements is getting a bit high - we could switch this up to use a hash map if it needs any more!

test included..
