### PR TITLE
fix: Restore original `alpha` value for cacheAsBitmap 

### DIFF
--- a/packages/mixin-cache-as-bitmap/src/index.ts
+++ b/packages/mixin-cache-as-bitmap/src/index.ts
@@ -276,6 +276,8 @@ DisplayObject.prototype._initCachedDisplayObject = function _initCachedDisplayOb
 
     this._mask = null;
     this.filterArea = null;
+    this.alpha = cacheAlpha;
+
 
     // create our cached sprite
     const cachedSprite = new Sprite(renderTexture);
@@ -391,6 +393,7 @@ DisplayObject.prototype._initCachedDisplayObjectCanvas = function _initCachedDis
 
     this._mask = null;
     this.filterArea = null;
+    this.alpha = cacheAlpha;
 
     // create our cached sprite
     const cachedSprite = new Sprite(renderTexture);

--- a/packages/mixin-cache-as-bitmap/src/index.ts
+++ b/packages/mixin-cache-as-bitmap/src/index.ts
@@ -278,7 +278,6 @@ DisplayObject.prototype._initCachedDisplayObject = function _initCachedDisplayOb
     this.filterArea = null;
     this.alpha = cacheAlpha;
 
-
     // create our cached sprite
     const cachedSprite = new Sprite(renderTexture);
 


### PR DESCRIPTION
Restore original alpha value of cached node, otherwith we corrupt node state and alpha will be missed while not changed outside after first calling a  `_initCachedDisplayObject`
Fix #7432

<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
