### PR TITLE
Fix GlobalMixins to be avoid issues with strictNullChecks

### DIFF
--- a/packages/canvas/canvas-display/global.d.ts
+++ b/packages/canvas/canvas-display/global.d.ts
@@ -1,5 +1,5 @@
 declare namespace GlobalMixins {
     interface Container {
-        _renderCanvas?(renderer: import('@pixi/canvas-renderer').CanvasRenderer): void;
+        _renderCanvas(renderer: import('@pixi/canvas-renderer').CanvasRenderer): void;
     }
 }

--- a/packages/canvas/canvas-graphics/global.d.ts
+++ b/packages/canvas/canvas-graphics/global.d.ts
@@ -1,6 +1,6 @@
 declare namespace GlobalMixins {
     interface Graphics {
-        _renderCanvas?(renderer: import('@pixi/canvas-renderer').CanvasRenderer): void;
+        _renderCanvas(renderer: import('@pixi/canvas-renderer').CanvasRenderer): void;
         generateCanvasTexture(scaleMode: import('@pixi/constants').SCALE_MODES, resolution?: number): Texture;
         cachedGraphicsData: import('@pixi/graphics').GraphicsData[];
     }

--- a/packages/canvas/canvas-mesh/global.d.ts
+++ b/packages/canvas/canvas-mesh/global.d.ts
@@ -1,6 +1,6 @@
 declare namespace GlobalMixins {
     interface Mesh {
-        _renderCanvas?(renderer: import('@pixi/canvas-renderer').CanvasRenderer): void;
+        _renderCanvas(renderer: import('@pixi/canvas-renderer').CanvasRenderer): void;
         _canvasPadding: number;
         canvasPadding: number;
         _cachedTint: number;

--- a/packages/canvas/canvas-sprite/global.d.ts
+++ b/packages/canvas/canvas-sprite/global.d.ts
@@ -1,6 +1,6 @@
 declare namespace GlobalMixins {
     interface Sprite {
-        _tintedCanvas?: HTMLCanvasElement|HTMLImageElement;
-        _renderCanvas?(renderer: import('@pixi/canvas-renderer').CanvasRenderer): void;
+        _tintedCanvas: HTMLCanvasElement|HTMLImageElement;
+        _renderCanvas(renderer: import('@pixi/canvas-renderer').CanvasRenderer): void;
     }
 }

--- a/packages/mixin-cache-as-bitmap/global.d.ts
+++ b/packages/mixin-cache-as-bitmap/global.d.ts
@@ -1,18 +1,18 @@
 declare namespace GlobalMixins
 {
     interface DisplayObject {
-        cacheAsBitmap?: boolean;
-        cacheAsBitmapResolution?: number;
-        _cacheAsBitmapResolution?: number;
-        _cacheAsBitmap?: boolean;
-        _cacheData?: import('@pixi/mixin-cache-as-bitmap').CacheData;
-        _renderCached?: (renderer: import('@pixi/core').Renderer) => void;
-        _initCachedDisplayObject?: (renderer: import('@pixi/core').Renderer) => void;
-        _calculateCachedBounds?: () => void;
-        _getCachedLocalBounds?: () => import('@pixi/math').Rectangle;
-        _renderCachedCanvas?: (renderer: import('@pixi/canvas-renderer').CanvasRenderer) => void;
-        _initCachedDisplayObjectCanvas?: (renderer: import('@pixi/canvas-renderer').CanvasRenderer) => void;
-        _destroyCachedDisplayObject?: () => void;
-        _cacheAsBitmapDestroy?: (options?: import('@pixi/display').IDestroyOptions|boolean) => void;
+        cacheAsBitmap: boolean;
+        cacheAsBitmapResolution: number;
+        _cacheAsBitmapResolution: number;
+        _cacheAsBitmap: boolean;
+        _cacheData: import('@pixi/mixin-cache-as-bitmap').CacheData;
+        _renderCached(renderer: import('@pixi/core').Renderer): void;
+        _initCachedDisplayObject(renderer: import('@pixi/core').Renderer): void;
+        _calculateCachedBounds(): void;
+        _getCachedLocalBounds(): import('@pixi/math').Rectangle;
+        _renderCachedCanvas(renderer: import('@pixi/canvas-renderer').CanvasRenderer): void;
+        _initCachedDisplayObjectCanvas(renderer: import('@pixi/canvas-renderer').CanvasRenderer): void;
+        _destroyCachedDisplayObject(): void;
+        _cacheAsBitmapDestroy(options?: import('@pixi/display').IDestroyOptions|boolean): void;
     }
 }

--- a/packages/mixin-get-child-by-name/global.d.ts
+++ b/packages/mixin-get-child-by-name/global.d.ts
@@ -2,7 +2,7 @@ declare namespace GlobalMixins
 {
     interface DisplayObject
     {
-        name?: string;
+        name: string;
     }
 
     interface Container

--- a/packages/mixin-get-global-position/global.d.ts
+++ b/packages/mixin-get-global-position/global.d.ts
@@ -2,6 +2,6 @@ declare namespace GlobalMixins
 {
     interface DisplayObject
     {
-        getGlobalPosition?: (point?: import('@pixi/math').Point, skipUpdate?: boolean) => import('@pixi/math').Point;
+        getGlobalPosition(point?: import('@pixi/math').Point, skipUpdate?: boolean): import('@pixi/math').Point;
     }
 }


### PR DESCRIPTION
Follow up to #7451

Conversation context #7444

This change makes the global mixins non-optional. Some of these were optional that shouldn't be. 