### PR TITLE
Fixes unit-test failures from npm@7.12.0

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         node-version: 12.x
     - name: Install npm
-      run: npm install -g npm@7
+      run: npm install -g npm@7.11.2
     - name: Install Dependencies
       run: npm ci
     - name: Install Code Coverage Dependency


### PR DESCRIPTION
The weird test failures in #7475 happened to overlap with the release of npm 7.12.0 yesterday. I have pinned our CI to 7.11.2 until this can be resolved.

Fixes #7475