### PR TITLE
Hot patch for flipping scissors (v6)

### DIFF
--- a/packages/core/src/mask/ScissorSystem.ts
+++ b/packages/core/src/mask/ScissorSystem.ts
@@ -117,8 +117,8 @@ export class ScissorSystem extends AbstractMaskSystem
             y = this.renderer.height - height - y;
         }
 
-        x = Math.round(x);
-        y = Math.round(y);
+        x = Math.max(Math.round(x), 0);
+        y = Math.max(Math.round(y), 0);
         width = Math.round(width);
         height = Math.round(height);
 


### PR DESCRIPTION
Follow degradation #7888
Negative values not allowed (was ok before, degradation) and scissor state reset.

Partial fix: #7855

This fix working in ANGLE backend on chrome, for Safari need check width/height !== 0.
Fix require minor refact of mask (Scissor) system to allow disable color mask or falling down to stencil for degenerated scissor rect.
Working on `little blood` implementation.

<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please 

- [ ] read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
