### PR TITLE
Type "next middleware" parameter of middleware functions as non-optional

### DIFF
--- a/packages/loaders/src/Loader.ts
+++ b/packages/loaders/src/Loader.ts
@@ -8,7 +8,7 @@ import { Dict } from '@pixi/utils';
 const MAX_PROGRESS = 100;
 const rgxExtractUrlHash = /(#[\w-]+)?$/;
 
-export type ILoaderMiddleware = (resource: LoaderResource, next?: (...args: any[]) => void) => void;
+export type ILoaderMiddleware = (resource: LoaderResource, next: (...args: any[]) => void) => void;
 
 export interface ILoaderAdd {
     (this: Loader, name: string, url: string, callback?: LoaderResource.OnCompleteSignal): Loader;
@@ -821,12 +821,12 @@ export interface ILoaderPlugin {
      * @param resource - resource
      * @param next - next middleware
      */
-    pre?(resource: LoaderResource, next?: (...args: any[]) => void): void;
+    pre?(resource: LoaderResource, next: (...args: any[]) => void): void;
 
     /**
      * Middleware function to run after load
      * @param resource - resource
      * @param next - next middleware
      */
-    use?(resource: LoaderResource, next?: (...args: any[]) => void): void;
+    use?(resource: LoaderResource, next: (...args: any[]) => void): void;
 }

--- a/packages/loaders/src/TextureLoader.ts
+++ b/packages/loaders/src/TextureLoader.ts
@@ -1,13 +1,12 @@
 import { Texture } from '@pixi/core';
 import { LoaderResource } from './LoaderResource';
-import { ILoaderPlugin } from './Loader';
 
 /**
  * Loader plugin for handling Texture resources.
  *
  * @memberof PIXI
  */
-export class TextureLoader implements ILoaderPlugin
+export class TextureLoader
 {
     /**
      * Handle SVG elements a text, render with SVGResource.


### PR DESCRIPTION
Fixes [7898](https://github.com/pixijs/pixijs/issues/7898)

##### Description of change

The "next middleware" parameter of middleware functions is now typed as non-optional.

Also, the `implements ILoaderPlugin` clause has been removed from the `TextureLoader` class, as it does not serve the intended purpose of typing the **static** methods of a plugin.

##### Pre-Merge Checklist

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
