### PR TITLE
Typescript types fix: exporting IHitArea

### DIFF
--- a/packages/interaction/src/interactiveTarget.ts
+++ b/packages/interaction/src/interactiveTarget.ts
@@ -37,7 +37,7 @@ type Cursor = 'auto'
     | 'grab'
     | 'grabbing';
 
-interface IHitArea {
+export interface IHitArea {
     contains(x: number, y: number): boolean;
 }
 


### PR DESCRIPTION
##### Description of change
Somewhere along the way, `IHitArea` got _unexported_

Since we allow the user to replace the `hitArea` of a `DisplayObject` with something that implements `IHitArea`  we should expose the interface so people can make their own code.

##### Pre-Merge Checklist
This edit was quickly made from the github UI. Let's see if it passes the checks 👀
(It would have taken me the same time to create an issue with this than to edit it from the github page. If this doesn't work, I will fix it when I get some free time)

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
