### PR TITLE
simple tiling sprite fix

### DIFF
--- a/packages/sprite-tiling/src/tilingSprite_simple.frag
+++ b/packages/sprite-tiling/src/tilingSprite_simple.frag
@@ -5,6 +5,6 @@ uniform vec4 uColor;
 
 void main(void)
 {
-    vec4 sample = texture2D(uSampler, vTextureCoord);
-    gl_FragColor = sample * uColor;
+    vec4 texSample = texture2D(uSampler, vTextureCoord);
+    gl_FragColor = texSample * uColor;
 }


### PR DESCRIPTION
##### Description of change
When running PIXI using `headless-gl` our `tilingSprite_simple.frag` fragment is given us the following syntax error:

<img width="409" alt="Screen Shot 2021-10-25 at 9 02 57 AM" src="https://user-images.githubusercontent.com/2272141/138734410-7ed95e48-c708-4846-8ad9-5ac5fb0ba197.png">

The fix in this PR resolves this error.

##### Pre-Merge Checklist
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
