### PR TITLE
Hide new letterSpacing API behind a flag

### DIFF
--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -57,7 +57,7 @@ export class Text extends Sprite
      * In the next major release, we'll enable this by default.
      */
     public static nextLineHeightBehavior = false;
-    
+
     /**
      * New rendering behavior for letter-spacing which uses Chrome's new native API. This will
      * lead to more accurate letter-spacing results because it does not try to manually draw
@@ -334,8 +334,8 @@ export class Text extends Sprite
         // https://developer.chrome.com/origintrials/#/view_trial/3585991203293757441
         // note: this is unstable API, Chrome less 94 use a `textLetterSpacing`, newest use a letterSpacing
         // eslint-disable-next-line max-len
-        const supportLetterSpacing = Text.experimentalLetterSpacing &&
-            ('letterSpacing' in CanvasRenderingContext2D.prototype
+        const supportLetterSpacing = Text.experimentalLetterSpacing
+            && ('letterSpacing' in CanvasRenderingContext2D.prototype
                 || 'textLetterSpacing' in CanvasRenderingContext2D.prototype);
 
         if (letterSpacing === 0 || supportLetterSpacing)


### PR DESCRIPTION
Fixes #8208 by hiding the new letterSpacing API behind a feature flag `Text.experimentalLetterSpacing` that way users can opt-in.