### PR TITLE
Add trigger workflow to update dev package on beta.pixijs.com

### DIFF
--- a/.github/workflows/trigger-website-build.yml
+++ b/.github/workflows/trigger-website-build.yml
@@ -3,8 +3,8 @@ name: Trigger Website Build
 on:
   pull_request:
     branches:
-      - deploy
-    types: [closed]
+      - dev
+    types: [ closed ]
 
 jobs:
   trigger-website-build:
@@ -17,7 +17,7 @@ jobs:
           event-type: update-dev
           repository: pixijs/beta.pixijs.com
           token: ${{ secrets.PAT }}
-          client-payload: '{"sha": "${{ github.sha }}"}'
+          client-payload: '{"sha": "${{ github.event.pull_request.head.sha }}"}'
 
 
 


### PR DESCRIPTION
This PR adds a github workflow trigger to call the `update-dev` event on `beta.pixijs.com`

I've confirmed the workflow runs as expected in a fork of `pixi.js`, including taking the commit sha from the last commit of the PR rather than the commit where the PR is actually merged:

pixi.js forked repo triggering the action:
<img width="1366" alt="Screenshot 2023-03-21 at 16 44 19" src="https://user-images.githubusercontent.com/1300909/226683903-4bd7c8ee-22eb-485e-9695-dda85b455da7.png">

beta.pixijs.com receiving the action:
<img width="1008" alt="Screenshot 2023-03-21 at 16 49 15" src="https://user-images.githubusercontent.com/1300909/226684409-c8043e76-7f4a-4b74-82de-52a54e145d5d.png">

