### PR TITLE
feat: support loading texture from blob by specifying format

### DIFF
--- a/src/assets/loader/parsers/textures/loadTextures.ts
+++ b/src/assets/loader/parsers/textures/loadTextures.ts
@@ -4,6 +4,7 @@ import { ImageSource } from '../../../../rendering/renderers/shared/texture/sour
 import { getResolutionOfUrl } from '../../../../utils/network/getResolutionOfUrl';
 import { checkDataUrl } from '../../../utils/checkDataUrl';
 import { checkExtension } from '../../../utils/checkExtension';
+import { checkFormat } from '../../../utils/checkFormat';
 import { WorkerManager } from '../../workers/WorkerManager';
 import { LoaderParserPriority } from '../LoaderParser';
 import { createTexture } from './utils/createTexture';
@@ -15,6 +16,7 @@ import type { Loader } from '../../Loader';
 import type { LoaderParser } from '../LoaderParser';
 
 const validImageExtensions = ['.jpeg', '.jpg', '.png', '.webp', '.avif'];
+const validImageFormats = validImageExtensions.map((ext) => ext.slice(1));
 const validImageMIMEs = [
     'image/jpeg',
     'image/png',
@@ -113,9 +115,11 @@ export const loadTextures: LoaderParser<Texture, TextureSourceOptions, LoadTextu
         crossOrigin: 'anonymous',
     },
 
-    test(url: string): boolean
+    test(url: string, asset: ResolvedAsset<TextureSourceOptions>): boolean
     {
-        return checkDataUrl(url, validImageMIMEs) || checkExtension(url, validImageExtensions);
+        return checkDataUrl(url, validImageMIMEs)
+            || checkExtension(url, validImageExtensions)
+            || checkFormat(asset?.format, validImageFormats);
     },
 
     async load(url: string, asset: ResolvedAsset<TextureSourceOptions>, loader: Loader): Promise<Texture>

--- a/src/assets/loader/parsers/textures/loadVideoTextures.ts
+++ b/src/assets/loader/parsers/textures/loadVideoTextures.ts
@@ -4,6 +4,7 @@ import { detectVideoAlphaMode } from '../../../../utils/browser/detectVideoAlpha
 import { getResolutionOfUrl } from '../../../../utils/network/getResolutionOfUrl';
 import { checkDataUrl } from '../../../utils/checkDataUrl';
 import { checkExtension } from '../../../utils/checkExtension';
+import { checkFormat } from '../../../utils/checkFormat';
 import { createTexture } from './utils/createTexture';
 
 import type { VideoSourceOptions } from '../../../../rendering/renderers/shared/texture/sources/VideoSource';
@@ -13,6 +14,7 @@ import type { Loader } from '../../Loader';
 import type { LoaderParser } from '../LoaderParser';
 
 const validVideoExtensions = ['.mp4', '.m4v', '.webm', '.ogg', '.ogv', '.h264', '.avi', '.mov'];
+const validVideoFormats = validVideoExtensions.map((ext) => ext.slice(1));
 const validVideoMIMEs = validVideoExtensions.map((ext) => `video/${ext.substring(1)}`);
 
 /**
@@ -126,12 +128,13 @@ export const loadVideoTextures = {
         name: 'loadVideo',
     },
 
-    test(url: string): boolean
+    test(url: string, asset: ResolvedAsset<VideoSourceOptions>): boolean
     {
         const isValidDataUrl = checkDataUrl(url, validVideoMIMEs);
         const isValidExtension = checkExtension(url, validVideoExtensions);
+        const isValidFormat = checkFormat(asset?.format, validVideoFormats);
 
-        return isValidDataUrl || isValidExtension;
+        return isValidDataUrl || isValidExtension || isValidFormat;
     },
 
     async load(url: string, asset: ResolvedAsset<VideoSourceOptions>, loader: Loader): Promise<Texture>

--- a/src/assets/utils/checkFormat.ts
+++ b/src/assets/utils/checkFormat.ts
@@ -1,0 +1,17 @@
+export function checkFormat(format: string | undefined, formats: string | string[]): boolean
+{
+    if (!format)
+    {
+        return false;
+    }
+
+    format = format.toLowerCase();
+
+    if (Array.isArray(formats))
+    {
+        return formats.includes(format);
+    }
+
+    return format === formats;
+}
+


### PR DESCRIPTION
##### Description of change
Support loading texture and videos from blob by specifying `format`

###### Reasons:
- to avoid allocating and passing large image data urls (as well as passing it to worker)
- to avoid setting specific loader manually (allows more flexible dependency)
- [performance comparison](https://jsbenchmark.com/#eyJjYXNlcyI6W3siaWQiOiJIOUlXNGRJQzFVOFBJUWRYRnlzZUIiLCJjb2RlIjoiREFUQS5tYXAoVVJMLmNyZWF0ZU9iamVjdFVSTCkuZm9yRWFjaCgodXJsKSA9PiBVUkwucmV2b2tlT2JqZWN0VVJMKHVybCkpXG4iLCJuYW1lIjoiY3JlYXRlT2JqZWN0VVJMIiwiZGVwZW5kZW5jaWVzIjpbXX0seyJpZCI6IjFtX295TVNWVnowVHFIY25hbWE5SCIsImNvZGUiOiJyZXR1cm4gUHJvbWlzZS5hbGwoXG4gIERBVEEubWFwKChibG9iKSA9PiBuZXcgUHJvbWlzZSgocmVzb2x2ZSwgcmVqZWN0KSA9PiB7XG4gICAgY29uc3QgcmVhZGVyID0gbmV3IEZpbGVSZWFkZXIoKTtcbiAgICByZWFkZXIuYWRkRXZlbnRMaXN0ZW5lcignbG9hZCcsIChlKSA9PiByZXNvbHZlKGUudGFyZ2V0LnJlc3VsdCkpO1xuICAgIHJlYWRlci5hZGRFdmVudExpc3RlbmVyKCdlcnJvcicsIChlKSA9PiByZWplY3QoZSkpO1xuICAgIHJlYWRlci5yZWFkQXNEYXRhVVJMKGJsb2IpO1xuICB9KSlcbikiLCJuYW1lIjoicmVhZEFzRGF0YVVSTCIsImRlcGVuZGVuY2llcyI6W10sImFzeW5jIjp0cnVlfV0sImNvbmZpZyI6eyJuYW1lIjoiQmFzaWMgZXhhbXBsZSIsInBhcmFsbGVsIjp0cnVlLCJnbG9iYWxUZXN0Q29uZmlnIjp7ImRlcGVuZGVuY2llcyI6W119LCJkYXRhQ29kZSI6ImNvbnN0IGJsb2IgPSBuZXcgQmxvYihbbmV3IFVpbnQ4QXJyYXkoMTAyNCAqIDEwMjQpXSk7XG5yZXR1cm4gQXJyYXkuZnJvbSh7bGVuZ3RoOiAxMH0sICgpID0-IGJsb2IpOyJ9fQ)

Related to #9568

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
