### PR TITLE
feat: add version to global hooks

### DIFF
--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -16,3 +16,6 @@ export const DATA_URI = /^\s*data:(?:([\w-]+)\/([\w+.-]+))?(?:;charset=([\w-]+))
 
 // export the event emitter so we can use it in external modules
 export { EventEmitter };
+
+/** The current version of PixiJS. This is automatically replaced by the build process. */
+export const VERSION = '$_VERSION';

--- a/src/utils/global/globalHooks.ts
+++ b/src/utils/global/globalHooks.ts
@@ -1,5 +1,5 @@
 import { type ExtensionMetadata, ExtensionType } from '../../extensions/Extensions';
-import { VERSION } from '../sayHello';
+import { VERSION } from '../const';
 
 import type { Application } from '../../app/Application';
 import type { System } from '../../rendering/renderers/shared/system/System';

--- a/src/utils/sayHello.ts
+++ b/src/utils/sayHello.ts
@@ -1,8 +1,7 @@
 import { DOMAdapter } from '../environment/adapter';
+import { VERSION } from './const';
 
 let saidHello = false;
-
-export const VERSION = '$_VERSION';
 
 /**
  * Prints out the version and renderer information for this running instance of PixiJS.


### PR DESCRIPTION
a simple PR to pass the version of pixi to the global hooks. Makes it easier to make changes to the devtool based on the version of pixi