### PR TITLE
fix: Don't bundle GIF dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@xmldom/xmldom": "^0.8.10",
         "earcut": "^2.2.4",
         "eventemitter3": "^5.0.1",
+        "gifuct-js": "^2.1.2",
         "ismobilejs": "^1.1.1",
         "parse-svg-path": "^0.1.2"
       },
@@ -46,7 +47,6 @@
         "eslint-plugin-jsdoc": "^50.6.0",
         "eslint-plugin-no-mixed-operators": "^1.1.1",
         "fs-extra": "^11.2.0",
-        "gifuct-js": "^2.1.2",
         "glob": "^8.1.0",
         "http-server": "^14.1.1",
         "husky": "^8.0.3",
@@ -8048,7 +8048,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/gifuct-js/-/gifuct-js-2.1.2.tgz",
       "integrity": "sha512-rI2asw77u0mGgwhV3qA+OEgYqaDn5UNqgs+Bx0FGwSpuqfYn+Ir6RQY5ENNQ8SbIiG/m5gVa7CD5RriO4f4Lsg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-binary-schema-parser": "^2.0.3"
@@ -11687,7 +11686,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/js-binary-schema-parser/-/js-binary-schema-parser-2.0.3.tgz",
       "integrity": "sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-tokens": {
@@ -23831,7 +23829,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/gifuct-js/-/gifuct-js-2.1.2.tgz",
       "integrity": "sha512-rI2asw77u0mGgwhV3qA+OEgYqaDn5UNqgs+Bx0FGwSpuqfYn+Ir6RQY5ENNQ8SbIiG/m5gVa7CD5RriO4f4Lsg==",
-      "dev": true,
       "requires": {
         "js-binary-schema-parser": "^2.0.3"
       }
@@ -26491,8 +26488,7 @@
     "js-binary-schema-parser": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/js-binary-schema-parser/-/js-binary-schema-parser-2.0.3.tgz",
-      "integrity": "sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg==",
-      "dev": true
+      "integrity": "sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@xmldom/xmldom": "^0.8.10",
     "earcut": "^2.2.4",
     "eventemitter3": "^5.0.1",
+    "gifuct-js": "^2.1.2",
     "ismobilejs": "^1.1.1",
     "parse-svg-path": "^0.1.2"
   },
@@ -96,7 +97,6 @@
     "eslint-plugin-jsdoc": "^50.6.0",
     "eslint-plugin-no-mixed-operators": "^1.1.1",
     "fs-extra": "^11.2.0",
-    "gifuct-js": "^2.1.2",
     "glob": "^8.1.0",
     "http-server": "^14.1.1",
     "husky": "^8.0.3",


### PR DESCRIPTION
Closes #11291

Bundling GIF module dependencies was doing some funny business coercing `gifunt-js` and it's dependencies into a weird state that make it unable to bundle in production mode with Vite. I verified using this test: https://github.com/bigtimebuddy/pixijs-gif-vite-bug/