### PR TITLE
fix: text gradient padding

### DIFF
--- a/src/scene/text/canvas/CanvasTextSystem.ts
+++ b/src/scene/text/canvas/CanvasTextSystem.ts
@@ -299,13 +299,13 @@ export class CanvasTextSystem implements System
             }
             else
             {
-                context.fillStyle = style._fill ? getCanvasFillStyle(style._fill, context, measured) : null;
+                context.fillStyle = style._fill ? getCanvasFillStyle(style._fill, context, measured, padding * 2) : null;
 
                 if (style._stroke?.width)
                 {
-                    const padding = style._stroke.width * style._stroke.alignment;
+                    const strokePadding = style._stroke.width * style._stroke.alignment;
 
-                    context.strokeStyle = getCanvasFillStyle(style._stroke, context, measured, padding);
+                    context.strokeStyle = getCanvasFillStyle(style._stroke, context, measured, strokePadding);
                 }
 
                 context.shadowColor = 'black';


### PR DESCRIPTION
## Summary
- align text gradients with text when padding is set

## Testing
- `npm test` *(fails: run-s not found)*