### PR TITLE
fix: TextMetrics tokenize didn't handle CRLF line ending

### DIFF
--- a/src/scene/text/__tests__/TextMetrics.test.ts
+++ b/src/scene/text/__tests__/TextMetrics.test.ts
@@ -565,6 +565,14 @@ describe('CanvasTextMetrics', () =>
             expect(arr.length).toEqual(1);
         });
 
+        it('newline char: CRLF', () =>
+        {
+            const arr = CanvasTextMetrics['_tokenize']('\r\n');
+
+            expect(arr).toBeArray();
+            expect(arr.length).toEqual(1);
+        });
+
         it('breakingSpaces', () =>
         {
             const arr = CanvasTextMetrics['_tokenize'](breakingSpaces.join(''));

--- a/src/scene/text/canvas/CanvasTextMetrics.ts
+++ b/src/scene/text/canvas/CanvasTextMetrics.ts
@@ -709,7 +709,16 @@ export class CanvasTextMetrics
                     token = '';
                 }
 
-                tokens.push(char);
+                // treat \r\n as a single new line token
+                if (char === '\r' && nextChar === '\n')
+                {
+                    tokens.push('\r\n');
+                    i++;
+                }
+                else
+                {
+                    tokens.push(char);
+                }
 
                 continue;
             }


### PR DESCRIPTION
##### Description of change
<!-- Provide a description of the change below this comment. -->

In the Text component, if the text contains Windows line ending (`\r\n`), setting `wordWrap` to `true` will cause `\r\n` to be treated as two lines.

```javascript
import { Application, Text } from "pixi.js";

(async () => {
  // Create a new application
  const app = new Application();

  // Initialize the application
  await app.init({ background: "#ffffff", resizeTo: window });

  // Append the application canvas to the document body
  document.getElementById("pixi-container").appendChild(app.canvas);

  // Create a text including \r\n, and set wordWrap: true
  const text = new Text({ text: 'Hello\r\nPixiJS!', style: { wordWrap: true } })

  app.stage.addChild(text);
})();
```

When `wordWrap` is `false`:

![image](https://github.com/user-attachments/assets/25a59062-16db-4044-b8b7-047fc7bd7ee5)

When `wordWrap` is `true`:

![image](https://github.com/user-attachments/assets/73913a2a-fd57-4748-9c68-eae64e0f5c1a)

View the source code in CanvasTextMetrics.ts:

https://github.com/pixijs/pixijs/blob/7be477f039d9d2c8c225058fae4587ba0b9b044e/src/scene/text/canvas/CanvasTextMetrics.ts#L268-L269

Although the `\r\n` case is already considered when splitting text into line, when `wordWrap` is `true`, the `CanvasTextMetrics._wordWrap` method is called first, which internally invokes the `_tokenize` method. In this method, `\r\n` is split into two separate tokens.

In this pull request, we implemented special handling for `\r\n`, treating it as a single token, consistent with the behavior of a single `\n`, to avoid generating extra line breaks.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)

visuals.test.ts fails even though I haven't modified any files. Maybe an issue with environment.
