### PR TITLE
feat: Implements replaceChild method for Container

### DIFF
--- a/src/scene/container/container-mixins/childrenHelperMixin.ts
+++ b/src/scene/container/container-mixins/childrenHelperMixin.ts
@@ -243,6 +243,12 @@ export interface ChildrenHelperMixin<C = ContainerChild>
      * @see {@link Container#addChildAt} For simple indexed parenting
      */
     reparentChildAt<U extends C>(child: U, index: number): U;
+    /**
+     * Replace a child in the container with a new child. Copying the local transform from the old child to the new one.
+     * @param {Container} oldChild - The child to replace.
+     * @param {Container} newChild - The new child to add.
+     */
+    replaceChild<U extends(C), T extends(C)>(oldChild: U, newChild: T): void;
 }
 
 /** @internal */
@@ -466,5 +472,15 @@ export const childrenHelperMixin: ChildrenHelperMixin<ContainerChild> = {
         child.setFromMatrix(childMat);
 
         return child;
-    }
+    },
+
+    replaceChild<U extends(ContainerChild), T extends(ContainerChild)>(oldChild: U, newChild: T)
+    {
+        oldChild.updateLocalTransform();
+        this.addChildAt(newChild, this.getChildIndex(oldChild));
+
+        newChild.setFromMatrix(oldChild.localTransform);
+        newChild.updateLocalTransform();
+        this.removeChild(oldChild);
+    },
 } as Container;


### PR DESCRIPTION
Adds a method to replace a child within a container with another,
copying the local transform from the old child to the new one.

This ensures seamless transitions and maintains visual consistency
when swapping display objects in the scene graph.

One use case for this would be to use in combination with `SegmentedText` to easily swap out an existing text with segmented one