### PR TITLE
fix: warn if transparent background is set after opaque init

### DIFF
--- a/src/rendering/renderers/shared/background/BackgroundSystem.ts
+++ b/src/rendering/renderers/shared/background/BackgroundSystem.ts
@@ -116,7 +116,7 @@ export class BackgroundSystem implements System<BackgroundSystemOptions>
     {
         // #if _DEBUG
 
-        const incoming = new Color(value);
+        const incoming = Color.shared.setValue(value);
 
         if (incoming.alpha < 1 && this._backgroundColor.alpha === 1)
         {


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Fixes #10162

This PR adds a developer-facing warning when a transparent background color (like `'rgba(255, 0, 0, 0.5)'`) is set **after** the canvas has been initialized with `backgroundAlpha: 1` (i.e., opaque).

Browsers do not allow changing the canvas alpha setting after initialization. This silent behavior has confused many developers.

✅ This PR includes:
- A `warn()` message wrapped in `#if _DEBUG` so it’s dev-only
- An updated JSDoc comment for `backgroundAlpha` explaining that the alpha must be set at initialization time
- Clean code style consistent with PixiJS standards

This was previously merged into my fork by mistake — resubmitting here for the official PixiJS `dev` branch.

---

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included _(N/A for dev-only warning)_
- [x] Documentation is changed or added (JSDoc for `backgroundAlpha`)
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
