### PR TITLE
fix: video texture loading with no extension

### DIFF
--- a/src/assets/loader/parsers/textures/loadVideoTextures.ts
+++ b/src/assets/loader/parsers/textures/loadVideoTextures.ts
@@ -102,6 +102,10 @@ export function determineCrossOrigin(url: string, loc: Location = globalThis.loc
     return '';
 }
 
+type LoadVideoData = VideoSourceOptions & {
+    mime?: string;
+};
+
 /**
  * A simple plugin to load video textures.
  *
@@ -137,10 +141,10 @@ export const loadVideoTextures = {
         return isValidDataUrl || isValidExtension;
     },
 
-    async load(url: string, asset: ResolvedAsset<VideoSourceOptions>, loader: Loader): Promise<Texture>
+    async load(url: string, asset: ResolvedAsset<LoadVideoData>, loader: Loader): Promise<Texture>
     {
         // --- Merge default and provided options ---
-        const options: VideoSourceOptions = {
+        const options: LoadVideoData = {
             ...VideoSource.defaultOptions,
             resolution: asset.data?.resolution || getResolutionOfUrl(url),
             alphaMode: asset.data?.alphaMode || await detectVideoAlphaMode(),
@@ -180,7 +184,11 @@ export const loadVideoTextures = {
         // Determine MIME type
         let mime: string | undefined;
 
-        if (url.startsWith('data:'))
+        if (options.mime)
+        {
+            mime = options.mime;
+        }
+        else if (url.startsWith('data:'))
         {
             mime = url.slice(5, url.indexOf(';'));
         }
@@ -230,4 +238,4 @@ export const loadVideoTextures = {
     {
         texture.destroy(true);
     }
-} satisfies LoaderParser<Texture, VideoSourceOptions>;
+} satisfies LoaderParser<Texture, LoadVideoData>;


### PR DESCRIPTION
Fixes: #10896

Allows specifying a MIME type for video textures during loading. This ensures correct handling of video data, particularly when the URL doesn't explicitly define it.

```ts
const textureVideo = await Assets.load({
  src: 'https://xxx/oss/xxx-video/123456789',
  data: {
    mime: 'video/mp4'
  }，
  loadParser: 'loadVideo'
});
```