### PR TITLE
fix: accessibility scaling issues

### DIFF
--- a/src/accessibility/AccessibilitySystem.ts
+++ b/src/accessibility/AccessibilitySystem.ts
@@ -823,6 +823,9 @@ export class AccessibilitySystem implements System<AccessibilitySystemOptions>
         this._deactivate();
         this._destroyTouchHook();
 
+        this._canvasObserver?.destroy();
+        this._canvasObserver = null;
+
         this._div = null;
         this._pool = null;
         this._children = null;


### PR DESCRIPTION
Fixes: #11016

Addresses incorrect scaling of accessibility elements due to resolution.

- Uses CanvasObserver to synchronize the DOM element with the canvas, ensuring correct positioning and sizing.
- Removes resolution scaling from individual accessibility element updates.

Before:

<img width="1486" height="1019" alt="image" src="https://github.com/user-attachments/assets/7bbec351-20e9-421b-b6c0-e68a2316e240" />

After:

<img width="972" height="739" alt="image" src="https://github.com/user-attachments/assets/1a9c034f-a1ed-49f8-be6b-98eaa24ccf3d" />
