### PR TITLE
fix: Remove deprecation version constants

### DIFF
--- a/src/utils/logging/deprecation.ts
+++ b/src/utils/logging/deprecation.ts
@@ -6,11 +6,13 @@ const warnings: Dict<boolean> = {};
 /**
  * deprecation name for version 8.0.0
  * @ignore
+ * @internal
  */
 export const v8_0_0 = '8.0.0';
 /**
  * deprecation name for version 8.1.0
  * @ignore
+ * @internal
  */
 export const v8_3_4 = '8.3.4';
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Currently the pixi.js node package exports 2 constants that represent internal use variables only used when calling the `deprecation` function (`v8_0_0` and `v8_3_4`).

In concept this is not an issue but sometimes my IDE, and I imagine other's as well, decide to autocomplete `0` to `v8_0_0`. As these serve no purpose other than to keep two specific versions as constants I propose they are removed.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
