### PR TITLE
fix: ensure correct parser for blob image paths in bitmap font loader

### DIFF
--- a/src/scene/text-bitmap/asset/loadBitmapFont.ts
+++ b/src/scene/text-bitmap/asset/loadBitmapFont.ts
@@ -96,7 +96,8 @@ export const loadBitmapFont = {
 
             textureUrls.push({
                 src: imagePath,
-                data: textureOptions
+                data: textureOptions,
+                parser: imagePath.startsWith('blob:') ? 'texture' : undefined
             });
         }
 


### PR DESCRIPTION
#### Description of change
This pull request extends BitmapFont support in PixiJS 8 to allow using Blob URLs as texture sources.

Previously, loadBitmapFont relied solely on file extensions to determine the appropriate loader, which fails for blob URLs (since they have no extension).
This change assumes that any file referenced within the .fnt file is a texture (e.g. PNG, JPG, WEBP, AVIF, or a Blob representing one of these formats), and treats it accordingly.

#### Potential impact:
This may affect cases where compressed textures (e.g. .ktx, .basis, etc.) are used as .fnt texture pages. Their handling is not explicitly addressed here and might require additional logic.

#### Pre-Merge Checklist
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)