### PR TITLE
fix: take in account uRound inside particles shader (webgpu)

### DIFF
--- a/src/scene/particle-container/shared/shader/particles.wgsl
+++ b/src/scene/particle-container/shared/shader/particles.wgsl
@@ -1,8 +1,8 @@
 
 struct ParticleUniforms {
-  uProjectionMatrix:mat3x3<f32>,
+  uTranslationMatrix:mat3x3<f32>,
   uColor:vec4<f32>,
-  uRoundPixels:f32,
+  uRound:f32,
   uResolution:vec2<f32>,
 };
 
@@ -35,9 +35,9 @@ fn mainVertex(
        aVertex.x * sin(aRotation) + aVertex.y * cos(aRotation)
    ) + aPosition;
 
-   var position = vec4((uniforms.uProjectionMatrix * vec3(v, 1.0)).xy, 0.0, 1.0);
+   var position = vec4((uniforms.uTranslationMatrix * vec3(v, 1.0)).xy, 0.0, 1.0);
 
-   if(uniforms.uRoundPixels == 1) {
+   if(uniforms.uRound == 1.0) {
        position = vec4(roundPixels(position.xy, uniforms.uResolution), position.zw);
    }
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
Adds missing `roundPixels` functionality to particles wgsl shader, also fixed layout of `ParticleUniforms` struct.
Same feature already used in webgl: https://github.com/pixijs/pixijs/blob/7c9453ab7e2d0dd0f24716112d1903099a3fa2bc/src/scene/particle-container/shared/shader/particles.vert#L32

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)