### PR TITLE
fix: `onRender` type should include `null`

### DIFF
--- a/src/scene/container/container-mixins/onRenderMixin.ts
+++ b/src/scene/container/container-mixins/onRenderMixin.ts
@@ -24,7 +24,7 @@ export interface OnRenderMixinConstructor
      * @param renderer - The renderer instance
      * @see {@link Renderer} For renderer capabilities
      */
-    onRender?: ((renderer: Renderer) => void | null);
+    onRender?: ((renderer: Renderer) => void) | null;
 }
 
 /**


### PR DESCRIPTION
closed #11626

##### Description of change
Fix the type error that occurs when `onRender` is set to `null`

- [x] Lint process passed (`npm run lint`)
