### PR TITLE
chore: fix outdated `textureSourceOptions` doc example

### DIFF
--- a/src/rendering/renderers/shared/extract/GenerateTextureSystem.ts
+++ b/src/rendering/renderers/shared/extract/GenerateTextureSystem.ts
@@ -141,7 +141,6 @@ export type GenerateTextureOptions = {
      *     target: sprite,
      *     textureSourceOptions: {
      *         scaleMode: 'linear',
-     *         multisample: 4
      *     }
      * });
      * ```


### PR DESCRIPTION
##### Description of change
This PR updates the GenerateTextureOptions doc for `textureSourceOptions`. The doc gave an example of with a `multisample: 4` argument but multisample no longer exists in `textureSourceOptions`. This change removes the outdated reference.

##### Pre-Merge Checklist
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
