### PR TITLE
fix: use updated childrenRenderablesToUpdate index in validateRenderables

### DIFF
--- a/src/scene/container/utils/validateRenderables.ts
+++ b/src/scene/container/utils/validateRenderables.ts
@@ -9,11 +9,11 @@ import type { RenderGroup } from '../RenderGroup';
  */
 export function validateRenderables(renderGroup: RenderGroup, renderPipes: RenderPipes): boolean
 {
-    const { list, index } = renderGroup.childrenRenderablesToUpdate;
+    const { list } = renderGroup.childrenRenderablesToUpdate;
 
     let rebuildRequired = false;
 
-    for (let i = 0; i < index; i++)
+    for (let i = 0; i < renderGroup.childrenRenderablesToUpdate.index; i++)
     {
         const container = list[i];
 


### PR DESCRIPTION
##### Description of Change

This issue relates to `spine-pixi-v8`, but may also affect other containers that adopt the same pattern in the future.

Spine supports clipping masks (attachments). [`spine-pixi-v8`](https://github.com/EsotericSoftware/spine-runtimes/tree/4.2/spine-ts/spine-pixi-v8) provides a feature ([`addSlotObject`](https://github.com/EsotericSoftware/spine-runtimes/blob/4.2/spine-ts/spine-pixi-v8/src/Spine.ts#L891)) to add Pixi containers to its slots/bones. When a Spine game object has a clipping mask and a Pixi container is added using `addSlotObject`, the Spine clipping mask is mapped to a Pixi `Graphics` object (as a polygon) and assigned to the Pixi object's `mask` property. The `Graphics` mask is added as a child of the Spine object.

If the mask is animated, the animation only updates when `add/validate/updateRenderable` of the [`SpinePipe`](https://github.com/EsotericSoftware/spine-runtimes/blob/4.2/spine-ts/spine-pixi-v8/src/SpinePipe.ts#L52) is invoked.

The chain is:
`add/validate/updateRenderable` → `_validateAndTransformAttachments` → `transformAttachments` → `updateAndSetPixiMask` → `mask.clear().poly(vertices)`.

As a result, it appears that when [`validateRenderables`](https://github.com/pixijs/pixijs/blob/dev/src/scene/container/utils/validateRenderables.ts#L10) is called, `renderGroup.childrenRenderablesToUpdate.index` does not account for the mask. When `pipe.validateRenderable(container)` is invoked in the loop for the Spine object, `mask.clear()` is executed via the chain above, and eventually `childrenRenderablesToUpdate.index` is updated. However, the loop still uses the old index value, and the mask’s `validateRenderable` is not invoked to determine whether `rebuildRequired` is needed.

If we use the updated `childrenRenderablesToUpdate.index`, the mask is considered in the loop.

I am not entirely sure whether the fix I proposed is correct, or if it only resolves my issue as a side effect.

##### CodeSandbox Example

I was able to reproduce this only with the Spine plugin and created a CodeSandbox: https://codesandbox.io/p/sandbox/yxkw8p?file=%2Findex.html%3A13%2C47

In the header, two versions are included for both Spine and Pixi:

* **Spine**: The local version is slightly modified to prevent assigning the mask to the Pixi object. Otherwise, the mask is not visible, making it difficult to understand what is happening.
* **Pixi**: The local version includes the fix applied as in this PR.

In the example there are:

* A Spine object that is composed of:
  * A blue square background (ignore this).
  * A dark red square in a fixed position; it does not rotate and sits under the rotating clipping attachment.
  * A square clipping attachment that rotates and clips only the dark red square.
* A Pixi container that contains a Pixi sprite (bunny) as its child. This container is added with `addSlotObject` to the Spine game object, in the same slot as the dark red square. Without the local Spine version, the bunny should be clipped.

Since the Spine object has a clipping attachment and a slot object, Spine creates a Pixi `Graphics` object as explained at the beginning. In the local Spine version, it is only attached to the Spine object so that you can see it; in the standard version, it is also added as a mask to the slot object, and it clips the bunny.

Without the fix the mask is not contisnuosly updated, resulting in the bunny not being clipped coherently with the Spine clipping attachment.

##### Pre-Merge Checklist

* [ ] ~Tests and/or benchmarks are included~
* [ ] ~Documentation is changed or added~
* [x] Lint process passed (`npm run lint`)
* [x] Tests passed (`npm run test`)
