### PR TITLE
fix: bytesPerRow calculation for BufferImageSource in WebGPU

### DIFF
--- a/src/rendering/renderers/gpu/texture/uploaders/gpuUploadBufferImageResource.ts
+++ b/src/rendering/renderers/gpu/texture/uploaders/gpuUploadBufferImageResource.ts
@@ -21,7 +21,7 @@ export const gpuUploadBufferImageResource = {
             {
                 offset: 0,
                 rowsPerImage: source.pixelHeight,
-                bytesPerRow: source.pixelHeight * bytesPerPixel,
+                bytesPerRow: source.pixelWidth * bytesPerPixel,
             },
             {
                 width: source.pixelWidth,


### PR DESCRIPTION
There was a small bug in BufferImageSource uploading due to an incorrect bytesPerRow calculation.

You didn’t notice it before because you had only used BufferImageSource for a 1x1 white texture. I made 2x1 BufferImageSource and got an error.
