### PR TITLE
fix: Guards mask reset from null reference

### DIFF
--- a/src/rendering/mask/alpha/AlphaMask.ts
+++ b/src/rendering/mask/alpha/AlphaMask.ts
@@ -51,6 +51,7 @@ export class AlphaMask implements Effect, PoolItem
 
     public reset()
     {
+        if (this.mask === null) return;
         this.mask.measurable = true;
         this.mask = null;
     }

--- a/src/rendering/mask/scissor/ScissorMask.ts
+++ b/src/rendering/mask/scissor/ScissorMask.ts
@@ -49,6 +49,7 @@ export class ScissorMask implements Effect
 
     public reset()
     {
+        if (this.mask === null) return;
         this.mask.measurable = true;
         this.mask = null;
     }

--- a/src/rendering/mask/stencil/StencilMask.ts
+++ b/src/rendering/mask/stencil/StencilMask.ts
@@ -42,6 +42,7 @@ export class StencilMask implements Effect, PoolItem
 
     public reset()
     {
+        if (this.mask === null) return;
         this.mask.measurable = true;
         this.mask.includeInBuild = true;
         this.mask = null;


### PR DESCRIPTION
##### Description of change

Fixes #11715

Adds a null check to the `reset()` method across `AlphaMask`, `ScissorMask`, and `StencilMask`. This change prevents potential null reference errors that could occur if the `reset()` method is invoked when the `mask` property is already `null`.

##### Pre-Merge Checklist


- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)