### PR TITLE
fix: Prevents errors during worker manager reset

### DIFF
--- a/src/assets/loader/workers/WorkerManager.ts
+++ b/src/assets/loader/workers/WorkerManager.ts
@@ -154,6 +154,12 @@ class WorkerManagerClass
      */
     private _complete(data: LoadImageBitmapResult): void
     {
+        if (!this._resolveHash[data.uuid])
+        {
+            // this can happen if the worker manager is reset before a task completes
+            return;
+        }
+
         if (data.error !== undefined)
         {
             this._resolveHash[data.uuid].reject(data.error);
@@ -163,7 +169,7 @@ class WorkerManagerClass
             this._resolveHash[data.uuid].resolve(data.data);
         }
 
-        this._resolveHash[data.uuid] = null;
+        delete this._resolveHash[data.uuid];
     }
 
     /**
@@ -247,7 +253,7 @@ class WorkerManagerClass
         // Reject pending promises
         Object.values(this._resolveHash).forEach(({ reject }) =>
         {
-            reject?.(new Error('WorkerManager destroyed'));
+            reject?.(new Error('WorkerManager has been reset before completion'));
         });
         this._resolveHash = {};
         this._queue.length = 0;


### PR DESCRIPTION
##### Description of change

Fixes: #11716

This change addresses errors that can occur when a `WorkerManager` is reset while tasks are still in progress.
- Prevents attempting to resolve or reject a promise for a task whose entry in `_resolveHash` has already been cleared during a manager reset.
- Updates the error message provided to pending promises during a reset, offering clearer context for why a task was interrupted.
- Refines the cleanup of completed task entries in `_resolveHash` by using `delete` instead of setting to `null`.