### PR TITLE
fix: SplitBitmapText requires "fill: 'white'"

### DIFF
--- a/src/scene/text-split/SplitBitmapText.ts
+++ b/src/scene/text-split/SplitBitmapText.ts
@@ -170,7 +170,7 @@ export class SplitBitmapText extends AbstractSplitText<BitmapText>
             ...config,
         };
 
-        completeOptions.style ??= completeOptions.style || {};
+        completeOptions.style ??= {};
         completeOptions.style.fill ??= 0xffffff;
 
         super(completeOptions);


### PR DESCRIPTION
##### Description of change
<!-- Provide a description of the change below this comment. -->
Added a default `fill = 0xffffff` to `SplitBitmapText` since it was inheriting the default black color.

Fix: #11711

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
