### PR TITLE
fix: filters with blendRequired but no gpuProgram not rendering correctly

### DIFF
--- a/src/filters/Filter.ts
+++ b/src/filters/Filter.ts
@@ -49,6 +49,9 @@ export interface FilterOptions
      * to and pass this into the shader. This is useful for blend modes that need to be aware of the pixels
      * they are rendering to. Only use if you need that data, otherwise its an extra gpu copy you don't need!
      * (default false)
+     *
+     * If given, the shader should have a uniform named `uBackTexture`, which is where the pixels of the
+     * area being rendered to can be sampled from.
      */
     blendRequired?: boolean;
     /**

--- a/src/rendering/renderers/shared/shader/Shader.ts
+++ b/src/rendering/renderers/shared/shader/Shader.ts
@@ -326,6 +326,13 @@ export class Shader extends EventEmitter<{'destroy': Shader}>
                     nameHash[data.name] = data;
                 });
             }
+            else if (resources.uBackTexture)
+            {
+                // we are using a backTexture, but no gpuProgram to give us the bindings.
+                nameHash.uBackTexture = { group: 0, binding: 3, name: 'uBackTexture' };
+                groupMap[0] = groupMap[0] || {};
+                groupMap[0][3] = 'uBackTexture';
+            }
 
             let bindTick = 0;
 
@@ -364,6 +371,11 @@ export class Shader extends EventEmitter<{'destroy': Shader}>
 
                 if (data)
                 {
+                    if (name === 'uBackTexture' && data.group === 0)
+                    {
+                        continue;
+                    }
+
                     if (!groups[data.group])
                     {
                         groups[data.group] = new BindGroup();


### PR DESCRIPTION
filters with blendRequired=true work if a glProgram is given, but no gpuProgram

Closes https://github.com/pixijs/pixijs/issues/11745

##### Description of change

See [this bug report](https://github.com/pixijs/pixijs/issues/11745) - filters with a blendRequired=true, and a glProgram (but no gpuProgram) were not working.

The reason is the gpuProgram was required to specify the binding, even if it wasn't doing any rendering. After my change, the name `uBackTexture` is bound to slot 3 if a resource called `uBackTexture` exists.

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
*no new tests added - I couldn't find an existing scene for blendMode=true to base this off*
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
