### PR TITLE
fix: typo in Application example: replace '-' with '=' in asset loading

### DIFF
--- a/src/app/Application.ts
+++ b/src/app/Application.ts
@@ -152,7 +152,7 @@ export interface Application extends PixiMixins.Application { }
  * document.body.appendChild(app.canvas);
  *
  * // Start adding content to your application
- * const texture - await Assets.load('your-image.png');
+ * const texture = await Assets.load('your-image.png');
  * const sprite = new Sprite(texture);
  * app.stage.addChild(sprite);
  * ```


### PR DESCRIPTION
This PR fixes a typo in the documentation example for the Application class. The variable assignment for texture used - instead of =, which is invalid JavaScript/TypeScript. This change corrects it to help developers who copy this example.

<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
This PR fixes a typo in the documentation example for the Application class. The variable assignment for texture used - instead of =, which is invalid JavaScript/TypeScript. This change corrects it to help developers who copy this example.
##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
