### PR TITLE
fix: correct uBackTexture binding for filters with blendRequired

### DIFF
--- a/src/filters/Filter.ts
+++ b/src/filters/Filter.ts
@@ -208,7 +208,14 @@ export class Filter extends Shader
         this.blendRequired = options.blendRequired;
         this.clipToViewport = options.clipToViewport;
 
+        // this is where the filter system will attach the filter texture
         this.addResource('uTexture', 0, 1);
+
+        if (options.blendRequired)
+        {
+            // this is where the filter system will attach the back texture
+            this.addResource('uBackTexture', 0, 3);
+        }
     }
 
     /**


### PR DESCRIPTION
##### Description of change
Fixes #11745

When filters had `blendRequired` set to true, the `uBackTexture` was being bound to the wrong texture unit (3 instead of 1), causing unexpected behavior where the back buffer would not display correctly.

The issue was that filters expecting to sample from the back buffer (the pixels behind the filtered object) were instead seeing stretched or incorrect textures. This was because the texture unit binding was set to 3 when it should have been 1.

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)