### PR TITLE
fix: resolve a typescript annoyance with Container.filters

### DIFF
--- a/src/scene/container/container-mixins/effectsMixin.ts
+++ b/src/scene/container/container-mixins/effectsMixin.ts
@@ -360,9 +360,9 @@ export const effectsMixin: Partial<Container> = {
         this._markStructureAsChanged();
     },
 
-    set filters(value: Filter | Filter[] | null | undefined)
+    set filters(value: Filter | readonly Filter[] | null | undefined)
     {
-        if (!Array.isArray(value) && value) value = [value];
+        if (!Array.isArray(value) && value) value = ([value] as Filter[]);
 
         const effect = this._filterEffect ||= new FilterEffect();
 


### PR DESCRIPTION
In `v8.14.0` it isn't possible to do this:

```ts
myContainer.filters = otherContainer.filters;
```

or this:
```ts
const originalFilters = myContainer.filters;

// temporarily change filters for rendering to a render texture
myContainer.filters = someOtherFIlters;
// -- render to a render texture here --

// put filters back again:
myContainer.filters = originalFilters;
```

or this:

```ts
// actually sub-optimal compared to an if since copies the array again, but should be possible to write this way I think
myContainer.filters = someCondition? myContainer.filters: otherFilters;
```

The reason this isn't possible is because the `get` for `.filters` returns `readonly Filters[]` but the `set` won't accept a `readonly` array.

Since a `readonly` is also assignable to a non-readonly (non-readonly has the extra ability of being mutable) it isn't harmful if the `set` takes `readonly Filters[]` since this will accept either readonly or non-readonly arrays.

[tsplayground example here](https://www.typescriptlang.org/play/?#code/MYewdgzgLgBAZmASgUwIYBNwBsCeMC8MAFKgFwwBOamYuMYArgLYBGyFA2gLoCUBAfDADeAXwBQoSLAQFiZeszadeA4eInhoMAA6oKqJigzY8hDgCYANAGYuMVBBiToAbg1Sdeg7Is2YXNzEEIxpcIl19Q2oTHjdg6NoccK8mWKCwZMiQmLiMiINYoA)


- [ ] Tests and/or benchmarks are included
* no new tests for this PR, all existing ones pass*
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
