### PR TITLE
fix: enable proper application reinitialization

### DIFF
--- a/src/app/Application.ts
+++ b/src/app/Application.ts
@@ -249,6 +249,7 @@ export class Application<R extends Renderer = Renderer>
         // The default options
         options = { ...options };
 
+        this.stage = new Container();
         this.renderer = await autoDetectRenderer(options as ApplicationOptions) as R;
 
         // install plugins here

--- a/src/app/ResizePlugin.ts
+++ b/src/app/ResizePlugin.ts
@@ -99,6 +99,7 @@ export class ResizePlugin
     {
         Object.defineProperty(this, 'resizeTo',
             {
+                configurable: true,
                 set(dom: Window | HTMLElement)
                 {
                     globalThis.removeEventListener('resize', this.queueResize);

--- a/src/app/TickerPlugin.ts
+++ b/src/app/TickerPlugin.ts
@@ -166,6 +166,7 @@ export class TickerPlugin
         // Create ticker setter
         Object.defineProperty(this, 'ticker',
             {
+                configurable: true,
                 set(ticker)
                 {
                     if (this._ticker)

--- a/src/app/__tests__/Application.test.ts
+++ b/src/app/__tests__/Application.test.ts
@@ -25,6 +25,29 @@ describe('Application', () =>
             expect(app.renderer).toBeNull();
         });
 
+        it('should allow for application to be reinitialized after destroy', async () =>
+        {
+            const app = await getApp();
+
+            expect(app.stage).toBeInstanceOf(Container);
+            expect(app.renderer).toBeTruthy();
+
+            app.destroy();
+
+            expect(app.stage).toBeNull();
+            expect(app.renderer).toBeNull();
+
+            await app.init();
+
+            expect(app.stage).toBeInstanceOf(Container);
+            expect(app.renderer).toBeTruthy();
+
+            app.destroy();
+
+            expect(app.stage).toBeNull();
+            expect(app.renderer).toBeNull();
+        });
+
         it('register a new plugin, then destroy it', async () =>
         {
             const plugin = {


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->
##### Description of change
<!-- Provide a description of the change below this comment. -->

fixes: #11737

Ensures the application's core stage is recreated when initialized,
addressing issues where a previously destroyed application could not be
reliably reinitialized.

Also makes plugin properties configurable, allowing them to be redefined
during reinitialization cycles.

A new test case validates this improved behavior.
