### PR TITLE
fix: bitmanFontXMLParser should recognize xml fonts with versions

### DIFF
--- a/src/scene/text-bitmap/asset/bitmapFontXMLStringParser.ts
+++ b/src/scene/text-bitmap/asset/bitmapFontXMLStringParser.ts
@@ -7,7 +7,7 @@ import type { BitmapFontData } from '../AbstractBitmapFont';
 export const bitmapFontXMLStringParser = {
     test(data: string | XMLDocument | BitmapFontData): boolean
     {
-        if (typeof data === 'string' && data.includes('<font>'))
+        if (typeof data === 'string' && data.match(/<font(\s|>)/))
         {
             return bitmapFontXMLParser.test(DOMAdapter.get().parseXML(data));
         }

--- a/tests/utils/assets/fonts/desyrel.xml
+++ b/tests/utils/assets/fonts/desyrel.xml
@@ -1,4 +1,4 @@
-<font>
+<font version="3.2">
     <info face="Desyrel" size="70" bold="0" italic="0" chasrset="" unicode="0" stretchH="100" smooth="1" aa="1" padding="0,0,0,0" spacing="1,1"/>
     <common lineHeight="87" base="61" scaleW="512" scaleH="512" pages="1" packed="0"/>
     <pages>


### PR DESCRIPTION
### Description of change
Fonts with xml `<font version="3">` can now be loaded by using regex instead of directly comparing `<font>`. Updated `<font version="3.2">` into one of the existing tests for font XML parsing. 

### Issue
I was able to recreate and resolve this issue: https://github.com/pixijs/pixijs/issues/11722

### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`) 
   `tests/visual/visuals.test.ts:98:29)` failed with and without my change, the rest of the tests passed

### Before Change (notice `<font version="3">` in the first font loaded)
https://github.com/user-attachments/assets/bb48738c-5d98-4cbb-a76f-fb2adc864b08

### After Change
https://github.com/user-attachments/assets/65d3c7d1-297c-49a7-91ee-30f4ff007cd9
