### PR TITLE
feat: add unload method to reset GPU data

### DIFF
--- a/src/rendering/renderers/types.ts
+++ b/src/rendering/renderers/types.ts
@@ -1,3 +1,5 @@
+import { type GPUData } from '../../scene/view/ViewContainer';
+
 import type { ICanvas } from '../../environment/canvas/ICanvas';
 import type { WebGLOptions, WebGLPipes, WebGLRenderer } from './gl/WebGLRenderer';
 import type { WebGPUOptions, WebGPUPipes, WebGPURenderer } from './gpu/WebGPURenderer';
@@ -54,4 +56,16 @@ export enum RendererType
  * @category rendering
  * @advanced
  */
-export type GpuPowerPreference = 'low-power' | 'high-performance';
+export type GpuPowerPreference = 'low-power' | 'high-performance';/** @internal */
+
+/**
+ * A resource that can have GPU data associated with it.
+ * @category rendering
+ * @advanced
+ */
+export interface GPUDataOwner<GPU_DATA extends GPUData = any>
+{
+    _gpuData: Record<number, GPU_DATA>;
+    unload: () => void;
+}
+

--- a/src/scene/graphics/__tests__/Graphics.Destroy.test.ts
+++ b/src/scene/graphics/__tests__/Graphics.Destroy.test.ts
@@ -42,7 +42,7 @@ describe('Graphics Destroy', () =>
 
         expect(graphics.context).toBeNull();
 
-        expect(graphics._gpuData).toBeNull();
+        expect(graphics._gpuData).toBeEmptyObject();
 
         expect(renderer.graphicsContext['_gpuContextHash'][context.uid]).not.toBeNull();
         expect(renderer.graphicsContext['_gpuContextHash'][context.uid]).not.toBeNull();

--- a/src/scene/graphics/shared/GraphicsPipe.ts
+++ b/src/scene/graphics/shared/GraphicsPipe.ts
@@ -2,6 +2,7 @@ import { ExtensionType } from '../../../extensions/Extensions';
 import { State } from '../../../rendering/renderers/shared/state/State';
 import { type Renderer } from '../../../rendering/renderers/types';
 import { BigPool } from '../../../utils/pool/PoolGroup';
+import { type GPUData } from '../../view/ViewContainer';
 import { color32BitToUniform } from '../gpu/colorToUniform';
 import { BatchableGraphics } from './BatchableGraphics';
 
@@ -22,7 +23,7 @@ export interface GraphicsAdaptor
 }
 
 /** @internal */
-export class GraphicsGpuData
+export class GraphicsGpuData implements GPUData
 {
     public batches: BatchableGraphics[] = [];
     public batched = false;

--- a/src/scene/mesh/__tests__/Mesh.test.ts
+++ b/src/scene/mesh/__tests__/Mesh.test.ts
@@ -50,7 +50,7 @@ describe('Mesh', () =>
         expect(mesh.geometry).toBeNull();
         expect(mesh.texture).toBeNull();
 
-        expect(mesh._gpuData).toBeNull();
+        expect(mesh._gpuData).toBeEmptyObject();
     });
 
     it('should clean up correctly when not batching', async () =>
@@ -74,7 +74,7 @@ describe('Mesh', () =>
         expect(mesh.geometry).toBeNull();
         expect(mesh.texture).toBeNull();
 
-        expect(mesh._gpuData).toBeNull();
+        expect(mesh._gpuData).toBeEmptyObject();
     });
 
     it('should support color tinting', () =>

--- a/src/scene/mesh/shared/Mesh.ts
+++ b/src/scene/mesh/shared/Mesh.ts
@@ -362,7 +362,5 @@ export class Mesh<
         this._texture = null;
         this._geometry = null;
         this._shader = null;
-
-        this._gpuData = null;
     }
 }

--- a/src/scene/particle-container/shared/ParticleBuffer.ts
+++ b/src/scene/particle-container/shared/ParticleBuffer.ts
@@ -3,6 +3,7 @@ import { BufferUsage } from '../../../rendering/renderers/shared/buffer/const';
 import { Geometry } from '../../../rendering/renderers/shared/geometry/Geometry';
 import { getAttributeInfoFromFormat } from '../../../rendering/renderers/shared/geometry/utils/getAttributeInfoFromFormat';
 import { ViewableBuffer } from '../../../utils/data/ViewableBuffer';
+import { type GPUData } from '../../view/ViewContainer';
 import { createIndicesForQuads } from './utils/createIndicesForQuads';
 import { generateParticleUpdateFunction } from './utils/generateParticleUpdateFunction';
 
@@ -28,7 +29,7 @@ export interface ParticleBufferOptions
  * It also contains the upload functions for the static and dynamic properties.
  * @internal
  */
-export class ParticleBuffer
+export class ParticleBuffer implements GPUData
 {
     /** The buffer containing static attribute data for all elements in the batch. */
     public staticAttributeBuffer: ViewableBuffer;

--- a/src/scene/particle-container/shared/__tests__/ParticleContainer.test.ts
+++ b/src/scene/particle-container/shared/__tests__/ParticleContainer.test.ts
@@ -58,7 +58,7 @@ describe('ParticleContainer', () =>
 
             particleContainer.destroy();
 
-            expect(particleContainer._gpuData).toBeNull();
+            expect(particleContainer._gpuData).toBeEmptyObject();
         });
     });
 

--- a/src/scene/sprite-nine-slice/NineSliceSpritePipe.ts
+++ b/src/scene/sprite-nine-slice/NineSliceSpritePipe.ts
@@ -1,5 +1,6 @@
 import { ExtensionType } from '../../extensions/Extensions';
 import { BatchableMesh } from '../mesh/shared/BatchableMesh';
+import { type GPUData } from '../view/ViewContainer';
 import { NineSliceGeometry } from './NineSliceGeometry';
 
 import type { InstructionSet } from '../../rendering/renderers/shared/instructions/InstructionSet';
@@ -11,7 +12,7 @@ import type { NineSliceSprite } from './NineSliceSprite';
  * GPU data for NineSliceSprite.
  * @internal
  */
-export class NineSliceSpriteGpuData extends BatchableMesh
+export class NineSliceSpriteGpuData extends BatchableMesh implements GPUData
 {
     constructor()
     {

--- a/src/scene/sprite-tiling/TilingSpritePipe.ts
+++ b/src/scene/sprite-tiling/TilingSpritePipe.ts
@@ -5,6 +5,7 @@ import { type Renderer, RendererType } from '../../rendering/renderers/types';
 import { color32BitToUniform } from '../graphics/gpu/colorToUniform';
 import { BatchableMesh } from '../mesh/shared/BatchableMesh';
 import { MeshGeometry } from '../mesh/shared/MeshGeometry';
+import { type GPUData } from '../view/ViewContainer';
 import { TilingSpriteShader } from './shader/TilingSpriteShader';
 import { QuadGeometry } from './utils/QuadGeometry';
 import { setPositions } from './utils/setPositions';
@@ -18,7 +19,7 @@ import type { TilingSprite } from './TilingSprite';
 const sharedQuad = new QuadGeometry();
 
 /** @internal */
-export class TilingSpriteGpuData
+export class TilingSpriteGpuData implements GPUData
 {
     public canBatch: boolean = true;
     public renderable: TilingSprite;

--- a/src/scene/sprite-tiling/__tests__/TilingSprite.test.ts
+++ b/src/scene/sprite-tiling/__tests__/TilingSprite.test.ts
@@ -99,7 +99,7 @@ describe('TilingSprite', () =>
 
             sprite.destroy();
 
-            expect(sprite._gpuData).toBeNull();
+            expect(sprite._gpuData).toBeEmptyObject();
 
             expect(sprite.texture).toBeNull();
         });

--- a/src/scene/sprite/BatchableSprite.ts
+++ b/src/scene/sprite/BatchableSprite.ts
@@ -1,3 +1,5 @@
+import { type GPUData } from '../view/ViewContainer';
+
 import type { Matrix } from '../../maths/matrix/Matrix';
 import type { Batch, Batcher } from '../../rendering/batcher/shared/Batcher';
 import type { DefaultBatchableQuadElement } from '../../rendering/batcher/shared/DefaultBatcher';
@@ -10,7 +12,7 @@ import type { Container } from '../container/Container';
  * A batchable sprite object.
  * @internal
  */
-export class BatchableSprite implements DefaultBatchableQuadElement
+export class BatchableSprite implements DefaultBatchableQuadElement, GPUData
 {
     public batcherName = 'default';
     public topology: Topology = 'triangle-list';

--- a/src/scene/sprite/Sprite.ts
+++ b/src/scene/sprite/Sprite.ts
@@ -359,7 +359,6 @@ export class Sprite extends ViewContainer<BatchableSprite>
         (this._visualBounds as null) = null;
         (this._bounds as null) = null;
         (this._anchor as null) = null;
-        this._gpuData = null;
     }
 
     /**

--- a/src/scene/sprite/__tests__/Sprite.test.ts
+++ b/src/scene/sprite/__tests__/Sprite.test.ts
@@ -74,7 +74,7 @@ describe('Sprite', () =>
 
             sprite.destroy();
 
-            expect(sprite._gpuData).toBeNull();
+            expect(sprite._gpuData).toBeEmptyObject();
         });
     });
 

--- a/src/scene/text-bitmap/BitmapTextPipe.ts
+++ b/src/scene/text-bitmap/BitmapTextPipe.ts
@@ -3,6 +3,7 @@ import { ExtensionType } from '../../extensions/Extensions';
 import { Graphics } from '../graphics/shared/Graphics';
 import { CanvasTextMetrics } from '../text/canvas/CanvasTextMetrics';
 import { SdfShader } from '../text/sdfShader/SdfShader';
+import { type GPUData } from '../view/ViewContainer';
 import { BitmapFontManager } from './BitmapFontManager';
 import { getBitmapTextLayout } from './utils/getBitmapTextLayout';
 
@@ -13,7 +14,7 @@ import type { Renderer } from '../../rendering/renderers/types';
 import type { BitmapText } from './BitmapText';
 
 /** @internal */
-export class BitmapTextGraphics extends Graphics
+export class BitmapTextGraphics extends Graphics implements GPUData
 {
     public destroy()
     {

--- a/src/scene/text/__tests__/Text.test.ts
+++ b/src/scene/text/__tests__/Text.test.ts
@@ -165,7 +165,7 @@ describe('Text', () =>
 
             text.destroy();
 
-            expect(text._gpuData).toBeNull();
+            expect(text._gpuData).toBeEmptyObject();
             expect(renderer.canvasText['_activeTextures'][key]).toBeNull();
         });
 
@@ -185,7 +185,7 @@ describe('Text', () =>
 
             text.destroy();
 
-            expect(text._gpuData).toBeNull();
+            expect(text._gpuData).toBeEmptyObject();
         });
 
         it('should destroy textStyle correctly', () =>


### PR DESCRIPTION
##### Description of change
- Add `unload` method to reset GPU data

```ts
sprite.unload()
```
- Ensure all gpu data objects implement `GPUData`

##### Pre-Merge Checklist
- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 8 in a stack** made with GitButler:
- <kbd>&nbsp;8&nbsp;</kbd> #11788 
- <kbd>&nbsp;7&nbsp;</kbd> #11781 
- <kbd>&nbsp;6&nbsp;</kbd> #11775 
- <kbd>&nbsp;5&nbsp;</kbd> #11774 
- <kbd>&nbsp;4&nbsp;</kbd> #11772 
- <kbd>&nbsp;3&nbsp;</kbd> #11763 
- <kbd>&nbsp;2&nbsp;</kbd> #11786 
- <kbd>&nbsp;1&nbsp;</kbd> #11762 👈 
<!-- GitButler Footer Boundary Bottom -->

