### PR TITLE
fix: Remove automatically added 'resize' event listener from TextureSource on Texture destroy()

### DIFF
--- a/src/rendering/renderers/shared/texture/Texture.ts
+++ b/src/rendering/renderers/shared/texture/Texture.ts
@@ -380,6 +380,8 @@ export class Texture<TextureSourceType extends TextureSource = TextureSource> ex
     {
         if (this._source)
         {
+            this._source.off('resize', this.update, this);
+
             if (destroySource)
             {
                 this._source.destroy();


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
I noticed my manually created Textures weren't being released from memory. I found it was due to a reference being held by TextureSource caused by the automatically added 'resize' event listener.

Example
https://stackblitz.com/edit/pixijs-v8-yo5njdcr?file=src%2Fmain.js

This change removes the listener from TextureSource when Texture destroy() is called 


##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
