### PR TITLE
fix: SVGParser.ts Allow negative values for Polygon(s)/polyline(s)

### DIFF
--- a/src/scene/graphics/shared/svg/SVGParser.ts
+++ b/src/scene/graphics/shared/svg/SVGParser.ts
@@ -283,7 +283,7 @@ function renderChildren(svg: SVGElement, session: Session, fillStyle: FillStyle,
 
         case 'polygon':
             pointsString = svg.getAttribute('points') as string;
-            points = pointsString.match(/\d+/g).map((n) => parseInt(n, 10));
+            points = pointsString.match(/-?\d+/g).map((n) => parseInt(n, 10));
             session.context.poly(points, true);
             if (fillStyle) session.context.fill(fillStyle);
             if (strokeStyle) session.context.stroke(strokeStyle);
@@ -291,7 +291,7 @@ function renderChildren(svg: SVGElement, session: Session, fillStyle: FillStyle,
 
         case 'polyline':
             pointsString = svg.getAttribute('points') as string;
-            points = pointsString.match(/\d+/g).map((n) => parseInt(n, 10));
+            points = pointsString.match(/-?\d+/g).map((n) => parseInt(n, 10));
             session.context.poly(points, false);
             if (strokeStyle) session.context.stroke(strokeStyle);
             break;


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change

SVGParser.ts Contained an regex that parses the number out of svg polygons and polylines.
This regex however ignores if an values is negative or not:

Bad Regex (current situation)
```js
'<polyline points="19967,-45533 19967,-45502"/>'.match(/\d+/g).map((n) => parseInt(n, 10));
// outputs  [19967, 45533, 19967, 45502]
```

Fixed Regex (suggested change for polygon and polyline parsing)
 ```js
 '<polyline points="19967,-45533 19967,-45502"/>'.match(/-?\d+/g).map((n) => parseInt(n, 10));
// outputs [19967, -45533, 19967, -45502]
```

Changed code to (without the comments)
```js
        case 'polygon':
            pointsString = svg.getAttribute('points') as string;
            points = pointsString.match(/-?\d+/g).map((n) => parseInt(n, 10)); // fixed regex
            session.context.poly(points, true);
            if (fillStyle) session.context.fill(fillStyle);
            if (strokeStyle) session.context.stroke(strokeStyle);
            break;

        case 'polyline':
            pointsString = svg.getAttribute('points') as string;
            points = pointsString.match(/-?\d+/g).map((n) => parseInt(n, 10)); // fixed regex
            session.context.poly(points, false);
            if (strokeStyle) session.context.stroke(strokeStyle);
            break;
```

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
