### PR TITLE
fix: RenderTexture ignoring format setting (WebGL)

### DIFF
--- a/src/rendering/renderers/gl/texture/GlTextureSystem.ts
+++ b/src/rendering/renderers/gl/texture/GlTextureSystem.ts
@@ -303,8 +303,17 @@ export class GlTextureSystem implements System, CanvasGenerator
         }
         else
         {
-            // eslint-disable-next-line max-len
-            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, source.pixelWidth, source.pixelHeight, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+            gl.texImage2D(
+                gl.TEXTURE_2D,
+                0,
+                glTexture.internalFormat,
+                source.pixelWidth,
+                source.pixelHeight,
+                0,
+                glTexture.format,
+                glTexture.type,
+                null,
+            );
         }
 
         if (source.autoGenerateMipmaps && source.mipLevelCount > 1)


### PR DESCRIPTION
Because I like it when this does something:

```ts
RenderTexture.create({
      // ...
      format: 'rgba32float', // epic!
});
```

Seems like an oversight that the actual settings were not honored? In any case leaving this PR here to get the opinion of someone who knows how this is supposed to happen (I don't feel like I have the full picture).

I did not test this besides "works for me".