### PR TITLE
fix: prevent double returning of batches to pool

### DIFF
--- a/src/rendering/batcher/shared/Batcher.ts
+++ b/src/rendering/batcher/shared/Batcher.ts
@@ -416,6 +416,7 @@ export abstract class Batcher
         }
 
         this.batchIndex = 0;
+
         this._batchIndexStart = 0;
         this._batchIndexSize = 0;
 
@@ -783,7 +784,7 @@ export abstract class Batcher
     {
         if (this.batches === null) return;
 
-        for (let i = 0; i < this.batches.length; i++)
+        for (let i = 0; i < this.batchIndex; i++)
         {
             returnBatchToPool(this.batches[i]);
         }


### PR DESCRIPTION
This PR fixes an issue where batches were being returned to the pool twice - once during begin() and again during destroy(). This caused batch corruption when the same batch instance was reused multiple times simultaneously.

Fixes https://github.com/pixijs/pixijs/issues/11765#issuecomment-3585480517