### PR TITLE
fix: make rendering to multiple textures work (WebGL)

### DIFF
--- a/src/rendering/renderers/gl/renderTarget/GlRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/gl/renderTarget/GlRenderTargetAdaptor.ts
@@ -314,7 +314,7 @@ export class GlRenderTargetAdaptor implements RenderTargetAdaptor<GlRenderTarget
                 0);// mipLevel);
         });
 
-        if (colorTextures.length > 0)
+        if (colorTextures.length > 1)
         {
             const bufferArray: number[] = [];
 


### PR DESCRIPTION
We need to call gl.drawBuffers to instruct GL to actually use the multiple buffers we bound. In WebGL1 this is available as an extension. This is also per-framebuffer state, so this setup is only required once.

Now something like this will work:

```frag
layout(location = 0) out vec4 fragNormal;
layout(location = 1) out vec4 fragMaterial;
layout(location = 2) out vec4 fragAlbedo;
```

```ts
const target = new RenderTarget({
    colorTextures: [normalTexture, materialTexture, albedoTexture],
});

renderer.render({
    container,
    target,
    clear: true,
    clearColor: [0, 0, 0, 0],
});
```

Before only writing to whatever was in ``(location = 0)`` would do anything.