### PR TITLE
feat: improved Pool typing for pool.get() method

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -120,7 +120,7 @@ export default tseslint.config(
             'jest/expect-expect': [
                 'error',
                 {
-                    assertFunctionNames: ['expect', 'check32BitColorMatches', 'assertRemovedFromParent'],
+                    assertFunctionNames: ['expect', 'check32BitColorMatches', 'assertRemovedFromParent', 'expectTypeOf'],
                     additionalTestBlockFunctions: [''],
                 },
             ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "eslint-plugin-jest": "^28.9.0",
         "eslint-plugin-jsdoc": "^50.6.0",
         "eslint-plugin-no-mixed-operators": "^1.1.1",
+        "expect-type": "^1.2.2",
         "fs-extra": "^11.2.0",
         "glob": "^8.1.0",
         "http-server": "^14.1.1",
@@ -7341,6 +7342,16 @@
       },
       "engines": {
         "node": ">= 10.14.2"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/expect/node_modules/ansi-styles": {
@@ -23229,6 +23240,12 @@
           }
         }
       }
+    },
+    "expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "eslint-plugin-jest": "^28.9.0",
     "eslint-plugin-jsdoc": "^50.6.0",
     "eslint-plugin-no-mixed-operators": "^1.1.1",
+    "expect-type": "^1.2.2",
     "fs-extra": "^11.2.0",
     "glob": "^8.1.0",
     "http-server": "^14.1.1",

--- a/src/utils/pool/Pool.ts
+++ b/src/utils/pool/Pool.ts
@@ -1,10 +1,11 @@
 /**
  * A generic class for managing a pool of items.
  * @template T The type of items in the pool. Must implement {@link PoolItem}.
+ * @template I The type of argument passed to item's `init` method if it exists.
  * @category utils
  * @advanced
  */
-export class Pool<T extends PoolItem>
+export class Pool<T extends PoolItem, I = Parameters<NonNullable<T['init']>>[0]>
 {
     /** @internal */
     public readonly _classType: PoolItemConstructor<T>;
@@ -44,10 +45,10 @@ export class Pool<T extends PoolItem>
     /**
      * Gets an item from the pool. Calls the item's `init` method if it exists.
      * If there are no items left in the pool, a new one will be created.
-     * @param {unknown} [data] - Optional data to pass to the item's constructor.
+     * @param {I} [data] - Optional data to pass to the item's constructor.
      * @returns {T} The item from the pool.
      */
-    public get(data?: unknown): T
+    public get(data?: I): T
     {
         let item;
 

--- a/src/utils/pool/__tests__/Pool.test.ts
+++ b/src/utils/pool/__tests__/Pool.test.ts
@@ -1,4 +1,5 @@
-import { Pool } from '../Pool';
+import { expectTypeOf } from 'expect-type';
+import { Pool, type PoolItemConstructor } from '../Pool';
 
 class TestItem
 {
@@ -17,6 +18,18 @@ class TestItem
     public reset()
     {
         this.value = 0;
+    }
+}
+
+class TestItem2
+{
+    public name!: string;
+    public id!: number;
+
+    public init(data?: { name: string, id: number })
+    {
+        this.name = data.name ?? '';
+        this.id = data.id ?? -1;
     }
 }
 
@@ -66,7 +79,7 @@ describe('Pool', () =>
         expect(item.value).toBe(0);
     });
 
-    it('should reuse returned items', () =>
+    it('should reuse returned items and call item.reset() if exists', () =>
     {
         const pool = new Pool(TestItem);
         const item1 = pool.get(10);
@@ -74,6 +87,9 @@ describe('Pool', () =>
         pool.get(20);
 
         pool.return(item1);
+
+        expect(item1.value).toBe(0);
+
         const item3 = pool.get(30);
 
         expect(item3).toBe(item1);
@@ -142,5 +158,74 @@ describe('Pool', () =>
         expect(pool.totalSize).toBe(0);
         expect(pool.totalFree).toBe(0);
         expect(pool.totalUsed).toBe(0);
+    });
+
+    it('should call item.destroy() on each item when pool.clear() is called', () =>
+    {
+        class TestItemDestroy
+        {
+            public destroyed = false;
+            public destroy()
+            {
+                this.destroyed = true;
+            }
+        }
+
+        const pool = new Pool(TestItemDestroy);
+        const item1 = new TestItemDestroy();
+        const item2 = new TestItemDestroy();
+
+        pool.return(item1);
+        pool.return(item2);
+
+        expect(item1.destroyed).toEqual(false);
+        expect(item2.destroyed).toEqual(false);
+
+        pool.clear();
+
+        expect(item1.destroyed).toEqual(true);
+        expect(item2.destroyed).toEqual(true);
+    });
+
+    it('should use the correct _classType', () =>
+    {
+        const pool = new Pool(TestItem);
+
+        expect(pool['_classType']).toEqual(TestItem);
+        expectTypeOf(pool['_classType']).toEqualTypeOf<PoolItemConstructor<TestItem>>();
+    });
+
+    it('should use the data argument type of item.init(data) for the pool.get() method', () =>
+    {
+        const pool = new Pool(TestItem2);
+
+        expectTypeOf<Parameters<typeof pool.get>[0]>().toEqualTypeOf<{
+            name: string,
+            id: number
+        }>();
+
+        const item2 = pool.get({ name: 'test item', id: 99 });
+
+        expect(item2).toEqual({
+            name: 'test item',
+            id: 99,
+        });
+    });
+
+    it('should ignore the data argument type of item.init(data) if the item does not have an init() method', () =>
+    {
+        class EmptyTestItem
+        {
+
+        }
+        const pool = new Pool(EmptyTestItem);
+
+        expectTypeOf<Parameters<typeof pool.get>[0]>().toEqualTypeOf<never>();
+
+        const item = new EmptyTestItem();
+
+        pool.return(item);
+
+        expect(pool.get()).toEqual(item);
     });
 });


### PR DESCRIPTION
This fixes the botched rebase in https://github.com/pixijs/pixijs/pull/11707

##### Description of change
The `pool.get(data)` method will automatically use the `data` type of the data argument from `item.init(data)`
improved tests for the Pool class

##### Pre-Merge Checklist
- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)

Question
Is there a reason that pool could not use a factory function instead of a class constructor?

