### PR TITLE
feat: Adds auto-GC option to view containers

### DIFF
--- a/src/scene/graphics/shared/Graphics.ts
+++ b/src/scene/graphics/shared/Graphics.ts
@@ -122,6 +122,7 @@ export class Graphics extends ViewContainer<GraphicsGpuData> implements Instruct
         if (!context)
         {
             this.context = this._ownedContext = new GraphicsContext();
+            this.context.autoGarbageCollect = this.autoGarbageCollect;
         }
         else
         {

--- a/src/scene/view/ViewContainer.ts
+++ b/src/scene/view/ViewContainer.ts
@@ -31,7 +31,11 @@ export interface GPUDataContainer<GPU_DATA extends GPUData = any>
  * @category scene
  * @advanced
  */
-export interface ViewContainerOptions extends ContainerOptions, PixiMixins.ViewContainerOptions {}
+export interface ViewContainerOptions extends ContainerOptions, PixiMixins.ViewContainerOptions
+{
+    /** If set to true, the resource will be garbage collected automatically when it is not used. */
+    autoGarbageCollect?: boolean;
+}
 // eslint-disable-next-line requireExport/require-export-jsdoc, requireMemberAPI/require-member-api-doc
 export interface ViewContainer<GPU_DATA extends GPUData = any> extends
     PixiMixins.ViewContainer, Container, GPUDataOwner<GPU_DATA>, GCable {}
@@ -115,10 +119,10 @@ export abstract class ViewContainer<GPU_DATA extends GPUData = any> extends Cont
         this._roundPixels = value ? 1 : 0;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-useless-constructor
     constructor(options: ViewContainerOptions)
     {
         super(options);
+        this.autoGarbageCollect = options.autoGarbageCollect ?? true;
     }
 
     /**


### PR DESCRIPTION
Introduces an `autoGarbageCollect` option to `ViewContainer` and also sets the value for a graphics that owns its own context for convenience.

This allows developers to explicitly control whether resources associated with a view container are automatically garbage collected. By default, this option is enabled (true), maintaining current behavior.