### PR TITLE
chore: Improve JSDoc documentation across modules

### DIFF
--- a/src/scene/layers/RenderLayer.ts
+++ b/src/scene/layers/RenderLayer.ts
@@ -245,7 +245,20 @@ export class RenderLayer extends Container
     public destroyed: boolean;
     /** @internal */
     public layerParentId: string;
-    /** @internal */
+    /**
+     * If true, the layer's children will be sorted by zIndex before rendering.
+     * If false, you can manually sort the children using sortRenderLayerChildren when needed.
+     * @default false
+     * @example
+     * ```ts
+     * const layer = new RenderLayer({
+     *     sortableChildren: true // Automatically sorts children by zIndex
+     * });
+     * ```
+     * @see {@link RenderLayer#sortRenderLayerChildren} For manual sorting
+     * @see {@link RenderLayer#sortFunction} For customizing the sort logic
+     * @see {@link Container#zIndex} For the default sort property
+     */
     public sortableChildren;
 
     /**

--- a/src/scene/text-html/HTMLText.ts
+++ b/src/scene/text-html/HTMLText.ts
@@ -84,7 +84,7 @@ export interface HTMLText extends PixiMixins.HTMLText, AbstractText<
  * This allows for rich text formatting using standard HTML tags and CSS styling.
  *
  * Key features:
- * - HTML tag support (<strong>, <em>, etc.)
+ * - HTML tag support (&lt;strong&gt;, &lt;em&gt;, etc.)
  * - CSS styling and custom style overrides
  * - Emoji and special character support
  * - Line breaking and word wrapping

--- a/src/ticker/Ticker.ts
+++ b/src/ticker/Ticker.ts
@@ -130,7 +130,6 @@ export class Ticker
      *
      * This is NOT in milliseconds - it's a scalar multiplier for frame-independent animations.
      * For actual milliseconds, use {@link Ticker#deltaMS}.
-     * @member {number}
      * @example
      * ```ts
      * // Frame-independent animation using deltaTime scalar
@@ -171,7 +170,6 @@ export class Ticker
      * This value is not capped or scaled and provides raw timing information.
      *
      * Unlike {@link Ticker#deltaMS}, this value is unmodified by speed scaling or FPS capping.
-     * @member {number}
      * @example
      * ```ts
      * ticker.add((ticker) => {
@@ -185,7 +183,6 @@ export class Ticker
      * Similar to performance.now() timestamp format.
      *
      * Used internally for calculating time deltas between frames.
-     * @member {number}
      * @example
      * ```ts
      * ticker.add((ticker) => {


### PR DESCRIPTION
Fixes: #11802

- Corrects HTML tag escaping in text documentation to ensure proper rendering.
- Removes redundant member JSDoc tags from ticker properties for cleaner documentation.

