### PR TITLE
chore: refactors CI workflows for trusted publishing

### DIFF
--- a/.github/workflows/publish-branch.yaml
+++ b/.github/workflows/publish-branch.yaml
@@ -1,17 +1,15 @@
 name: Publish Branch
 
 on:
-    push:
-        branches:
-            - main
-            - dev
+    workflow_call:
 
 jobs:
     release_candidate:
         runs-on: ubuntu-22.04
+        permissions:
+          id-token: write
+          contents: write
         env:
-            NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-            NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
             BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/publish-switch.yml
+++ b/.github/workflows/publish-switch.yml
@@ -1,0 +1,28 @@
+name: Publish switch
+
+on:
+  release:
+    types: [ published ]
+  push:
+    branches:
+      - main
+      - dev
+
+permissions:
+  id-token: write # Required for OIDC
+  contents: write # Required for npm beta version updates
+
+jobs:
+  publish-prod:
+    if: github.event_name == 'release'
+    uses: ./.github/workflows/release.yml
+    permissions:
+      id-token: write
+      contents: read
+
+  publish-branch:
+    if: github.event_name == 'push'
+    uses: ./.github/workflows/publish-branch.yaml
+    permissions:
+      id-token: write
+      contents: write

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,7 +11,6 @@ concurrency:
 jobs:
   build:
     env:
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN || '' }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID || '' }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,20 @@
 name: Release
 
 on:
-  release:
-    types: [ published ]
+  workflow_call:
 
 jobs:
   release:
     env:
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN || '' }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID || '' }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
       SOURCE_DIR: '.s3_uploads'
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -21,19 +22,12 @@ jobs:
     - name: Setup project
       uses: ./.github/actions/setup
 
-    # Check unit tests
-    - name: Unit Tests
-      uses: ./.github/actions/unit
-      with:
-        type: Unit
-
     # Build the project
     - name: Build
       run: npm run dist
 
     # Append assets to releases
     - name: Upload Assets to Release
-      if: github.event_name == 'release'
       uses: softprops/action-gh-release@v2
       with:
         files: |
@@ -42,7 +36,7 @@ jobs:
     # Release is published and deployed into s3://bucket-name/v5.22/
     - name: Deploy Released Branches
       uses: jakejarvis/s3-sync-action@master
-      if: github.event_name == 'release' && env.AWS_ACCESS_KEY_ID != ''
+      if: env.AWS_ACCESS_KEY_ID != ''
       with:
         args: --acl public-read --follow-symlinks --delete --cache-control "max-age=2592000"
       env:
@@ -51,7 +45,7 @@ jobs:
     # Same release from previous deployed into s3://bucket-name/release/
     - name: Deploy Latest Release
       uses: jakejarvis/s3-sync-action@master
-      if: github.event_name == 'release' && github.event.release.prerelease == false && env.AWS_ACCESS_KEY_ID != ''
+      if: github.event.release.prerelease == false && env.AWS_ACCESS_KEY_ID != ''
       with:
         args: --acl public-read --follow-symlinks --delete --cache-control "max-age=1209600"
       env:
@@ -59,10 +53,10 @@ jobs:
 
     # Publish to NPM
     - name: Publish Latest Release
-      if: github.event.release.prerelease == false && env.NODE_AUTH_TOKEN != ''
+      if: github.event.release.prerelease == false
       run: npm run publish-ci
 
     # Publish to NPM with prerelease dist-tag
     - name: Publish Latest Prerelease
-      if: github.event.release.prerelease && env.NODE_AUTH_TOKEN != ''
+      if: github.event.release.prerelease
       run: npm run publish-ci -- --tag prerelease-v8


### PR DESCRIPTION
Refactors CI workflows for trusted publishing:

https://docs.npmjs.com/trusted-publishers

- Converts `publish-branch` and `release` workflows to `workflow_call` for shared execution
- Creates new `publish-switch` workflow to handle dual triggering (release publication and branch pushes). This is needed as currently only one workflow file can be configured
- Updates permissions to properly handle OIDC tokens and content access
- Removes redundant `NODE_AUTH_TOKEN` from `push.yml`