### PR TITLE
fix: improves tree-shaking by optimizing module imports

### DIFF
--- a/src/app/Application.ts
+++ b/src/app/Application.ts
@@ -3,6 +3,7 @@ import { autoDetectRenderer } from '../rendering/renderers/autoDetectRenderer';
 import { Container } from '../scene/container/Container';
 import { ApplicationInitHook } from '../utils/global/globalHooks';
 import { deprecation, v8_0_0 } from '../utils/logging/deprecation';
+import '../app/init';
 
 import type { Rectangle } from '../maths/shapes/Rectangle';
 import type { AutoDetectOptions } from '../rendering/renderers/autoDetectRenderer';

--- a/src/dom/DOMContainer.ts
+++ b/src/dom/DOMContainer.ts
@@ -1,8 +1,12 @@
 /* eslint-disable no-restricted-globals */
+import { extensions } from '../extensions/Extensions';
 import { Point } from '../maths/point/Point';
 import { ViewContainer, type ViewContainerOptions } from '../scene/view/ViewContainer';
+import { DOMPipe } from './DOMPipe';
 
 import type { PointData } from '../maths/point/PointData';
+
+extensions.add(DOMPipe);
 
 /**
  * Options for configuring a {@link DOMContainer}.

--- a/src/dom/init.ts
+++ b/src/dom/init.ts
@@ -1,6 +1,1 @@
-import { extensions } from '../extensions/Extensions';
-import { DOMPipe } from './DOMPipe';
-
 export * from './index';
-
-extensions.add(DOMPipe);

--- a/src/environment-browser/browserAll.ts
+++ b/src/environment-browser/browserAll.ts
@@ -1,15 +1,5 @@
 import '../accessibility/init';
-import '../app/init';
 import '../events/init';
-import '../dom/init';
 import '../spritesheet/init';
 import '../rendering/init';
-import '../scene/graphics/init';
-import '../scene/mesh/init';
-import '../scene/particle-container/init';
-import '../scene/text/init';
-import '../scene/text-bitmap/init';
-import '../scene/text-html/init';
-import '../scene/sprite-tiling/init';
-import '../scene/sprite-nine-slice/init';
 import '../filters/init';

--- a/src/environment-webworker/webworkerAll.ts
+++ b/src/environment-webworker/webworkerAll.ts
@@ -1,12 +1,3 @@
-import '../app/init';
 import '../spritesheet/init';
 import '../rendering/init';
-import '../scene/graphics/init';
-import '../scene/mesh/init';
-import '../scene/particle-container/init';
-import '../scene/text/init';
-import '../scene/text-bitmap/init';
-import '../scene/text-html/init';
-import '../scene/sprite-tiling/init';
-import '../scene/sprite-nine-slice/init';
 import '../filters/init';

--- a/src/scene/graphics/shared/Graphics.ts
+++ b/src/scene/graphics/shared/Graphics.ts
@@ -2,6 +2,7 @@ import { deprecation, v8_0_0 } from '../../../utils/logging/deprecation';
 import { ViewContainer, type ViewContainerOptions } from '../../view/ViewContainer';
 import { GraphicsContext } from './GraphicsContext';
 import { type GraphicsGpuData } from './GraphicsPipe';
+import '../init';
 
 import type { ColorSource } from '../../../color/Color';
 import type { Matrix } from '../../../maths/matrix/Matrix';

--- a/src/scene/mesh/shared/Mesh.ts
+++ b/src/scene/mesh/shared/Mesh.ts
@@ -6,6 +6,7 @@ import { deprecation, v8_0_0 } from '../../../utils/logging/deprecation';
 import { ViewContainer } from '../../view/ViewContainer';
 import { MeshGeometry } from './MeshGeometry';
 import { type MeshGpuData } from './MeshPipe';
+import '../init';
 
 import type { PointData } from '../../../maths/point/PointData';
 import type { Topology } from '../../../rendering/renderers/shared/geometry/const';

--- a/src/scene/particle-container/shared/ParticleContainer.ts
+++ b/src/scene/particle-container/shared/ParticleContainer.ts
@@ -2,6 +2,7 @@ import { Bounds } from '../../container/bounds/Bounds';
 import { ViewContainer, type ViewContainerOptions } from '../../view/ViewContainer';
 import { type ParticleBuffer } from './ParticleBuffer';
 import { particleData } from './particleData';
+import '../init';
 
 import type { Instruction } from '../../../rendering/renderers/shared/instructions/Instruction';
 import type { Shader } from '../../../rendering/renderers/shared/shader/Shader';

--- a/src/scene/sprite-nine-slice/NineSliceSprite.ts
+++ b/src/scene/sprite-nine-slice/NineSliceSprite.ts
@@ -5,6 +5,7 @@ import { deprecation, v8_0_0 } from '../../utils/logging/deprecation';
 import { ViewContainer, type ViewContainerOptions } from '../view/ViewContainer';
 import { NineSliceGeometry } from './NineSliceGeometry';
 import { type NineSliceSpriteGpuData } from './NineSliceSpritePipe';
+import './init';
 
 import type { Size } from '../../maths/misc/Size';
 import type { View } from '../../rendering/renderers/shared/view/View';

--- a/src/scene/sprite-tiling/TilingSprite.ts
+++ b/src/scene/sprite-tiling/TilingSprite.ts
@@ -5,6 +5,7 @@ import { deprecation, v8_0_0 } from '../../utils/logging/deprecation';
 import { Transform } from '../../utils/misc/Transform';
 import { ViewContainer, type ViewContainerOptions } from '../view/ViewContainer';
 import { type TilingSpriteGpuData } from './TilingSpritePipe';
+import './init';
 
 import type { Size } from '../../maths/misc/Size';
 import type { PointData } from '../../maths/point/PointData';

--- a/src/scene/text-bitmap/BitmapText.ts
+++ b/src/scene/text-bitmap/BitmapText.ts
@@ -3,6 +3,7 @@ import { AbstractText, ensureTextOptions } from '../text/AbstractText';
 import { TextStyle } from '../text/TextStyle';
 import { BitmapFontManager } from './BitmapFontManager';
 import { type BitmapTextGraphics } from './BitmapTextPipe';
+import './init';
 
 import type { View } from '../../rendering/renderers/shared/view/View';
 import type { TextOptions, TextString } from '../text/AbstractText';

--- a/src/scene/text-bitmap/asset/loadBitmapFont.ts
+++ b/src/scene/text-bitmap/asset/loadBitmapFont.ts
@@ -3,7 +3,6 @@ import { copySearchParams } from '../../../assets/utils/copySearchParams';
 import { DOMAdapter } from '../../../environment/adapter';
 import { ExtensionType } from '../../../extensions/Extensions';
 import { path } from '../../../utils/path';
-import { BitmapFont } from '../BitmapFont';
 import { bitmapFontTextParser } from './bitmapFontTextParser';
 import { bitmapFontXMLStringParser } from './bitmapFontXMLStringParser';
 
@@ -12,6 +11,7 @@ import type { Loader } from '../../../assets/loader/Loader';
 import type { LoaderParserAdvanced } from '../../../assets/loader/parsers/LoaderParser';
 import type { ResolvedAsset } from '../../../assets/types';
 import type { Texture } from '../../../rendering/renderers/shared/texture/Texture';
+import type { BitmapFont } from '../BitmapFont';
 
 const validExtensions = ['.xml', '.fnt'];
 
@@ -25,7 +25,7 @@ export const bitmapFontCachePlugin = {
         type: ExtensionType.CacheParser,
         name: 'cacheBitmapFont',
     },
-    test: (asset: BitmapFont) => asset instanceof BitmapFont,
+    test: (asset: BitmapFont) => !!asset?.pages && !!asset?.chars && typeof asset?.fontFamily === 'string',
     getCacheableAssets(keys: string[], asset: BitmapFont)
     {
         const out: Record<string, BitmapFont> = {};
@@ -100,7 +100,10 @@ export const loadBitmapFont = {
             });
         }
 
-        const loadedTextures = await loader.load<Texture>(textureUrls);
+        const [loadedTextures, { BitmapFont }] = await Promise.all([
+            loader.load<Texture>(textureUrls),
+            import('../BitmapFont'),
+        ]);
         const textures = textureUrls.map((url) => loadedTextures[url.src]);
 
         const bitmapFont = new BitmapFont({

--- a/src/scene/text-html/HTMLText.ts
+++ b/src/scene/text-html/HTMLText.ts
@@ -3,6 +3,7 @@ import { AbstractText, ensureTextOptions } from '../text/AbstractText';
 import { type BatchableHTMLText } from './BatchableHTMLText';
 import { HTMLTextStyle } from './HTMLTextStyle';
 import { measureHtmlText } from './utils/measureHtmlText';
+import './init';
 
 import type { View } from '../../rendering/renderers/shared/view/View';
 import type { TextOptions, TextString } from '../text/AbstractText';

--- a/src/scene/text/Text.ts
+++ b/src/scene/text/Text.ts
@@ -4,6 +4,7 @@ import { type BatchableText } from './canvas/BatchableText';
 import { CanvasTextGenerator } from './canvas/CanvasTextGenerator';
 import { CanvasTextMetrics } from './canvas/CanvasTextMetrics';
 import { TextStyle } from './TextStyle';
+import './init';
 
 import type { View } from '../../rendering/renderers/shared/view/View';
 import type { TextOptions, TextString } from './AbstractText';


### PR DESCRIPTION
Improves import organization across the codebase to increase tree-shaking efficiency:
- Moves module-level initialization imports to individual component files, allowing unused modules to be excluded from the final bundle
- Streamlines the `browserAll.ts` and `webworkerAll.ts` files to only import necessary modules
- Dynamically import `BitmapFont` to avoid text being bundled

This change helps reduce the final bundle size by up to 15% on a simple project.