### PR TITLE
fix: prevent autoGenerateMipmaps from affecting TexturePool render targets

### DIFF
--- a/src/rendering/renderers/shared/texture/TexturePool.ts
+++ b/src/rendering/renderers/shared/texture/TexturePool.ts
@@ -65,6 +65,7 @@ export class TexturePoolClass
             resolution: 1,
             antialias,
             autoGarbageCollect: false,
+            autoGenerateMipmaps: false,
         });
 
         return new Texture({


### PR DESCRIPTION
##### Description of change

Fixes #11717 where setting `TextureSource.defaultOptions.autoGenerateMipmaps = true` causes filter rendering to break.

**The Problem:**
When users set `TextureSource.defaultOptions.autoGenerateMipmaps = true`, TexturePool textures (used as render targets for filters) were also affected because `createTexture()` did not explicitly set `autoGenerateMipmaps`. This caused:

1. Pool textures inherited `autoGenerateMipmaps: true` from `defaultOptions`
2. GPU textures were created with multiple mipmap levels
3. Filters render to level 0, but mipmaps are never updated (render targets don't trigger `update` event)
4. GPU samples from uninitialized mipmap levels, causing visual corruption

**The Fix:**
Explicitly set `autoGenerateMipmaps: false` in `TexturePool.createTexture()` to ensure pool textures are never affected by the global default setting.

| Before | 
|:------:|
| <img width="907" height="709" alt="스크린샷 2026-01-17 오후 4 23 54" src="https://github.com/user-attachments/assets/0c06bdf5-1622-4d7a-a1a6-0a68c8b98c1d" /> | 

| After |
|:------:|
| <img width="906" height="710" alt="스크린샷 2026-01-17 오후 4 27 49" src="https://github.com/user-attachments/assets/a757045f-c601-4bf2-92e8-d1f58b537787" /> |

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)