### PR TITLE
fix: Clear page mesh data and update texture references in BitmapText

### DIFF
--- a/packages/text-bitmap/src/BitmapText.ts
+++ b/packages/text-bitmap/src/BitmapText.ts
@@ -921,14 +921,16 @@ export class BitmapText extends Container
         for (const pageMeshData of this._activePagesMeshData)
         {
             this.removeChild(pageMeshData.mesh);
-            pageMeshData.vertices = null;
-            pageMeshData.uvs = null;
-            pageMeshData.indices = null;
-            pageMeshData.index = 0;
-            pageMeshData.indexCount = 0;
-            pageMeshData.vertexCount = 0;
-            pageMeshData.uvsCount = 0;
-            pageMeshData.total = 0;
+            Object.assign(pageMeshData, {
+                vertices: null,
+                uvs: null,
+                indices: null,
+                index: 0,
+                indexCount: 0,
+                vertexCount: 0,
+                uvsCount: 0,
+                total: 0,
+            });
         }
         pageMeshDataPool.push(...this._activePagesMeshData);
         this._activePagesMeshData = [];

--- a/packages/text-bitmap/src/BitmapText.ts
+++ b/packages/text-bitmap/src/BitmapText.ts
@@ -918,11 +918,19 @@ export class BitmapText extends Container
         const pageMeshDataPool = data.distanceFieldType === 'none'
             ? pageMeshDataDefaultPageMeshData : pageMeshDataMSDFPageMeshData;
 
-        pageMeshDataPool.push(...this._activePagesMeshData);
         for (const pageMeshData of this._activePagesMeshData)
         {
             this.removeChild(pageMeshData.mesh);
+            pageMeshData.vertices = null;
+            pageMeshData.uvs = null;
+            pageMeshData.indices = null;
+            pageMeshData.index = 0;
+            pageMeshData.indexCount = 0;
+            pageMeshData.vertexCount = 0;
+            pageMeshData.uvsCount = 0;
+            pageMeshData.total = 0;
         }
+        pageMeshDataPool.push(...this._activePagesMeshData);
         this._activePagesMeshData = [];
 
         // Release references to any cached textures in page pool


### PR DESCRIPTION
Good day. This PR aims to fix an issue with rendering bitmap fonts when BitmapText instances are reused from a pool.
I would like to describe the problem I encountered in my project

##### Description of change
We have a scene that contains a UI slider with around 8 different slides, which can be switched using left and right arrows. Each slide is implemented as a separate layer that contains a certain number of BitmapFont objects with different text values. Using layers allows us to easily handle slide transition logic by simply setting the required layer to visible and the others to invisible. It is worth noting that the total number of BitmapText instances is around 57.

After we leave this scene, we call `Scene::unload()`, which in turn calls `destroy()` on all objects in the scene. This eventually leads to `BitmapText::destroy`. As is known, during the execution of this method we populate the `pageMeshDataPool` array, where mesh data is stored for reuse. After leaving the scene, around 57 `_activePagesMeshData` instances remain in the pool.

In the next scene, completely different bitmap fonts reuse instances from this pool, and we encountered an issue where some of them are rendered incorrectly (the result looks terrible). When a mesh is taken from the pool, its WebGL buffers (geometry.buffers) already exist and still contain references to TypedArrays from the previous usage. Performing a deeper cleanup helps to avoid this problem.

I would appreciate your review and feedback. If you see an alternative or better approach to solving this problem, I would be glad to read your comments and suggestions.

##### Pre-Merge Checklist
- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
