### PR TITLE
fix: allow custom parsers to override src in Resolver (#11828)

### DIFF
--- a/src/assets/resolver/Resolver.ts
+++ b/src/assets/resolver/Resolver.ts
@@ -512,8 +512,8 @@ export class Resolver
                 const parser = this._parsers.find((p) => p.test(url));
 
                 return {
-                    ...parser?.parse(url),
                     src: url,
+                    ...parser?.parse(url),
                 };
             };
 

--- a/src/assets/resolver/__tests__/Resolver.test.ts
+++ b/src/assets/resolver/__tests__/Resolver.test.ts
@@ -762,6 +762,24 @@ describe('Resolver', () =>
         expect(resolver.resolveUrl('my-image.png')).toBe('my-image.png?hello=world&lucky=23');
     });
 
+    it('should allow custom parsers to override src', () =>
+    {
+        const resolver = new Resolver();
+
+        resolver['_parsers'].push({
+            test: (url: string) => url.includes('custom://'),
+            parse: (value: string) => ({
+                src: value.replace('custom://', 'https://cdn.example.com/'),
+            }),
+        });
+
+        resolver.add({ alias: 'test', src: 'custom://my-image.png' });
+
+        const resolved = resolver.resolve('test');
+
+        expect(resolved.src).toBe('https://cdn.example.com/my-image.png');
+    });
+
     it('should parse url extensions correctly', () =>
     {
         expect(getUrlExtension('http://example.com/bunny.webp')).toBe('webp');


### PR DESCRIPTION
## Description of change

Fixes a regression in the custom asset resolver where parser-provided `src` modifications were discarded. The `parseUrl` helper function now spreads parser results after the default `src` assignment, allowing custom parsers to override the original URL when needed. This was broken in PR #11747 (v8.14.2).

## Changes

- Reordered spread in `parseUrl()` to allow parser override
- Added test case verifying custom parsers can override src

## Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)

Fixes #11828