### PR TITLE
fix: prevent bitmap font texture leaks when styles are mutated

### DIFF
--- a/src/scene/text-bitmap/BitmapFontManager.ts
+++ b/src/scene/text-bitmap/BitmapFontManager.ts
@@ -1,5 +1,6 @@
 import { lru } from 'tiny-lru';
 import { Cache } from '../../assets/cache/Cache';
+import { Color } from '../../color/Color';
 import { type TextureStyle, type TextureStyleOptions } from '../../rendering/renderers/shared/texture/TextureStyle';
 import { deprecation, v8_0_0 } from '../../utils/logging/deprecation';
 import { warn } from '../../utils/logging/warn';
@@ -321,9 +322,7 @@ class BitmapFontManagerClass
         }
         else if (style._stroke || style.dropShadow)
         {
-            // if there is a stoke, we need to use the style key as this the font generated cannot be tinted
-            // due to the fact the font has at least two colors.
-            fontFamilyKey = `${style.styleKey}-bitmap`;
+            fontFamilyKey = this._getStyledFontKey(style);
             overrideFill = false;
         }
 
@@ -520,6 +519,52 @@ class BitmapFontManagerClass
             && (!style.dropShadow || style.dropShadow.color === 0x000000)
             && !style._fill.fill
             && style._fill.color === 0xFFFFFF;
+    }
+
+    /**
+     * Returns a stable bitmap font cache key for styles with stroke or dropShadow.
+     * Caches the key directly on the style, invalidated by _tick.
+     * @param style - The text style to generate a key for
+     */
+    private _getStyledFontKey(style: TextStyle): string
+    {
+        if (style._bitmapFontKeyTick === style._tick)
+        {
+            return style._bitmapFontKey;
+        }
+
+        const parts: (string | number)[] = [style.fontFamily as string];
+
+        // Fill properties
+        parts.push(style._fill.color, style._fill.alpha);
+        if (style._fill.fill) parts.push(style._fill.fill.styleKey);
+
+        // Stroke properties
+        if (style._stroke)
+        {
+            parts.push(
+                style._stroke.color, style._stroke.alpha, style._stroke.width,
+                style._stroke.alignment, style._stroke.cap,
+                style._stroke.join, style._stroke.miterLimit,
+            );
+            if (style._stroke.fill) parts.push(style._stroke.fill.styleKey);
+        }
+
+        // Drop shadow properties
+        if (style.dropShadow)
+        {
+            const ds = style.dropShadow;
+
+            parts.push(ds.alpha, ds.angle, ds.blur, ds.distance);
+            parts.push(Color.shared.setValue(ds.color).toNumber());
+        }
+
+        const key = `${parts.join('-')}-bitmap`;
+
+        style._bitmapFontKey = key;
+        style._bitmapFontKeyTick = style._tick;
+
+        return key;
     }
 }
 

--- a/src/scene/text-bitmap/__tests__/BitmapFontManager.test.ts
+++ b/src/scene/text-bitmap/__tests__/BitmapFontManager.test.ts
@@ -51,4 +51,62 @@ describe('BitmapFontManager', () =>
         expect(layoutTrimmed.width).toEqual(layout.width);
         expect(layoutUntrimmed.width).toBeGreaterThan(layout.width);
     });
+
+    it('should not leak fonts when style with stroke is mutated', () =>
+    {
+        const style = new TextStyle({ fontFamily: 'Arial', stroke: { color: 'black', width: 2 } });
+
+        // First call creates a font
+        const font1 = BitmapFontManager.getFont('A', style);
+
+        // Mutate an unrelated property (wordWrap does not affect the stroke/fill visual key)
+        style.wordWrap = true;
+
+        // Second call should reuse the same font (same visual properties)
+        const font2 = BitmapFontManager.getFont('A', style);
+
+        expect(font2).toBe(font1);
+    });
+
+    it('should create a new font when a visual property changes', () =>
+    {
+        const style = new TextStyle({ fontFamily: 'Arial', stroke: { color: 'black', width: 2 } });
+
+        const font1 = BitmapFontManager.getFont('A', style);
+
+        // Changing stroke width is a visual property — should produce a different font
+        style.stroke = { color: 'black', width: 4 };
+
+        const font2 = BitmapFontManager.getFont('A', style);
+
+        expect(font2).not.toBe(font1);
+    });
+
+    it('should not leak fonts when style with dropShadow is mutated', () =>
+    {
+        const style = new TextStyle({
+            fontFamily: 'Arial',
+            dropShadow: { alpha: 1, angle: 0.5, blur: 2, distance: 3, color: 'black' },
+        });
+
+        const font1 = BitmapFontManager.getFont('A', style);
+
+        // Mutate a non-visual property
+        style.wordWrap = true;
+
+        const font2 = BitmapFontManager.getFont('A', style);
+
+        expect(font2).toBe(font1);
+    });
+
+    it('should share fonts across different style instances with identical visuals', () =>
+    {
+        const style1 = new TextStyle({ fontFamily: 'Arial', stroke: { color: 'black', width: 2 } });
+        const style2 = new TextStyle({ fontFamily: 'Arial', stroke: { color: 'black', width: 2 } });
+
+        const font1 = BitmapFontManager.getFont('A', style1);
+        const font2 = BitmapFontManager.getFont('A', style2);
+
+        expect(font2).toBe(font1);
+    });
 });

--- a/src/scene/text/TextStyle.ts
+++ b/src/scene/text/TextStyle.ts
@@ -733,6 +733,11 @@ export class TextStyle extends EventEmitter<{
      */
     public _tick = 0;
 
+    /** @internal */
+    public _bitmapFontKey = '';
+    /** @internal */
+    public _bitmapFontKeyTick = -1;
+
     /**
      * Default text style settings used when creating new text objects.
      * These values serve as the base configuration and can be customized globally.


### PR DESCRIPTION
### Overview

Bitmap font textures were leaking when styles with stroke or drop shadow were mutated. The font cache key used `style.styleKey`, which includes a volatile `_tick` counter that increments on any property change. Mutating unrelated properties (e.g., `wordWrap`, `align`) would create orphaned cache entries. This PR replaces the volatile key with a stable one derived from actual visual properties (fill, stroke, drop shadow), cached on the style and invalidated by `_tick`.

Fixes #11751

#### Fixes
- Bitmap font textures no longer leak when non-visual style properties (e.g., `wordWrap`, `align`) are mutated on styles with stroke or drop shadow
- Styles with identical visual properties now correctly share the same bitmap font across instances

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added