### PR TITLE
fix: recognise WGSL vertex attributes followed by closing parenthesis

### DIFF
--- a/src/rendering/renderers/gpu/shader/utils/__tests__/extractAttributesFromGpuProgram.test.ts
+++ b/src/rendering/renderers/gpu/shader/utils/__tests__/extractAttributesFromGpuProgram.test.ts
@@ -68,4 +68,39 @@ describe('extractAttributesFromGpuProgram', () =>
             }
         });
     });
+
+    it('should extract attributes when type is immediately followed by closing parenthesis', () =>
+    {
+        // Test case for issue #11819: attributes should be recognized even without whitespace before ')'
+        const shaderWithNoSpaceBeforeParen = `
+            @vertex
+            fn main(@location(0) aPosition: vec2f, @location(1) aColor: vec3f) -> @builtin(position) vec4f {
+                return vec4f(aPosition, 0.0, 1.0);
+            }
+        `;
+
+        const extractedAttributeData = extractAttributesFromGpuProgram({
+            source: shaderWithNoSpaceBeforeParen,
+            entryPoint: 'main'
+        });
+
+        expect(extractedAttributeData).toEqual({
+            aPosition: {
+                format: 'float32x2',
+                instance: false,
+                offset: 0,
+                location: 0,
+                start: 0,
+                stride: 8
+            },
+            aColor: {
+                format: 'float32x3',
+                instance: false,
+                offset: 0,
+                location: 1,
+                start: 0,
+                stride: 12
+            }
+        });
+    });
 });

--- a/src/rendering/renderers/gpu/shader/utils/extractAttributesFromGpuProgram.ts
+++ b/src/rendering/renderers/gpu/shader/utils/extractAttributesFromGpuProgram.ts
@@ -55,7 +55,7 @@ export function extractAttributesFromGpuProgram(
             const functionArgsSubstring = source.substring(mainVertStart, arrowFunctionStart);
 
             // Apply the inputs regex directly to the trimmed string
-            const inputsRegex = /@location\((\d+)\)\s+([a-zA-Z0-9_]+)\s*:\s*([a-zA-Z0-9_<>]+)(?:,|\s|$)/g;
+            const inputsRegex = /@location\((\d+)\)\s+([a-zA-Z0-9_]+)\s*:\s*([a-zA-Z0-9_<>]+)(?:,|\s|\)|$)/g;
             let match;
 
             while ((match = inputsRegex.exec(functionArgsSubstring)) !== null)


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
Fixes #11819 by updating the WebGPU shader reflection parser to correctly extract vertex attributes when the type identifier is immediately followed by a closing parenthesis without whitespace. This aligns with the W3C WGSL specification where whitespace between tokens is optional.

1. Fixed the regex pattern in src/rendering/renderers/gpu/shader/utils/extractAttributesFromGpuProgram.ts
    - Added `\)` to the terminator group to handle attributes immediately followed by closing parenthesis
2. Added a comprehensive test case in the existing test file
    - Tests the specific scenario where vec3f) appears without whitespace
    - Ensures both attributes are correctly extracted

Fix verified using the repro case linked in #11819.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
