### PR TITLE
fix: Video Loader Not Catching Load Errors

### DIFF
--- a/src/assets/loader/parsers/textures/loadVideoTextures.ts
+++ b/src/assets/loader/parsers/textures/loadVideoTextures.ts
@@ -274,12 +274,12 @@ export const loadVideoTextures = {
                 reject(event);
             };
 
-            function cleanup(): void
+            const cleanup = (): void =>
             {
                 videoElement.removeEventListener('canplay', onCanPlay);
                 videoElement.removeEventListener('error', onError);
                 sourceElement.removeEventListener('error', onError);
-            }
+            };
 
             if (options.preload && !options.autoPlay)
             {

--- a/src/assets/loader/parsers/textures/loadVideoTextures.ts
+++ b/src/assets/loader/parsers/textures/loadVideoTextures.ts
@@ -252,13 +252,13 @@ export const loadVideoTextures = {
 
         // this promise will make sure that video is ready to play - as in we have a valid width, height and it can be
         // uploaded to the GPU. Our textures are kind of dumb now, and don't want to handle resizing right now.
-        return new Promise((resolve) =>
+        return new Promise((resolve, reject) =>
         {
             const onCanPlay = async () =>
             {
                 const base = new VideoSource({ ...options, resource: videoElement });
 
-                videoElement.removeEventListener('canplay', onCanPlay);
+                cleanup();
 
                 if (asset.data.preload)
                 {
@@ -268,12 +268,25 @@ export const loadVideoTextures = {
                 resolve(createTexture(base, loader, url));
             };
 
+            const onError = (event: ErrorEvent) =>
+            {
+                cleanup();
+                reject(event);
+            };
+
+            function cleanup(): void
+            {
+                videoElement.removeEventListener('canplay', onCanPlay);
+                videoElement.removeEventListener('error', onError);
+            }
+
             if (options.preload && !options.autoPlay)
             {
                 videoElement.load();
             }
 
             videoElement.addEventListener('canplay', onCanPlay);
+            videoElement.addEventListener('error', onError);
             videoElement.appendChild(sourceElement);
         });
     },

--- a/src/assets/loader/parsers/textures/loadVideoTextures.ts
+++ b/src/assets/loader/parsers/textures/loadVideoTextures.ts
@@ -268,7 +268,7 @@ export const loadVideoTextures = {
                 resolve(createTexture(base, loader, url));
             };
 
-            const onError = (event: ErrorEvent) =>
+            const onError = (event: Event | ErrorEvent) =>
             {
                 cleanup();
                 reject(event);
@@ -278,6 +278,7 @@ export const loadVideoTextures = {
             {
                 videoElement.removeEventListener('canplay', onCanPlay);
                 videoElement.removeEventListener('error', onError);
+                sourceElement.removeEventListener('error', onError);
             }
 
             if (options.preload && !options.autoPlay)
@@ -287,6 +288,7 @@ export const loadVideoTextures = {
 
             videoElement.addEventListener('canplay', onCanPlay);
             videoElement.addEventListener('error', onError);
+            sourceElement.addEventListener('error', onError);
             videoElement.appendChild(sourceElement);
         });
     },

--- a/src/assets/loader/parsers/textures/loadVideoTextures.ts
+++ b/src/assets/loader/parsers/textures/loadVideoTextures.ts
@@ -254,7 +254,17 @@ export const loadVideoTextures = {
         // uploaded to the GPU. Our textures are kind of dumb now, and don't want to handle resizing right now.
         return new Promise((resolve, reject) =>
         {
-            const onCanPlay = async () =>
+            if (options.preload && !options.autoPlay)
+            {
+                videoElement.load();
+            }
+
+            videoElement.addEventListener('canplay', onCanPlay);
+            videoElement.addEventListener('error', onError);
+            sourceElement.addEventListener('error', onError);
+            videoElement.appendChild(sourceElement);
+
+            async function onCanPlay()
             {
                 const base = new VideoSource({ ...options, resource: videoElement });
 
@@ -266,30 +276,20 @@ export const loadVideoTextures = {
                 }
 
                 resolve(createTexture(base, loader, url));
-            };
+            }
 
-            const onError = (event: Event | ErrorEvent) =>
+            function onError(event: Event | ErrorEvent)
             {
                 cleanup();
                 reject(event);
-            };
+            }
 
-            const cleanup = (): void =>
+            function cleanup()
             {
                 videoElement.removeEventListener('canplay', onCanPlay);
                 videoElement.removeEventListener('error', onError);
                 sourceElement.removeEventListener('error', onError);
-            };
-
-            if (options.preload && !options.autoPlay)
-            {
-                videoElement.load();
             }
-
-            videoElement.addEventListener('canplay', onCanPlay);
-            videoElement.addEventListener('error', onError);
-            sourceElement.addEventListener('error', onError);
-            videoElement.appendChild(sourceElement);
         });
     },
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
Fixes #11845 by adding error event handlers to both the video element and source element. Video error events can fire on the `<source>` element, not just the parent `<video>` element, so both need listeners.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
Automated tests are difficult due to the reliance on DOM events and callbacks. The jsFiddle in the linked issue was used to validate the fix, although it should be noted that the error message is still logged to `console.error` in Chrome 143.0.7499.193 despite bring handled by `Promise::catch`.

- [ ] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
