### PR TITLE
chore: guide to use envinfo to get environment information

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -61,11 +61,12 @@ body:
     validations:
       required: true
   - type: textarea
+    id: system-info
     attributes:
-      label: Environment
-      value: |
-        - **Browser & Version**: *e.g. Chrome 108*
-        - **OS & Version**: *e.g. Ubuntu 22.04*
+      label: System Info
+      description: Output of `npx envinfo --system --browsers`
+      render: Shell
+      placeholder: System, Browsers
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
Replaces #11610 as for whatever reason the PR fails to merge

##### Description of change
Updates the bug report issue template to use the `envinfo` package for collecting system and browser information. Replaces the manual input fields with a single textarea that renders the output of `npx envinfo --system --browsers`.