### PR TITLE
fix: preserve VAO cache in GlGeometrySystem

### DIFF
--- a/src/rendering/renderers/gl/geometry/GlGeometrySystem.ts
+++ b/src/rendering/renderers/gl/geometry/GlGeometrySystem.ts
@@ -263,10 +263,14 @@ export class GlGeometrySystem implements System
 
         const signature = this.getSignature(geometry, program);
 
-        const gpuData = new GlGeometryGpuData();
+        let gpuData = geometry._gpuData[this._renderer.uid];
 
-        geometry._gpuData[this._renderer.uid] = gpuData;
-        this._managedGeometries.add(geometry);
+        if (!gpuData)
+        {
+            gpuData = new GlGeometryGpuData();
+            geometry._gpuData[this._renderer.uid] = gpuData;
+            this._managedGeometries.add(geometry);
+        }
 
         const vaoObjectHash = gpuData.vaoCache;
         let vao = vaoObjectHash[signature];


### PR DESCRIPTION
##### Description of change

Fixes a bug in GlGeometrySystem.initGeometryVao where the method unconditionally created a new GlGeometryGpuData object, destroying any cached VAOs for geometries used with multiple shader programs. Now the method checks if gpuData already exists before creating a new one, preserving the VAO cache across multiple program bindings.

This fix restores the correct behavior that was lost during PR #11772 when GPU data storage was refactored.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)