### PR TITLE
fix: add bounds-based hit testing fallback for containers with interactiveChildren=false

### DIFF
--- a/src/events/EventBoundary.ts
+++ b/src/events/EventBoundary.ts
@@ -631,6 +631,16 @@ export class EventBoundary
             return (container as Renderable).containsPoint(tempLocalMapping) as boolean;
         }
 
+        // Fallback to bounds-based hit testing for containers with interactiveChildren = false.
+        // This allows plain Containers (which have no containsPoint) to still receive events
+        // when their children's hit testing is disabled.
+        if (!container.interactiveChildren && container.isInteractive())
+        {
+            const bounds = container.getBounds();
+
+            return bounds.containsPoint(location.x, location.y);
+        }
+
         // TODO: Should we hit test based on bounds?
 
         return false;

--- a/src/events/__tests__/EventBoundary.test.ts
+++ b/src/events/__tests__/EventBoundary.test.ts
@@ -112,6 +112,64 @@ describe('EventBoundary', () =>
         expect(boundary.hitTest(50, 50)).toEqual(null);
     });
 
+    it(`should hit test an interactive container using bounds when interactiveChildren is false`, () =>
+    {
+        const stage = new Container();
+        const boundary = new EventBoundary(stage);
+        // Plain Container with no containsPoint method
+        const container = stage.addChild(new Container());
+        // Add a child with visual content to give the container bounds
+        const child = container.addChild(graphicsWithRect(0, 0, 100, 100));
+
+        // Container is interactive but children should not receive events
+        container.eventMode = 'static';
+        container.interactiveChildren = false;
+        child.interactive = true;
+
+        // Should hit the container (using bounds), not the child
+        const hitTest = boundary.hitTest(50, 50);
+
+        expect(hitTest).toEqual(container);
+
+        // Child should not be hit even though it's interactive
+        // because parent has interactiveChildren = false
+    });
+
+    it(`should hit test an interactive container with interactiveChildren false even without interactive children`, () =>
+    {
+        const stage = new Container();
+        const boundary = new EventBoundary(stage);
+        const container = stage.addChild(new Container());
+        // Non-interactive child just for visual bounds
+        const child = container.addChild(graphicsWithRect(0, 0, 100, 100));
+
+        container.eventMode = 'static';
+        container.interactiveChildren = false;
+        // Child is NOT interactive
+        child.eventMode = 'passive';
+
+        // Should still hit the container using bounds
+        const hitTest = boundary.hitTest(50, 50);
+
+        expect(hitTest).toEqual(container);
+    });
+
+    it(`should not hit test outside bounds when using bounds fallback`, () =>
+    {
+        const stage = new Container();
+        const boundary = new EventBoundary(stage);
+        const container = stage.addChild(new Container());
+
+        container.eventMode = 'static';
+        container.interactiveChildren = false;
+
+        // Inside bounds - should hit
+        expect(boundary.hitTest(50, 50)).toEqual(container);
+
+        // Outside bounds - should not hit
+        expect(boundary.hitTest(150, 150)).toEqual(null);
+    });
+
     it(`should not block an interaction event if the display object is a mask`, () =>
     {
         const stage = new Container();

--- a/src/events/__tests__/EventBoundary.test.ts
+++ b/src/events/__tests__/EventBoundary.test.ts
@@ -160,6 +160,9 @@ describe('EventBoundary', () =>
         const boundary = new EventBoundary(stage);
         const container = stage.addChild(new Container());
 
+        // Add a child with visual content to give the container bounds
+        container.addChild(graphicsWithRect(0, 0, 100, 100));
+
         container.eventMode = 'static';
         container.interactiveChildren = false;
 


### PR DESCRIPTION
## Summary

When a container has `interactiveChildren = false` and is interactive (`eventMode = 'static'` or `'dynamic'`), but has no `containsPoint` method (plain Container) or `hitArea`, the container was not receiving events.

This was unintuitive because the [documentation states](https://github.com/pixijs/pixijs/blob/dev/src/events/__docs__/events-overview.md#L115) that `interactiveChildren = false` is for "when you only need to interact with the container itself" - implying the container should remain hittable.

### The Problem

- When `interactiveChildren = true` (default): children are hit tested → event bubbles up → container receives event
- When `interactiveChildren = false`: children are skipped → container itself is tested via `containsPoint` → plain Containers have no `containsPoint` → nothing is hit

### The Fix

This PR adds a bounds-based hit testing fallback in `hitTestFn` that activates when:
1. Container is interactive (`eventMode = 'static'` or `'dynamic'`)
2. Container has `interactiveChildren = false`
3. Container has no `hitArea`
4. Container has no `containsPoint` method

### Usage

```typescript
// Now works without needing to manually set hitArea
container.eventMode = 'static';
container.interactiveChildren = false;
// Container is hittable based on bounds, children don't receive individual events
```

## Test Plan

- [x] Added 3 new tests for bounds-based hit testing fallback
- [x] All existing EventBoundary and EventSystem tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
##### Fixes
- Plain Containers with `interactiveChildren = false` could miss events; bounds-based hit testing is now used as a fallback for interactive Containers that have no `hitArea` and no `containsPoint` implementation, making them hittable by their bounds.
    ```ts
    const container = new Container();
    container.eventMode = 'static';
    container.interactiveChildren = false;
    // container will now receive pointer events based on its bounds without a custom hitArea
    ```
<!-- end of auto-generated comment: release notes by coderabbit.ai -->