### PR TITLE
chore: use texImage2D instead of texSubImage2D for video in Safari

### DIFF
--- a/src/rendering/renderers/gl/texture/uploaders/glUploadVideoResource.ts
+++ b/src/rendering/renderers/gl/texture/uploaders/glUploadVideoResource.ts
@@ -1,9 +1,14 @@
+import { isSafari } from '../../../../../utils/browser/isSafari';
 import { glUploadImageResource } from './glUploadImageResource';
 
 import type { VideoSource } from '../../../shared/texture/sources/VideoSource';
 import type { GlRenderingContext } from '../../context/GlRenderingContext';
 import type { GlTexture } from '../GlTexture';
 import type { GLTextureUploader } from './GLTextureUploader';
+
+// In Safari, texImage2D is significantly faster than texSubImage2D for video sources
+// (see https://github.com/pixijs/pixijs/pull/10383)
+const defaultForceAllocation = isSafari();
 
 /** @internal */
 export const glUploadVideoResource = {
@@ -16,7 +21,7 @@ export const glUploadVideoResource = {
         gl: GlRenderingContext,
         webGLVersion: number,
         targetOverride?: number,
-        forceAllocation?: boolean
+        forceAllocation = defaultForceAllocation
     )
     {
         if (!source.isValid)


### PR DESCRIPTION
In Safari, texImage2D is significantly faster than texSubImage2D for video texture uploads (~3x improvement in benchmarks). This change defaults forceAllocation to true only in Safari to get the performance benefit while preserving existing behavior in other browsers.

See https://github.com/pixijs/pixijs/pull/10383

<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

---

##### Behavior Changes
- Video texture uploads in Safari now use `texImage2D` instead of `texSubImage2D` by default, providing ~3x performance improvement. The `forceAllocation` parameter in `glUploadVideoResource.upload` now defaults to `true` in Safari only.
  ```ts
  // In Safari, texImage2D is significantly faster than texSubImage2D for video sources
  const defaultForceAllocation = isSafari();
  ```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->