### PR TITLE
fix: restore text rendering after WebGL context loss

### DIFF
--- a/src/scene/text-html/HTMLTextPipe.ts
+++ b/src/scene/text-html/HTMLTextPipe.ts
@@ -32,6 +32,7 @@ export class HTMLTextPipe implements RenderPipe<HTMLText>
     {
         this._renderer = renderer;
         renderer.runners.resolutionChange.add(this);
+        renderer.runners.contextChange.add(this);
         this._managedTexts = new GCManagedHash({
             renderer,
             type: 'renderable',
@@ -50,6 +51,36 @@ export class HTMLTextPipe implements RenderPipe<HTMLText>
             {
                 text.onViewUpdate();
             }
+        }
+    }
+
+    /**
+     * Called when the WebGL/WebGPU context is restored after being lost.
+     * Forces all managed HTML text objects to regenerate their textures since
+     * the previous GPU textures were destroyed when the context was lost.
+     */
+    public contextChange(): void
+    {
+        for (const key in this._managedTexts.items)
+        {
+            const htmlText = this._managedTexts.items[key];
+
+            if (!htmlText) continue;
+
+            const gpuData = htmlText._gpuData[this._renderer.uid];
+
+            if (gpuData)
+            {
+                // Clear stale texture reference - the GPU texture was destroyed
+                // when context was lost, so reset to empty texture
+                gpuData.texture = Texture.EMPTY;
+                gpuData.texturePromise = null;
+                gpuData.currentKey = '--';
+                gpuData.generatingTexture = false;
+            }
+
+            // Force text to regenerate its texture on next render
+            htmlText._didTextUpdate = true;
         }
     }
 

--- a/src/scene/text/canvas/CanvasTextPipe.ts
+++ b/src/scene/text/canvas/CanvasTextPipe.ts
@@ -28,6 +28,7 @@ export class CanvasTextPipe implements RenderPipe<Text>
     {
         this._renderer = renderer;
         renderer.runners.resolutionChange.add(this);
+        renderer.runners.contextChange.add(this);
         this._managedTexts = new GCManagedHash({
             renderer,
             type: 'renderable',
@@ -43,6 +44,34 @@ export class CanvasTextPipe implements RenderPipe<Text>
             const text = this._managedTexts.items[key];
 
             if (text?._autoResolution) text.onViewUpdate();
+        }
+    }
+
+    /**
+     * Called when the WebGL/WebGPU context is restored after being lost.
+     * Forces all managed text objects to regenerate their textures since
+     * the previous GPU textures were destroyed when the context was lost.
+     */
+    public contextChange(): void
+    {
+        for (const key in this._managedTexts.items)
+        {
+            const text = this._managedTexts.items[key];
+
+            if (!text) continue;
+
+            const gpuData = text._gpuData[this._renderer.uid];
+
+            if (gpuData)
+            {
+                // Clear stale texture reference - the GPU texture was destroyed
+                // when context was lost, so we shouldn't try to release it
+                gpuData.texture = null;
+                gpuData.currentKey = '--';
+            }
+
+            // Force text to regenerate its texture on next render
+            text._didTextUpdate = true;
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes text disappearing when WebGL context is lost and restored (e.g., via GPU crash recovery, `chrome://gpucrash`, or browser resource management).

## The Problem

When WebGL context is lost and restored:
1. `GlTextureSystem.contextChange()` clears all GPU textures
2. `CanvasTextPipe` and `HTMLTextPipe` didn't subscribe to `contextChange` runner
3. They still held stale texture references pointing to destroyed GPU resources
4. Text wasn't flagged for re-rendering, so textures weren't regenerated
5. **Result: text remains invisible after context restoration**

## The Fix

- Subscribe both `CanvasTextPipe` and `HTMLTextPipe` to `renderer.runners.contextChange`
- In `contextChange()` handler:
  - Clear stale GPU texture references
  - Reset `currentKey` to trigger re-validation
  - Set `_didTextUpdate = true` to force texture regeneration on next render

This follows the same pattern used by `GraphicsPipe` for context restoration.

## Test Plan

1. Open https://pixijs.com/8.x/examples/text/pixi-text
2. Navigate to `chrome://gpucrash` or `chrome://gpuclean` in a new tab
3. Return to PixiJS example
4. **Before fix**: Text remains invisible
5. **After fix**: Text reappears correctly

## Files Changed

- `src/scene/text/canvas/CanvasTextPipe.ts` - Add context restoration handling
- `src/scene/text-html/HTMLTextPipe.ts` - Add context restoration handling

Fixes #11685

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

---
##### Fixes
- Fixed text rendering becoming invisible after WebGL context loss and restoration by ensuring `CanvasTextPipe` and `HTMLTextPipe` properly handle context changes, clear stale GPU texture references, and regenerate textures on the next render.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->