### PR TITLE
fix: Graphics bounds account for miter joins at sharp angles

### DIFF
--- a/src/scene/graphics/__tests__/Graphics.Bounds.test.ts
+++ b/src/scene/graphics/__tests__/Graphics.Bounds.test.ts
@@ -70,6 +70,55 @@ describe('Graphics Bounds', () =>
             expect(height).toEqual(208);
         });
 
+        it('should expand bounds for miter joins on sharp angles', () =>
+        {
+            const graphics = new Graphics();
+
+            // V-shape with a sharp angle at the bottom
+            graphics
+                .moveTo(0, 0)
+                .lineTo(50, 100)
+                .lineTo(100, 0)
+                .stroke({ width: 10, color: 0xff0000 });
+
+            const bounds = graphics.context.bounds;
+
+            // The miter at (50, 100) should extend the bounds beyond 100 + halfWidth
+            expect(bounds.maxY).toBeGreaterThan(105);
+        });
+
+        it('should not expand bounds for bevel joins on sharp angles', () =>
+        {
+            const graphics = new Graphics();
+
+            graphics
+                .moveTo(0, 0)
+                .lineTo(50, 100)
+                .lineTo(100, 0)
+                .stroke({ width: 10, color: 0xff0000, join: 'bevel' });
+
+            const bounds = graphics.context.bounds;
+
+            // Bevel join: padding is just halfWidth (5)
+            expect(bounds.maxY).toEqual(105);
+        });
+
+        it('should not expand bounds for round joins on sharp angles', () =>
+        {
+            const graphics = new Graphics();
+
+            graphics
+                .moveTo(0, 0)
+                .lineTo(50, 100)
+                .lineTo(100, 0)
+                .stroke({ width: 10, color: 0xff0000, join: 'round' });
+
+            const bounds = graphics.context.bounds;
+
+            // Round join: padding is just halfWidth (5)
+            expect(bounds.maxY).toEqual(105);
+        });
+
         it('should be zero for empty Graphics', () =>
         {
             const graphics = new Graphics();

--- a/src/scene/graphics/shared/GraphicsContext.ts
+++ b/src/scene/graphics/shared/GraphicsContext.ts
@@ -12,6 +12,7 @@ import { type GpuGraphicsContext } from './GraphicsContextSystem';
 import { GraphicsPath } from './path/GraphicsPath';
 import { SVGParser } from './svg/SVGParser';
 import { toFillStyle, toStrokeStyle } from './utils/convertFillInputToFillStyle';
+import { getMaxMiterRatio } from './utils/getMaxMiterRatio';
 
 import type { PointData } from '../../../maths/point/PointData';
 import type { Shader } from '../../../rendering/renderers/shared/shader/Shader';
@@ -1124,7 +1125,12 @@ export class GraphicsContext extends EventEmitter<{
 
                 const alignment = data.style.alignment;
 
-                const outerPadding = (data.style.width * (1 - alignment));
+                let outerPadding = (data.style.width * (1 - alignment));
+
+                if (data.style.join === 'miter')
+                {
+                    outerPadding *= getMaxMiterRatio(data.path, data.style.miterLimit);
+                }
 
                 const _bounds = data.path.bounds;
 

--- a/src/scene/graphics/shared/utils/getMaxMiterRatio.ts
+++ b/src/scene/graphics/shared/utils/getMaxMiterRatio.ts
@@ -1,0 +1,76 @@
+import { type Polygon } from '../../../../maths/shapes/Polygon';
+
+import type { GraphicsPath } from '../path/GraphicsPath';
+
+/**
+ * Computes the maximum miter ratio from polygon corner angles in a graphics path.
+ * The miter ratio determines how much the stroke padding must expand to contain miter joins
+ * at sharp angles. Returns a value >= 1, clamped by the miterLimit.
+ * @param path - The graphics path containing polygon shapes
+ * @param miterLimit - The maximum allowed miter ratio
+ * @returns The maximum miter ratio found in all polygon corners, clamped by miterLimit
+ * @internal
+ */
+export function getMaxMiterRatio(path: GraphicsPath, miterLimit: number): number
+{
+    let maxRatio = 1;
+
+    const shapePrimitives = path.shapePath.shapePrimitives;
+
+    for (let i = 0; i < shapePrimitives.length; i++)
+    {
+        const shape = shapePrimitives[i].shape;
+
+        if (shape.type !== 'polygon') continue;
+
+        const points = (shape as Polygon).points;
+        const n = points.length;
+
+        if (n < 6) continue;
+
+        const closed = (shape as Polygon).closePath;
+
+        for (let j = 0; j < n; j += 2)
+        {
+            // For open paths, skip first and last points (they use caps, not joins)
+            if (!closed && (j === 0 || j === n - 2)) continue;
+
+            const prevIdx = (j - 2 + n) % n;
+            const nextIdx = (j + 2) % n;
+
+            const x0 = points[prevIdx];
+            const y0 = points[prevIdx + 1];
+            const x1 = points[j];
+            const y1 = points[j + 1];
+            const x2 = points[nextIdx];
+            const y2 = points[nextIdx + 1];
+
+            const dx0 = x0 - x1;
+            const dy0 = y0 - y1;
+            const dx1 = x2 - x1;
+            const dy1 = y2 - y1;
+
+            const len0Sq = (dx0 * dx0) + (dy0 * dy0);
+            const len1Sq = (dx1 * dx1) + (dy1 * dy1);
+
+            if (len0Sq < 1e-12 || len1Sq < 1e-12) continue;
+
+            const dot = (dx0 * dx1) + (dy0 * dy1);
+            const cosAngle = dot / Math.sqrt(len0Sq * len1Sq);
+            let clampedCos = cosAngle;
+
+            if (clampedCos < -1) clampedCos = -1;
+            else if (clampedCos > 1) clampedCos = 1;
+
+            const sinHalfAngle = Math.sqrt((1 - clampedCos) * 0.5);
+
+            if (sinHalfAngle < 1e-6) continue;
+
+            const miterRatio = Math.min(1 / sinHalfAngle, miterLimit);
+
+            if (miterRatio > maxRatio) maxRatio = miterRatio;
+        }
+    }
+
+    return maxRatio;
+}

--- a/src/scene/index.ts
+++ b/src/scene/index.ts
@@ -78,6 +78,7 @@ export * from './graphics/shared/utils/buildContextBatches';
 export * from './graphics/shared/utils/buildGeometryFromPath';
 export * from './graphics/shared/utils/convertFillInputToFillStyle';
 export * from './graphics/shared/utils/generateTextureFillMatrix';
+export * from './graphics/shared/utils/getMaxMiterRatio';
 export * from './graphics/shared/utils/getOrientationOfPoints';
 export * from './graphics/shared/utils/triangulateWithHoles';
 export * from './layers/RenderLayer';


### PR DESCRIPTION
##### Description of change

Fixes #11587

Graphics polygon bounds didn't account for miter join extensions at sharp angles, causing parts of the stroke to render outside the bounding box.

**Changes:**
- Added `getMaxMiterRatio(path, miterLimit)` utility (`src/scene/graphics/shared/utils/getMaxMiterRatio.ts`) that computes the maximum miter ratio from polygon corner angles, clamped by the miter limit
- Modified `GraphicsContext.bounds` getter to multiply outer stroke padding by the miter ratio when `join === 'miter'`
- Exported `getMaxMiterRatio` from `src/scene/index.ts`
- Added 3 unit tests verifying bounds behavior for miter, bevel, and round joins on sharp angles

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)