### PR TITLE
fix: Graphics getLocalBounds stale between ops

### DIFF
--- a/src/scene/graphics/__tests__/Graphics.Drawing.test.ts
+++ b/src/scene/graphics/__tests__/Graphics.Drawing.test.ts
@@ -189,6 +189,28 @@ describe('Graphics Drawing', () =>
         });
     });
 
+    describe('getLocalBounds', () =>
+    {
+        it('should return updated bounds when called between graphics operations in the same frame', () =>
+        {
+            const graphics = new Graphics();
+
+            graphics.rect(0, 0, 50, 50).fill(0xFF0000);
+
+            const bounds1 = graphics.getLocalBounds();
+
+            expect(bounds1.width).toBe(50);
+            expect(bounds1.height).toBe(50);
+
+            graphics.rect(0, 0, 100, 100).fill(0xFF0000);
+
+            const bounds2 = graphics.getLocalBounds();
+
+            expect(bounds2.width).toBe(100);
+            expect(bounds2.height).toBe(100);
+        });
+    });
+
     describe('lineStyle', () =>
     {
         it('should support a list of parameters', () =>

--- a/src/scene/graphics/shared/GraphicsContext.ts
+++ b/src/scene/graphics/shared/GraphicsContext.ts
@@ -1078,15 +1078,9 @@ export class GraphicsContext extends EventEmitter<{
 
     protected onUpdate(): void
     {
-        // Every time the content is updated - we must invalidate bounds, regardless rendering `dirty` state.
-        // Bounds can be read multiple times per frame.
         this._boundsDirty = true;
-
-        // Visual updates happen only once per frame.
-        // There is no need to dispatch an `update` in if it was already dispatched this frame.
-        if (this.dirty) return;
-        this.emit('update', this, 0x10);
         this.dirty = true;
+        this.emit('update', this, 0x10);
     }
 
     /** The bounds of the graphic shape. */


### PR DESCRIPTION
## Summary

- Fixes #11870
- `GraphicsContext.onUpdate()` had an early return that suppressed the `update` event after the first call per frame. This meant `getLocalBounds()` returned stale cached data when called between graphics operations (e.g. between two `fill()` calls) in the same frame.
- The fix removes the early return so the event always fires. `ViewContainer.onViewUpdate()` already guards against duplicate rendering work, so this is safe.
- `onUpdate()` only fires on `fill()`, `stroke()`, `texture()`, and `clear()` — not on path-building ops like `rect()`/`lineTo()`, so the call frequency is low.
- Benchmarked at 1000 fills/frame — no measurable performance difference.

## Test plan

- [x] Added unit test: `getLocalBounds` returns updated bounds when called between graphics operations in the same frame
- [x] Existing tests pass
- [x] Benchmarked with 1000 rect+fill ops per frame, results identical with and without fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

---

##### Fixes
- Fixed Graphics.getLocalBounds returning stale cached bounds when called between graphics operations in the same frame. The update event in GraphicsContext now always fires to trigger bounds cache invalidation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->