### PR TITLE
fix: WebGPU UBO batch overflow crash by dynamically growing the uniform buffer

### DIFF
--- a/src/rendering/renderers/gpu/buffer/UboBatch.ts
+++ b/src/rendering/renderers/gpu/buffer/UboBatch.ts
@@ -4,6 +4,13 @@ export class UboBatch
     public data: Float32Array;
     private readonly _minUniformOffsetAlignment: number = 256;
 
+    /**
+     * Optional callback invoked immediately when the backing buffer is resized.
+     * This allows consumers to react to the new data reference (e.g. update GPU buffers)
+     * before any new buffer resources are created with offsets into the grown buffer.
+     */
+    public onResize?: (data: Float32Array) => void;
+
     public byteIndex = 0;
 
     constructor({ minUniformOffsetAlignment }: {minUniformOffsetAlignment: number})
@@ -33,13 +40,30 @@ export class UboBatch
 
         if (newSize > this.data.length * 4)
         {
-            // TODO push a new buffer
-            throw new Error('UniformBufferBatch: ubo batch got too big');
+            this._resize(newSize);
         }
 
         this.byteIndex = newSize;
 
         return start;
+    }
+
+    private _resize(newByteSize: number): void
+    {
+        // Grow buffer by doubling until it can fit the required byte size
+        const requiredFloats = Math.ceil(newByteSize / 4);
+        let newLength = this.data.length;
+
+        while (newLength < requiredFloats)
+        {
+            newLength *= 2;
+        }
+
+        const newData = new Float32Array(newLength);
+
+        newData.set(this.data);
+        this.data = newData;
+        this.onResize?.(this.data);
     }
 
     public addGroup(array: Float32Array): number


### PR DESCRIPTION
## Summary

- Replace the hard crash (`"UniformBufferBatch: ubo batch got too big"`) with dynamic buffer growth — the backing `Float32Array` doubles in size when full, matching the existing `// TODO push a new buffer` intent.
- Synchronize GPU buffer sizes immediately on resize via a callback, preventing WebGPU bind group validation errors (`"Binding offset is larger than the size of Buffer"`).
- Null out `_gpuData` before triggering the buffer `change` event so the old `GPUBuffer` is not destroyed mid-frame — avoids `"Buffer used in submit while destroyed"` errors from bind groups already recorded in the current render pass.

## Test plan

- [x] Render a scene with enough draw calls to exceed the original 65535-float (~256 KB) uniform buffer capacity — should no longer crash
- [x] Verify no WebGPU validation warnings/errors in the browser console
- [x] Confirm visual correctness (no missing/corrupt draws) on scenes both below and above the old buffer limit
- [x] Check that GPU memory usage remains stable across frames (buffer grows once, does not re-allocate every frame)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

---

##### Fixes
- Fixed WebGPU UBO batch overflow crash by dynamically growing the uniform buffer when capacity is exceeded, replacing the hard error with automatic doubling of capacity
- Fixed GPU buffer synchronization issues that caused WebGPU validation errors by immediately syncing GPU buffer sizes when the backing buffer resizes
- Fixed potential destruction of GPU buffers mid-frame by nullifying GPU data references before triggering buffer change events

##### Features
- Added optional `onResize` callback to `UboBatch` to notify consumers when the backing buffer resizes:
  ```ts
  batch.onResize = (newData: Float32Array) => {
    // Update GPU resources with new buffer reference
  };
  ```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->