### PR TITLE
fix: Fixed Ticker minFPS setting when maxFPS is 0

### DIFF
--- a/src/ticker/Ticker.ts
+++ b/src/ticker/Ticker.ts
@@ -770,7 +770,7 @@ export class Ticker
     set minFPS(fps: number)
     {
         // Minimum must be below the maxFPS
-        const minFPS = Math.min(this.maxFPS, fps);
+        const minFPS = this.maxFPS ? Math.min(this.maxFPS, fps) : fps;
 
         // Must be at least 0, but below 1 / Ticker.targetFPMS
         const minFPMS = Math.min(Math.max(0, minFPS) / 1000, Ticker.targetFPMS);


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
I noticed it was impossible to change the Ticker minFPS unless maxFPS is set to a non-zero value first. Since maxFPS is zero by default this causes minFPS to not be set in most use cases .

Example
https://stackblitz.com/edit/pixijs-v8-4aerx4o5?file=src%2Fmain.js

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

---
#### Overview
##### Fixes
- Fixed an issue where `Ticker.minFPS` could not be set when `Ticker.maxFPS` was 0 (the default). The minFPS setter now correctly applies the value directly when maxFPS is unset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->