### PR TITLE
chore: increase HTMLText visual test wait from 250ms to 350ms

### DIFF
--- a/tests/visual/scenes/text-html/html-text-alignment-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-alignment-tagged.scene.ts
@@ -55,6 +55,6 @@ export const scene: TestScene = {
         });
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-alignment.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-alignment.scene.ts
@@ -51,6 +51,6 @@ export const scene: TestScene = {
         });
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-bounds-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-bounds-tagged.scene.ts
@@ -66,6 +66,6 @@ export const scene: TestScene = {
         scene.addChild(textRect2);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-bounds.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-bounds.scene.ts
@@ -59,6 +59,6 @@ export const scene: TestScene = {
         scene.addChild(textRect2);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-broken.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-broken.scene.ts
@@ -19,6 +19,6 @@ export const scene: TestScene = {
 
         scene.addChild(text);
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-drop-shadow-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-drop-shadow-tagged.scene.ts
@@ -35,10 +35,10 @@ export const scene: TestScene = {
         scene.addChild(text);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
         text.style.dropShadow.color = 'green';
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-drop-shadow-word-wrap-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-drop-shadow-word-wrap-tagged.scene.ts
@@ -102,6 +102,6 @@ export const scene: TestScene = {
         scene.addChild(text3);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-drop-shadow-word-wrap.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-drop-shadow-word-wrap.scene.ts
@@ -78,6 +78,6 @@ export const scene: TestScene = {
         scene.addChild(text3);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-drop-shadow.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-drop-shadow.scene.ts
@@ -34,6 +34,6 @@ export const scene: TestScene = {
         text.style.dropShadow.color = 'red';
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-dynamic-destroy.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-dynamic-destroy.scene.ts
@@ -35,7 +35,7 @@ export const scene: TestScene = {
         scene.addChild(container);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
         container.destroy({ children: true });
 
         container = new Container();
@@ -66,6 +66,6 @@ export const scene: TestScene = {
         container.addChild(text2);
         scene.addChild(container);
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-dynamic-update.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-dynamic-update.scene.ts
@@ -30,10 +30,10 @@ export const scene: TestScene = {
         scene.addChild(text2);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
         text2.text = '1';
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-dynamic.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-dynamic.scene.ts
@@ -24,10 +24,10 @@ export const scene: TestScene = {
         scene.addChild(text);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
         text.resolution = 0.5;
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-family-multi.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-family-multi.scene.ts
@@ -51,6 +51,6 @@ export const scene: TestScene = {
 
         scene.addChild(text);
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-family.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-family.scene.ts
@@ -40,6 +40,6 @@ export const scene: TestScene = {
 
         scene.addChild(text);
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-font-styles-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-font-styles-tagged.scene.ts
@@ -62,6 +62,6 @@ export const scene: TestScene = {
         scene.addChild(styleComparison, variantComparison, combinedStyle);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-font-styles.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-font-styles.scene.ts
@@ -65,6 +65,6 @@ export const scene: TestScene = {
         );
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-font-weights-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-font-weights-tagged.scene.ts
@@ -49,6 +49,6 @@ export const scene: TestScene = {
         scene.addChild(text);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-font-weights.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-font-weights.scene.ts
@@ -31,6 +31,6 @@ export const scene: TestScene = {
         });
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-letter-spacing.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-letter-spacing.scene.ts
@@ -36,6 +36,6 @@ export const scene: TestScene = {
         }
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-line-height.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-line-height.scene.ts
@@ -37,6 +37,6 @@ export const scene: TestScene = {
         }
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-stroke-alpha-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-stroke-alpha-tagged.scene.ts
@@ -38,6 +38,6 @@ export const scene: TestScene = {
         scene.addChild(text);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-stroke-alpha.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-stroke-alpha.scene.ts
@@ -20,6 +20,6 @@ export const scene: TestScene = {
         scene.addChild(text1);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-stroke-anchor-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-stroke-anchor-tagged.scene.ts
@@ -41,6 +41,6 @@ export const scene: TestScene = {
         scene.addChild(text);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-stroke-shadow-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-stroke-shadow-tagged.scene.ts
@@ -44,6 +44,6 @@ export const scene: TestScene = {
         scene.addChild(text);
         renderer.render(scene);
 
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-stroke-shadow.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-stroke-shadow.scene.ts
@@ -37,6 +37,6 @@ export const scene: TestScene = {
 
         renderer.render(scene);
 
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-stroke-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-stroke-tagged.scene.ts
@@ -41,6 +41,6 @@ export const scene: TestScene = {
         scene.addChild(text);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-stroke.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-stroke.scene.ts
@@ -34,6 +34,6 @@ export const scene: TestScene = {
         scene.addChild(text);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-tagged.scene.ts
@@ -42,6 +42,6 @@ export const scene: TestScene = {
         text.style.wordWrapWidth = 120;
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-texture-style.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-texture-style.scene.ts
@@ -26,6 +26,6 @@ export const scene: TestScene = {
         text.scale = 10;
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-whitespace-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-whitespace-tagged.scene.ts
@@ -77,6 +77,6 @@ export const scene: TestScene = {
         scene.addChild(text4);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-whitespace.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-whitespace.scene.ts
@@ -55,6 +55,6 @@ export const scene: TestScene = {
         });
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-word-wrap-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-word-wrap-tagged.scene.ts
@@ -70,6 +70,6 @@ export const scene: TestScene = {
         scene.addChild(text3);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-word-wrap.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-word-wrap.scene.ts
@@ -59,6 +59,6 @@ export const scene: TestScene = {
         scene.addChild(text3);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text.scene.ts
+++ b/tests/visual/scenes/text-html/html-text.scene.ts
@@ -33,6 +33,6 @@ export const scene: TestScene = {
         text.style.wordWrapWidth = 120;
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };


### PR DESCRIPTION
### Overview
- HTMLText visual tests use a `setTimeout` to wait for async texture generation (font loading, SVG-to-image, canvas conversion). The 250ms wait was insufficient for WebGPU, which has an extra canvas conversion step, causing sporadic failures.
- Increased wait from 250ms to 350ms across all 34 HTMLText visual test scenes (38 occurrences).

#### Fixes
- Sporadic WebGPU failures in HTMLText visual regression tests due to async texture generation not completing within 250ms

#### Chores
- Updated all `tests/visual/scenes/text-html/*.scene.ts` files: `setTimeout(resolve, 250)` -> `setTimeout(resolve, 350)`

##### Pre-Merge Checklist
- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

---
#### Overview
##### Fixes
- Increased HTMLText visual test wait time from 250ms to 350ms to prevent sporadic WebGPU failures. WebGPU's additional canvas conversion step for async texture generation (font loading, SVG-to-image, canvas conversion) requires the extended wait time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->