### PR TITLE
fix: MSDF BitmapText alpha applied twice (squared)

### DIFF
--- a/src/scene/text/sdfShader/shader-bits/mSDFBit.ts
+++ b/src/scene/text/sdfShader/shader-bits/mSDFBit.ts
@@ -22,9 +22,13 @@ export const mSDFBit = {
                 }
 
                 // Gamma correction for coverage-like alpha
+                // Note: do NOT multiply by shapeColor.a here. The shader
+                // template already applies vColor (which carries the user's
+                // alpha) via: finalColor = outColor * vColor.
+                // Including shapeColor.a here would square the alpha.
                 var luma: f32 = dot(shapeColor.rgb, vec3<f32>(0.299, 0.587, 0.114));
                 var gamma: f32 = mix(1.0, 1.0 / 2.2, luma);
-                var coverage: f32 = pow(shapeColor.a * alpha, gamma);
+                var coverage: f32 = pow(alpha, gamma);
 
                 return coverage;
 
@@ -59,9 +63,13 @@ export const mSDFBitGl = {
                 }
 
                 // Gamma correction for coverage-like alpha
+                // Note: do NOT multiply by shapeColor.a here. The shader
+                // template already applies vColor (which carries the user's
+                // alpha) via: finalColor = outColor * vColor.
+                // Including shapeColor.a here would square the alpha.
                 float luma = dot(shapeColor.rgb, vec3(0.299, 0.587, 0.114));
                 float gamma = mix(1.0, 1.0 / 2.2, luma);
-                float coverage = pow(shapeColor.a * alpha, gamma);
+                float coverage = pow(alpha, gamma);
 
                 return coverage;
             }


### PR DESCRIPTION
## Summary

Fixes an issue where setting `alpha` on a `BitmapText` using MSDF fonts resulted in the
alpha being much stronger than expected (e.g. setting `alpha = 0.5` produced ~25% opacity
instead of 50%), making it inconsistent with other display objects.

## Root Cause

The `calculateMSDFAlpha` function in the MSDF shader was multiplying the coverage by
`shapeColor.a` (the user's alpha from `vColor`):

```glsl
float coverage = pow(shapeColor.a * alpha, gamma);
```

However, the high-shader fragment template in `defaultProgramTemplate.ts` **always** applies
`vColor` to the output afterwards:

```glsl
finalColor = outColor * vColor;
```

This caused the alpha to be applied **twice**, effectively squaring it (`alpha * alpha`).

## Fix

Removed `shapeColor.a` from the `pow()` call in `calculateMSDFAlpha` (both WGSL and GLSL
variants), so the function returns only the SDF edge coverage. The user's alpha is then
correctly applied once by the shader template.

```glsl
// Before (alpha squared)
float coverage = pow(shapeColor.a * alpha, gamma);

// After (alpha applied once by template)
float coverage = pow(alpha, gamma);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

---
#### Overview
##### Fixes
- Fixed alpha being applied twice (squared) when setting `alpha` on `BitmapText` with MSDF fonts. The `calculateMSDFAlpha` function was multiplying by `shapeColor.a` inside the gamma correction, but the shader template already applies user alpha via `finalColor = outColor * vColor`. Removed `shapeColor.a` from the `pow()` call in both WGSL and GLSL shader variants to apply user alpha only once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->