### PR TITLE
chore: add ESLint rule enforcing ~/ imports in test and scene files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,7 @@ import tseslint from 'typescript-eslint';
 import config from '@pixi/eslint-config';
 import requireExport from './scripts/plugins/eslint-require-export.mjs';
 import requireMemberAPI from './scripts/plugins/eslint-require-modifier.mjs';
+import requireTildeImports from './scripts/plugins/eslint-require-tilde-imports.mjs';
 
 export default tseslint.config(
     ...config,
@@ -124,6 +125,15 @@ export default tseslint.config(
                     additionalTestBlockFunctions: [''],
                 },
             ],
+        },
+    },
+    {
+        files: ['**/*.test.ts', '**/*.scene.ts'],
+        plugins: {
+            requireTildeImports,
+        },
+        rules: {
+            'requireTildeImports/require-tilde-imports': 'error',
         },
     },
     {

--- a/scripts/plugins/eslint-require-tilde-imports.mjs
+++ b/scripts/plugins/eslint-require-tilde-imports.mjs
@@ -1,0 +1,100 @@
+import path from 'path';
+
+const rule = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'Require ~/ imports for source code in .test.ts and .scene.ts files',
+        },
+        fixable: 'code',
+        messages: {
+            useAliasImport:
+                'Use \'~/{{ replacement }}\' instead of relative import \'{{ original }}\'. '
+                + 'Test and scene files should use ~/ paths for source imports.',
+        },
+        schema: [],
+    },
+    create(context)
+    {
+        const filename = context.filename ?? context.getFilename();
+
+        if (!filename.endsWith('.test.ts') && !filename.endsWith('.scene.ts'))
+        {
+            return {};
+        }
+
+        const cwd = context.cwd ?? context.getCwd?.() ?? process.cwd();
+        const srcDir = path.join(cwd, 'src');
+
+        function checkImport(node)
+        {
+            const source = node.source;
+
+            if (!source) return;
+
+            const importPath = source.value;
+
+            if (!importPath.startsWith('.')) return;
+
+            const fileDir = path.dirname(filename);
+            const resolvedPath = path.resolve(fileDir, importPath);
+
+            if (!resolvedPath.startsWith(srcDir + path.sep) && resolvedPath !== srcDir)
+            {
+                return;
+            }
+
+            const relativeToSrc = path.relative(srcDir, resolvedPath).split(path.sep).join('/');
+
+            // In .test.ts files, allow relative imports within the same top-level src/ folder
+            if (filename.endsWith('.test.ts'))
+            {
+                const fileRelativeToSrc = path.relative(srcDir, filename).split(path.sep).join('/');
+                const fileTopLevel = fileRelativeToSrc.split('/')[0];
+                const importTopLevel = relativeToSrc.split('/')[0];
+
+                if (fileTopLevel === importTopLevel)
+                {
+                    return;
+                }
+            }
+
+            const replacement = relativeToSrc.split('/')[0];
+
+            context.report({
+                node: source,
+                messageId: 'useAliasImport',
+                data: {
+                    replacement,
+                    original: importPath,
+                },
+                fix(fixer)
+                {
+                    const quote = source.raw?.[0] ?? '\'';
+
+                    return fixer.replaceText(source, `${quote}~/${replacement}${quote}`);
+                },
+            });
+        }
+
+        return {
+            ImportDeclaration: checkImport,
+            ExportNamedDeclaration: checkImport,
+            ExportAllDeclaration: checkImport,
+        };
+    },
+};
+
+const plugin = {
+    meta: {
+        name: 'eslint-plugin-require-tilde-imports',
+        version: '1.0.0',
+    },
+    configs: {},
+    rules: {
+        'require-tilde-imports': rule,
+    },
+    processors: {},
+};
+
+export default plugin;

--- a/src/culling/__tests__/Culler.test.ts
+++ b/src/culling/__tests__/Culler.test.ts
@@ -1,7 +1,7 @@
-import { Application } from '../../app/Application';
 import { Culler } from '../Culler';
 import { CullerPlugin } from '../CullerPlugin';
 import { basePath } from '@test-utils';
+import { Application } from '~/app';
 import { Assets, loadTextures } from '~/assets';
 import { extensions } from '~/extensions';
 import { AlphaFilter } from '~/filters';

--- a/src/rendering/renderers/shared/__tests__/GCSystem.test.ts
+++ b/src/rendering/renderers/shared/__tests__/GCSystem.test.ts
@@ -1,5 +1,5 @@
-import { type NOOP } from '../../../../utils/misc/NOOP';
 import { GCSystem } from '../GCSystem';
+import { type NOOP } from '~/utils';
 
 import type { Renderer } from '../../types';
 import type { GCable, GCSystemOptions } from '../GCSystem';

--- a/src/scene/container/__tests__/display-status.test.ts
+++ b/src/scene/container/__tests__/display-status.test.ts
@@ -1,5 +1,5 @@
-import { Application } from '../../../app/Application';
 import { Container } from '../Container';
+import { Application } from '~/app';
 
 describe('Container Display Status', () =>
 {

--- a/src/scene/graphics/__tests__/Graphics.test.ts
+++ b/src/scene/graphics/__tests__/Graphics.test.ts
@@ -1,11 +1,10 @@
-import { Rectangle } from '../../../maths/shapes/Rectangle';
 import { Graphics } from '../shared/Graphics';
 import { GraphicsContext } from '../shared/GraphicsContext';
 import { GraphicsPath } from '../shared/path/GraphicsPath';
 import { toFillStyle } from '../shared/utils/convertFillInputToFillStyle';
 import { generateTextureMatrix as generateTextureFillMatrix } from '../shared/utils/generateTextureFillMatrix';
 import { getWebGLRenderer } from '@test-utils';
-import { Matrix } from '~/maths';
+import { Matrix, Rectangle } from '~/maths';
 import { Texture } from '~/rendering';
 
 describe('Graphics', () =>


### PR DESCRIPTION
### Overview

Adds a new ESLint plugin (`eslint-require-tilde-imports`) that enforces the use of `~/` path aliases instead of relative imports when test and scene files import from other top-level `src/` modules. This keeps cross-module imports consistent and readable. Existing violations in four test files are fixed.

#### Chores
- Add `require-tilde-imports` ESLint rule for `.test.ts` and `.scene.ts` files, with autofix support
- Fix existing relative cross-module imports in `Culler.test.ts`, `GCSystem.test.ts`, `display-status.test.ts`, and `Graphics.test.ts`

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

---

##### Chores
- Added ESLint plugin `eslint-require-tilde-imports` that enforces using `~/` path aliases instead of relative imports in test (`.test.ts`) and scene (`.scene.ts`) files when importing top-level `src/` modules, with autofix support.
- Updated test files to comply with the new ESLint rule: Culler.test.ts, GCSystem.test.ts, display-status.test.ts, and Graphics.test.ts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->