### PR TITLE
chore: convert waits to setTimeout promise in node.js

### DIFF
--- a/tests/utils/async.ts
+++ b/tests/utils/async.ts
@@ -1,5 +1,7 @@
+import { setTimeout } from 'node:timers/promises';
+
 export function nextTick(): Promise<void>
 {
-    return new Promise((resolve) => setTimeout(resolve, 0));
+    return setTimeout(0);
 }
 

--- a/tests/visual/scenes/text-html/html-text-alignment-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-alignment-tagged.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { Assets } from '~/assets';
 import { Graphics, HTMLText } from '~/scene';
 
@@ -55,6 +56,6 @@ export const scene: TestScene = {
         });
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-alignment.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-alignment.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { Assets } from '~/assets';
 import { Graphics, HTMLText } from '~/scene';
 
@@ -51,6 +52,6 @@ export const scene: TestScene = {
         });
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-bounds-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-bounds-tagged.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { Assets } from '~/assets';
 import { Graphics, HTMLText } from '~/scene';
 
@@ -66,6 +67,6 @@ export const scene: TestScene = {
         scene.addChild(textRect2);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-bounds.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-bounds.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { Assets } from '~/assets';
 import { Graphics, HTMLText } from '~/scene';
 
@@ -59,6 +60,6 @@ export const scene: TestScene = {
         scene.addChild(textRect2);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-broken.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-broken.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { HTMLText } from '~/scene';
 
 import type { TestScene } from '../../types';
@@ -19,6 +20,6 @@ export const scene: TestScene = {
 
         scene.addChild(text);
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-drop-shadow-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-drop-shadow-tagged.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { HTMLText, HTMLTextStyle } from '~/scene';
 
 import type { TestScene } from '../../types';
@@ -35,10 +36,10 @@ export const scene: TestScene = {
         scene.addChild(text);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
         text.style.dropShadow.color = 'green';
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-drop-shadow-word-wrap-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-drop-shadow-word-wrap-tagged.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { Assets } from '~/assets';
 import { HTMLText } from '~/scene';
 
@@ -102,6 +103,6 @@ export const scene: TestScene = {
         scene.addChild(text3);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-drop-shadow-word-wrap.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-drop-shadow-word-wrap.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { Assets } from '~/assets';
 import { HTMLText } from '~/scene';
 
@@ -78,6 +79,6 @@ export const scene: TestScene = {
         scene.addChild(text3);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-drop-shadow.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-drop-shadow.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { HTMLText, HTMLTextStyle } from '~/scene';
 
 import type { TestScene } from '../../types';
@@ -34,6 +35,6 @@ export const scene: TestScene = {
         text.style.dropShadow.color = 'red';
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-dynamic-destroy.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-dynamic-destroy.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { Container, HTMLText } from '~/scene';
 
 import type { TestScene } from '../../types';
@@ -35,7 +36,7 @@ export const scene: TestScene = {
         scene.addChild(container);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
         container.destroy({ children: true });
 
         container = new Container();
@@ -66,6 +67,6 @@ export const scene: TestScene = {
         container.addChild(text2);
         scene.addChild(container);
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-dynamic-update.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-dynamic-update.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { HTMLText, HTMLTextStyle } from '~/scene';
 
 import type { TestScene } from '../../types';
@@ -30,10 +31,10 @@ export const scene: TestScene = {
         scene.addChild(text2);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
         text2.text = '1';
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-dynamic.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-dynamic.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { HTMLText, HTMLTextStyle } from '~/scene';
 
 import type { TestScene } from '../../types';
@@ -24,10 +25,10 @@ export const scene: TestScene = {
         scene.addChild(text);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
         text.resolution = 0.5;
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-family-multi.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-family-multi.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { Assets } from '~/assets';
 import { HTMLText } from '~/scene';
 
@@ -51,6 +52,6 @@ export const scene: TestScene = {
 
         scene.addChild(text);
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-family.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-family.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { Assets } from '~/assets';
 import { HTMLText } from '~/scene';
 
@@ -40,6 +41,6 @@ export const scene: TestScene = {
 
         scene.addChild(text);
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-font-styles-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-font-styles-tagged.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { Assets } from '~/assets';
 import { HTMLText } from '~/scene';
 
@@ -62,6 +63,6 @@ export const scene: TestScene = {
         scene.addChild(styleComparison, variantComparison, combinedStyle);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-font-styles.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-font-styles.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { Assets } from '~/assets';
 import { HTMLText } from '~/scene';
 
@@ -65,6 +66,6 @@ export const scene: TestScene = {
         );
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-font-weights-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-font-weights-tagged.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { Assets } from '~/assets';
 import { HTMLText } from '~/scene';
 
@@ -49,6 +50,6 @@ export const scene: TestScene = {
         scene.addChild(text);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-font-weights.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-font-weights.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { HTMLText } from '~/scene';
 
 import type { TestScene } from '../../types';
@@ -31,6 +32,6 @@ export const scene: TestScene = {
         });
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-letter-spacing.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-letter-spacing.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { Assets } from '~/assets';
 import { HTMLText } from '~/scene';
 
@@ -36,6 +37,6 @@ export const scene: TestScene = {
         }
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-line-height.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-line-height.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { Assets } from '~/assets';
 import { HTMLText } from '~/scene';
 
@@ -37,6 +38,6 @@ export const scene: TestScene = {
         }
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-stroke-alpha-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-stroke-alpha-tagged.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { HTMLText } from '~/scene';
 
 import type { TestScene } from '../../types';
@@ -38,6 +39,6 @@ export const scene: TestScene = {
         scene.addChild(text);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-stroke-alpha.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-stroke-alpha.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { HTMLText, HTMLTextStyle } from '~/scene';
 
 import type { TestScene } from '../../types';
@@ -20,6 +21,6 @@ export const scene: TestScene = {
         scene.addChild(text1);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-stroke-anchor-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-stroke-anchor-tagged.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { HTMLText } from '~/scene';
 
 import type { TestScene } from '../../types';
@@ -41,6 +42,6 @@ export const scene: TestScene = {
         scene.addChild(text);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-stroke-shadow-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-stroke-shadow-tagged.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { HTMLText } from '~/scene';
 
 import type { TestScene } from '../../types';
@@ -44,6 +45,6 @@ export const scene: TestScene = {
         scene.addChild(text);
         renderer.render(scene);
 
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-stroke-shadow.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-stroke-shadow.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { HTMLText, HTMLTextStyle } from '~/scene';
 
 import type { TestScene } from '../../types';
@@ -37,6 +38,6 @@ export const scene: TestScene = {
 
         renderer.render(scene);
 
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-stroke-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-stroke-tagged.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { Graphics, HTMLText } from '~/scene';
 
 import type { TestScene } from '../../types';
@@ -41,6 +42,6 @@ export const scene: TestScene = {
         scene.addChild(text);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-stroke.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-stroke.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { Graphics, HTMLText, HTMLTextStyle } from '~/scene';
 
 import type { TestScene } from '../../types';
@@ -34,6 +35,6 @@ export const scene: TestScene = {
         scene.addChild(text);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-tagged.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { Assets } from '~/assets';
 import { HTMLText } from '~/scene';
 
@@ -42,6 +43,6 @@ export const scene: TestScene = {
         text.style.wordWrapWidth = 120;
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-texture-style.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-texture-style.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { HTMLText } from '~/scene';
 
 import type { TestScene } from '../../types';
@@ -26,6 +27,6 @@ export const scene: TestScene = {
         text.scale = 10;
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-whitespace-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-whitespace-tagged.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { Assets } from '~/assets';
 import { HTMLText } from '~/scene';
 
@@ -77,6 +78,6 @@ export const scene: TestScene = {
         scene.addChild(text4);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-whitespace.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-whitespace.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { Assets } from '~/assets';
 import { HTMLText } from '~/scene';
 
@@ -55,6 +56,6 @@ export const scene: TestScene = {
         });
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-word-wrap-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-word-wrap-tagged.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { Assets } from '~/assets';
 import { HTMLText } from '~/scene';
 
@@ -70,6 +71,6 @@ export const scene: TestScene = {
         scene.addChild(text3);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text-word-wrap.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-word-wrap.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { Assets } from '~/assets';
 import { HTMLText } from '~/scene';
 
@@ -59,6 +60,6 @@ export const scene: TestScene = {
         scene.addChild(text3);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text-html/html-text.scene.ts
+++ b/tests/visual/scenes/text-html/html-text.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { HTMLText } from '~/scene';
 
 import type { TestScene } from '../../types';
@@ -33,6 +34,6 @@ export const scene: TestScene = {
         text.style.wordWrapWidth = 120;
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
+        await setTimeout(350);
     },
 };

--- a/tests/visual/scenes/text/text-invisible-value-update.scene.ts
+++ b/tests/visual/scenes/text/text-invisible-value-update.scene.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { BitmapText, Text, TextStyle } from '~/scene';
 
 import type { TestScene } from '../../types';
@@ -18,7 +19,7 @@ export const scene: TestScene = {
         scene.addChild(text1);
         scene.addChild(text2);
 
-        const delay = () => new Promise((resolve) => setTimeout(resolve, 200));
+        const delay = () => setTimeout(200);
         const setText = (text: string) =>
         {
             bText1.text = `B${text}`;


### PR DESCRIPTION
### Changes

* Replace `new Promise(resolve => setTimeout(resolve, [time]))` with Node.js native `setTimeout` from `timers/promiese`.