### PR TITLE
fix: remove listener from old resource in BindGroup.setResource

### DIFF
--- a/src/rendering/renderers/gpu/shader/BindGroup.ts
+++ b/src/rendering/renderers/gpu/shader/BindGroup.ts
@@ -95,11 +95,7 @@ export class BindGroup
 
         if (resource === currentResource) return;
 
-        if (currentResource)
-        {
-            currentResource.off?.('change', this.onResourceChange, this);
-        }
-
+        currentResource?.off?.('change', this.onResourceChange, this);
         resource.on?.('change', this.onResourceChange, this);
 
         this.resources[index] = resource;

--- a/src/rendering/renderers/gpu/shader/BindGroup.ts
+++ b/src/rendering/renderers/gpu/shader/BindGroup.ts
@@ -97,7 +97,7 @@ export class BindGroup
 
         if (currentResource)
         {
-            resource.off?.('change', this.onResourceChange, this);
+            currentResource.off?.('change', this.onResourceChange, this);
         }
 
         resource.on?.('change', this.onResourceChange, this);


### PR DESCRIPTION
### Overview
Fixes a listener leak in `BindGroup.setResource()` where the change listener was being removed from the new resource instead of the old resource being replaced.

#### Fixes
- When replacing a resource in a bind group, the change listener is now correctly removed from `currentResource` (the old resource) instead of `resource` (the new resource).

##### Pre-Merge Checklist
- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

---
##### Fixes
- Fixed a listener leak in `BindGroup.setResource()` where the change listener was being removed from the new resource instead of the old one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->