### PR TITLE
fix: use quotes when loading a Web font to support old versions of Chrome

### DIFF
--- a/src/assets/loader/parsers/loadWebFont.ts
+++ b/src/assets/loader/parsers/loadWebFont.ts
@@ -171,7 +171,7 @@ export const loadWebFont = {
             {
                 const weight = weights[i];
 
-                const font = new FontFace(name, `url(${encodeURIWhenNeeded(url)})`, {
+                const font = new FontFace(name, `url('${encodeURIWhenNeeded(url)}')`, {
                     ...data,
                     weight,
                 });


### PR DESCRIPTION
Hello!

##### Problem I'm fixing

When trying to preload a WebFont inside an Electron bundle on Windows, I am experiencing this error:
```
The source provided ([Web Font URL]) could not be parsed as a value list.
```

It seems that some versions of Chrome do not support loading a Web font without using quotes around the URL. The only source talking about this exact error is this page: https://www.remotion.dev/docs/troubleshooting/could-not-be-parsed-as-a-value-list

##### Description of change

I am proposing that Web font URLs are always wrapped in single quotes, to support older versions of Chrome. I've confirmed with my project that this change fixes the issue for me, and it seems to be sufficiently benign that I assume it won't impact anything negatively.

##### Pre-Merge Checklist

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)

Cheers,
Adrian

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

##### Fixes
- Fixed Web font loading in older Chrome versions by wrapping font URLs in single quotes within the CSS `url()` function, resolving parsing errors in Electron on Windows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->