### PR TITLE
fix: copy modifier keys from TouchEvent to normalized touch objects

### DIFF
--- a/src/events/EventSystem.ts
+++ b/src/events/EventSystem.ts
@@ -999,10 +999,10 @@ export class EventSystem implements System<EventSystemOptions>
 
                 // Copy modifier keys from the TouchEvent to the touch object
                 // These properties exist on TouchEvent, not on individual Touch objects
-                if (typeof touch.altKey === 'undefined') touch.altKey = event.altKey;
-                if (typeof touch.ctrlKey === 'undefined') touch.ctrlKey = event.ctrlKey;
-                if (typeof touch.metaKey === 'undefined') touch.metaKey = event.metaKey;
-                if (typeof touch.shiftKey === 'undefined') touch.shiftKey = event.shiftKey;
+                touch.altKey ??= event.altKey;
+                touch.ctrlKey ??= event.ctrlKey;
+                touch.metaKey ??= event.metaKey;
+                touch.shiftKey ??= event.shiftKey;
 
                 normalizedEvents.push(touch);
             }

--- a/src/events/EventSystem.ts
+++ b/src/events/EventSystem.ts
@@ -997,6 +997,13 @@ export class EventSystem implements System<EventSystemOptions>
                 touch.isNormalized = true;
                 touch.type = event.type;
 
+                // Copy modifier keys from the TouchEvent to the touch object
+                // These properties exist on TouchEvent, not on individual Touch objects
+                if (typeof touch.altKey === 'undefined') touch.altKey = event.altKey;
+                if (typeof touch.ctrlKey === 'undefined') touch.ctrlKey = event.ctrlKey;
+                if (typeof touch.metaKey === 'undefined') touch.metaKey = event.metaKey;
+                if (typeof touch.shiftKey === 'undefined') touch.shiftKey = event.shiftKey;
+
                 normalizedEvents.push(touch);
             }
         }

--- a/src/events/FederatedEvent.ts
+++ b/src/events/FederatedEvent.ts
@@ -79,6 +79,18 @@ export interface PixiTouch extends Touch
 
     /** The type of touch event */
     type: string;
+
+    /** Whether the "alt" key was pressed when this touch event occurred (copied from TouchEvent) */
+    altKey: boolean;
+
+    /** Whether the "control" key was pressed when this touch event occurred (copied from TouchEvent) */
+    ctrlKey: boolean;
+
+    /** Whether the "meta" key was pressed when this touch event occurred (copied from TouchEvent) */
+    metaKey: boolean;
+
+    /** Whether the "shift" key was pressed when this touch event occurred (copied from TouchEvent) */
+    shiftKey: boolean;
 }
 
 /**

--- a/src/events/__tests__/EventBoundary.test.ts
+++ b/src/events/__tests__/EventBoundary.test.ts
@@ -471,4 +471,43 @@ describe('EventBoundary', () =>
         expect(eventSpy3).not.toHaveBeenCalled();
         expect(eventSpy4).not.toHaveBeenCalled();
     });
+
+    it('should preserve modifier keys (ctrlKey, shiftKey, altKey, metaKey) in events', () =>
+    {
+        const stage = new Container();
+        const boundary = new EventBoundary(stage);
+        const target = stage.addChild(graphicsWithRect(0, 0, 100, 100));
+
+        target.interactive = true;
+
+        const receivedEvents: FederatedPointerEvent[] = [];
+
+        target.addEventListener('pointerdown', (e) =>
+        {
+            receivedEvents.push(e as FederatedPointerEvent);
+        });
+
+        // Create event with modifier keys
+        const event = new FederatedPointerEvent(boundary);
+
+        event.target = target;
+        event.global.set(50, 50);
+        event.type = 'pointerdown';
+        event.ctrlKey = true;
+        event.shiftKey = true;
+        event.altKey = false;
+        event.metaKey = true;
+        event.button = 0;
+        event.buttons = 1;
+
+        boundary.dispatchEvent(event);
+
+        expect(receivedEvents).toHaveLength(1);
+        expect(receivedEvents[0].ctrlKey).toBe(true);
+        expect(receivedEvents[0].shiftKey).toBe(true);
+        expect(receivedEvents[0].altKey).toBe(false);
+        expect(receivedEvents[0].metaKey).toBe(true);
+        expect(receivedEvents[0].button).toBe(0);
+        expect(receivedEvents[0].buttons).toBe(1);
+    });
 });


### PR DESCRIPTION
## Summary

Fixes #11879 - `ctrlKey`, `shiftKey`, `altKey`, and `metaKey` properties are always `false` in FederatedEvent for touch events.

## Root Cause

When touch events are normalized in `_normalizeToPointerData`, the modifier keys (`ctrlKey`, `shiftKey`, `altKey`, `metaKey`) were not being copied from the `TouchEvent` to the normalized touch objects.

These modifier key properties exist on the `TouchEvent` interface, not on individual `Touch` objects. When `_transferMouseData` later tried to read these properties from the normalized touch object, they were `undefined`.

## Changes

1. **PixiTouch interface** (`FederatedEvent.ts`): Added `altKey`, `ctrlKey`, `metaKey`, and `shiftKey` properties

2. **_normalizeToPointerData** (`EventSystem.ts`): Copy modifier keys from the parent `TouchEvent` to each normalized touch object

3. **Tests**: Added test to verify modifier keys are preserved in events

## Testing

- All existing tests pass
- Added new test that verifies modifier keys are correctly preserved through the event system

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
---

##### Fixes
- Copy modifier keys (ctrlKey, shiftKey, altKey, metaKey) from the original TouchEvent to normalized touch objects so FederatedEvent touch events reflect the correct modifier state.
- Add modifier key properties to the PixiTouch interface so normalized touch objects expose these keys.
    ```ts
    interface PixiTouch {
      altKey?: boolean;
      ctrlKey?: boolean;
      metaKey?: boolean;
      shiftKey?: boolean;
      // ...existing properties
    }
    ```
- Ensure modifier keys are preserved end-to-end through the event system; includes a new test verifying modifier key (and button/buttons) preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->