### PR TITLE
fix: guard against missing characters and kerning data in bitmap text

### DIFF
--- a/src/scene/text-bitmap/DynamicBitmapFont.ts
+++ b/src/scene/text-bitmap/DynamicBitmapFont.ts
@@ -305,7 +305,7 @@ export class DynamicBitmapFont extends AbstractBitmapFont<DynamicBitmapFont>
                 let total = context.measureText(first + second).width;
                 let amount = total - (c1 + c2);
 
-                if (amount)
+                if (amount && this.chars[first])
                 {
                     this.chars[first].kerning[second] = amount;
                 }
@@ -314,7 +314,7 @@ export class DynamicBitmapFont extends AbstractBitmapFont<DynamicBitmapFont>
                 total = context.measureText(first + second).width;
                 amount = total - (c1 + c2);
 
-                if (amount)
+                if (amount && this.chars[second])
                 {
                     this.chars[second].kerning[first] = amount;
                 }

--- a/src/scene/text-bitmap/__tests__/BitmapText.test.ts
+++ b/src/scene/text-bitmap/__tests__/BitmapText.test.ts
@@ -1,7 +1,9 @@
 import { Text } from '../../text/Text';
+import { TextStyle } from '../../text/TextStyle';
 import { loadBitmapFont } from '../asset/loadBitmapFont';
 import { type BitmapFont } from '../BitmapFont';
 import { BitmapText } from '../BitmapText';
+import { getBitmapTextLayout } from '../utils/getBitmapTextLayout';
 import '../../text/init';
 import '../init';
 import '../../graphics/init';
@@ -266,5 +268,26 @@ describe('BitmapText', () =>
 
         expect(bmpText.width).toBe(refText.width);
         expect(bmpText.height).toBe(refText.height);
+    });
+
+    it('should not crash when text contains characters missing from the font', () =>
+    {
+        // Font that only has 'A' and 'B', no space character
+        const mockFont = {
+            chars: {
+                A: { id: 65, xOffset: 0, yOffset: 0, xAdvance: 20, kerning: {} },
+                B: { id: 66, xOffset: 0, yOffset: 0, xAdvance: 20, kerning: {} },
+            },
+            baseMeasurementFontSize: 32,
+            baseLineOffset: 0,
+            lineHeight: 40,
+        };
+
+        const style = new TextStyle({ fontSize: 32 });
+
+        // Text with missing characters (space and 'Z') — should not throw
+        expect(() =>
+            getBitmapTextLayout(['A', ' ', 'Z', 'B'], style, mockFont as any, false)
+        ).not.toThrow();
     });
 });

--- a/src/scene/text-bitmap/asset/bitmapFontTextParser.ts
+++ b/src/scene/text-bitmap/asset/bitmapFontTextParser.ts
@@ -176,7 +176,7 @@ export const bitmapFontTextParser = {
             const second = parseInt(kerning[i].second, 10);
             const amount = parseInt(kerning[i].amount, 10);
 
-            font.chars[map[second]].kerning[map[first]] = amount;
+            if (font.chars[map[second]]) font.chars[map[second]].kerning[map[first]] = amount;
         }
 
         return font;

--- a/src/scene/text-bitmap/asset/bitmapFontXMLParser.ts
+++ b/src/scene/text-bitmap/asset/bitmapFontXMLParser.ts
@@ -91,7 +91,7 @@ export const bitmapFontXMLParser = {
             const second = parseInt(kerning[i].getAttribute('second'), 10);
             const amount = parseInt(kerning[i].getAttribute('amount'), 10);
 
-            data.chars[map[second]].kerning[map[first]] = amount;// * 10000;
+            if (data.chars[map[second]]) data.chars[map[second]].kerning[map[first]] = amount;// * 10000;
         }
 
         return data;

--- a/src/scene/text-bitmap/utils/getBitmapTextLayout.ts
+++ b/src/scene/text-bitmap/utils/getBitmapTextLayout.ts
@@ -146,7 +146,7 @@ export function getBitmapTextLayout(
             char = chars[i];
         }
 
-        const charData = font.chars[char] || font.chars[' '];
+        const charData = font.chars[char];
 
         const isSpace = (/(?:\s)/).test(char);
         const isWordBreak = isSpace || char === '\r' || char === '\n' || isEnd;
@@ -185,9 +185,9 @@ export function getBitmapTextLayout(
             {
                 nextLine();
             }
-            else if (!isEnd)
+            else if (!isEnd && charData)
             {
-                const spaceWidth = charData.xAdvance + (charData.kerning[previousChar] || 0) + adjustedLetterSpacing;
+                const spaceWidth = charData.xAdvance + (charData.kerning?.[previousChar] || 0) + adjustedLetterSpacing;
 
                 currentLine.width += spaceWidth;
 
@@ -198,9 +198,9 @@ export function getBitmapTextLayout(
                 // spaceCount++;
             }
         }
-        else
+        else if (charData)
         {
-            const kerning = charData.kerning[previousChar] || 0;
+            const kerning = charData.kerning?.[previousChar] || 0;
 
             const nextCharWidth = charData.xAdvance + kerning + adjustedLetterSpacing;
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
Fixes #11595 by adding null guards against missing character data in bitmap fonts.

The existing `' '` fallback in `getBitmapTextLayout` has also been removed - this appears to have been including layout data for glyphs that are not actually rendered, causing a mismatch:
https://github.com/pixijs/pixijs/blob/c52309f3f8b6ff8da3538483f6ffc9faff11c929/src/scene/text-bitmap/AbstractBitmapTextPipe.ts#L168

Fix is verified with a new unit test and functional testing of the Stackblitz linked to the issue.

<img width="415" alt="Screenshot 2026-02-12 at 4 00 25 PM" src="https://github.com/user-attachments/assets/419aefbd-d8de-43f6-b10f-21e885749074" />


##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

---
#### Overview

##### Fixes
- Fixed crash when bitmap fonts are missing character or kerning data by adding null/undefined guards in `DynamicBitmapFont._applyKerning`, `bitmapFontTextParser`, and `bitmapFontXMLParser`
- Removed implicit fallback to space glyph in `getBitmapTextLayout`, which was incorrectly including layout data for non-rendered glyphs and causing mismatches
- Added optional chaining for kerning access to prevent undefined property errors when glyph data is missing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->