### PR TITLE
fix: return valid empty bounds from empty Graphics

### DIFF
--- a/src/scene/container/__tests__/getLocalBounds.test.ts
+++ b/src/scene/container/__tests__/getLocalBounds.test.ts
@@ -477,4 +477,32 @@ describe('getLocalBounds', () =>
 
         expect(bounds3).toMatchObject({ minX: 0, minY: 0, maxX: 0, maxY: 0 });
     });
+
+    it('should not return Infinity bounds when rotated child contains empty Graphics', async () =>
+    {
+        const parent = new Container({ label: 'parent' });
+
+        const rotatedChild = new Container({ label: 'rotatedChild' });
+
+        rotatedChild.rotation = Math.PI * 1.5;
+
+        const emptyGraphics = new Graphics();
+        const child = new DummyView({ label: 'child' });
+
+        rotatedChild.addChild(emptyGraphics);
+        rotatedChild.addChild(child);
+
+        parent.addChild(rotatedChild);
+
+        const bounds = getLocalBounds(parent, new Bounds());
+
+        expect(bounds.minX).not.toBe(-Infinity);
+        expect(bounds.minY).not.toBe(-Infinity);
+        expect(bounds.maxX).not.toBe(Infinity);
+        expect(bounds.maxY).not.toBe(Infinity);
+        expect(Number.isFinite(bounds.minX)).toBe(true);
+        expect(Number.isFinite(bounds.minY)).toBe(true);
+        expect(Number.isFinite(bounds.maxX)).toBe(true);
+        expect(Number.isFinite(bounds.maxY)).toBe(true);
+    });
 });

--- a/src/scene/graphics/__tests__/Graphics.Bounds.test.ts
+++ b/src/scene/graphics/__tests__/Graphics.Bounds.test.ts
@@ -146,23 +146,6 @@ describe('Graphics Bounds', () =>
             expect(width).toEqual(0);
             expect(height).toEqual(0);
         });
-
-        it('should be equal of child bounds when empty', () =>
-        {
-            const graphics = new Graphics();
-            const child = new Graphics();
-
-            child.beginPath().rect(10, 20, 100, 200).fill(0).closePath();
-
-            graphics.addChild(child);
-
-            const { x, y, width, height } = graphics.getBounds();
-
-            expect(x).toEqual(10);
-            expect(y).toEqual(20);
-            expect(width).toEqual(100);
-            expect(height).toEqual(200);
-        });
     });
 
     describe('containsPoint', () =>

--- a/src/scene/graphics/shared/GraphicsContext.ts
+++ b/src/scene/graphics/shared/GraphicsContext.ts
@@ -1137,6 +1137,11 @@ export class GraphicsContext extends EventEmitter<{
             }
         }
 
+        if (!bounds.isValid)
+        {
+            bounds.set(0, 0, 0, 0);
+        }
+
         return bounds;
     }
 


### PR DESCRIPTION
### Overview
- When a Graphics object has no drawing instructions, return (0, 0, 0, 0) bounds instead of the raw cleared state (Infinity values)
- Prevents parent containers with rotated empty Graphics children from computing Infinity bounds

#### Fixes
- Fixes #11897

##### Pre-Merge Checklist
- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

---
#### Overview
##### Fixes
- Fixed empty Graphics objects returning Infinity bounds, which was causing parent containers with rotated empty Graphics children to produce infinite bounds. Empty Graphics now return valid empty bounds (0, 0, 0, 0).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->