### PR TITLE
fix: respect explicit alphaMode in VideoSource, skip detectVideoAlphaMode()

### DIFF
--- a/src/rendering/renderers/shared/texture/sources/VideoSource.ts
+++ b/src/rendering/renderers/shared/texture/sources/VideoSource.ts
@@ -116,6 +116,7 @@ export class VideoSource extends TextureSource<VideoResource>
 
     private _msToNextUpdate: number;
     private _preloadTimeout: number;
+    private _alphaModeExplicit: boolean;
 
     /** Callback when completed with load. */
     private _resolve: (value?: this | PromiseLike<this>) => void;
@@ -130,6 +131,8 @@ export class VideoSource extends TextureSource<VideoResource>
     {
         super(options);
 
+        const alphaModeExplicit = options.alphaMode !== undefined;
+
         // Merge provided options with default ones
         options = {
             ...VideoSource.defaultOptions,
@@ -141,6 +144,7 @@ export class VideoSource extends TextureSource<VideoResource>
         this._updateFPS = options.updateFPS || 0;
         this._msToNextUpdate = 0;
         this.autoPlay = options.autoPlay !== false;
+        this._alphaModeExplicit = alphaModeExplicit;
         this.alphaMode = options.alphaMode ?? 'premultiply-alpha-on-upload';
 
         // Binding for frame updates
@@ -261,7 +265,10 @@ export class VideoSource extends TextureSource<VideoResource>
             this._mediaReady();
         }
 
-        this.alphaMode = await detectVideoAlphaMode();
+        if (!this._alphaModeExplicit)
+        {
+            this.alphaMode = await detectVideoAlphaMode();
+        }
 
         // Create and return the loading promise
         this._load = new Promise((resolve, reject): void =>


### PR DESCRIPTION
## Summary

When `alphaMode` is explicitly provided to `VideoSource` (via `Assets.load` data or constructor options), the detection routine `detectVideoAlphaMode()` should be skipped entirely.

Fixes #11473

## Problem

`VideoSource.load()` unconditionally overwrites `alphaMode` with the detected value at line 264:

```ts
this.alphaMode = await detectVideoAlphaMode();
```

This ignores any user-provided `alphaMode` option, making it impossible to override the unreliable auto-detection (as noted in #11461).

## Solution

1. Track whether `alphaMode` was explicitly provided via a private `_alphaModeExplicit` flag (checked **before** the options merge with defaults)
2. In `load()`, only run `detectVideoAlphaMode()` when no explicit value was given

This is a minimal, backward-compatible fix:
- No explicit `alphaMode` → behavior unchanged (auto-detection runs)
- Explicit `alphaMode` → detection skipped, user value respected

## Testing

```ts
// Before: alphaMode override ignored, detectVideoAlphaMode() always runs
// After: alphaMode override respected, detectVideoAlphaMode() skipped
const texture = await PIXI.Assets.load({
  src: 'video.webm',
  data: { alphaMode: 'no-premultiply-alpha' }
});
// texture.source.alphaMode === 'no-premultiply-alpha' ✓
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Release Notes</summary>

##### Fixes
- Respect explicit `alphaMode` option in `VideoSource` by skipping `detectVideoAlphaMode()` when an alpha mode is explicitly provided. Previously, any user-supplied `alphaMode` was unconditionally overwritten by auto-detection.
  ```ts
  const source = new VideoSource({
    resource: videoElement,
    alphaMode: 'no-premultiply-alpha'
  });
  // alphaMode is now preserved and detectVideoAlphaMode() is skipped
  ```

</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->