### PR TITLE
fix: emit removed event when using addChildAt

### DIFF
--- a/src/scene/container/__tests__/Container.Events.test.ts
+++ b/src/scene/container/__tests__/Container.Events.test.ts
@@ -76,6 +76,64 @@ describe('Container Events', () =>
 
             expect(listener).toHaveBeenCalledTimes(3);
         });
+
+        it('should trigger removed listeners when addChildAt is used', () =>
+        {
+            const removedListener = jest.fn();
+            const child = new Container();
+            const parentA = new Container();
+            const parentB = new Container();
+            const sibling = new Container();
+
+            parentB.addChild(sibling);
+
+            child.on('removed', removedListener);
+
+            parentA.addChild(child);
+
+            parentB.addChildAt(child, 1);
+
+            expect(removedListener).toHaveBeenCalledTimes(1);
+
+            parentB.addChildAt(child, 0);
+
+            expect(removedListener).toHaveBeenCalledTimes(2);
+
+            parentB.setChildIndex(child, 1);
+
+            expect(removedListener).toHaveBeenCalledTimes(3);
+
+            parentA.addChildAt(child, 0);
+
+            expect(removedListener).toHaveBeenCalledTimes(4);
+        });
+
+        it('should emit "removed" on child and "childRemoved" on old parent when addChildAt re-parents', () =>
+        {
+            const child = new Container();
+            const parentA = new Container();
+            const parentB = new Container();
+
+            const removedListener = jest.fn();
+            const childRemovedListener = jest.fn();
+
+            child.on('removed', removedListener);
+            parentA.on('childRemoved', childRemovedListener);
+
+            parentA.addChild(child);
+            expect(removedListener).not.toHaveBeenCalled();
+            expect(childRemovedListener).not.toHaveBeenCalled();
+
+            parentB.addChildAt(child, 0);
+
+            expect(removedListener).toHaveBeenCalledTimes(1);
+            expect(removedListener).toHaveBeenCalledWith(parentA);
+            expect(childRemovedListener).toHaveBeenCalledTimes(1);
+            expect(childRemovedListener).toHaveBeenCalledWith(child, parentA, 0);
+            expect(child.parent).toBe(parentB);
+            expect(parentA.children).not.toContain(child);
+            expect(parentB.children).toContain(child);
+        });
     });
 
     describe('destroy', () =>

--- a/src/scene/container/__tests__/Container.Events.test.ts
+++ b/src/scene/container/__tests__/Container.Events.test.ts
@@ -97,15 +97,15 @@ describe('Container Events', () =>
 
             parentB.addChildAt(child, 0);
 
-            expect(removedListener).toHaveBeenCalledTimes(2);
+            expect(removedListener).toHaveBeenCalledTimes(1);
 
             parentB.setChildIndex(child, 1);
 
-            expect(removedListener).toHaveBeenCalledTimes(3);
+            expect(removedListener).toHaveBeenCalledTimes(1);
 
             parentA.addChildAt(child, 0);
 
-            expect(removedListener).toHaveBeenCalledTimes(4);
+            expect(removedListener).toHaveBeenCalledTimes(2);
         });
 
         it('should emit "removed" on child and "childRemoved" on old parent when addChildAt re-parents', () =>
@@ -133,6 +133,49 @@ describe('Container Events', () =>
             expect(child.parent).toBe(parentB);
             expect(parentA.children).not.toContain(child);
             expect(parentB.children).toContain(child);
+        });
+
+        it('should not emit "childAdded" or "added" when addChildAt moves child within same container', () =>
+        {
+            const container = new Container();
+            const childA = new Container();
+            const childB = new Container();
+
+            container.addChild(childA, childB);
+
+            const childAddedListener = jest.fn();
+            const addedListener = jest.fn();
+
+            container.on('childAdded', childAddedListener);
+            childA.on('added', addedListener);
+
+            container.addChildAt(childA, 0);
+
+            expect(childAddedListener).not.toHaveBeenCalled();
+            expect(addedListener).not.toHaveBeenCalled();
+            expect(container.children[0]).toBe(childA);
+            expect(container.children[1]).toBe(childB);
+        });
+
+        it('should not emit "childAdded" or "added" when addChildAt is called with same index in same container', () =>
+        {
+            const container = new Container();
+            const childA = new Container();
+            const childB = new Container();
+
+            container.addChild(childA, childB);
+
+            const childAddedListener = jest.fn();
+            const addedListener = jest.fn();
+
+            container.on('childAdded', childAddedListener);
+            childA.on('added', addedListener);
+
+            container.addChildAt(childA, 1);
+
+            expect(childAddedListener).not.toHaveBeenCalled();
+            expect(addedListener).not.toHaveBeenCalled();
+            expect(container.children[1]).toBe(childA);
         });
     });
 

--- a/src/scene/container/__tests__/Container.Events.test.ts
+++ b/src/scene/container/__tests__/Container.Events.test.ts
@@ -135,7 +135,7 @@ describe('Container Events', () =>
             expect(parentB.children).toContain(child);
         });
 
-        it('should not emit "childAdded" or "added" when addChildAt moves child within same container', () =>
+        it('should not emit "childAdded" or "added" when addChildAt is called with same index in same container', () =>
         {
             const container = new Container();
             const childA = new Container();
@@ -157,7 +157,7 @@ describe('Container Events', () =>
             expect(container.children[1]).toBe(childB);
         });
 
-        it('should not emit "childAdded" or "added" when addChildAt is called with same index in same container', () =>
+        it('should not emit "childAdded" or "added" when addChildAt moves child within same container', () =>
         {
             const container = new Container();
             const childA = new Container();

--- a/src/scene/container/__tests__/Container.test.ts
+++ b/src/scene/container/__tests__/Container.test.ts
@@ -400,6 +400,52 @@ describe('Container', () =>
 
             assertRemovedFromParent(parent, container, child, () => { container.addChildAt(child, 0); });
         });
+
+        it('should be no-op when child is already in container at same index', () =>
+        {
+            const container = new Container();
+            const childA = new Container();
+            const childB = new Container();
+
+            container.addChild(childB, childA);
+
+            expect(container.children).toHaveLength(2);
+            expect(container.getChildIndex(childA)).toBe(1);
+
+            const result = container.addChildAt(childA, 1);
+
+            expect(result).toBe(childA);
+            expect(container.children).toHaveLength(2);
+            expect(container.children[0]).toBe(childB);
+            expect(container.children[1]).toBe(childA);
+            expect(childA.parent).toBe(container);
+        });
+
+        it('should move child to new index when child is already in container', () =>
+        {
+            const container = new Container();
+            const childA = new Container();
+            const childB = new Container();
+            const childC = new Container();
+
+            container.addChild(childA, childB, childC);
+
+            expect(container.getChildIndex(childB)).toBe(1);
+
+            container.addChildAt(childB, 0);
+
+            expect(container.children).toHaveLength(3);
+            expect(container.children[0]).toBe(childB);
+            expect(container.children[1]).toBe(childA);
+            expect(container.children[2]).toBe(childC);
+            expect(childB.parent).toBe(container);
+
+            container.addChildAt(childB, 2);
+
+            expect(container.children[0]).toBe(childA);
+            expect(container.children[1]).toBe(childC);
+            expect(container.children[2]).toBe(childB);
+        });
     });
 
     describe('removeChild', () =>

--- a/src/scene/container/container-mixins/childrenHelperMixin.ts
+++ b/src/scene/container/container-mixins/childrenHelperMixin.ts
@@ -377,7 +377,7 @@ export const childrenHelperMixin: ChildrenHelperMixin<ContainerChild> = {
 
             if (currentIndex !== -1)
             {
-                child.parent.children.splice(currentIndex, 1);
+                child.removeFromParent();
             }
         }
 

--- a/src/scene/container/container-mixins/childrenHelperMixin.ts
+++ b/src/scene/container/container-mixins/childrenHelperMixin.ts
@@ -410,7 +410,7 @@ export const childrenHelperMixin: ChildrenHelperMixin<ContainerChild> = {
 
         if (this.sortableChildren) this.sortDirty = true;
 
-        // If same parent, don't emit remove events
+        // If same parent, don't emit added events
         if (sameParent)
         {
             return child;

--- a/src/scene/container/container-mixins/childrenHelperMixin.ts
+++ b/src/scene/container/container-mixins/childrenHelperMixin.ts
@@ -365,17 +365,24 @@ export const childrenHelperMixin: ChildrenHelperMixin<ContainerChild> = {
         // TODO - check if child is already in the list?
         // we should be able to optimise this!
 
+        const sameParent = child.parent === this;
+
         if (child.parent)
         {
             const currentIndex = child.parent.children.indexOf(child);
 
-            // If this child is in the container and in the same position, do nothing
-            if (child.parent === this && currentIndex === index)
+            if (sameParent)
             {
-                return child;
+                // Same parent, same position - do nothing
+                if (currentIndex === index)
+                {
+                    return child;
+                }
+                // Same parent, different position
+                child.parent.children.splice(currentIndex, 1);
             }
-
-            if (currentIndex !== -1)
+            else
+            // Different parent, full removal
             {
                 child.removeFromParent();
             }
@@ -402,6 +409,12 @@ export const childrenHelperMixin: ChildrenHelperMixin<ContainerChild> = {
         }
 
         if (this.sortableChildren) this.sortDirty = true;
+
+        // If same parent, don't emit remove events
+        if (sameParent)
+        {
+            return child;
+        }
 
         this.emit('childAdded', child, this, index);
         child.emit('added', this);


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

In addChildAt, when the child already had a parent (including when re-parenting or moving within the same container), the code removed it from the old parent by mutating the array directly:

`child.parent.children.splice(currentIndex, 1);`

That only changed the children array. It did not:
Emit removal events (removed / childRemoved)
Run the normal removal path (e.g. render group updates, clearing parent refs via the public API)
So listeners and internal state could get out of sync when using addChildAt to move or re-parent a child.

What was changed

The direct splice was replaced with the public removal API:

`child.removeFromParent();`

So when addChildAt has to remove the child from its current parent, it now goes through the same removal logic as removeChild/removeFromParent: events are emitted and render groups and parent refs are updated correctly.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Release Notes</summary>

##### Fixes
- Fixed `addChildAt` to properly emit `removed` and `childRemoved` events when re-parenting a child to a different parent. Previously, these events were bypassed due to direct array manipulation.
- `addChildAt` no longer emits removal events when re-indexing a child within the same parent, keeping re-indexing semantically distinct from parent changes.

</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->