### PR TITLE
fix: re-render text after WebGL context restore

### DIFF
--- a/src/scene/text-html/HTMLTextPipe.ts
+++ b/src/scene/text-html/HTMLTextPipe.ts
@@ -32,6 +32,7 @@ export class HTMLTextPipe implements RenderPipe<HTMLText>
     {
         this._renderer = renderer;
         renderer.runners.resolutionChange.add(this);
+        renderer.runners.contextChange.add(this);
         this._managedTexts = new GCManagedHash({
             renderer,
             type: 'renderable',
@@ -48,6 +49,29 @@ export class HTMLTextPipe implements RenderPipe<HTMLText>
 
             if (text?._autoResolution)
             {
+                text.onViewUpdate();
+            }
+        }
+    }
+
+    protected contextChange()
+    {
+        this._renderer.htmlText.clearActiveTextures();
+
+        for (const key in this._managedTexts.items)
+        {
+            const text = this._managedTexts.items[key];
+
+            if (text)
+            {
+                const gpuText = text._gpuData[this._renderer.uid] as BatchableHTMLText;
+
+                if (gpuText)
+                {
+                    gpuText.currentKey = '--';
+                    gpuText.texture = Texture.EMPTY;
+                }
+
                 text.onViewUpdate();
             }
         }

--- a/src/scene/text-html/HTMLTextPipe.ts
+++ b/src/scene/text-html/HTMLTextPipe.ts
@@ -154,9 +154,23 @@ export class HTMLTextPipe implements RenderPipe<HTMLText>
         }
 
         batchableHTMLText.texturePromise = texturePromise;
-        batchableHTMLText.currentKey = htmlText.styleKey;
+        const expectedKey = htmlText.styleKey;
 
-        batchableHTMLText.texture = await texturePromise;
+        batchableHTMLText.currentKey = expectedKey;
+
+        const resolvedTexture = await texturePromise;
+
+        // If a WebGL context loss/restore occurred while we were awaiting the texture,
+        // contextChange() will have reset currentKey to '--' and texture to Texture.EMPTY.
+        // In that case, discard the now-stale texture to avoid overwriting the reset state.
+        if (batchableHTMLText.currentKey !== expectedKey)
+        {
+            batchableHTMLText.generatingTexture = false;
+
+            return;
+        }
+
+        batchableHTMLText.texture = resolvedTexture;
 
         // need a rerender...
         const renderGroup = htmlText.renderGroup || htmlText.parentRenderGroup;

--- a/src/scene/text-html/HTMLTextSystem.ts
+++ b/src/scene/text-html/HTMLTextSystem.ts
@@ -110,6 +110,19 @@ export class HTMLTextSystem implements System
         return this._activeTextures[textKey]?.usageCount ?? null;
     }
 
+    /**
+     * Clears all active texture references without returning them to the pool.
+     * This is used when the WebGL context is lost and restored, as the GPU textures
+     * are already invalidated and new ones need to be created.
+     */
+    public clearActiveTextures()
+    {
+        for (const key in this._activeTextures)
+        {
+            this._activeTextures[key] = null;
+        }
+    }
+
     private _increaseReferenceCount(textKey: string)
     {
         this._activeTextures[textKey].usageCount++;

--- a/src/scene/text/canvas/CanvasTextPipe.ts
+++ b/src/scene/text/canvas/CanvasTextPipe.ts
@@ -1,5 +1,6 @@
 import { ExtensionType } from '../../../extensions/Extensions';
 import { GCManagedHash } from '../../../utils/data/GCManagedHash';
+import { Texture } from '../../../rendering/renderers/shared/texture/Texture';
 import { updateTextBounds } from '../utils/updateTextBounds';
 import { BatchableText } from './BatchableText';
 
@@ -62,7 +63,7 @@ export class CanvasTextPipe implements RenderPipe<Text>
                 if (gpuText)
                 {
                     gpuText.currentKey = '--';
-                    gpuText.texture = null;
+                    gpuText.texture = Texture.EMPTY;
                 }
 
                 text.onViewUpdate();

--- a/src/scene/text/canvas/CanvasTextPipe.ts
+++ b/src/scene/text/canvas/CanvasTextPipe.ts
@@ -28,6 +28,7 @@ export class CanvasTextPipe implements RenderPipe<Text>
     {
         this._renderer = renderer;
         renderer.runners.resolutionChange.add(this);
+        renderer.runners.contextChange.add(this);
         this._managedTexts = new GCManagedHash({
             renderer,
             type: 'renderable',
@@ -43,6 +44,29 @@ export class CanvasTextPipe implements RenderPipe<Text>
             const text = this._managedTexts.items[key];
 
             if (text?._autoResolution) text.onViewUpdate();
+        }
+    }
+
+    protected contextChange()
+    {
+        this._renderer.canvasText.clearActiveTextures();
+
+        for (const key in this._managedTexts.items)
+        {
+            const text = this._managedTexts.items[key];
+
+            if (text)
+            {
+                const gpuText = text._gpuData[this._renderer.uid] as BatchableText;
+
+                if (gpuText)
+                {
+                    gpuText.currentKey = '--';
+                    gpuText.texture = null;
+                }
+
+                text.onViewUpdate();
+            }
         }
     }
 

--- a/src/scene/text/shared/AbstractTextSystem.ts
+++ b/src/scene/text/shared/AbstractTextSystem.ts
@@ -243,6 +243,19 @@ export abstract class AbstractTextSystem implements System
         return this._activeTextures[textKey]?.usageCount ?? 0;
     }
 
+    /**
+     * Clears all active texture references without returning them to the pool.
+     * This is used when the WebGL context is lost and restored, as the GPU textures
+     * are already invalidated and new ones need to be created.
+     */
+    public clearActiveTextures()
+    {
+        for (const key in this._activeTextures)
+        {
+            this._activeTextures[key] = null;
+        }
+    }
+
     private _increaseReferenceCount(textKey: string)
     {
         this._activeTextures[textKey].usageCount++;


### PR DESCRIPTION
## Summary

Fixes #11685

When WebGL context is lost and restored (e.g., via `chrome://gpuclean`), all text objects (both Canvas `Text` and `HTMLText`) remain invisible because:

1. The `GlTextureSystem` correctly destroys all GL textures on context change, but the text rendering pipes (`CanvasTextPipe`, `HTMLTextPipe`) are not notified
2. The `_activeTextures` cache in `AbstractTextSystem` and `HTMLTextSystem` still holds references to stale/destroyed textures
3. Since text content hasn't changed, `_didTextUpdate` remains `false` and textures are never regenerated

This PR:
- Registers `CanvasTextPipe` and `HTMLTextPipe` to the `contextChange` runner
- On context change, clears the stale `_activeTextures` cache entries via a new `clearActiveTextures()` method
- Resets each `BatchableText`/`BatchableHTMLText` `currentKey` to force texture regeneration on next render
- Calls `text.onViewUpdate()` to mark all managed text objects as dirty

## Changes

- **`src/scene/text/canvas/CanvasTextPipe.ts`** - Listen to `contextChange` runner and invalidate all cached text on context restore
- **`src/scene/text/shared/AbstractTextSystem.ts`** - Add `clearActiveTextures()` method to clear stale texture references
- **`src/scene/text-html/HTMLTextPipe.ts`** - Same context change handling for HTML text
- **`src/scene/text-html/HTMLTextSystem.ts`** - Add `clearActiveTextures()` method for HTML text system

## Test plan

- [ ] Open a PixiJS scene with `Text` objects in Chrome
- [ ] Navigate to `chrome://gpuclean` or `chrome://gpucrash` to force WebGL context loss/restore
- [ ] Verify that all text objects are visible after the context is restored
- [ ] Verify that `HTMLText` objects also survive context loss/restore
- [ ] Verify no regression in normal text rendering

/claim #11685

Generated with [Claude Code](https://claude.com/claude-code)