### PR TITLE
fix: Reduce work done by the blur shader

### DIFF
--- a/src/filters/defaults/blur/gl/generateBlurFragSource.ts
+++ b/src/filters/defaults/blur/gl/generateBlurFragSource.ts
@@ -7,7 +7,6 @@ const fragTemplate = [
 
     'void main(void)',
     '{',
-    '    finalColor = vec4(0.0);',
     '    %blur%',
     '}',
 
@@ -22,31 +21,23 @@ export function generateBlurFragSource(kernelSize: number): string
     const kernel = GAUSSIAN_VALUES[kernelSize];
     const halfLength = kernel.length;
 
-    let fragSource = fragTemplate;
-
     let blurLoop = '';
-    const template = 'finalColor += texture(uTexture, vBlurTexCoords[%index%]) * %value%;';
-    let value: number;
+    const prefixFirst = 'finalColor = ';
+    const prefixRest = '    + ';
+    const template = 'texture(uTexture, vBlurTexCoords[%index%]) * %value%';
 
     for (let i = 0; i < kernelSize; i++)
     {
-        let blur = template.replace('%index%', i.toString());
+        const prefix = i === 0 ? prefixFirst : prefixRest;
+        const value = i < halfLength ? i : kernelSize - i - 1;
+        const blur = template
+            .replace('%index%', i.toString())
+            .replace('%value%', kernel[value].toString());
 
-        value = i;
-
-        if (i >= halfLength)
-        {
-            value = kernelSize - i - 1;
-        }
-
-        blur = blur.replace('%value%', kernel[value].toString());
-
-        blurLoop += blur;
-        blurLoop += '\n';
+        blurLoop += `${prefix}${blur}\n`;
     }
 
-    fragSource = fragSource.replace('%blur%', blurLoop);
-    fragSource = fragSource.replace('%size%', kernelSize.toString());
-
-    return fragSource;
+    return fragTemplate
+        .replace('%blur%', `${blurLoop};`)
+        .replace('%size%', kernelSize.toString());
 }


### PR DESCRIPTION
##### Description of change
By merging the add rather than having multiple assign adds we can get a few fewer operations per kernel size. Change is backwards compatible.

[SPIR-V disassembly before][before] and [SPIR-V disassembly after][after].

I have not made any changes to the webgpu shader as I do not know how to get the disassembly of a webgpu fragment shader.

[before]: https://shader-playground.timjones.io/9d830035b1439b6b6378d8a674eadde6
[after]: https://shader-playground.timjones.io/b713f7f1d53a1786f7389b25212a000a

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Release Notes</summary>

##### Fixes
- Optimized blur shader to reduce operations by merging additions instead of performing multiple compound-add assignments.

</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->