### PR TITLE
fix: invalidate cached source in color.setAlpha() to prevent stale alpha reuse

### DIFF
--- a/src/color/Color.ts
+++ b/src/color/Color.ts
@@ -974,6 +974,7 @@ export class Color
     public setAlpha(alpha: number): this
     {
         this._components[3] = this._clamp(alpha);
+        this._value = null;
 
         return this;
     }

--- a/src/color/__docs__/color.md
+++ b/src/color/__docs__/color.md
@@ -112,6 +112,10 @@ console.log(color.blue);  // 0
 console.log(color.alpha); // 1
 
 color.setAlpha(0.5); // 50% transparent
+
+// Calling setValue() again restores alpha from that source
+color.setValue(0xffffff);
+console.log(color.alpha); // 1
 ```
 
 ## Color conversions

--- a/src/color/__tests__/Color.test.ts
+++ b/src/color/__tests__/Color.test.ts
@@ -280,6 +280,17 @@ describe('Color', () =>
         expect(color.value).toBe(0x999999);
     });
 
+    it('should reset alpha when setting same numeric value after setAlpha', () =>
+    {
+        const color = new Color();
+
+        color.setValue(0xffffff).setAlpha(0.8);
+        color.setValue(0xffffff);
+
+        expect(color.toHexa()).toBe('#ffffffff');
+        expect(color.alpha).toBe(1);
+    });
+
     it('should premultiply color correctly', () =>
     {
         const color = new Color([0.5, 0.5, 0.5, 1]).premultiply(0.5);


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Fixes a `Color` cache invalidation bug where `setAlpha()` could leak stale alpha into later `setValue()` calls with the same source value. Fix for #11918 

What changed:
- Updated `Color.setAlpha()` to invalidate cached source state by setting `_value = null`.
- Added a regression unit test in `src/color/__tests__/Color.test.ts` that reproduces:
  - `setValue(0xffffff).setAlpha(0.8)`
  - `setValue(0xffffff)`
  - and asserts resulting alpha is fully opaque (`#ffffffff`, `alpha === 1`).

Why:
- Prevents `Graphics.fill(0xffffff)` (and similar flows using `Color.shared`) from inheriting alpha from previous shared color usage.

##### Pre-Merge Checklist
- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Release Notes</summary>

##### Fixes
- Fixed `Color.setAlpha()` cache invalidation bug where stale alpha values could be reused by subsequent `setValue()` calls with the same source. The cached source is now properly invalidated when alpha is updated.

</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->