### PR TITLE
fix: Correctly handle offset in ColorMatrixFilter

### DIFF
--- a/src/filters/defaults/color-matrix/ColorMatrixFilter.ts
+++ b/src/filters/defaults/color-matrix/ColorMatrixFilter.ts
@@ -113,17 +113,20 @@ export class ColorMatrixFilter extends Filter
      */
     private _loadMatrix(matrix: ColorMatrix, multiply = false): void
     {
-        let newMatrix = matrix;
-
         if (multiply)
         {
+            const newMatrix = [...matrix] as ColorMatrix;
+
             this._multiply(newMatrix, this.matrix, matrix);
-            newMatrix = this._colorMatrix(newMatrix) as any;
+            this.resources.colorMatrixUniforms.uniforms.uColorMatrix = newMatrix;
+        }
+        else
+        {
+            this.resources.colorMatrixUniforms.uniforms.uColorMatrix = matrix;
         }
 
         // set the new matrix
 
-        this.resources.colorMatrixUniforms.uniforms.uColorMatrix = newMatrix;
         this.resources.colorMatrixUniforms.update();
     }
 
@@ -166,24 +169,6 @@ export class ColorMatrixFilter extends Filter
         out[19] = (a[15] * b[4]) + (a[16] * b[9]) + (a[17] * b[14]) + (a[18] * b[19]) + a[19];
 
         return out;
-    }
-
-    /**
-     * Create a Float32 Array and normalize the offset component to 0-1
-     * @param {number[]} matrix - 5x4 matrix
-     * @returns {number[]} 5x4 matrix with all values between 0-1
-     */
-    private _colorMatrix(matrix: ColorMatrix): ColorMatrix
-    {
-        // Create a Float32 Array and normalize the offset component to 0-1
-        const m = new Float32Array(matrix);
-
-        m[4] /= 255;
-        m[9] /= 255;
-        m[14] /= 255;
-        m[19] /= 255;
-
-        return m as any;
     }
 
     /**
@@ -626,9 +611,9 @@ export class ColorMatrixFilter extends Filter
     public technicolor(multiply: boolean): void
     {
         const matrix: ColorMatrix = [
-            1.9125277891456083, -0.8545344976951645, -0.09155508482755585, 0, 11.793603434377337,
-            -0.3087833385928097, 1.7658908555458428, -0.10601743074722245, 0, -70.35205161461398,
-            -0.231103377548616, -0.7501899197440212, 1.847597816108189, 0, 30.950940869491138,
+            1.9125277891456083, -0.8545344976951645, -0.09155508482755585, 0, 0.046249425232852304,
+            -0.3087833385928097, 1.7658908555458428, -0.10601743074722245, 0, -0.2758903984886823,
+            -0.231103377548616, -0.7501899197440212, 1.847597816108189, 0, 0.12137623870388682,
             0, 0, 0, 1, 0,
         ];
 
@@ -727,9 +712,9 @@ export class ColorMatrixFilter extends Filter
     public kodachrome(multiply: boolean): void
     {
         const matrix: ColorMatrix = [
-            1.1285582396593525, -0.3967382283601348, -0.03992559172921793, 0, 63.72958762196502,
-            -0.16404339962244616, 1.0835251566291304, -0.05498805115633132, 0, 24.732407896706203,
-            -0.16786010706155763, -0.5603416277695248, 1.6014850761964943, 0, 35.62982807460946,
+            1.1285582396593525, -0.3967382283601348, -0.03992559172921793, 0, 0.24991995145868634,
+            -0.16404339962244616, 1.0835251566291304, -0.05498805115633132, 0, 0.09698983488904393,
+            -0.16786010706155763, -0.5603416277695248, 1.6014850761964943, 0, 0.13972481597886063,
             0, 0, 0, 1, 0,
         ];
 
@@ -760,9 +745,9 @@ export class ColorMatrixFilter extends Filter
     public browni(multiply: boolean): void
     {
         const matrix: ColorMatrix = [
-            0.5997023498159715, 0.34553243048391263, -0.2708298674538042, 0, 47.43192855600873,
-            -0.037703249837783157, 0.8609577587992641, 0.15059552388459913, 0, -36.96841498319127,
-            0.24113635128153335, -0.07441037908422492, 0.44972182064877153, 0, -7.562075277591283,
+            0.5997023498159715, 0.34553243048391263, -0.2708298674538042, 0, 0.1860075629647401,
+            -0.037703249837783157, 0.8609577587992641, 0.15059552388459913, 0, -0.14497417640467167,
+            0.24113635128153335, -0.07441037908422492, 0.44972182064877153, 0, -0.029655197167024642,
             0, 0, 0, 1, 0,
         ];
 
@@ -793,9 +778,9 @@ export class ColorMatrixFilter extends Filter
     public vintage(multiply: boolean): void
     {
         const matrix: ColorMatrix = [
-            0.6279345635605994, 0.3202183420819367, -0.03965408211312453, 0, 9.651285835294123,
-            0.02578397704808868, 0.6441188644374771, 0.03259127616149294, 0, 7.462829176470591,
-            0.0466055556782719, -0.0851232987247891, 0.5241648018700465, 0, 5.159190588235296,
+            0.6279345635605994, 0.3202183420819367, -0.03965408211312453, 0, 0.037848179746251466,
+            0.02578397704808868, 0.6441188644374771, 0.03259127616149294, 0, 0.029265996770472907,
+            0.0466055556782719, -0.0851232987247891, 0.5241648018700465, 0, 0.020232119953863904,
             0, 0, 0, 1, 0,
         ];
 

--- a/src/filters/defaults/color-matrix/__tests__/ColorMatrixFilter.test.ts
+++ b/src/filters/defaults/color-matrix/__tests__/ColorMatrixFilter.test.ts
@@ -81,4 +81,17 @@ describe('ColorMatrixFilter', () =>
         filter.destroy();
         expect(multiplySpy).toHaveBeenCalledTimes(19);
     });
+
+    it('should be able to apply technicolor matrix with multiply and get same values as without multiply', () =>
+    {
+        const filter1 = new ColorMatrixFilter();
+        const filter2 = new ColorMatrixFilter();
+
+        filter1.technicolor(true);
+        filter2.technicolor(false);
+
+        expect(filter1.matrix).toEqual(filter2.matrix);
+        filter1.destroy();
+        filter2.destroy();
+    });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Fixes #8359. Split from #11923.

Before the filter behaved differently if you used the multiply flag or not:

<img width="500" height="557" alt="ColorMatrixFilter technicolor, multiply=false, before change" src="https://github.com/user-attachments/assets/9a4097b2-b5da-4469-b59e-c916eac47e4c" />
<img width="500" height="557" alt="ColorMatrixFilter technicolor, multiply=true, before change" src="https://github.com/user-attachments/assets/9942c129-104b-4597-bd6c-67cdc8b98771" />

Now they should behave the same:

<img width="500" height="557" alt="ColorMatrixFilter technicolor, multiply=false, after change" src="https://github.com/user-attachments/assets/a37fb94a-24c1-47e6-ad76-ff08460a16bc" />
<img width="500" height="557" alt="ColorMatrixFilter technicolor, multiply=true, after change" src="https://github.com/user-attachments/assets/01657464-78bf-46d1-8b4c-00b90c23319e" />

The images above were generated using the following filters:
```ts
const filter1 = new ColorMatrixFilter();
filter1.technicolor(false);

const filter2 = new ColorMatrixFilter();
filter2.technicolor(true);
```

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Release Notes</summary>

##### Fixes
- Fixed `ColorMatrixFilter` to produce consistent results regardless of the `multiply` flag setting. Color matrix transformations (including `technicolor()`, `sepia()`, `kodachrome()`, `browni()`, `vintage()`, and others) now produce identical output whether `multiply=true` or `multiply=false`, resolving an issue where the multiply path would incorrectly normalize color offsets.

</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->