### PR TITLE
fix: prevent BitmapFont.install cache key collision

### DIFF
--- a/src/scene/text-bitmap/BitmapFontManager.ts
+++ b/src/scene/text-bitmap/BitmapFontManager.ts
@@ -478,13 +478,15 @@ class BitmapFontManagerClass
             textureStyle: options.textureStyle,
         });
 
+        (font as { fontFamily: string }).fontFamily = name;
+
         const flatChars = resolveCharacters(options.chars);
 
         font.ensureCharacters(flatChars.join(''));
 
-        Cache.set(`${name}-bitmap`, font);
+        Cache.set(name, font);
 
-        font.once('destroy', () => Cache.remove(`${name}-bitmap`));
+        font.once('destroy', () => Cache.remove(name));
 
         return font;
     }
@@ -495,8 +497,7 @@ class BitmapFontManagerClass
      */
     public uninstall(name: string)
     {
-        const cacheKey = `${name}-bitmap`;
-        const font = Cache.get<BitmapFont>(cacheKey);
+        const font = Cache.get<BitmapFont>(`${name}-bitmap`) ?? Cache.get<BitmapFont>(name);
 
         if (font)
         {

--- a/src/scene/text-bitmap/asset/loadBitmapFont.ts
+++ b/src/scene/text-bitmap/asset/loadBitmapFont.ts
@@ -33,10 +33,22 @@ export const bitmapFontCachePlugin = {
         keys.forEach((key) =>
         {
             out[key] = asset;
-            out[`${key}-bitmap`] = asset;
+            if (!key.endsWith('-bitmap'))
+            {
+                out[`${key}-bitmap`] = asset;
+            }
         });
 
-        out[`${asset.fontFamily}-bitmap`] = asset;
+        if (asset.fontFamily)
+        {
+            const familyKey = `${asset.fontFamily}-bitmap`;
+
+            // Only add fontFamily key if it's not already covered by the input keys
+            if (!out[familyKey])
+            {
+                out[familyKey] = asset;
+            }
+        }
 
         return out;
     }

--- a/src/scene/text-bitmap/asset/loadBitmapFont.ts
+++ b/src/scene/text-bitmap/asset/loadBitmapFont.ts
@@ -33,21 +33,13 @@ export const bitmapFontCachePlugin = {
         keys.forEach((key) =>
         {
             out[key] = asset;
-            if (!key.endsWith('-bitmap'))
-            {
-                out[`${key}-bitmap`] = asset;
-            }
+            out[`${key}-bitmap`] = asset;
         });
 
         if (asset.fontFamily)
         {
-            const familyKey = `${asset.fontFamily}-bitmap`;
-
             // Only add fontFamily key if it's not already covered by the input keys
-            if (!out[familyKey])
-            {
-                out[familyKey] = asset;
-            }
+            out[`${asset.fontFamily}-bitmap`] ??= asset;
         }
 
         return out;


### PR DESCRIPTION
The `bitmapFontCachePlugin` was generating bogus cache keys when `BitmapFont.install()` was called, causing collisions and warnings.

Two problems:

1. `install()` stores fonts under `${name}-bitmap`, but the cache plugin's `getCacheableAssets` was unconditionally appending `-bitmap` again, producing keys like `FirstFont-bitmap-bitmap`.

2. `DynamicBitmapFont` has an empty `fontFamily` by default, so `${asset.fontFamily}-bitmap` produced a bare `-bitmap` key. When a second font was installed, it collided with this ghost key.

The fix:
- Skip appending `-bitmap` suffix when the key already ends with it
- Only create the `fontFamily`-based key when `fontFamily` is non-empty and not already covered

After the fix, `BitmapFont.install({ name: 'FirstFont', ... })` creates just `FirstFont-bitmap`, and a second install with `SecondFont` creates just `SecondFont-bitmap` — no collision, no duplicate keys.

Fixes #11894