### PR TITLE
fix: NineSliceSprite renders outside trimmed frame

### DIFF
--- a/src/scene/sprite-nine-slice/NineSliceGeometry.ts
+++ b/src/scene/sprite-nine-slice/NineSliceGeometry.ts
@@ -28,6 +28,9 @@ export interface NineSliceGeometryOptions
 
     /** The anchor point of the NineSliceSprite. */
     anchor?: PointData
+
+    /** The texture UVs to use for mapping. When provided, UVs are computed directly in texture-source space. */
+    textureUvs?: { x0: number; y0: number; x1: number; y1: number; x2: number; y2: number; x3: number; y3: number }
 }
 
 /**
@@ -71,6 +74,8 @@ export class NineSliceGeometry extends PlaneGeometry
     private _originalHeight: number;
     private _anchorX: any;
     private _anchorY: number;
+    /** @internal */
+    public _textureUvs: { x0: number; y0: number; x1: number; y1: number; x2: number; y2: number; x3: number; y3: number } | null = null;
 
     constructor(options: NineSliceGeometryOptions = {})
     {
@@ -103,6 +108,8 @@ export class NineSliceGeometry extends PlaneGeometry
 
         this._anchorX = options.anchor?.x;
         this._anchorY = options.anchor?.y;
+
+        this._textureUvs = options.textureUvs ?? this._textureUvs;
 
         this.updateUvs();
         this.updatePositions();
@@ -151,21 +158,60 @@ export class NineSliceGeometry extends PlaneGeometry
     public updateUvs()
     {
         const uvs = this.uvs;
+        const textureUvs = this._textureUvs;
 
-        uvs[0] = uvs[8] = uvs[16] = uvs[24] = 0;
-        uvs[1] = uvs[3] = uvs[5] = uvs[7] = 0;
+        if (textureUvs)
+        {
+            // When texture UVs are provided, compute UVs directly in texture-source space.
+            // This correctly handles trimmed/atlas textures where the frame
+            // does not cover the entire source texture.
+            const uLeft = textureUvs.x0;
+            const uRight = textureUvs.x1;
+            const vTop = textureUvs.y0;
+            const vBottom = textureUvs.y3;
 
-        uvs[6] = uvs[14] = uvs[22] = uvs[30] = 1;
-        uvs[25] = uvs[27] = uvs[29] = uvs[31] = 1;
+            const frameW = uRight - uLeft;
+            const frameH = vBottom - vTop;
 
-        const _uvw = 1.0 / this._originalWidth;
-        const _uvh = 1.0 / this._originalHeight;
+            // leftWidth etc. are in pixels relative to the frame content,
+            // matching the Canvas renderer behaviour.
+            const _uvw = frameW / this._originalWidth;
+            const _uvh = frameH / this._originalHeight;
 
-        uvs[2] = uvs[10] = uvs[18] = uvs[26] = _uvw * this._leftWidth;
-        uvs[9] = uvs[11] = uvs[13] = uvs[15] = _uvh * this._topHeight;
+            const uCutLeft = uLeft + (_uvw * this._leftWidth);
+            const uCutRight = uRight - (_uvw * this._rightWidth);
+            const vCutTop = vTop + (_uvh * this._topHeight);
+            const vCutBottom = vBottom - (_uvh * this._bottomHeight);
 
-        uvs[4] = uvs[12] = uvs[20] = uvs[28] = 1 - (_uvw * this._rightWidth);
-        uvs[17] = uvs[19] = uvs[21] = uvs[23] = 1 - (_uvh * this._bottomHeight);
+            // x (horizontal) UVs for each column
+            uvs[0] = uvs[8] = uvs[16] = uvs[24] = uLeft;
+            uvs[2] = uvs[10] = uvs[18] = uvs[26] = uCutLeft;
+            uvs[4] = uvs[12] = uvs[20] = uvs[28] = uCutRight;
+            uvs[6] = uvs[14] = uvs[22] = uvs[30] = uRight;
+
+            // y (vertical) UVs for each row
+            uvs[1] = uvs[3] = uvs[5] = uvs[7] = vTop;
+            uvs[9] = uvs[11] = uvs[13] = uvs[15] = vCutTop;
+            uvs[17] = uvs[19] = uvs[21] = uvs[23] = vCutBottom;
+            uvs[25] = uvs[27] = uvs[29] = uvs[31] = vBottom;
+        }
+        else
+        {
+            uvs[0] = uvs[8] = uvs[16] = uvs[24] = 0;
+            uvs[1] = uvs[3] = uvs[5] = uvs[7] = 0;
+
+            uvs[6] = uvs[14] = uvs[22] = uvs[30] = 1;
+            uvs[25] = uvs[27] = uvs[29] = uvs[31] = 1;
+
+            const _uvw = 1.0 / this._originalWidth;
+            const _uvh = 1.0 / this._originalHeight;
+
+            uvs[2] = uvs[10] = uvs[18] = uvs[26] = _uvw * this._leftWidth;
+            uvs[9] = uvs[11] = uvs[13] = uvs[15] = _uvh * this._topHeight;
+
+            uvs[4] = uvs[12] = uvs[20] = uvs[28] = 1 - (_uvw * this._rightWidth);
+            uvs[17] = uvs[19] = uvs[21] = uvs[23] = 1 - (_uvh * this._bottomHeight);
+        }
 
         this.getBuffer('aUV').update();
     }

--- a/src/scene/sprite-nine-slice/NineSliceSpritePipe.ts
+++ b/src/scene/sprite-nine-slice/NineSliceSpritePipe.ts
@@ -21,6 +21,24 @@ export class NineSliceSpriteGpuData extends BatchableMesh implements GPUData
         this.geometry = new NineSliceGeometry();
     }
 
+    /**
+     * Override uvs getter to return geometry UVs directly when texture UVs
+     * are baked into the geometry (for trimmed/atlas textures).
+     * This bypasses the TextureMatrix transformation that would otherwise
+     * double-transform the already-correct UVs.
+     */
+    get uvs()
+    {
+        const geometry = this.geometry as NineSliceGeometry;
+
+        if (geometry._textureUvs)
+        {
+            return geometry.getBuffer('aUV').data as Float32Array;
+        }
+
+        return super.uvs;
+    }
+
     public destroy()
     {
         this.geometry.destroy();
@@ -81,11 +99,24 @@ export class NineSliceSpritePipe implements RenderPipe<NineSliceSprite>
 
     private _updateBatchableSprite(sprite: NineSliceSprite, batchableSprite: BatchableMesh)
     {
-        (batchableSprite.geometry as NineSliceGeometry)
-            .update(sprite);
+        const texture = sprite._texture;
+        const geometry = batchableSprite.geometry as NineSliceGeometry;
+
+        // Check if the texture frame covers the entire source (no atlas/trim).
+        // When it doesn't, pass texture UVs so the geometry computes UVs directly
+        // in texture-source space, correctly handling trimmed/atlas textures.
+        const source = texture.source;
+        const isSimple = texture.frame.x === 0
+            && texture.frame.y === 0
+            && texture.frame.width === source.width
+            && texture.frame.height === source.height
+            && texture.rotate === 0;
+
+        geometry._textureUvs = isSimple ? null : texture.uvs;
+        geometry.update(sprite);
 
         // = sprite.bounds;
-        batchableSprite.setTexture(sprite._texture);
+        batchableSprite.setTexture(texture);
     }
 
     private _getGpuSprite(sprite: NineSliceSprite): NineSliceSpriteGpuData

--- a/src/scene/sprite-nine-slice/__tests__/NineSliceSprite.test.ts
+++ b/src/scene/sprite-nine-slice/__tests__/NineSliceSprite.test.ts
@@ -1,10 +1,11 @@
 import { Bounds } from '../../container/bounds/Bounds';
 import { getGlobalBounds } from '../../container/bounds/getGlobalBounds';
 import { NineSliceSprite } from '../NineSliceSprite';
+import { NineSliceGeometry } from '../NineSliceGeometry';
 import '../../mesh/init';
 import '../init';
 import { getTexture } from '@test-utils';
-import { Point } from '~/maths';
+import { Point, Rectangle } from '~/maths';
 import { Texture } from '~/rendering';
 
 import type { TextureSource } from '~/rendering';
@@ -178,6 +179,93 @@ describe('NineSliceSprite', () =>
             sprite.anchor.x = 0.5;
 
             expect(spy).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('Trimmed Texture Support', () =>
+    {
+        it('should compute UVs correctly when textureUvs are provided', () =>
+        {
+            const geometry = new NineSliceGeometry({
+                width: 100,
+                height: 100,
+                originalWidth: 64,
+                originalHeight: 64,
+                leftWidth: 10,
+                topHeight: 10,
+                rightWidth: 10,
+                bottomHeight: 10,
+            });
+
+            // Simulate a trimmed/atlas texture with frame at (0.25, 0.25) to (0.75, 0.75)
+            // in source-normalized space (i.e., frame occupies the center quarter of the source)
+            geometry._textureUvs = {
+                x0: 0.25, y0: 0.25,
+                x1: 0.75, y1: 0.25,
+                x2: 0.75, y2: 0.75,
+                x3: 0.25, y3: 0.75,
+            };
+            geometry.update({
+                originalWidth: 64,
+                originalHeight: 64,
+                leftWidth: 10,
+                topHeight: 10,
+                rightWidth: 10,
+                bottomHeight: 10,
+            });
+
+            const uvs = geometry.uvs;
+
+            const frameW = 0.75 - 0.25; // 0.5
+            const frameH = 0.75 - 0.25; // 0.5
+
+            // UV boundaries should be within the frame UV range
+            // Left edge
+            expect(uvs[0]).toBeCloseTo(0.25);
+            // Left cut: 0.25 + (0.5 / 64) * 10
+            expect(uvs[2]).toBeCloseTo(0.25 + (frameW / 64) * 10);
+            // Right cut: 0.75 - (0.5 / 64) * 10
+            expect(uvs[4]).toBeCloseTo(0.75 - (frameW / 64) * 10);
+            // Right edge
+            expect(uvs[6]).toBeCloseTo(0.75);
+
+            // Top edge
+            expect(uvs[1]).toBeCloseTo(0.25);
+            // Top cut: 0.25 + (0.5 / 64) * 10
+            expect(uvs[9]).toBeCloseTo(0.25 + (frameH / 64) * 10);
+            // Bottom cut: 0.75 - (0.5 / 64) * 10
+            expect(uvs[17]).toBeCloseTo(0.75 - (frameH / 64) * 10);
+            // Bottom edge
+            expect(uvs[25]).toBeCloseTo(0.75);
+        });
+
+        it('should use 0-1 UV range when textureUvs are not provided', () =>
+        {
+            const geometry = new NineSliceGeometry({
+                width: 100,
+                height: 100,
+                originalWidth: 64,
+                originalHeight: 64,
+                leftWidth: 10,
+                topHeight: 10,
+                rightWidth: 10,
+                bottomHeight: 10,
+            });
+
+            const uvs = geometry.uvs;
+
+            // Left edge = 0, right edge = 1
+            expect(uvs[0]).toBeCloseTo(0);
+            expect(uvs[6]).toBeCloseTo(1);
+
+            // Top edge = 0, bottom edge = 1
+            expect(uvs[1]).toBeCloseTo(0);
+            expect(uvs[25]).toBeCloseTo(1);
+
+            // Left cut = 10/64
+            expect(uvs[2]).toBeCloseTo(10 / 64);
+            // Right cut = 1 - 10/64
+            expect(uvs[4]).toBeCloseTo(1 - (10 / 64));
         });
     });
 });


### PR DESCRIPTION
## Summary

Fixes #11706

When a `NineSliceSprite` uses a trimmed/atlas texture (e.g. from a `Spritesheet` with `spriteSourceSize` and `sourceSize`), the UV coordinates were computed assuming the texture occupies the full 0–1 UV range. This caused the sprite to render pixels outside the trimmed frame area, unlike `Sprite` which correctly clips to the trimmed region.

## Changes

### `NineSliceGeometry`
- Added optional `textureUvs` field to `NineSliceGeometryOptions`
- When `textureUvs` is provided, `updateUvs()` computes UV coordinates directly in texture-source space, mapping the nine-slice cut points within the actual frame UV boundaries
- When `textureUvs` is not provided, behavior is unchanged (0–1 UV range)

### `NineSliceSpritePipe`
- Detects when a texture has a non-trivial frame (atlas/trimmed) by checking if the frame covers the entire source
- Passes `texture.uvs` to the geometry so UVs are computed in source space
- Overrides the `uvs` getter in `NineSliceSpriteGpuData` to bypass `TextureMatrix` transformation when UVs are already baked in source space (prevents double-transformation)

### Tests
- Added unit tests verifying correct UV computation with and without `textureUvs`

## How it works

For a trimmed texture with frame UVs `(x0, y0)` to `(x1, y3)` in source-normalized space:
- The nine-slice UV boundaries are mapped to `[x0, x1]` × `[y0, y3]` instead of `[0, 1]` × `[0, 1]`
- Cut points (left/right/top/bottom) are computed as fractions of the frame UV range
- The `NineSliceSpriteGpuData.uvs` getter returns the geometry UVs directly, bypassing `TextureMatrix.multiplyUvs()` which would otherwise double-transform them

For non-trimmed textures, the existing behavior is preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Release Notes</summary>

##### Fixes
- Fixed NineSliceSprite rendering pixels outside the trimmed frame when using trimmed or atlas textures. The sprite now correctly computes UVs in texture-source space for trimmed frames, matching the behavior of regular Sprite.

</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->