### PR TITLE
fix: correct MeshRope aspect ratio when textureScale > 0

### DIFF
--- a/src/scene/mesh-simple/MeshRope.ts
+++ b/src/scene/mesh-simple/MeshRope.ts
@@ -196,7 +196,7 @@ export class MeshRope extends Mesh
     {
         const geometry: RopeGeometry = this.geometry as any;
 
-        if (this.autoUpdate || geometry._width !== this.texture.height)
+        if (this.autoUpdate || geometry._width !== this.texture.height || geometry._textureWidth !== this.texture.width)
         {
             geometry._width = this.texture.height;
             geometry._textureWidth = this.texture.width;

--- a/src/scene/mesh-simple/MeshRope.ts
+++ b/src/scene/mesh-simple/MeshRope.ts
@@ -169,7 +169,12 @@ export class MeshRope extends Mesh
     constructor(options: MeshRopeOptions)
     {
         const { texture, points, textureScale, ...rest } = { ...MeshRope.defaultOptions, ...options };
-        const ropeGeometry = new RopeGeometry(definedProps({ width: texture.height, points, textureScale }));
+        const ropeGeometry = new RopeGeometry(definedProps({
+            width: texture.height,
+            points,
+            textureScale,
+            textureWidth: texture.width,
+        }));
 
         if (textureScale > 0)
         {
@@ -194,6 +199,7 @@ export class MeshRope extends Mesh
         if (this.autoUpdate || geometry._width !== this.texture.height)
         {
             geometry._width = this.texture.height;
+            geometry._textureWidth = this.texture.width;
             geometry.update();
         }
     }

--- a/src/scene/mesh-simple/RopeGeometry.ts
+++ b/src/scene/mesh-simple/RopeGeometry.ts
@@ -33,6 +33,12 @@ export interface RopeGeometryOptions
      * i.e. set textureScale=0.5 to scale it down twice.
      */
     textureScale?: number;
+    /**
+     * The horizontal width of the texture, used for correct aspect ratio
+     * when `textureScale > 0`. If not provided, defaults to `width`
+     * (which produces a 1:1 aspect ratio).
+     */
+    textureWidth?: number;
 }
 
 /**
@@ -57,6 +63,8 @@ export class RopeGeometry extends MeshGeometry
         points: [],
         /** Rope texture scale, if zero then the rope texture is stretched. */
         textureScale: 0,
+        /** The horizontal width of the texture for correct aspect ratio. */
+        textureWidth: 0,
     };
 
     /** An array of points that determine the rope. */
@@ -73,11 +81,18 @@ export class RopeGeometry extends MeshGeometry
     public _width: number;
 
     /**
+     * The horizontal width of the texture, used for correct aspect ratio
+     * when `textureScale > 0`. If zero, falls back to `_width`.
+     * @internal
+     */
+    public _textureWidth: number;
+
+    /**
      * @param options - Options to be applied to rope geometry
      */
     constructor(options: RopeGeometryOptions)
     {
-        const { width, points, textureScale } = { ...RopeGeometry.defaultOptions, ...options };
+        const { width, points, textureScale, textureWidth } = { ...RopeGeometry.defaultOptions, ...options };
 
         super({
             positions: new Float32Array(points.length * 4),
@@ -87,6 +102,7 @@ export class RopeGeometry extends MeshGeometry
 
         this.points = points;
         this._width = width;
+        this._textureWidth = textureWidth || width;
         this.textureScale = textureScale;
 
         this._build();
@@ -136,7 +152,7 @@ export class RopeGeometry extends MeshGeometry
 
         let amount = 0;
         let prev = points[0];
-        const textureWidth = this._width * this.textureScale;
+        const textureWidth = this._textureWidth * this.textureScale;
         const total = points.length; // - 1;
 
         for (let i = 0; i < total; i++)

--- a/src/scene/mesh-simple/RopeGeometry.ts
+++ b/src/scene/mesh-simple/RopeGeometry.ts
@@ -152,7 +152,7 @@ export class RopeGeometry extends MeshGeometry
 
         let amount = 0;
         let prev = points[0];
-        const textureWidth = this._textureWidth * this.textureScale;
+        const textureWidth = this._textureWidth * this.textureScale || 1;
         const total = points.length; // - 1;
 
         for (let i = 0; i < total; i++)

--- a/src/scene/mesh-simple/__tests__/RopeGeometry.test.ts
+++ b/src/scene/mesh-simple/__tests__/RopeGeometry.test.ts
@@ -1,0 +1,111 @@
+import { Point } from '../../../maths/point/Point';
+import { RopeGeometry } from '../RopeGeometry';
+
+describe('RopeGeometry', () =>
+{
+    it('should use correct aspect ratio when textureScale > 0', () =>
+    {
+        // Create a rope with points spaced 100px apart horizontally
+        const points = [
+            new Point(0, 0),
+            new Point(100, 0),
+            new Point(200, 0),
+        ];
+
+        // Simulate a texture that is 200px wide and 50px tall
+        // width (rope thickness) = texture.height = 50
+        // textureWidth = texture.width = 200
+        const ropeWithAspectRatio = new RopeGeometry({
+            width: 50,
+            points,
+            textureScale: 1,
+            textureWidth: 200,
+        });
+
+        // Without the fix, textureWidth would default to width (50),
+        // causing UV to advance by distance/50 instead of distance/200
+        // With the fix, UV advances by distance/200, preserving aspect ratio
+
+        const uvs = ropeWithAspectRatio.getBuffer('aUV').data;
+
+        // Point 0 at x=0: UV.x should be 0
+        expect(uvs[0]).toBe(0);
+
+        // Point 1 at x=100: UV.x should be 100/200 = 0.5
+        expect(uvs[4]).toBeCloseTo(0.5, 5);
+
+        // Point 2 at x=200: UV.x should be 200/200 = 1.0
+        expect(uvs[8]).toBeCloseTo(1.0, 5);
+    });
+
+    it('should produce 1:1 aspect ratio when textureWidth equals width', () =>
+    {
+        const points = [
+            new Point(0, 0),
+            new Point(100, 0),
+            new Point(200, 0),
+        ];
+
+        // When textureWidth == width (old behavior), UV advances by distance/width
+        const ropeSquare = new RopeGeometry({
+            width: 50,
+            points,
+            textureScale: 1,
+            textureWidth: 50,
+        });
+
+        const uvs = ropeSquare.getBuffer('aUV').data;
+
+        // Point 1 at x=100: UV.x should be 100/50 = 2.0
+        expect(uvs[4]).toBeCloseTo(2.0, 5);
+
+        // Point 2 at x=200: UV.x should be 200/50 = 4.0
+        expect(uvs[8]).toBeCloseTo(4.0, 5);
+    });
+
+    it('should fall back to _width when textureWidth is not provided', () =>
+    {
+        const points = [
+            new Point(0, 0),
+            new Point(100, 0),
+        ];
+
+        // No textureWidth provided - should fall back to width (backward compatible)
+        const rope = new RopeGeometry({
+            width: 50,
+            points,
+            textureScale: 1,
+        });
+
+        // _textureWidth should default to width
+        expect(rope._textureWidth).toBe(50);
+
+        const uvs = rope.getBuffer('aUV').data;
+
+        // UV.x should be 100/50 = 2.0 (same as old behavior)
+        expect(uvs[4]).toBeCloseTo(2.0, 5);
+    });
+
+    it('should stretch texture when textureScale is 0', () =>
+    {
+        const points = [
+            new Point(0, 0),
+            new Point(100, 0),
+            new Point(200, 0),
+        ];
+
+        const rope = new RopeGeometry({
+            width: 50,
+            points,
+            textureScale: 0,
+            textureWidth: 200,
+        });
+
+        const uvs = rope.getBuffer('aUV').data;
+
+        // When textureScale is 0, UV is stretched: i / (total - 1)
+        expect(uvs[0]).toBe(0);
+        expect(uvs[4]).toBeCloseTo(0.5, 5);
+        expect(uvs[8]).toBeCloseTo(1.0, 5);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes the incorrect 1:1 aspect ratio when using `textureScale > 0` on `MeshRope`.

Fixes #10821

## Problem

When `textureScale > 0`, the UV tiling calculation in `RopeGeometry._build()` used `_width` (rope thickness = `texture.height`) for the horizontal UV scale:

```ts
const textureWidth = this._width * this.textureScale;
```

Since `_width` equals `texture.height`, this produces a 1:1 aspect ratio regardless of the texture's actual dimensions. A 200x50 texture would tile as if it were 50x50.

## Solution

Added a `_textureWidth` property to `RopeGeometry` that stores the texture's horizontal width separately from `_width` (rope thickness). The UV calculation now uses:

```ts
const textureWidth = this._textureWidth * this.textureScale;
```

`MeshRope` passes `texture.width` as `textureWidth` to `RopeGeometry` and keeps it in sync during render updates.

## Backward Compatibility

- When `textureWidth` is not provided, it falls back to `_width` (old behavior)
- When `textureScale` is 0 (stretch mode), behavior is unchanged
- No breaking changes to the public API

## Files Changed

- `src/scene/mesh-simple/RopeGeometry.ts` - Added `_textureWidth` property and `textureWidth` option, fixed UV calculation
- `src/scene/mesh-simple/MeshRope.ts` - Pass `texture.width` as `textureWidth`, sync on render
- `src/scene/mesh-simple/__tests__/RopeGeometry.test.ts` - Unit tests for aspect ratio fix

## Testing

```ts
// Before: texture tiles as squares (1:1 aspect ratio)
// After: texture tiles with correct aspect ratio
const rope = new MeshRope({
  texture: snakeTexture, // e.g. 200x50
  points,
  textureScale: 1
});
```