### PR TITLE
fix: handle custom protocol schemes (e.g. tauri://) in path utilities

### DIFF
--- a/src/utils/__tests__/path.test.ts
+++ b/src/utils/__tests__/path.test.ts
@@ -389,4 +389,27 @@ describe('Paths', () =>
             name: 'my-font'
         });
     });
+
+    it('should handle custom protocol schemes like tauri://', () =>
+    {
+        // rootname should extract host for custom protocols with ://
+        expect(path.rootname('tauri://localhost/assets/atlas.json')).toBe('tauri://localhost/');
+        expect(path.rootname('tauri://localhost')).toBe('tauri://localhost/');
+        expect(path.rootname('tauri://localhost/')).toBe('tauri://localhost/');
+        expect(path.rootname('custom-app://myhost/path/to/file')).toBe('custom-app://myhost/');
+
+        // toAbsolute should preserve host for custom protocols
+        expect(path.toAbsolute('/assets/atlas.json', undefined, 'tauri://localhost/'))
+            .toEqual('tauri://localhost/assets/atlas.json');
+        expect(path.toAbsolute('/assets/atlas.json', 'tauri://localhost/'))
+            .toEqual('tauri://localhost/assets/atlas.json');
+
+        // dirname should work with custom protocols
+        expect(path.dirname('tauri://localhost/assets/atlas.json')).toBe('tauri://localhost/assets');
+        expect(path.dirname('tauri://localhost/assets')).toBe('tauri://localhost/');
+        expect(path.dirname('tauri://localhost/')).toBe('tauri://localhost/');
+
+        // file:/// should still work as before (no host)
+        expect(path.rootname('file:///foo/bar')).toBe('file:///');
+    });
 });

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -566,7 +566,7 @@ export const path: Path = {
 
         // if end is -1 and its a url then we need to add the path back
         // eslint-disable-next-line no-nested-ternary
-        if (end === -1) return hasRoot ? '/' : this.isUrl(origpath) ? proto + path : proto;
+        if (end === -1) return hasRoot ? '/' : (this.isUrl(origpath) || ((/^[^/:]+:\/\//).test(origpath) && !origpath.startsWith('file://'))) ? proto + path : proto;
         if (hasRoot && end === 1) return '//';
 
         return proto + path.slice(0, end);
@@ -598,9 +598,13 @@ export const path: Path = {
             root = this.getProtocol(path);
         }
 
-        if (this.isUrl(path))
+        // For any protocol with a double-slash authority (e.g. http://, https://, tauri://),
+        // extract the host portion as part of the root. This ensures custom protocols like
+        // tauri://localhost/ are handled correctly, not just http(s).
+        // Exclude file:/// which has no host component.
+        if (this.isUrl(path) || ((/^[^/:]+:\/\//).test(path) && !path.startsWith('file://')))
         {
-            // need to find the first path separator
+            // need to find the first path separator after the protocol
             const index = path.indexOf('/', root.length);
 
             if (index !== -1)


### PR DESCRIPTION
## Summary

Fixes incorrect path resolution for custom protocol schemes like `tauri://`.

Fixes #11106

## Problem

`path.rootname()` and `path.dirname()` only recognized `http://` and `https://` as URL protocols with host components (via `isUrl()`). Custom protocols like `tauri://localhost/` had their host portion dropped:

```ts
path.rootname('tauri://localhost/assets/atlas.json');
// Before: 'tauri://'
// After:  'tauri://localhost/'

path.toAbsolute('/assets/atlas.json', 'tauri://localhost/');
// Before: 'tauri://assets/atlas.json'  (localhost dropped!)
// After:  'tauri://localhost/assets/atlas.json'
```

## Solution

Extended the URL-with-host detection in `rootname()` and `dirname()` to match any protocol with `://` authority, excluding `file:///` which has no host component.

The regex `(/^[^/:]+:\/\//)` matches protocols like `tauri://`, `custom-app://`, etc., while the `!path.startsWith('file://')` guard preserves the existing `file:///` behavior.

## Backward Compatibility

- `http://` and `https://` behavior unchanged
- `file:///` behavior unchanged
- `C:/` Windows paths unchanged
- Only affects protocols with `://` that were previously not handled

## Files Changed

- `src/utils/path.ts` - Extended URL-with-host detection in `rootname()` and `dirname()`
- `src/utils/__tests__/path.test.ts` - Added tests for `tauri://` and custom protocols

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Release Notes</summary>

##### Fixes
- Fixed incorrect path resolution for custom protocol schemes (e.g., `tauri://`) in path utilities. The `path.rootname()` and `path.dirname()` functions now correctly handle any protocol with an authority component (`://) instead of only recognizing `http://` and `https://`. This ensures the host portion is preserved when resolving root-relative paths with custom protocols.

</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->