### PR TITLE
fix: clarify BackgroundLoader cache behavior in documentation (issue #11823)

### DIFF
--- a/src/assets/__docs__/background-loader.md
+++ b/src/assets/__docs__/background-loader.md
@@ -6,7 +6,10 @@ category: assets
 
 # Background loader
 
-The background loader queues asset downloads at low priority so they happen between frames while your application runs. Assets loaded this way are cached normally; when you later call `Assets.load()` or `Assets.loadBundle()` for the same asset, it resolves instantly if the background load already finished.
+The background loader queues asset downloads at low priority so they happen between frames while your application runs. Assets added to the background queue are **not** downloaded immediately – they are fetched one at a time (or up to the configured concurrency limit) while the main application continues. Only once each item has actually finished downloading is it placed into the regular cache.
+
+> **Important:** a background‑queued asset is *not* instantly available just because you called `Assets.backgroundLoad`. If you call `Assets.load()` or `Assets.loadBundle()` for the same asset before the background fetch has completed, the loader will treat it as a high‑priority request and perform a fresh download (pausing the background process); the call only resolves instantly when the background load has already finished.
+
 
 ## Loading bundles
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
✅ Documentation updated to reflect real behaviour

The “cached immediately” line in the background‑loader docs turned out to be the source of confusion.

In reality the loader just queues assets at low priority.
They only enter the normal cache once the background fetch actually finishes – not at the moment you call Assets.backgroundLoad().

That means:

calling [Assets.load()](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for an asset that’s still in the background queue will not resolve instantly; the loader will bump it to high priority and download it again, pausing the background process.
only when the background loader has completed the individual request will subsequent [Assets.load()](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)/loadBundle() calls become instant.
What changed
The top of [background-loader.md](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) now reads:

The background loader queues asset downloads at low priority so they happen between frames while your application runs. Assets added to the background queue are not downloaded immediately – they are fetched one at a time (or up to the configured concurrency limit) while the main application continues. Only once each item has actually finished downloading is it placed into the regular cache.

Important: a background‑queued asset is not instantly available just because you called Assets.backgroundLoad. If you call [Assets.load()](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) or Assets.loadBundle() for the same asset before the background fetch has completed, the loader will treat it as a high‑priority request and perform a fresh download (pausing the background process); the call only resolves instantly when the background load has already finished.

This aligns the docs with the behaviour described in [BackgroundLoader.ts](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and resolves the discrepancy mentioned in issue #11823.



- [ ] Tests and/or benchmarks are included
- [✅] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Release Notes</summary>

##### Chores
- Updated Background Loader documentation to clarify that background-queued assets are not immediately downloaded. Assets are fetched sequentially (or up to configured concurrency) and only placed in cache after completion. Added note that calling `Assets.load()` or `Assets.loadBundle()` before background fetch completes triggers a fresh high-priority download, pausing the background process.

</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->