### PR TITLE
fix: toAbsolute root-relative path handling for tauri://localhost

### DIFF
--- a/src/utils/__tests__/path.test.ts
+++ b/src/utils/__tests__/path.test.ts
@@ -320,6 +320,8 @@ describe('Paths', () =>
         expect(path.toAbsolute('/windows.png', undefined, 'C:\\foo\\')).toEqual(`C:/foo/windows.png`);
         expect(path.toAbsolute('/mac.png', undefined, '/foo/')).toEqual(`/foo/mac.png`);
         expect(path.toAbsolute('/mac.png', undefined, '/foo')).toEqual(`/foo/mac.png`);
+        expect(path.toAbsolute('/assets/atlas.json', 'tauri://localhost/pages/view.html'))
+            .toEqual('tauri://localhost/assets/atlas.json');
 
         // url is already absolute
         expect(path.toAbsolute('http://example.com/browser.png')).toEqual(`http://example.com/browser.png`);

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -590,6 +590,15 @@ export const path: Path = {
         assertPath(path);
         path = this.toPosix(path);
 
+        const protocolWithAuthority = (/^[^/:]+:\/\/[^/]+/).exec(path);
+
+        if (protocolWithAuthority)
+        {
+            const rootWithAuthority = protocolWithAuthority[0];
+
+            return rootWithAuthority.endsWith('/') ? rootWithAuthority : `${rootWithAuthority}/`;
+        }
+
         let root = '';
 
         if (path.startsWith('/')) root = '/';


### PR DESCRIPTION
## Summary
- preserve URL authority in `path.rootname` for non-http custom schemes that include host segments
- keep root-relative joins for `tauri://localhost` paths from dropping `localhost`
- add regression coverage in `path.toAbsolute` tests

## Test Plan
- `npm run test:unit -- --testPathPattern=src/utils/__tests__/path.test.ts`

Fixes #11106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Release Notes</summary>

##### Fixes
- Fixed `path.toAbsolute()` dropping authority (hostname) from custom-scheme URLs when resolving root-relative paths. Root-relative paths like `/assets/atlas.json` now correctly resolve against `tauri://localhost` as `tauri://localhost/assets/atlas.json` instead of `tauri://assets/atlas.json`.

</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->