### PR TITLE
fix: meshrope tiling aspect ratio when textureScale > 0

### DIFF
--- a/src/scene/mesh-simple/MeshRope.ts
+++ b/src/scene/mesh-simple/MeshRope.ts
@@ -169,7 +169,9 @@ export class MeshRope extends Mesh
     constructor(options: MeshRopeOptions)
     {
         const { texture, points, textureScale, ...rest } = { ...MeshRope.defaultOptions, ...options };
-        const ropeGeometry = new RopeGeometry(definedProps({ width: texture.height, points, textureScale }));
+        const ropeGeometry = new RopeGeometry(
+            definedProps({ width: texture.height, textureWidth: texture.width, points, textureScale })
+        );
 
         if (textureScale > 0)
         {

--- a/src/scene/mesh-simple/RopeGeometry.ts
+++ b/src/scene/mesh-simple/RopeGeometry.ts
@@ -20,6 +20,8 @@ export interface RopeGeometryOptions
 {
     /** The width (i.e., thickness) of the rope. */
     width?: number;
+    /** The texture width used to calculate UV tiling distance when textureScale is enabled. */
+    textureWidth?: number;
     /** An array of points that determine the rope. */
     points?: PointData[];
     /**
@@ -71,13 +73,14 @@ export class RopeGeometry extends MeshGeometry
      * @internal
      */
     public _width: number;
+    protected _textureWidth: number;
 
     /**
      * @param options - Options to be applied to rope geometry
      */
     constructor(options: RopeGeometryOptions)
     {
-        const { width, points, textureScale } = { ...RopeGeometry.defaultOptions, ...options };
+        const { width, points, textureScale, textureWidth } = { ...RopeGeometry.defaultOptions, ...options };
 
         super({
             positions: new Float32Array(points.length * 4),
@@ -87,6 +90,7 @@ export class RopeGeometry extends MeshGeometry
 
         this.points = points;
         this._width = width;
+        this._textureWidth = textureWidth ?? width;
         this.textureScale = textureScale;
 
         this._build();
@@ -136,7 +140,7 @@ export class RopeGeometry extends MeshGeometry
 
         let amount = 0;
         let prev = points[0];
-        const textureWidth = this._width * this.textureScale;
+        const textureWidth = this._textureWidth * this.textureScale;
         const total = points.length; // - 1;
 
         for (let i = 0; i < total; i++)

--- a/src/scene/mesh-simple/__tests__/RopeGeometry.test.ts
+++ b/src/scene/mesh-simple/__tests__/RopeGeometry.test.ts
@@ -1,0 +1,33 @@
+import { RopeGeometry } from '../RopeGeometry';
+
+describe('RopeGeometry', () =>
+{
+    it('uses texture width for uv tiling when textureScale is enabled', () =>
+    {
+        const geometry = new RopeGeometry({
+            points: [{ x: 0, y: 0 }, { x: 100, y: 0 }],
+            width: 50,
+            textureScale: 1,
+            textureWidth: 100,
+        } as any);
+
+        const uvs = geometry.getBuffer('aUV').data;
+
+        expect(uvs[4]).toBeCloseTo(1);
+        expect(uvs[6]).toBeCloseTo(1);
+    });
+
+    it('keeps existing width behavior when texture width is not provided', () =>
+    {
+        const geometry = new RopeGeometry({
+            points: [{ x: 0, y: 0 }, { x: 100, y: 0 }],
+            width: 50,
+            textureScale: 1,
+        });
+
+        const uvs = geometry.getBuffer('aUV').data;
+
+        expect(uvs[4]).toBeCloseTo(2);
+        expect(uvs[6]).toBeCloseTo(2);
+    });
+});


### PR DESCRIPTION
## Summary
- add a dedicated rope UV tiling width so uv distance can use texture width instead of rope thickness
- pass `texture.width` from `MeshRope` into `RopeGeometry` for textureScale tiling calculations
- add regression tests for both the new path and backward-compatible fallback behavior

## Test Plan
- `npm run test:unit -- --testPathPattern=src/scene/mesh-simple/__tests__/RopeGeometry.test.ts`

Fixes #10821

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Release Notes</summary>

##### Fixes
- Fixed MeshRope tiling textures with incorrect aspect ratio when `textureScale > 0`. MeshRope now uses the texture's actual aspect ratio instead of 1:1 (square) tiling.

##### Features
- Added optional `textureWidth` parameter to `RopeGeometry` to explicitly specify texture width for UV tiling calculations, independent of rope width. When not provided, falls back to rope width for backward compatibility.
  ```ts
  const geometry = new RopeGeometry({
    width: 50,
    textureWidth: 256, // Texture's actual width
    points: [...],
    textureScale: 1,
  });
  ```

</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->