### PR TITLE
feat: add visibleChanged event to container

### DIFF
--- a/src/scene/container/Container.ts
+++ b/src/scene/container/Container.ts
@@ -161,6 +161,20 @@ export interface ContainerEvents<C extends ContainerChild> extends PixiMixins.Co
      * ```
      */
     destroyed: [container: Container];
+
+    /**
+     * Emitted when the visible property on the container is changed.
+     * Useful for tracking visibility changes and triggering related behaviors.
+     * @param visible - The new visibility state of the container
+     * @example
+     * ```ts
+     * const container = new Container();
+     * container.on('visibleChanged', (visible) => {
+     *     console.log('Container visibility changed:', visible);
+     * });
+     * ```
+     */
+    visibleChanged: [visible: boolean];
 }
 
 type AnyEvent = {
@@ -1979,6 +1993,7 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
         this.localDisplayStatus ^= 0b010;
 
         this._onUpdate();
+        this.emit('visibleChanged', value);
     }
 
     /** @ignore */

--- a/src/scene/container/__tests__/Container.test.ts
+++ b/src/scene/container/__tests__/Container.test.ts
@@ -97,6 +97,34 @@ describe('Container', () =>
         expect(addedSpy).toHaveBeenCalledTimes(1);
     });
 
+    it('should emit a visibleChanged event when visibility is changed', () =>
+    {
+        const container = new Container();
+        const visibleChangedSpy = jest.fn();
+
+        container.on('visibleChanged', visibleChangedSpy);
+
+        container.visible = false;
+        expect(visibleChangedSpy).toHaveBeenCalledWith(false);
+
+        container.visible = true;
+        expect(visibleChangedSpy).toHaveBeenCalledWith(true);
+    });
+
+    it('should not emit a visibleChanged event when visibility is set to the same value', () =>
+    {
+        const container = new Container();
+        const visibleChangedSpy = jest.fn();
+
+        container.on('visibleChanged', visibleChangedSpy);
+
+        container.visible = true;
+        expect(visibleChangedSpy).toHaveBeenCalledTimes(0);
+
+        container.visible = true;
+        expect(visibleChangedSpy).toHaveBeenCalledTimes(0);
+    });
+
     it('should a global position correctly', async () =>
     {
         const container = new Container({


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

We're looking into adding some optimizations to automatically change behavior when visibility on containers change. With this event we would be able to avoid monkey patching the setter.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Release Notes</summary>

##### Features
- Added `visibleChanged` event to `Container` that emits when the container's visibility changes, carrying the new visibility state as a boolean parameter.
  ```ts
  container.on('visibleChanged', (visible) => {
    console.log('Visibility changed to:', visible);
  });
  ```

</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->