### PR TITLE
fix: GraphicsPath - deep is not deep enough

### DIFF
--- a/src/scene/graphics/shared/__tests__/GraphicsPath.test.ts
+++ b/src/scene/graphics/shared/__tests__/GraphicsPath.test.ts
@@ -1,0 +1,39 @@
+import { GraphicsPath, Matrix, Point } from '~/bundle.browser';
+
+describe('GraphicsPath', () =>
+{
+    it('deep clone should break reference to subpath', () =>
+    {
+        const path = new GraphicsPath().lineTo(12, 34);
+
+        const subPath = new GraphicsPath().lineTo(56, 78);
+
+        path.addPath(subPath);
+
+        const clone = path.clone(true);
+
+        clone.transform(new Matrix().scale(2, 2));
+
+        expect(clone.getLastPoint(new Point())).toEqual(new Point(56 * 2, 78 * 2));
+        expect(path.getLastPoint(new Point())).toEqual(new Point(56, 78));
+    });
+
+    it('deep clone should break reference to subpath of subpath', () =>
+    {
+        const path = new GraphicsPath().lineTo(12, 34);
+
+        const firstSubPath = new GraphicsPath().lineTo(56, 78);
+
+        const secondSubPath = new GraphicsPath().lineTo(100, 200);
+
+        firstSubPath.addPath(secondSubPath);
+        path.addPath(firstSubPath);
+
+        const clone = path.clone(true);
+
+        clone.transform(new Matrix().scale(2, 2));
+
+        expect(clone.getLastPoint(new Point())).toEqual(new Point(100 * 2, 200 * 2));
+        expect(path.getLastPoint(new Point())).toEqual(new Point(100, 200));
+    });
+});

--- a/src/scene/graphics/shared/path/GraphicsPath.ts
+++ b/src/scene/graphics/shared/path/GraphicsPath.ts
@@ -10,21 +10,40 @@ import type { Bounds } from '../../../container/bounds/Bounds';
 import type { RoundedPoint } from './roundShape';
 
 /**
- * Represents a single drawing instruction in a `GraphicsPath`.
- * Each instruction consists of an action type and associated data.
+ * Represents a instruction which adds a subpath into `GraphicsPath`.
  * @category scene
  * @advanced
  */
-export interface PathInstruction
+export interface PathInstructionAddPath
+{
+    action: 'addPath',
+    data: [GraphicsPath, Matrix | undefined]
+}
+
+/**
+ * Represents a single drawing instruction in a `GraphicsPath`.
+ * Each instruction consists of an action type and associated untyped data.
+ * @category scene
+ * @advanced
+ */
+export interface PathInstructionCommon
 {
     action: 'moveTo' | 'lineTo' | 'quadraticCurveTo' |
     'bezierCurveTo' | 'arc' | 'closePath' |
-    'addPath' | 'arcTo' | 'ellipse' |
+    'arcTo' | 'ellipse' |
     'rect' | 'roundRect' | 'arcToSvg' |
     'poly' | 'circle' |
     'regularPoly' | 'roundPoly' | 'roundShape' | 'filletRect' | 'chamferRect'
     data: any[];
 }
+
+/**
+ * Represents a single drawing instruction in a `GraphicsPath`.
+ * Each instruction consists of an action type and associated data.
+ * @category scene
+ * @advanced
+ */
+export type PathInstruction = PathInstructionCommon | PathInstructionAddPath;
 
 /**
  * The `GraphicsPath` class is designed to represent a graphical path consisting of multiple drawing instructions.
@@ -623,7 +642,17 @@ export class GraphicsPath
             {
                 const instruction = this.instructions[i];
 
-                newGraphicsPath2D.instructions.push({ action: instruction.action, data: instruction.data.slice() });
+                if (instruction.action === 'addPath')
+                {
+                    newGraphicsPath2D.instructions.push(
+                        {
+                            action: instruction.action, data: [instruction.data[0].clone(deep), instruction.data[1]?.clone()]
+                        });
+                }
+                else
+                {
+                    newGraphicsPath2D.instructions.push({ action: instruction.action, data: instruction.data.slice() });
+                }
             }
         }
 


### PR DESCRIPTION
GraphicsPath's deep clone is not deep enough.

##### Description of change
The deep clone of the GraphicsPath uses slice for the data parameter which makes shallow copy.
It  does not break the reference to GraphicsPath in the data for the addPath instruction.

Additionally defined type of the data for the addPath instruction.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Release Notes</summary>

##### Breaking Changes / Behavior Changes
- `PathInstruction` type is now a union type `PathInstructionCommon | PathInstructionAddPath`. Code that relies on the direct structure of all instruction types may require updates.

##### Fixes
- Fixed `GraphicsPath.clone(true)` to perform true deep copies of nested subpaths in addPath instructions, preventing unintended reference sharing and mutations when transforming cloned paths.

</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->