### PR TITLE
chore: Update formating for docs in rendering and Filter.ts

### DIFF
--- a/src/filters/Filter.ts
+++ b/src/filters/Filter.ts
@@ -90,18 +90,13 @@ export type FilterAntialias = 'on' | 'off' | 'inherit';
  * Its worth noting Performance-wise filters can be pretty expensive if used too much in a single scene.
  * The following happens under the hood when a filter is applied:
  *
- * .1. Break the current batch
- * <br>
- * .2. The target is measured using getGlobalBounds
- * (recursively go through all children and figure out how big the object is)
- * <br>
- * .3. Get the closest Po2 Textures from the texture pool
- * <br>
- * .4. Render the target to that texture
- * <br>
- * .5. Render that texture back to the main frame buffer as a quad using the filters program.
- * <br>
- * <br>
+ * 1. Break the current batch
+ * 2. The target is measured using getGlobalBounds
+ *    (recursively go through all children and figure out how big the object is)
+ * 3. Get the closest Po2 Textures from the texture pool
+ * 4. Render the target to that texture
+ * 5. Render that texture back to the main frame buffer as a quad using the filters program.
+ *
  * Some filters (such as blur) require multiple passes too which can result in an even bigger performance hit. So be careful!
  * Its not generally the complexity of the shader that is the bottle neck,
  * but all the framebuffer / shader switching that has to take place.
@@ -109,6 +104,7 @@ export type FilterAntialias = 'on' | 'off' | 'inherit';
  * @category filters
  * @advanced
  * @example
+ * ```ts
  * import { Filter } from 'pixi.js';
  *
  * const customFilter = new Filter({
@@ -130,6 +126,7 @@ export type FilterAntialias = 'on' | 'off' | 'inherit';
  * app.ticker.add((ticker) => {
  *     filter.resources.timeUniforms.uniforms.uTime += 0.04 * ticker.deltaTime;
  * });
+ * ```
  */
 export class Filter extends Shader
 {

--- a/src/rendering/renderers/autoDetectRenderer.ts
+++ b/src/rendering/renderers/autoDetectRenderer.ts
@@ -38,16 +38,16 @@ const renderPriority = ['webgl', 'webgpu', 'canvas'];
  * To maximize the benefits of dynamic imports, it's recommended to use a modern bundler
  * that supports code splitting. This will place the renderer code in a separate chunk,
  * which is loaded only when needed.
- * @example
- *
- * // create a renderer
+ * @example Create a renderer
+ * ```typescript
  * const renderer = await autoDetectRenderer({
  *   width: 800,
  *   height: 600,
  *   antialias: true,
  * });
- *
- * // custom for each renderer
+ * ```
+ * @example Custom for each renderer
+ * ```typescript
  * const renderer = await autoDetectRenderer({
  *   width: 800,
  *   height: 600,
@@ -60,6 +60,7 @@ const renderPriority = ['webgl', 'webgpu', 'canvas'];
  *     backgroundColor: 'green'
  *   }
  *  });
+ * ```
  * @param options - A partial configuration object based on the `AutoDetectOptions` type.
  * @returns A Promise that resolves to an instance of the selected renderer.
  * @category rendering

--- a/src/rendering/renderers/canvas/renderTarget/CanvasRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/canvas/renderTarget/CanvasRenderTargetAdaptor.ts
@@ -1,7 +1,7 @@
 import { Color } from '../../../../color/Color';
 import { DOMAdapter } from '../../../../environment/adapter';
-import { type Size } from '../../../../maths/misc/Size.ts';
-import { type PointData } from '../../../../maths/point/PointData.ts';
+import { type Size } from '../../../../maths/misc/Size';
+import { type PointData } from '../../../../maths/point/PointData';
 import { CanvasSource } from '../../shared/texture/sources/CanvasSource';
 
 import type { ICanvas } from '../../../../environment/canvas/ICanvas';

--- a/src/rendering/renderers/canvas/renderTarget/CanvasRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/canvas/renderTarget/CanvasRenderTargetAdaptor.ts
@@ -1,5 +1,7 @@
 import { Color } from '../../../../color/Color';
 import { DOMAdapter } from '../../../../environment/adapter';
+import { type Size } from '../../../../maths/misc/Size.ts';
+import { type PointData } from '../../../../maths/point/PointData.ts';
 import { CanvasSource } from '../../shared/texture/sources/CanvasSource';
 
 import type { ICanvas } from '../../../../environment/canvas/ICanvas';
@@ -156,23 +158,17 @@ export class CanvasRenderTargetAdaptor implements RenderTargetAdaptor<CanvasRend
      * Copies a render target into a texture source.
      * @param {RenderTarget} sourceRenderSurfaceTexture - Source render target.
      * @param {Texture} destinationTexture - Destination texture.
-     * @param {object} originSrc - Source origin.
-     * @param {number} originSrc.x - Source x origin.
-     * @param {number} originSrc.y - Source y origin.
-     * @param {object} size - Copy size.
-     * @param {number} size.width - Copy width.
-     * @param {number} size.height - Copy height.
-     * @param {object} [originDest] - Destination origin.
-     * @param {number} originDest.x - Destination x origin.
-     * @param {number} originDest.y - Destination y origin.
+     * @param {PointData} originSrc - Source origin.
+     * @param {Size} size - Copy size.
+     * @param {PointData} [originDest] - Destination origin.
      * @advanced
      */
     public copyToTexture(
         sourceRenderSurfaceTexture: RenderTarget,
         destinationTexture: Texture,
-        originSrc: { x: number; y: number },
-        size: { width: number; height: number },
-        originDest?: { x: number; y: number },
+        originSrc: PointData,
+        size: Size,
+        originDest?: PointData,
     ): Texture
     {
         const sourceGpuTarget = this._renderTargetSystem.getGpuRenderTarget(sourceRenderSurfaceTexture);

--- a/src/rendering/renderers/gl/context/GlContextSystem.ts
+++ b/src/rendering/renderers/gl/context/GlContextSystem.ts
@@ -304,7 +304,7 @@ export class GlContextSystem implements System<ContextSystemOptions>
      * @protected
      * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext
      * @param preferWebGLVersion
-     * @param {object} options - context attributes
+     * @param options - context attributes
      */
     protected createContext(preferWebGLVersion: 1 | 2, options: WebGLContextAttributes): void
     {

--- a/src/rendering/renderers/gl/renderTarget/GlRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/gl/renderTarget/GlRenderTargetAdaptor.ts
@@ -1,5 +1,5 @@
-import { type Size } from '../../../../maths/misc/Size.ts';
-import { type PointData } from '../../../../maths/point/PointData.ts';
+import { type Size } from '../../../../maths/misc/Size';
+import { type PointData } from '../../../../maths/point/PointData';
 import { Rectangle } from '../../../../maths/shapes/Rectangle';
 import { warn } from '../../../../utils/logging/warn';
 import { CanvasSource } from '../../shared/texture/sources/CanvasSource';

--- a/src/rendering/renderers/gl/renderTarget/GlRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/gl/renderTarget/GlRenderTargetAdaptor.ts
@@ -1,3 +1,5 @@
+import { type Size } from '../../../../maths/misc/Size.ts';
+import { type PointData } from '../../../../maths/point/PointData.ts';
 import { Rectangle } from '../../../../maths/shapes/Rectangle';
 import { warn } from '../../../../utils/logging/warn';
 import { CanvasSource } from '../../shared/texture/sources/CanvasSource';
@@ -53,9 +55,9 @@ export class GlRenderTargetAdaptor implements RenderTargetAdaptor<GlRenderTarget
     public copyToTexture(
         sourceRenderSurfaceTexture: RenderTarget,
         destinationTexture: Texture,
-        originSrc: { x: number; y: number; },
-        size: { width: number; height: number; },
-        originDest: { x: number; y: number; },
+        originSrc: PointData,
+        size: Size,
+        originDest: PointData,
     )
     {
         const renderTargetSystem = this._renderTargetSystem;

--- a/src/rendering/renderers/gl/shader/GlProgram.ts
+++ b/src/rendering/renderers/gl/shader/GlProgram.ts
@@ -71,24 +71,20 @@ const programCache: Record<string, GlProgram> = Object.create(null);
  *
  * To get the most out of this class, you should be familiar with glsl shaders and how they work.
  * @see https://developer.mozilla.org/en-US/docs/Web/API/WebGLProgram
- * @example
- *
- * // Create a new program
+ * @example Create a new program
+ * ```typescript
  * const program = new GlProgram({
  *   vertex: '...',
  *   fragment: '...',
  * });
- *
+ * ```
  *
  * There are a few key things that pixi shader will do for you automatically:
- * <br>
  * - If no precision is provided in the shader, it will be injected into the program source for you.
  * This precision will be taken form the options provided, if none is provided,
  * then the program will default to the defaultOptions.
- * <br>
  * - It will inject the program name into the shader source if none is provided.
- * <br>
- *  - It will set the program version to 300 es.
+ * - It will set the program version to 300 es.
  *
  * For optimal usage and best performance, its best to reuse programs as much as possible.
  * You should use the {@link GlProgram.from} helper function to create programs.

--- a/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetAdaptor.ts
@@ -1,5 +1,5 @@
-import { type Size } from '../../../../maths/misc/Size.ts';
-import { type PointData } from '../../../../maths/point/PointData.ts';
+import { type Size } from '../../../../maths/misc/Size';
+import { type PointData } from '../../../../maths/point/PointData';
 import { CLEAR } from '../../gl/const';
 import { CanvasSource } from '../../shared/texture/sources/CanvasSource';
 import { TextureSource } from '../../shared/texture/sources/TextureSource';

--- a/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetAdaptor.ts
@@ -1,3 +1,5 @@
+import { type Size } from '../../../../maths/misc/Size.ts';
+import { type PointData } from '../../../../maths/point/PointData.ts';
 import { CLEAR } from '../../gl/const';
 import { CanvasSource } from '../../shared/texture/sources/CanvasSource';
 import { TextureSource } from '../../shared/texture/sources/TextureSource';
@@ -31,9 +33,9 @@ export class GpuRenderTargetAdaptor implements RenderTargetAdaptor<GpuRenderTarg
     public copyToTexture(
         sourceRenderSurfaceTexture: RenderTarget,
         destinationTexture: Texture,
-        originSrc: { x: number; y: number; },
-        size: { width: number; height: number; },
-        originDest: { x: number; y: number; },
+        originSrc: PointData,
+        size: Size,
+        originDest: PointData,
     )
     {
         const renderer = this._renderer;

--- a/src/rendering/renderers/gpu/shader/BindGroup.ts
+++ b/src/rendering/renderers/gpu/shader/BindGroup.ts
@@ -7,12 +7,13 @@ import type { BindResource } from './BindResource';
  * They are essentially a wrapper for the WebGPU BindGroup class. But with the added bonus
  * that WebGL can also work with them.
  * @see https://gpuweb.github.io/gpuweb/#dictdef-gpubindgroupdescriptor
- * @example
- * // Create a bind group with a single texture and sampler
+ * @example Create a bind group with a single texture and sampler
+ * ```typescript
  * const bindGroup = new BindGroup({
  *    uTexture: texture.source,
  *    uTexture: texture.style,
  * });
+ * ```
  *
  * Bind groups resources must implement the {@link BindResource} interface.
  * The following resources are supported:

--- a/src/rendering/renderers/gpu/shader/GpuProgram.ts
+++ b/src/rendering/renderers/gpu/shader/GpuProgram.ts
@@ -65,9 +65,8 @@ const programCache: Record<string, GpuProgram> = Object.create(null);
  *
  * To leverage the full capabilities of this class, familiarity with WGSL shaders is recommended.
  * @see https://gpuweb.github.io/gpuweb/#index
- * @example
- *
- * // Create a new program
+ * @example Create a new program
+ * ```typescript
  * const program = new GpuProgram({
  *   vertex: {
  *    source: '...',
@@ -78,15 +77,15 @@ const programCache: Record<string, GpuProgram> = Object.create(null);
  *    entryPoint: 'main',
  *   },
  * });
+ * ```
  *
- *
- * Note: Both fragment and vertex shader sources can coexist within a single WGSL source file
- * this can make things a bit simpler.
+ * > [!NOTE] Both fragment and vertex shader sources can coexist within a single WGSL source file this can
+ * make things a bit simpler.
  *
  * For optimal usage and best performance, it help to reuse programs whenever possible.
  * The {@link GpuProgram.from} helper function is designed for this purpose, utilizing an
- * internal cache to efficiently manage and retrieve program instances.
- * By leveraging this function, you can significantly reduce overhead and enhance the performance of your rendering pipeline.
+ * internal cache to efficiently manage and retrieve program instances. By leveraging this function, you can
+ * significantly reduce overhead and enhance the performance of your rendering pipeline.
  *
  * An important distinction between WebGL and WebGPU regarding program data retrieval:
  * While WebGL allows extraction of program information directly from its compiled state,
@@ -105,27 +104,31 @@ export class GpuProgram
     /**
      * Mapping of uniform names to group indexes for organizing shader program uniforms.
      * Automatically generated from shader sources if not provided.
-     * @example
-     * // Assuming a shader with two uniforms, `u_time` and `u_resolution`, grouped respectively:
+     * @example Assuming a shader with two uniforms, u_time and u_resolution, grouped respectively
+     * ```typescript
      * [
      *   { "u_time": 0 },
      *   { "u_resolution": 1 }
      * ]
+     * ```
      */
     public readonly layout: ProgramLayout;
 
     /**
      * Configuration for the WebGPU bind group layouts, detailing resource organization for the shader.
      * Generated from shader sources if not explicitly provided.
-     * @example
-     * // Assuming a shader program that requires two bind groups:
+     * @example Assuming a shader program that requires two bind groups
+     * ```typescript
      * [
      *   // First bind group layout entries
      *   [{ binding: 0, visibility: GPUShaderStage.VERTEX, type: "uniform-buffer" }],
      *   // Second bind group layout entries
-     *   [{ binding: 1, visibility: GPUShaderStage.FRAGMENT, type: "sampler" },
-     *    { binding: 2, visibility: GPUShaderStage.FRAGMENT, type: "sampled-texture" }]
+     *   [
+     *     { binding: 1, visibility: GPUShaderStage.FRAGMENT, type: "sampler" },
+     *     { binding: 2, visibility: GPUShaderStage.FRAGMENT, type: "sampled-texture" }
+     *   ]
      * ]
+     * ```
      */
     public readonly gpuLayout: ProgramPipelineLayoutDescription;
 

--- a/src/rendering/renderers/shared/GCSystem.ts
+++ b/src/rendering/renderers/shared/GCSystem.ts
@@ -76,18 +76,19 @@ export interface GCSystemOptions
  * A unified garbage collection system for managing GPU resources.
  * Resources register themselves with a cleanup callback and are automatically
  * cleaned up when they haven't been used for a specified amount of time.
- * @example
+ * @example Register a resource for GC
  * ```ts
- * // Register a resource for GC
  * gc.addResource(myResource, () => {
  *     // cleanup logic here
  *     myResource.unload();
  * });
- *
- * // Touch the resource when used (resets idle timer)
+ * ```
+ * @example Touch the resource when used (resets idle timer)
+ * ```ts
  * gc.touch(myResource);
- *
- * // Remove from GC tracking (e.g., on manual destroy)
+ * ```
+ * @example Remove from GC tracking (e.g., on manual destroy)
+ * ```ts
  * gc.removeResource(myResource);
  * ```
  * @category rendering

--- a/src/rendering/renderers/shared/buffer/Buffer.ts
+++ b/src/rendering/renderers/shared/buffer/Buffer.ts
@@ -64,13 +64,9 @@ export interface BufferDescriptor
  * In PixiJS, the Buffer class is used to manage the data that is sent to the GPU rendering pipeline.
  * It abstracts away the underlying GPU buffer and provides an interface for uploading typed arrays or other data to the GPU,
  * They are used in the following places:
- * <br><br>
- * .1. {@link Geometry} as attribute data or index data for geometry
- * <br>
- * .2. {@link UniformGroup} as an underlying buffer for uniform data
- * <br>
- * .3. {@link BufferResource} as an underlying part of a buffer used directly by the GPU program
- * <br>
+ * 1. {@link Geometry} as attribute data or index data for geometry
+ * 2. {@link UniformGroup} as an underlying buffer for uniform data
+ * 3. {@link BufferResource} as an underlying part of a buffer used directly by the GPU program
  *
  * It is important to note that you must provide a usage type when creating a buffer. This is because
  * the underlying GPU buffer needs to know how it will be used. For example, if you are creating a buffer
@@ -83,11 +79,12 @@ export interface BufferDescriptor
  * In WebGPU, a GPU buffer cannot resized. This limitation is abstracted away, but know that resizing a buffer means
  * creating a brand new one and destroying the old, so it is best to limit this if possible.
  * @example
- *
+ * ```typescript
  * const buffer = new Buffer({
  *     data: new Float32Array([1, 2, 3, 4]),
  *     usage: BufferUsage.VERTEX,
  * });
+ * ```
  * @category rendering
  * @advanced
  */

--- a/src/rendering/renderers/shared/extract/ExtractSystem.ts
+++ b/src/rendering/renderers/shared/extract/ExtractSystem.ts
@@ -23,22 +23,23 @@ type Formats = keyof typeof imageTypes;
 /**
  * Options for creating an image from a renderer.
  * Controls the output format and quality of extracted images.
- * @example
+ * @example Extract as PNG (default)
  * ```ts
- * // Extract as PNG (default)
  * const pngImage = await renderer.extract.image({
  *     target: sprite,
  *     format: 'png'
  * });
- *
- * // Extract as JPEG with quality setting
+ * ```
+ * @example Extract as JPEG with quality setting
+ * ```ts
  * const jpgImage = await renderer.extract.image({
  *     target: sprite,
  *     format: 'jpg',
  *     quality: 0.8
  * });
- *
- * // Extract as WebP for better compression
+ * ```
+ * @example Extract as WebP for better compression
+ * ```ts
  * const webpImage = await renderer.extract.image({
  *     target: sprite,
  *     format: 'webp',
@@ -55,14 +56,15 @@ export interface ImageOptions
      * - 'png': Lossless format, best for images with text or sharp edges
      * - 'jpg': Lossy format, smaller file size, good for photos
      * - 'webp': Modern format with better compression
-     * @example
+     * @example Extract as PNG
      * ```ts
-     * // Extract as PNG
      * const pngImage = await renderer.extract.image({
      *     target: sprite,
      *     format: 'png'
      * });
-     * // Extract as JPEG
+     * ```
+     * @example Extract as JPEG
+     * ```ts
      * const jpgImage = await renderer.extract.image({
      *     target: sprite,
      *     format: 'jpg',
@@ -77,15 +79,16 @@ export interface ImageOptions
      * Only applies to lossy formats (jpg, webp).
      * - 1: Maximum quality
      * - 0: Maximum compression
-     * @example
+     * @example Extract as JPEG with 80% quality
      * ```ts
-     * // Extract as JPEG with 80% quality
      * const jpgImage = await renderer.extract.image({
      *     target: sprite,
      *     format: 'jpg',
      *     quality: 0.8
      * });
-     * // Extract as WebP with 90% quality
+     * ```
+     * @example Extract as WebP with 90% quality
+     * ```ts
      * const webpImage = await renderer.extract.image({
      *     target: sprite,
      *     format: 'webp',
@@ -100,14 +103,14 @@ export interface ImageOptions
 /**
  * Options for extracting content from a renderer.
  * These options control how content is extracted and processed from the renderer.
- * @example
+ * @example Basic extraction
  * ```ts
- * // Basic extraction
  * const pixels = renderer.extract.pixels({
  *     target: sprite,
  * });
- *
- * // Extract with custom region and resolution
+ * ```
+ * @example Extract with custom region and resolution
+ * ```ts
  * const canvas = renderer.extract.canvas({
  *     target: container,
  *     frame: new Rectangle(0, 0, 100, 100),
@@ -128,13 +131,13 @@ export interface BaseExtractOptions
 {
     /**
      * The target to extract. Can be a Container or Texture.
-     * @example
+     * @example Extract from a sprite
      * ```ts
-     * // Extract from a sprite
      * const sprite = new Sprite(texture);
      * renderer.extract.pixels({ target: sprite });
-     *
-     * // Extract from a texture directly
+     * ```
+     * @example Extract from a texture directly
+     * ```ts
      * renderer.extract.pixels({ target: texture });
      * ```
      */
@@ -142,9 +145,8 @@ export interface BaseExtractOptions
 
     /**
      * The region of the target to extract. If not specified, extracts the entire target.
-     * @example
+     * @example Extract a specific region
      * ```ts
-     * // Extract a specific region
      * renderer.extract.canvas({
      *     target: sprite,
      *     frame: new Rectangle(10, 10, 100, 100)
@@ -156,9 +158,8 @@ export interface BaseExtractOptions
     /**
      * The resolution of the extracted content. Higher values create sharper images.
      * @default 1
-     * @example
+     * @example Extract at 2x resolution for retina displays
      * ```ts
-     * // Extract at 2x resolution for retina displays
      * renderer.extract.image({
      *     target: sprite,
      *     resolution: 2
@@ -170,15 +171,15 @@ export interface BaseExtractOptions
     /**
      * The color used to clear the extracted content before rendering.
      * Can be a hex number, string, or array of numbers.
-     * @example
+     * @example Clear with red background
      * ```ts
-     * // Clear with red background
      * renderer.extract.canvas({
      *     target: sprite,
      *     clearColor: '#ff0000'
      * });
-     *
-     * // Clear with semi-transparent black
+     * ```
+     * @example Clear with semi-transparent black
+     * ```ts
      * renderer.extract.canvas({
      *     target: sprite,
      *     clearColor: [0, 0, 0, 0.5]
@@ -191,9 +192,8 @@ export interface BaseExtractOptions
      * Whether to enable anti-aliasing during extraction.
      * Improves quality but may affect performance.
      * @default false
-     * @example
+     * @example Enable anti-aliasing for smoother edges
      * ```ts
-     * // Enable anti-aliasing for smoother edges
      * renderer.extract.image({
      *     target: graphics,
      *     antialias: true
@@ -205,15 +205,15 @@ export interface BaseExtractOptions
 /**
  * Options for extracting an HTMLImage from the renderer.
  * Combines base extraction options with image-specific settings.
- * @example
+ * @example Basic PNG extraction
  * ```ts
- * // Basic PNG extraction
  * const image = await renderer.extract.image({
  *     target: sprite,
  *     format: 'png'
  * });
- *
- * // High-quality JPEG with custom region
+ * ```
+ * @example High-quality JPEG with custom region
+ * ```ts
  * const image = await renderer.extract.image({
  *     target: container,
  *     format: 'jpg',
@@ -221,8 +221,9 @@ export interface BaseExtractOptions
  *     frame: new Rectangle(0, 0, 100, 100),
  *     resolution: 2
  * });
- *
- * // WebP with background and anti-aliasing
+ * ```
+ * @example WebP with background and anti-aliasing
+ * ```ts
  * const image = await renderer.extract.image({
  *     target: graphics,
  *     format: 'webp',
@@ -251,29 +252,32 @@ export type ExtractImageOptions = BaseExtractOptions & ImageOptions;
 /**
  * Options for extracting and downloading content from a renderer.
  * Combines base extraction options with download-specific settings.
- * @example
+ * @example Basic download with default filename
  * ```ts
- * // Basic download with default filename
  * renderer.extract.download({
  *     target: sprite
  * });
- *
- * // Download with custom filename and region
+ * ```
+ * @example Download with custom filename and region
+ * ```ts
+ * //
  * renderer.extract.download({
  *     target: container,
  *     filename: 'screenshot.png',
  *     frame: new Rectangle(0, 0, 100, 100)
  * });
- *
- * // Download with high resolution and background
+ * ```
+ * @example Download with high resolution and background
+ * ```ts
  * renderer.extract.download({
  *     target: stage,
  *     filename: 'hd-capture.png',
  *     resolution: 2,
  *     clearColor: '#ff0000'
  * });
- *
- * // Download with anti-aliasing
+ * ```
+ * @example Download with anti-aliasing
+ * ```ts
  * renderer.extract.download({
  *     target: graphics,
  *     filename: 'smooth.png',
@@ -314,27 +318,29 @@ export type ExtractDownloadOptions = BaseExtractOptions & {
 /**
  * Options for extracting content from a renderer. Represents a union of all possible extraction option types.
  * Used by various extraction methods to support different output formats and configurations.
- * @example
+ * @example Basic canvas extraction
  * ```ts
- * // Basic canvas extraction
  * const canvas = renderer.extract.canvas({
  *     target: sprite
  * });
- *
- * // Image extraction with format
+ * ```
+ * @example Image extraction with format
+ * ```ts
  * const image = await renderer.extract.image({
  *     target: sprite,
  *     format: 'png',
  *     quality: 1
  * });
- *
- * // Download with filename
+ * ```
+ * @example Download with filename
+ * ```ts
  * renderer.extract.download({
  *     target: sprite,
  *     filename: 'screenshot.png'
  * });
- *
- * // Advanced extraction with multiple options
+ * ```
+ * @example Advanced extraction with multiple options
+ * ```ts
  * const image = await renderer.extract.image({
  *     target: container,
  *     frame: new Rectangle(0, 0, 100, 100),
@@ -442,9 +448,8 @@ export class ExtractSystem implements System
 
     /**
      * Default options for image extraction.
-     * @example
+     * @example Customize default options
      * ```ts
-     * // Customize default options
      * ExtractSystem.defaultImageOptions.format = 'webp';
      * ExtractSystem.defaultImageOptions.quality = 0.8;
      *
@@ -488,14 +493,14 @@ export class ExtractSystem implements System
      * Creates an IImage from a display object or texture.
      * @param options - Options for creating the image, or the target to extract
      * @returns Promise that resolves with the generated IImage
-     * @example
+     * @example Basic usage with a sprite
      * ```ts
-     * // Basic usage with a sprite
      * const sprite = new Sprite(texture);
      * const image = await renderer.extract.image(sprite);
      * document.body.appendChild(image);
-     *
-     * // Advanced usage with options
+     * ```
+     * @example Advanced usage with options
+     * ```ts
      * const image = await renderer.extract.image({
      *     target: container,
      *     format: 'webp',
@@ -505,8 +510,9 @@ export class ExtractSystem implements System
      *     clearColor: '#ff0000',
      *     antialias: true
      * });
-     *
-     * // Extract directly from a texture
+     * ```
+     * @example Extract directly from a texture
+     * ```ts
      * const texture = Texture.from('myTexture.png');
      * const image = await renderer.extract.image(texture);
      * ```
@@ -532,14 +538,14 @@ export class ExtractSystem implements System
      * a canvas using `Extract.canvas` and then converting it to a base64 string.
      * @param options - The options for creating the base64 string, or the target to extract
      * @returns Promise that resolves with the base64 encoded string
-     * @example
+     * @example Basic usage with a sprite
      * ```ts
-     * // Basic usage with a sprite
      * const sprite = new Sprite(texture);
      * const base64 = await renderer.extract.base64(sprite);
      * console.log(base64); // data:image/png;base64,...
-     *
-     * // Advanced usage with options
+     * ```
+     * @example Advanced usage with options
+     * ```ts
      * const base64 = await renderer.extract.base64({
      *     target: container,
      *     format: 'webp',
@@ -616,31 +622,34 @@ export class ExtractSystem implements System
      * This method is useful for creating static images or when you need direct canvas access.
      * @param options - The options for creating the canvas, or the target to extract
      * @returns A Canvas element with the texture rendered on
-     * @example
+     * @example Basic canvas extraction from a sprite
      * ```ts
-     * // Basic canvas extraction from a sprite
      * const sprite = new Sprite(texture);
      * const canvas = renderer.extract.canvas(sprite);
      * document.body.appendChild(canvas);
-     *
-     * // Extract with custom region
+     * ```
+     * @example Extract with custom region
+     * ```ts
      * const canvas = renderer.extract.canvas({
      *     target: container,
      *     frame: new Rectangle(0, 0, 100, 100)
      * });
-     *
-     * // Extract with high resolution
+     * ```
+     * @example Extract with high resolution
+     * ```ts
      * const canvas = renderer.extract.canvas({
      *     target: sprite,
      *     resolution: 2,
      *     clearColor: '#ff0000'
      * });
-     *
-     * // Extract directly from a texture
+     * ```
+     * @example Extract directly from a texture
+     * ```ts
      * const texture = Texture.from('myTexture.png');
      * const canvas = renderer.extract.canvas(texture);
-     *
-     * // Extract with anti-aliasing
+     * ```
+     * @example Extract with anti-aliasing
+     * ```ts
      * const canvas = renderer.extract.canvas({
      *     target: graphics,
      *     antialias: true
@@ -676,23 +685,24 @@ export class ExtractSystem implements System
     /**
      * Returns a one-dimensional array containing the pixel data of the entire texture in RGBA order,
      * with integer values between 0 and 255 (inclusive).
-     * > [!NOE] The returned array is a flat Uint8Array where every 4 values represent RGBA
+     * > [!NOTE] The returned array is a flat Uint8Array where every 4 values represent RGBA
      * @param options - The options for extracting the image, or the target to extract
      * @returns One-dimensional Uint8Array containing the pixel data in RGBA format
-     * @example
+     * @example Basic pixel extraction
      * ```ts
-     * // Basic pixel extraction
      * const sprite = new Sprite(texture);
      * const pixels = renderer.extract.pixels(sprite);
      * console.log(pixels[0], pixels[1], pixels[2], pixels[3]); // R,G,B,A values
-     *
-     * // Extract with custom region
+     * ```
+     * @example Extract with custom region
+     * ```ts
      * const pixels = renderer.extract.pixels({
      *     target: sprite,
      *     frame: new Rectangle(0, 0, 100, 100)
      * });
-     *
-     * // Extract with high resolution
+     * ```
+     * @example Extract with high resolution
+     * ```ts
      * const pixels = renderer.extract.pixels({
      *     target: sprite,
      *     resolution: 2
@@ -733,34 +743,37 @@ export class ExtractSystem implements System
      * > [!NOTE] The returned texture should be destroyed when no longer needed
      * @param options - The options for creating the texture, or the target to extract
      * @returns A new texture containing the extracted content
-     * @example
+     * @example Basic texture extraction from a sprite
      * ```ts
-     * // Basic texture extraction from a sprite
      * const sprite = new Sprite(texture);
      * const extractedTexture = renderer.extract.texture(sprite);
-     *
-     * // Extract with custom region
+     * ```
+     * @example Extract with custom region
+     * ```ts
      * const regionTexture = renderer.extract.texture({
      *     target: container,
      *     frame: new Rectangle(0, 0, 100, 100)
      * });
-     *
-     * // Extract with high resolution
+     * ```
+     * @example Extract with high resolution
+     * ```ts
      * const hiResTexture = renderer.extract.texture({
      *     target: sprite,
      *     resolution: 2,
      *     clearColor: '#ff0000'
      * });
-     *
-     * // Create a new sprite from extracted texture
+     * ```
+     * @example Create a new sprite from extracted texture
+     * ```ts
      * const newSprite = new Sprite(
      *     renderer.extract.texture({
      *         target: graphics,
      *         antialias: true
      *     })
      * );
-     *
-     * // Clean up when done
+     * ```
+     * @example Clean up when done
+     * ```ts
      * extractedTexture.destroy(true);
      * ```
      * @see {@link ExtractOptions} For detailed options
@@ -782,34 +795,37 @@ export class ExtractSystem implements System
      * This is a convenient way to save screenshots or export rendered content.
      * > [!NOTE] The download will use PNG format regardless of the filename extension
      * @param options - The options for downloading and extracting the image, or the target to extract
-     * @example
+     * @example Basic download with default filename
      * ```ts
-     * // Basic download with default filename
      * const sprite = new Sprite(texture);
      * renderer.extract.download(sprite); // Downloads as 'image.png'
-     *
-     * // Download with custom filename
+     * ```
+     * @example Download with custom filename
+     * ```ts
      * renderer.extract.download({
      *     target: sprite,
      *     filename: 'screenshot.png'
      * });
-     *
-     * // Download with custom region
+     * ```
+     * @example Download with custom region
+     * ```ts
      * renderer.extract.download({
      *     target: container,
      *     filename: 'region.png',
      *     frame: new Rectangle(0, 0, 100, 100)
      * });
-     *
-     * // Download with high resolution and background
+     * ```
+     * @example Download with high resolution and background
+     * ```ts
      * renderer.extract.download({
      *     target: stage,
      *     filename: 'hd-screenshot.png',
      *     resolution: 2,
      *     clearColor: '#ff0000'
      * });
-     *
-     * // Download with anti-aliasing
+     * ```
+     * @example Download with anti-aliasing
+     * ```ts
      * renderer.extract.download({
      *     target: graphics,
      *     filename: 'smooth.png',
@@ -843,9 +859,8 @@ export class ExtractSystem implements System
      * The image will be displayed in the browser's console using CSS background images.
      * @param options - The options for logging the image, or the target to log
      * @param options.width - The width of the logged image preview in the console (in pixels)
-     * @example
+     * @example Basic usage
      * ```ts
-     * // Basic usage
      * const sprite = new Sprite(texture);
      * renderer.extract.log(sprite);
      * ```

--- a/src/rendering/renderers/shared/extract/GenerateTextureSystem.ts
+++ b/src/rendering/renderers/shared/extract/GenerateTextureSystem.ts
@@ -23,22 +23,23 @@ export type GenerateTextureSourceOptions = Omit<TextureSourceOptions, 'resource'
  * Options for generating a texture from a container.
  * Used to create reusable textures from display objects, which can improve performance
  * when the same content needs to be rendered multiple times.
- * @example
+ * @example Basic texture generation
  * ```ts
- * // Basic texture generation
  * const sprite = new Sprite(texture);
  * const generatedTexture = renderer.generateTexture({
  *     target: sprite
  * });
- *
- * // Generate with custom region and resolution
+ * ```
+ * @example Generate with custom region and resolution
+ * ```ts
  * const texture = renderer.generateTexture({
  *     target: container,
  *     frame: new Rectangle(0, 0, 100, 100),
  *     resolution: 2
  * });
- *
- * // Generate with background color and anti-aliasing
+ * ```
+ * @example Generate with background color and anti-aliasing
+ * ```ts
  * const highQualityTexture = renderer.generateTexture({
  *     target: graphics,
  *     clearColor: '#ff0000',
@@ -71,9 +72,8 @@ export type GenerateTextureOptions = {
     /**
      * The region of the container that should be rendered.
      * If not specified, defaults to the local bounds of the container.
-     * @example
+     * @example Extract only a portion of the container
      * ```ts
-     * // Extract only a portion of the container
      * const texture = renderer.generateTexture({
      *     target: container,
      *     frame: new Rectangle(10, 10, 100, 100)
@@ -86,9 +86,8 @@ export type GenerateTextureOptions = {
      * The resolution of the texture being generated.
      * Higher values create sharper textures at the cost of memory.
      * @default renderer.resolution
-     * @example
+     * @example Generate a high-resolution texture
      * ```ts
-     * // Generate a high-resolution texture
      * const hiResTexture = renderer.generateTexture({
      *     target: sprite,
      *     resolution: 2 // 2x resolution
@@ -100,15 +99,15 @@ export type GenerateTextureOptions = {
     /**
      * The color used to clear the texture before rendering.
      * Can be a hex number, string, or array of numbers.
-     * @example
+     * @example Clear with red background
      * ```ts
-     * // Clear with red background
      * const texture = renderer.generateTexture({
      *     target: sprite,
      *     clearColor: '#ff0000'
      * });
-     *
-     * // Clear with semi-transparent black
+     * ```
+     * @example Clear with semi-transparent black
+     * ```ts
      * const texture = renderer.generateTexture({
      *     target: sprite,
      *     clearColor: [0, 0, 0, 0.5]
@@ -120,9 +119,8 @@ export type GenerateTextureOptions = {
     /**
      * Whether to enable anti-aliasing. This may affect performance.
      * @default false
-     * @example
+     * @example Generate a smooth texture
      * ```ts
-     * // Generate a smooth texture
      * const texture = renderer.generateTexture({
      *     target: graphics,
      *     antialias: true
@@ -170,8 +168,7 @@ const noColor: ColorSource = [0, 0, 0, 0];
  *     .circle(0, 0, 50)
  *     .fill('red');
  *
- * const sprite = new Sprite(texture);
- * sprite.x = 100;
+ * const sprite = new Sprite({ texture, x: 100 });
  *
  * container.addChild(graphics, sprite);
  *
@@ -249,20 +246,23 @@ export class GenerateTextureSystem implements System
      * );
      *
      * const texture = renderer.textureGenerator.generateTexture(container);
-     *
-     * // Advanced usage with options
+     * ```
+     * @example Advanced usage with options
+     * ```ts
      * const texture = renderer.textureGenerator.generateTexture({
      *     target: container,
      *     frame: new Rectangle(0, 0, 100, 100), // Specific region
      *     resolution: 2,                        // High DPI
-     *     clearColor: '#ff0000',               // Red background
-     *     antialias: true                      // Smooth edges
+     *     clearColor: '#ff0000',              // Red background
+     *     antialias: true                       // Smooth edges
      * });
-     *
-     * // Create a sprite from the generated texture
+     * ```
+     * @example Create a sprite from the generated texture
+     * ```ts
      * const sprite = new Sprite(texture);
-     *
-     * // Clean up when done
+     * ```
+     * @example Clean up when done
+     * ```ts
      * texture.destroy(true);
      * ```
      * @see {@link GenerateTextureOptions} For detailed texture generation options

--- a/src/rendering/renderers/shared/geometry/Geometry.ts
+++ b/src/rendering/renderers/shared/geometry/Geometry.ts
@@ -104,14 +104,14 @@ function ensureIsAttribute(attribute: AttributeOption): Attribute
  * Essentially, a Geometry object holds the data you'd send to a GPU buffer.
  *
  * A geometry is basically made of two components:
- * <br>
- * <b>Attributes</b>: These are essentially arrays that define properties of the vertices like position, color,
+ *
+ * '''Attributes''': These are essentially arrays that define properties of the vertices like position, color,
  * texture coordinates, etc. They map directly to attributes in your vertex shaders.
- * <br>
- * <b>Indices</b>: An optional array that describes how the vertices are connected.
+ *
+ * '''Indices''': An optional array that describes how the vertices are connected.
  * If not provided, vertices will be interpreted in the sequence they're given.
  * @example
- *
+ * ```typescript
  * const geometry = new Geometry({
  *   attributes: {
  *     aPosition: [ // add some positions
@@ -128,6 +128,7 @@ function ensureIsAttribute(attribute: AttributeOption): Attribute
  *     ]
  *   }
  * });
+ * ```
  * @category rendering
  * @advanced
  */

--- a/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
+++ b/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
@@ -1,6 +1,6 @@
 import { Matrix } from '../../../../maths/matrix/Matrix';
-import { type Size } from '../../../../maths/misc/Size.ts';
-import { type PointData } from '../../../../maths/point/PointData.ts';
+import { type Size } from '../../../../maths/misc/Size';
+import { type PointData } from '../../../../maths/point/PointData';
 import { Rectangle } from '../../../../maths/shapes/Rectangle';
 import { CLEAR } from '../../gl/const';
 import { calculateProjection } from '../../gpu/renderTarget/calculateProjection';

--- a/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
+++ b/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
@@ -1,4 +1,6 @@
 import { Matrix } from '../../../../maths/matrix/Matrix';
+import { type Size } from '../../../../maths/misc/Size.ts';
+import { type PointData } from '../../../../maths/point/PointData.ts';
 import { Rectangle } from '../../../../maths/shapes/Rectangle';
 import { CLEAR } from '../../gl/const';
 import { calculateProjection } from '../../gpu/renderTarget/calculateProjection';
@@ -75,22 +77,16 @@ export interface RenderTargetAdaptor<RENDER_TARGET extends RendererRenderTarget>
      * A function copies the contents of a render surface to a texture
      * @param {RenderTarget} sourceRenderSurfaceTexture - the render surface to copy from
      * @param {Texture} destinationTexture - the texture to copy to
-     * @param {object} originSrc - the origin of the copy
-     * @param {number} originSrc.x - the x origin of the copy
-     * @param {number} originSrc.y - the y origin of the copy
-     * @param {object} size - the size of the copy
-     * @param {number} size.width - the width of the copy
-     * @param {number} size.height - the height of the copy
-     * @param {object} originDest - the destination origin (top left to paste from!)
-     * @param {number} originDest.x - the x destination origin of the copy
-     * @param {number} originDest.y - the y destination origin of the copy
+     * @param {PointData} originSrc - the origin of the copy
+     * @param {Size} size - the size of the copy
+     * @param {PointData} originDest - the destination origin (top left to paste from!)
      */
     copyToTexture(
         sourceRenderSurfaceTexture: RenderTarget,
         destinationTexture: Texture,
-        originSrc: { x: number; y: number },
-        size: { width: number; height: number },
-        originDest?: { x: number; y: number },
+        originSrc: PointData,
+        size: Size,
+        originDest?: PointData,
     ): Texture
 
     /**
@@ -182,9 +178,7 @@ export interface RenderTargetAdaptor<RENDER_TARGET extends RendererRenderTarget>
  * as it can have multiple textures attached to it.
  * It will also give ou fine grain control over the stencil buffer / depth texture.
  * @example
- *
  * ```js
- *
  * // create a render target
  * const renderTarget = new RenderTarget({
  *   colorTextures: [new TextureSource({ width: 100, height: 100 })],
@@ -541,11 +535,11 @@ export class RenderTargetSystem<RENDER_TARGET extends RendererRenderTarget> impl
     /**
      * Copies a render surface to another texture.
      *
-     * NOTE:
-     * for sourceRenderSurfaceTexture, The render target must be something that is written too by the renderer
+     * > [!NOTE] For sourceRenderSurfaceTexture, The render target must be something that is written too by the renderer
      *
      * The following is not valid:
      * @example
+     * ```ts
      * const canvas = document.createElement('canvas')
      * canvas.width = 200;
      * canvas.height = 200;
@@ -561,28 +555,23 @@ export class RenderTargetSystem<RENDER_TARGET extends RendererRenderTarget> impl
      * const renderTarget = renderer.renderTarget.getRenderTarget(canvas2);
      *
      * renderer.renderTarget.copyToTexture(renderTarget,texture, {x:0,y:0},{width:200,height:200},{x:0,y:0});
+     * ```
      *
      * The best way to copy a canvas is to create a texture from it. Then render with that.
      *
      * Parsing in a RenderTarget canvas context (with a 2d context)
      * @param sourceRenderSurfaceTexture - the render surface to copy from
      * @param {Texture} destinationTexture - the texture to copy to
-     * @param {object} originSrc - the origin of the copy
-     * @param {number} originSrc.x - the x origin of the copy
-     * @param {number} originSrc.y - the y origin of the copy
-     * @param {object} size - the size of the copy
-     * @param {number} size.width - the width of the copy
-     * @param {number} size.height - the height of the copy
-     * @param {object} originDest - the destination origin (top left to paste from!)
-     * @param {number} originDest.x - the x origin of the paste
-     * @param {number} originDest.y - the y origin of the paste
+     * @param {PointData} originSrc - the origin of the copy
+     * @param {Size} size - the size of the copy
+     * @param {PointData} originDest - the destination origin (top left to paste from!)
      */
     public copyToTexture(
         sourceRenderSurfaceTexture: RenderTarget,
         destinationTexture: Texture,
-        originSrc: { x: number; y: number },
-        size: { width: number; height: number },
-        originDest: { x: number; y: number; },
+        originSrc: PointData,
+        size: Size,
+        originDest: PointData,
     )
     {
         // fit the size to the source we don't want to go out of bounds

--- a/src/rendering/renderers/shared/shader/Shader.ts
+++ b/src/rendering/renderers/shared/shader/Shader.ts
@@ -173,7 +173,6 @@ export type ShaderFromResources = (GlShaderFromWith | GpuShaderFromWith)
  *  - TextureSource {@link TextureSource}
  *  - UniformsGroups {@link UniformGroup}
  * @example
- *
  * const shader = new Shader({
  *     glProgram: glProgram,
  *     gpuProgram: gpuProgram,

--- a/src/rendering/renderers/shared/texture/Texture.ts
+++ b/src/rendering/renderers/shared/texture/Texture.ts
@@ -1,5 +1,6 @@
 import EventEmitter from 'eventemitter3';
 import { groupD8 } from '../../../../maths/matrix/groupD8';
+import { type PointData } from '../../../../maths/point/PointData.ts';
 import { Rectangle } from '../../../../maths/shapes/Rectangle';
 import { uid } from '../../../../utils/data/uid';
 import { deprecation, v8_0_0 } from '../../../../utils/logging/deprecation';
@@ -61,7 +62,7 @@ export interface TextureOptions<TextureSourceType extends TextureSource = Textur
     /** Trimmed rectangle of original texture */
     trim?: Rectangle;
     /** Default anchor point used for sprite placement / rotation */
-    defaultAnchor?: { x: number; y: number };
+    defaultAnchor?: PointData;
     /** Default borders used for 9-slice scaling {@link NineSlicePlane}*/
     defaultBorders?: TextureBorders;
     /** indicates how the texture was rotated by texture packer. See {@link groupD8} */
@@ -182,7 +183,7 @@ export class Texture<TextureSourceType extends TextureSource = TextureSource> ex
      * Changing the `defaultAnchor` at a later point of time will not update Sprite's anchor point.
      * @default {0,0}
      */
-    public readonly defaultAnchor?: { x: number; y: number };
+    public readonly defaultAnchor?: PointData;
     /**
      * Default width of the non-scalable border that is used if 9-slice plane is created with this texture.
      * @since 7.2.0

--- a/src/rendering/renderers/shared/texture/Texture.ts
+++ b/src/rendering/renderers/shared/texture/Texture.ts
@@ -1,6 +1,6 @@
 import EventEmitter from 'eventemitter3';
 import { groupD8 } from '../../../../maths/matrix/groupD8';
-import { type PointData } from '../../../../maths/point/PointData.ts';
+import { type PointData } from '../../../../maths/point/PointData';
 import { Rectangle } from '../../../../maths/shapes/Rectangle';
 import { uid } from '../../../../utils/data/uid';
 import { deprecation, v8_0_0 } from '../../../../utils/logging/deprecation';


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Updating some types and documentation in the rendering folder as well as some formatting in `Filter.ts`.

I've focused on:
* Splitting examples with multiple comments indicating sections into separate examples and moving the comment as a title
* Making use of existing types `PointData` and `Size`
* Fixing issues where an example began and more description was added, but the example code block was never closed.

I also fixed a typo and added `[!NOTE]` to a spot that looked liked it wanted it.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
