### PR TITLE
fix: removeAllListeners() on Renderer.destroy()

### DIFF
--- a/src/rendering/renderers/__tests__/Renderer.test.ts
+++ b/src/rendering/renderers/__tests__/Renderer.test.ts
@@ -17,4 +17,16 @@ describe('Renderer', () =>
 
         renderer.destroy();
     });
+
+    it('should remove all event listeners when destroyed', async () =>
+    {
+        const renderer = new WebGLRenderer();
+
+        renderer.on('resize', jest.fn());
+        renderer.on('resize', jest.fn());
+        expect(renderer.listenerCount('resize')).toBe(2);
+
+        renderer.destroy();
+        expect(renderer.listenerCount('resize')).toBe(0);
+    });
 });

--- a/src/rendering/renderers/shared/system/AbstractRenderer.ts
+++ b/src/rendering/renderers/shared/system/AbstractRenderer.ts
@@ -582,6 +582,8 @@ export class AbstractRenderer<
 
         // destroy all pipes
         (this.renderPipes as null) = null;
+
+        this.removeAllListeners();
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
While profiling memory usage, I noticed some objects not being garbage collected because they were still referenced by event listeners that weren't removed by a renderer after destroying it. This PR resolves the issue by calling `this.removeAllListeners()` in the destroy method.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
