### PR TITLE
fix: correct minFPS/maxFPS mutual clamping in Ticker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "lint-staged": "^16.2.7",
         "nodemon": "^3.1.11",
         "pixelmatch": "^5.3.0",
-        "pkg-pr-new": "^0.0.62",
+        "pkg-pr-new": "^0.0.65",
         "pngjs": "^7.0.0",
         "rimraf": "^6.1.2",
         "rollup": "^4.55.1",
@@ -98,54 +98,41 @@
       }
     },
     "node_modules/@actions/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-zYt6cz+ivnTmiT/ksRVriMBOiuoUpDCJJlZ5KPl2/FRdvwU3f7MPh9qftvbkXJThragzUZieit2nyHUyw53Seg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@actions/exec": "^1.1.1",
-        "@actions/http-client": "^2.0.1"
+        "@actions/exec": "^3.0.0",
+        "@actions/http-client": "^4.0.0"
       }
     },
     "node_modules/@actions/exec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
-      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
+      "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@actions/io": "^1.0.1"
+        "@actions/io": "^3.0.2"
       }
     },
     "node_modules/@actions/http-client": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
-      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.0.tgz",
+      "integrity": "sha512-QuwPsgVMsD6qaPD57GLZi9sqzAZCtiJT8kVBCDpLtxhL5MydQ4gS+DrejtZZPdIYyB1e95uCK9Luyds7ybHI3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "tunnel": "^0.0.6",
-        "undici": "^5.25.4"
-      }
-    },
-    "node_modules/@actions/http-client/node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0"
+        "undici": "^6.23.0"
       }
     },
     "node_modules/@actions/io": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
-      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2024,16 +2011,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@gerrit0/mini-shiki": {
@@ -14836,13 +14813,13 @@
       }
     },
     "node_modules/pkg-pr-new": {
-      "version": "0.0.62",
-      "resolved": "https://registry.npmjs.org/pkg-pr-new/-/pkg-pr-new-0.0.62.tgz",
-      "integrity": "sha512-K2jtf1PLCJJFDimQIpasPXDdnRTZSYPy36Ldz+QhMpLz2YN1Wi0ZQkomVt5Wi3NdBZcYuYGXekyFWfJ6fAHYjg==",
+      "version": "0.0.65",
+      "resolved": "https://registry.npmjs.org/pkg-pr-new/-/pkg-pr-new-0.0.65.tgz",
+      "integrity": "sha512-yZGN17qf6SX/go2rlLL3OWtwO0ppKZBxAfG5M3a9N44WMDrhqkuyfQOpKdvRE9plFsCzF7L/Xtp/1hQQHqhhCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@actions/core": "^1.11.1",
+        "@actions/core": "^3.0.0",
         "@jsdevtools/ez-spawn": "^3.0.4",
         "@octokit/action": "^6.1.0",
         "ignore": "^5.3.1",
@@ -18075,9 +18052,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "6.21.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
-      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -19439,49 +19416,38 @@
   },
   "dependencies": {
     "@actions/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-zYt6cz+ivnTmiT/ksRVriMBOiuoUpDCJJlZ5KPl2/FRdvwU3f7MPh9qftvbkXJThragzUZieit2nyHUyw53Seg==",
       "dev": true,
       "requires": {
-        "@actions/exec": "^1.1.1",
-        "@actions/http-client": "^2.0.1"
+        "@actions/exec": "^3.0.0",
+        "@actions/http-client": "^4.0.0"
       }
     },
     "@actions/exec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
-      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
+      "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
       "dev": true,
       "requires": {
-        "@actions/io": "^1.0.1"
+        "@actions/io": "^3.0.2"
       }
     },
     "@actions/http-client": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
-      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.0.tgz",
+      "integrity": "sha512-QuwPsgVMsD6qaPD57GLZi9sqzAZCtiJT8kVBCDpLtxhL5MydQ4gS+DrejtZZPdIYyB1e95uCK9Luyds7ybHI3g==",
       "dev": true,
       "requires": {
         "tunnel": "^0.0.6",
-        "undici": "^5.25.4"
-      },
-      "dependencies": {
-        "undici": {
-          "version": "5.29.0",
-          "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-          "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-          "dev": true,
-          "requires": {
-            "@fastify/busboy": "^2.0.0"
-          }
-        }
+        "undici": "^6.23.0"
       }
     },
     "@actions/io": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
-      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
       "dev": true
     },
     "@babel/code-frame": {
@@ -20612,12 +20578,6 @@
           "dev": true
         }
       }
-    },
-    "@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "dev": true
     },
     "@gerrit0/mini-shiki": {
       "version": "3.19.0",
@@ -29620,12 +29580,12 @@
       }
     },
     "pkg-pr-new": {
-      "version": "0.0.62",
-      "resolved": "https://registry.npmjs.org/pkg-pr-new/-/pkg-pr-new-0.0.62.tgz",
-      "integrity": "sha512-K2jtf1PLCJJFDimQIpasPXDdnRTZSYPy36Ldz+QhMpLz2YN1Wi0ZQkomVt5Wi3NdBZcYuYGXekyFWfJ6fAHYjg==",
+      "version": "0.0.65",
+      "resolved": "https://registry.npmjs.org/pkg-pr-new/-/pkg-pr-new-0.0.65.tgz",
+      "integrity": "sha512-yZGN17qf6SX/go2rlLL3OWtwO0ppKZBxAfG5M3a9N44WMDrhqkuyfQOpKdvRE9plFsCzF7L/Xtp/1hQQHqhhCQ==",
       "dev": true,
       "requires": {
-        "@actions/core": "^1.11.1",
+        "@actions/core": "^3.0.0",
         "@jsdevtools/ez-spawn": "^3.0.4",
         "@octokit/action": "^6.1.0",
         "ignore": "^5.3.1",
@@ -31998,9 +31958,9 @@
       "dev": true
     },
     "undici": {
-      "version": "6.21.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
-      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
       "dev": true
     },
     "undici-types": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "lint-staged": "^16.2.7",
     "nodemon": "^3.1.11",
     "pixelmatch": "^5.3.0",
-    "pkg-pr-new": "^0.0.62",
+    "pkg-pr-new": "^0.0.65",
     "pngjs": "^7.0.0",
     "rimraf": "^6.1.2",
     "rollup": "^4.55.1",

--- a/src/ticker/Ticker.ts
+++ b/src/ticker/Ticker.ts
@@ -245,7 +245,7 @@ export class Ticker
      */
     private _maxElapsedMS = 100;
     /**
-     * Internal value managed by minFPS property setter and getter.
+     * Internal value managed by maxFPS property setter and getter.
      * This is the minimum allowed milliseconds between updates.
      */
     private _minElapsedMS = 0;
@@ -769,13 +769,16 @@ export class Ticker
 
     set minFPS(fps: number)
     {
-        // Minimum must be below the maxFPS
-        const minFPS = Math.min(this.maxFPS, fps);
-
         // Must be at least 0, but below 1 / Ticker.targetFPMS
-        const minFPMS = Math.min(Math.max(0, minFPS) / 1000, Ticker.targetFPMS);
+        const minFPMS = Math.min(Math.max(0, fps) / 1000, Ticker.targetFPMS);
 
         this._maxElapsedMS = 1 / minFPMS;
+
+        // If maxFPS is set (non-zero) and now lower than minFPS, push it up
+        if (this._minElapsedMS && fps > this.maxFPS)
+        {
+            this.maxFPS = fps;
+        }
     }
 
     /**
@@ -822,10 +825,12 @@ export class Ticker
         }
         else
         {
-            // Max must be at least the minFPS
-            const maxFPS = Math.max(this.minFPS, fps);
+            if (fps < this.minFPS)
+            {
+                this.minFPS = fps;
+            }
 
-            this._minElapsedMS = 1 / (maxFPS / 1000);
+            this._minElapsedMS = 1 / (fps / 1000);
         }
     }
 

--- a/src/ticker/__tests__/Ticker.test.ts
+++ b/src/ticker/__tests__/Ticker.test.ts
@@ -457,4 +457,100 @@ describe('Ticker', () =>
 
             ticker.start();
         }));
+
+    describe('minFPS / maxFPS', () =>
+    {
+        it('should set minFPS independently when maxFPS is unlimited (0)', () =>
+        {
+            const ticker = new Ticker();
+
+            expect(ticker.maxFPS).toBe(0);
+
+            ticker.minFPS = 30;
+
+            expect(ticker.minFPS).toBeCloseTo(30, 0);
+            expect(ticker.maxFPS).toBe(0);
+
+            ticker.destroy();
+        });
+
+        it('should push maxFPS up when minFPS exceeds it', () =>
+        {
+            const ticker = new Ticker();
+
+            ticker.maxFPS = 30;
+            ticker.minFPS = 60;
+
+            expect(ticker.minFPS).toBeCloseTo(60, 0);
+            expect(ticker.maxFPS).toBeCloseTo(60, 0);
+
+            ticker.destroy();
+        });
+
+        it('should not change maxFPS when minFPS is below it', () =>
+        {
+            const ticker = new Ticker();
+
+            ticker.maxFPS = 60;
+            ticker.minFPS = 30;
+
+            expect(ticker.minFPS).toBeCloseTo(30, 0);
+            expect(ticker.maxFPS).toBeCloseTo(60, 0);
+
+            ticker.destroy();
+        });
+
+        it('should pull minFPS down when maxFPS is set below it', () =>
+        {
+            const ticker = new Ticker();
+
+            ticker.minFPS = 60;
+            ticker.maxFPS = 30;
+
+            expect(ticker.maxFPS).toBeCloseTo(30, 0);
+            expect(ticker.minFPS).toBeCloseTo(30, 0);
+
+            ticker.destroy();
+        });
+
+        it('should not change minFPS when maxFPS is above it', () =>
+        {
+            const ticker = new Ticker();
+
+            ticker.minFPS = 30;
+            ticker.maxFPS = 60;
+
+            expect(ticker.maxFPS).toBeCloseTo(60, 0);
+            expect(ticker.minFPS).toBeCloseTo(30, 0);
+
+            ticker.destroy();
+        });
+
+        it('should allow maxFPS to be reset to 0 (unlimited)', () =>
+        {
+            const ticker = new Ticker();
+
+            ticker.minFPS = 30;
+            ticker.maxFPS = 60;
+            ticker.maxFPS = 0;
+
+            expect(ticker.maxFPS).toBe(0);
+            expect(ticker.minFPS).toBeCloseTo(30, 0);
+
+            ticker.destroy();
+        });
+
+        it('should keep minFPS and maxFPS equal when set to the same value', () =>
+        {
+            const ticker = new Ticker();
+
+            ticker.minFPS = 60;
+            ticker.maxFPS = 60;
+
+            expect(ticker.minFPS).toBeCloseTo(60, 0);
+            expect(ticker.maxFPS).toBeCloseTo(60, 0);
+
+            ticker.destroy();
+        });
+    });
 });


### PR DESCRIPTION
### Overview

The Ticker's `minFPS` and `maxFPS` setters silently clamped input values against each other before applying them. This made it impossible to set `minFPS` above `maxFPS` (or vice versa) without first adjusting the other property, leading to confusing behavior. Now each setter stores the exact value and pushes the opposing bound to match when a conflict arises.

replaces: https://github.com/pixijs/pixijs/pull/11889/

#### Fixes
- `minFPS` setter no longer silently clamps to `maxFPS`; instead pushes `maxFPS` up when exceeded
- `maxFPS` setter no longer silently clamps to `minFPS`; instead pulls `minFPS` down when exceeded
- Fixed incorrect JSDoc comment on `_minElapsedMS` (was referencing `minFPS` instead of `maxFPS`)

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
