### PR TITLE
fix: move DOMPipe registration to init.ts to fix Web Worker support

### DIFF
--- a/src/dom/DOMContainer.ts
+++ b/src/dom/DOMContainer.ts
@@ -1,12 +1,8 @@
 /* eslint-disable no-restricted-globals */
-import { extensions } from '../extensions/Extensions';
 import { Point } from '../maths/point/Point';
 import { ViewContainer, type ViewContainerOptions } from '../scene/view/ViewContainer';
-import { DOMPipe } from './DOMPipe';
 
 import type { PointData } from '../maths/point/PointData';
-
-extensions.add(DOMPipe);
 
 /**
  * Options for configuring a {@link DOMContainer}.

--- a/src/dom/init.ts
+++ b/src/dom/init.ts
@@ -1,1 +1,6 @@
+import { extensions } from '../extensions/Extensions';
+import { DOMPipe } from './DOMPipe';
+
 export * from './index';
+
+extensions.add(DOMPipe);

--- a/src/environment-browser/browserAll.ts
+++ b/src/environment-browser/browserAll.ts
@@ -1,4 +1,5 @@
 import '../accessibility/init';
+import '../dom/init';
 import '../events/init';
 import '../spritesheet/init';
 import '../rendering/init';


### PR DESCRIPTION
### Overview

Reverts part of #11833 which moved `extensions.add(DOMPipe)` from `init.ts` into `DOMContainer.ts` for tree-shaking. That change caused `DOMPipe` to always register, including in Web Worker environments where `document` is unavailable. This broke `Application.init()` in workers with `WebWorkerAdapter`.

Moving the registration back to `init.ts` restores worker compatibility. A better tree-shaking approach for the DOM module will need to be explored separately.

#### Fixes
- Fix `ReferenceError: document is not defined` when initializing PixiJS in a Web Worker (#11950)

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
