### PR TITLE
chore: expand build, test, and API documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -65,7 +65,16 @@ Tips for a faster workflow:
 
 - Run `npm start` in one terminal. This watches the source tree and compiles it incrementally.
 - Run `npm run test unit` to run unit tests, or `npm run test visual` to run visual regression tests.
-- Run `npm run test unit debug` to use headful DevTools to debug or develop tests
+- Run `npm run test unit debug` to use headful DevTools to debug or develop tests.
+
+You can also run individual check categories:
+
+- `npm run test lint` — ESLint only
+- `npm run test types` — Type checking only
+- `npm run test unit` — Unit tests only
+- `npm run test visual` — Visual regression tests only
+
+For more details on the build and test pipeline, see [scripts/README.md](../scripts/README.md).
 
 #### Visual Regression Testing
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,76 @@
+# Build & Test Scripts
+
+This directory contains the build and test orchestration for PixiJS.
+
+## Quick reference
+
+| Command | Description |
+| --- | --- |
+| `npm run build` | Full production build (bundle + types + DTS bundle) |
+| `npm run build:lib` | Dev build (bundle + types, no DTS bundling) |
+| `npm run build:docs` | Generate TypeDoc API documentation |
+| `npm start` | Start playground dev server + watch mode |
+| `npm test` | Run all checks (lint, types, index, prune, unit, visual) |
+| `npm run test:unit` | Unit tests only |
+| `npm run test:visual` | Visual regression tests only |
+| `npm run test:lint` | Lint checks only |
+| `npm run test:types` | Type checking only |
+| `npm run lint` | Lint with auto-fix |
+
+## Build pipeline (`build.mts`)
+
+The build script accepts two flags:
+
+- `--lib` — Library-only build. Skips package exports validation and DTS bundle generation. Sets `LIB_ONLY=1` for Rollup so only the library bundle is emitted.
+- `--dev` — Development mode. Allows type-check errors without failing, and skips `dts-bundle-generator`.
+
+### Build phases
+
+1. **Index + exports** (parallel) — Regenerates the barrel `index.ts` files and validates package exports. The exports step is skipped for `--lib` without `--dev`.
+2. **Rollup + types** (parallel) — Bundles the library with Rollup while concurrently running `tsc`, copying `.d.ts` files, fixing types, and optionally generating the DTS bundle.
+
+### Watch modes
+
+- `watch:lib` — Rebuilds on source changes with `--lib --dev`. Writes `.build-status.json` via `build-status.mjs` so the playground can show a compiling/ready indicator.
+- `watch:build` — Full dev rebuild on source changes (includes types).
+- `watch:docs` — Rebuilds TypeDoc docs on source or markdown changes.
+
+## Test pipeline (`test.mts`)
+
+The test script runs checks in two phases. Pass selectors to run specific checks:
+
+```
+npm run test [selector...] [-- flags]
+```
+
+### Selectors
+
+| Selector | Phase | Blocking | Description |
+| --- | --- | --- | --- |
+| `lint` | Static | Yes | ESLint with `--max-warnings 0` |
+| `types` | Static | Yes | `tsc --noEmit` against build, examples, and playground configs |
+| `index` | Static | Yes | Validates barrel index files are up to date |
+| `prune` | Static | No | Knip dead-code analysis (failure is reported but non-blocking) |
+| `unit` | Jest | Yes | Unit tests (excludes `tests/visual/`) |
+| `visual` | Jest | Yes | Visual regression tests (`tests/visual/`) |
+| `debug` | — | — | Modifier: runs Jest in headful mode with `DEBUG_MODE=1` |
+
+When no selectors are specified, all checks run.
+
+### Phases
+
+1. **Static checks** — `lint`, `types`, `index`, and `prune` run in parallel. If any blocking check fails, Jest tests are skipped and the process exits with code 1.
+2. **Jest tests** — `unit` and `visual` run sequentially. The `debug` selector enables headful browser DevTools for interactive debugging.
+
+Extra CLI flags (those starting with `-`) are forwarded to the underlying tool.
+
+## Build status (`build-status.mjs`)
+
+A small helper used by `watch:lib` to signal the playground's build status indicator:
+
+```
+node scripts/build-status.mjs start   # writes { status: 'compiling', startedAt: ... }
+node scripts/build-status.mjs done    # writes { status: 'ready', completedAt: ... }
+```
+
+The status is written to `.build-status.json` in the project root (git-ignored). The playground's `useBuildStatus` hook polls this file to show a yellow (compiling) or green (ready) indicator.

--- a/src/assets/__docs__/resolver.md
+++ b/src/assets/__docs__/resolver.md
@@ -92,6 +92,29 @@ PixiJS selects the best match based on runtime capabilities (e.g. chooses WebP i
 
 ---
 
+## Removing aliases
+
+Use `removeAlias` to unregister an alias from the resolver without destroying the underlying asset. This is useful when you need to remap an alias to a different asset, or when cleaning up aliases that are no longer needed.
+
+```ts
+import { Assets } from 'pixi.js';
+
+// Add an alias
+Assets.resolver.add({ alias: 'hero', src: 'hero-v1.png' });
+
+// Remove it
+Assets.resolver.removeAlias('hero');
+
+// Conditionally remove: only if the alias currently points to a specific asset
+const resolved = Assets.resolver.resolve('hero');
+Assets.resolver.removeAlias('hero', resolved);
+```
+
+> [!NOTE]
+> `removeAlias` only removes the alias mapping. It does **not** unload or destroy the asset itself. If the asset is already cached, it remains in memory until you call `Assets.unload`.
+
+---
+
 ## Related tools and features
 
 - **AssetPack**: For managing large asset sets, [AssetPack](https://pixijs.io/assetpack) can generate optimized manifests using glob patterns and output `UnresolvedAsset` structures automatically.

--- a/src/assets/resolver/Resolver.ts
+++ b/src/assets/resolver/Resolver.ts
@@ -318,11 +318,30 @@ export class Resolver
     }
 
     /**
-     * Removes the specified alias for an asset
+     * Removes the specified alias for an asset.
      *
-     * This does not remove or destroy the asset!
+     * This only removes the alias mapping. It does **not** remove, unload, or destroy the
+     * underlying asset. If the asset is already cached, it stays in memory until you call
+     * `Assets.unload`.
+     *
+     * If `asset` is provided, the alias is only removed when the resolver's current mapping for
+     * that alias matches the given `ResolvedAsset`. This lets you avoid accidentally removing an
+     * alias that has been reassigned.
+     *
+     * Silently returns if the alias does not exist or the asset does not match.
      * @param alias - the alias to remove
-     * @param asset - only remove the alias if it is assigned to the asset
+     * @param asset - only remove the alias if it is currently assigned to this asset
+     * @example
+     * ```ts
+     * resolver.add({ alias: 'hero', src: 'hero.png' });
+     *
+     * // Simple removal
+     * resolver.removeAlias('hero');
+     *
+     * // Conditional removal — only if alias currently maps to a specific asset
+     * const resolved = resolver.resolve('hero');
+     * resolver.removeAlias('hero', resolved);
+     * ```
      */
     public removeAlias(alias: string, asset?: ResolvedAsset): void
     {

--- a/src/events/__docs__/events.md
+++ b/src/events/__docs__/events.md
@@ -98,6 +98,9 @@ PixiJS supports pointer, mouse, and touch event types. Pointer events are recomm
 | `tap` | Touch tap on the object. |
 | `globaltouchmove` | Fires on every touch move, regardless of hit target. |
 
+> [!NOTE]
+> Touch events include modifier key states (`altKey`, `ctrlKey`, `metaKey`, `shiftKey`). These are copied from the native `TouchEvent` to each touch object during normalization, so you can check modifier keys the same way you would with mouse or pointer events.
+
 ### Global move events
 
 > [!IMPORTANT]

--- a/src/rendering/__docs__/rendering.md
+++ b/src/rendering/__docs__/rendering.md
@@ -131,6 +131,16 @@ function render() {
 requestAnimationFrame(render);
 ```
 
+## Destroying renderers
+
+Call `destroy()` to clean up all GPU resources, systems, event listeners, and internal state:
+
+```ts
+renderer.destroy();
+```
+
+This removes all `EventEmitter` listeners attached to the renderer and nullifies internal systems and pipes. A destroyed renderer cannot be used for further rendering.
+
 ---
 
 ## API reference

--- a/src/rendering/renderers/shared/texture/TexturePool.ts
+++ b/src/rendering/renderers/shared/texture/TexturePool.ts
@@ -139,10 +139,14 @@ export class TexturePoolClass
     }
 
     /**
-     * Gets extra texture of the same size as input renderTexture
-     * @param texture - The texture to check what size it is.
-     * @param antialias - Whether to use antialias.
-     * @returns A texture that is a power of two
+     * Gets a pooled texture matching the dimensions and resolution of the given texture.
+     *
+     * This is a convenience wrapper around {@link TexturePoolClass#getOptimalTexture|getOptimalTexture}
+     * that copies width, height, and resolution from an existing texture. Useful when a filter needs
+     * a temporary texture the same size as its input (e.g., for multi-pass blur).
+     * @param texture - The texture whose dimensions to match.
+     * @param antialias - Whether to use antialias on the pooled texture. Defaults to `false`.
+     * @returns A pooled texture with power-of-two backing dimensions at the source resolution.
      */
     public getSameSizeTexture(texture: Texture, antialias = false)
     {
@@ -152,10 +156,15 @@ export class TexturePoolClass
     }
 
     /**
-     * Place a render texture back into the pool. Optionally reset the style of the texture to the default texture style.
-     * useful if you modified the style of the texture after getting it from the pool.
-     * @param renderTexture - The renderTexture to free
-     * @param resetStyle - Whether to reset the style of the texture to the default texture style
+     * Returns a texture to the pool so it can be reused by future
+     * {@link TexturePoolClass#getOptimalTexture|getOptimalTexture}
+     * or {@link TexturePoolClass#getSameSizeTexture|getSameSizeTexture} calls.
+     *
+     * If you modified the texture's style after obtaining it (e.g., changed filtering or wrapping),
+     * pass `resetStyle = true` to restore the pool's default {@link TexturePoolClass#textureStyle|textureStyle}.
+     * This prevents style changes from leaking into subsequent consumers of the same pooled texture.
+     * @param renderTexture - The texture to return to the pool.
+     * @param resetStyle - When `true`, replaces the texture source's style with the pool default. Defaults to `false`.
      */
     public returnTexture(renderTexture: Texture, resetStyle = false): void
     {

--- a/src/scene/__docs__/container/index.md
+++ b/src/scene/__docs__/container/index.md
@@ -51,11 +51,51 @@ otherContainer.reparentChild(child);
 
 ### Events
 
-Containers emit events when children are added or removed:
+Containers emit lifecycle events you can listen to. There are two perspectives: events on the **parent** and events on the **child**.
+
+#### Parent-side events
+
+`childAdded` and `childRemoved` fire on the container whose children changed:
 
 ```ts
 group.on('childAdded', (child, parent, index) => { ... });
 group.on('childRemoved', (child, parent, index) => { ... });
+```
+
+#### Child-side events
+
+`added` and `removed` fire on the child itself when its parent changes:
+
+```ts
+const sprite = Sprite.from('bunny.png');
+
+sprite.on('added', (parent) => {
+    console.log('Added to:', parent.label);
+});
+sprite.on('removed', (oldParent) => {
+    console.log('Removed from:', oldParent.label);
+});
+```
+
+> [!NOTE]
+> When using `addChildAt` to reposition a child that is **already in the same container**, the child is moved silently. None of the add/remove events fire, since the parent-child relationship hasn't changed.
+
+#### Property and lifecycle events
+
+`visibleChanged` fires whenever a container's `visible` property changes:
+
+```ts
+container.on('visibleChanged', (visible) => {
+    console.log('Visibility:', visible);
+});
+```
+
+`destroyed` fires when `destroy()` is called, after internal cleanup but before listeners are removed:
+
+```ts
+container.on('destroyed', (container) => {
+    console.log('Destroyed:', container.label);
+});
 ```
 
 ### Finding children

--- a/src/scene/__docs__/graphics/index.md
+++ b/src/scene/__docs__/graphics/index.md
@@ -147,6 +147,7 @@ This means you can build, reuse, and transform `Graphics` objects freely without
 - **SVG and holes**: Not all SVG hole paths triangulate correctly.
 - **Changing geometry**: Use `.clear()` sparingly. Prefer swapping contexts.
 - **Transparency and blend modes**: These apply per primitive. Use `RenderTexture` to flatten effects.
+- **Empty Graphics bounds**: A `Graphics` object with no drawing instructions returns bounds of `(0, 0, 0, 0)`. This prevents `Infinity` values from contaminating parent container bounds calculations.
 
 ---
 

--- a/src/scene/__docs__/text/bitmap.md
+++ b/src/scene/__docs__/text/bitmap.md
@@ -91,6 +91,10 @@ text.resolution = 2;
 // ⚠️ [BitmapText] dynamically updating the resolution is not supported.
 ```
 
+### Missing glyphs
+
+If text contains characters that aren't in the bitmap font's atlas, those characters are skipped during layout and rendering. Text may appear incomplete but will not crash. To fix this, either add the missing characters to your bitmap font (e.g. via [AssetPack](https://pixijs.io/assetpack/)) or use `Text` / `HTMLText` for content with unpredictable character sets.
+
 ### Large character sets not practical
 
 Each character needs space in the atlas texture. For CJK, Arabic, or emoji-heavy content, the atlas can exceed GPU texture size limits or consume too much memory. For these cases, use `Text` (renders any character the browser supports) or `HTMLText` (supports emoji and RTL natively).

--- a/src/scene/__docs__/text/canvas.md
+++ b/src/scene/__docs__/text/canvas.md
@@ -77,6 +77,23 @@ const myText = new Text({
 myText.resolution = 1; // Reset to default
 ```
 
+## Mipmaps
+
+Set `autoGenerateMipmaps` to improve rendering quality when text is scaled down. Without mipmaps, downscaled text can appear noisy or shimmer during animation.
+
+```ts
+const text = new Text({
+    text: 'Smooth when small',
+    style: { fontSize: 48 },
+    autoGenerateMipmaps: true,
+});
+```
+
+When enabled, the text texture is allocated from a separate mipmap-enabled pool, so it won't interfere with non-mipmapped textures used by filters or other systems.
+
+> [!NOTE]
+> `HTMLText` also supports `autoGenerateMipmaps` with the same behavior.
+
 ## Font loading
 
 PixiJS loads custom fonts via the `Assets` API. Supported formats:

--- a/src/scene/container/container-mixins/childrenHelperMixin.ts
+++ b/src/scene/container/container-mixins/childrenHelperMixin.ts
@@ -136,12 +136,16 @@ export interface ChildrenHelperMixin<C = ContainerChild>
     /**
      * Adds a child to the container at a specified index. If the index is out of bounds an error will be thrown.
      * If the child is already in this container, it will be moved to the specified index.
+     *
+     * When moving a child within the **same** container, `childAdded` and `added` events are
+     * **not** emitted because the parent-child relationship hasn't changed. Events only fire when
+     * a child is added from a different parent (or from no parent).
      * @example
      * ```ts
      * // Add at specific index
      * container.addChildAt(sprite, 0); // Add to front
      *
-     * // Move existing child
+     * // Move existing child (no events emitted)
      * const index = container.children.length - 1;
      * container.addChildAt(existingChild, index); // Move to back
      *

--- a/src/ticker/Ticker.ts
+++ b/src/ticker/Ticker.ts
@@ -743,7 +743,10 @@ export class Ticker
      * but does not effect the measured value of {@link Ticker#FPS|FPS}.
      *
      * When setting this property it is clamped to a value between
-     * `0` and `Ticker.targetFPMS * 1000`.
+     * `0` and `Ticker.targetFPMS * 1000` (typically 60).
+     *
+     * If `maxFPS` is currently set (non-zero) and `minFPS` is set above it,
+     * `maxFPS` is automatically raised to match. This keeps the two limits consistent.
      * @example
      * ```ts
      * // Set minimum acceptable frame rate
@@ -754,11 +757,8 @@ export class Ticker
      * ticker.minFPS = 30;
      * ticker.maxFPS = 60;
      *
-     * // Monitor delta capping
-     * ticker.add(() => {
-     *     // Delta time will be capped based on minFPS
-     *     console.log(`Delta time: ${ticker.deltaTime}`);
-     * });
+     * // minFPS above maxFPS pushes maxFPS up
+     * ticker.minFPS = 50; // maxFPS is raised to 50
      * ```
      * @default 10
      */
@@ -788,22 +788,22 @@ export class Ticker
      * This will effect the measured value of {@link Ticker#FPS|FPS}.
      *
      * If it is set to `0`, then there is no limit; PixiJS will render as many frames as it can.
-     * Otherwise it will be at least `minFPS`
+     * Otherwise it will be at least `minFPS`.
+     *
+     * If `maxFPS` is set below the current `minFPS`, `minFPS` is automatically lowered to match.
+     * This keeps the two limits consistent.
      * @example
      * ```ts
-     * // Set minimum acceptable frame rate
+     * // Cap the frame rate
      * const ticker = new Ticker();
      * ticker.maxFPS = 60; // Never go above 60 FPS
      *
-     * // Use with maxFPS for frame rate clamping
+     * // Use with minFPS for frame rate clamping
      * ticker.minFPS = 30;
      * ticker.maxFPS = 60;
      *
-     * // Monitor delta capping
-     * ticker.add(() => {
-     *     // Delta time will be capped based on maxFPS
-     *     console.log(`Delta time: ${ticker.deltaTime}`);
-     * });
+     * // maxFPS below minFPS pushes minFPS down
+     * ticker.maxFPS = 20; // minFPS is now also 20
      * ```
      * @default 0
      */

--- a/src/ticker/__docs__/ticker.md
+++ b/src/ticker/__docs__/ticker.md
@@ -97,6 +97,8 @@ Caps how large `deltaTime` can get during slow frames. If the real frame rate dr
 ticker.minFPS = 30; // deltaTime won't exceed ~2.0, even if a frame takes 500ms
 ```
 
+The value is clamped between `0` and `Ticker.targetFPMS * 1000` (typically 60).
+
 ### `maxFPS`
 
 Limits how _fast_ the ticker runs. Useful for conserving CPU/GPU:
@@ -109,6 +111,21 @@ Set to `0` to allow unlimited frame rate:
 
 ```ts
 ticker.maxFPS = 0;
+```
+
+### Mutual clamping between `minFPS` and `maxFPS`
+
+The two properties stay consistent with each other automatically:
+
+- Setting `minFPS` above the current `maxFPS` raises `maxFPS` to match.
+- Setting `maxFPS` below the current `minFPS` lowers `minFPS` to match.
+
+```ts
+ticker.minFPS = 10;
+ticker.maxFPS = 30;
+
+ticker.minFPS = 50; // maxFPS is raised to 50
+ticker.maxFPS = 20; // minFPS is lowered to 20
 ```
 
 ## Speed control


### PR DESCRIPTION
### Overview

Adds and improves documentation across the codebase, covering build/test scripts, API methods, and behavioral notes for recent bug fixes. Includes a new `scripts/README.md` reference, expanded JSDoc on several public APIs, and new guide sections for features that were previously undocumented or under-documented.

#### Chores
- Add `scripts/README.md` documenting the build pipeline, test phases, selectors, and watch modes
- Expand CONTRIBUTING.md with individual test command references
- Document `Resolver.removeAlias` usage in guides and JSDoc
- Add touch event modifier key note to events guide
- Document renderer `destroy()` behavior in rendering guide
- Improve `TexturePool.getSameSizeTexture` and `returnTexture` JSDoc
- Expand container events docs with child-side, property, and lifecycle events
- Document `addChildAt` silent move behavior in JSDoc
- Add empty Graphics bounds note
- Add missing glyphs section to BitmapText guide
- Add mipmaps section to canvas Text and HTMLText guide
- Document `minFPS`/`maxFPS` mutual clamping behavior in Ticker guide and JSDoc

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
