### PR TITLE
fix: add secrets: inherit to publish-switch workflow for S3 docs upload

### DIFF
--- a/.github/workflows/publish-switch.yml
+++ b/.github/workflows/publish-switch.yml
@@ -16,6 +16,7 @@ jobs:
   publish-prod:
     if: github.event_name == 'release'
     uses: ./.github/workflows/release.yml
+    secrets: inherit
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
### Overview

When the CI workflows were refactored for trusted publishing (#11820, included in v8.15.0), `release.yml` was changed from a direct `on: release` trigger to a `workflow_call` invoked by `publish-switch.yml`. However, `secrets: inherit` was not added to the caller, so the called workflow has no access to AWS secrets. The S3 upload steps check `if: env.AWS_ACCESS_KEY_ID != ''`, which silently evaluates to false, skipping docs upload on every release since v8.15.0.

NPM publishing was unaffected because it was switched to OIDC trusted publishing in the same refactor.

#### Fixes
- S3 documentation upload silently skipped on every release since v8.15.0 due to missing `secrets: inherit` in the publish-switch workflow

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
