### PR TITLE
feat: provide a getter to the domElement via app.domContainerRoot

### DIFF
--- a/src/app/Application.ts
+++ b/src/app/Application.ts
@@ -358,6 +358,16 @@ export class Application<R extends Renderer = Renderer>
     }
 
     /**
+     * Get the html div element that holds all DOM Container elements.
+     * @readonly
+     * @type {HTMLDivElement}
+     */
+    get domContainerRoot()
+    {
+        return this.renderer.renderPipes.dom._domElement;
+    }
+
+    /**
      * Destroys the application and all of its resources.
      *
      * This method should be called when you want to completely

--- a/src/dom/DOMPipe.ts
+++ b/src/dom/DOMPipe.ts
@@ -32,7 +32,7 @@ export class DOMPipe implements RenderPipe<DOMContainer>
     /** Array to keep track of attached DOM elements */
     private readonly _attachedDomElements: DOMContainer[] = [];
     /** The main DOM element that acts as a container for other DOM elements */
-    private readonly _domElement: HTMLDivElement;
+    public readonly _domElement: HTMLDivElement;
     /** The CanvasTransformSync instance that keeps the DOM element in sync with the canvas */
     private _canvasObserver: CanvasObserver;
 


### PR DESCRIPTION

##### Description of change
Add a getter to the domElement that is the wrapper/root container for DOMContainers. This way its possible to add a class, or change any aspects of that ` HTMLDivElement`.

Related: https://github.com/pixijs/pixijs/pull/11932

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
