### PR TITLE
fix: restore all text rendering after WebGL context loss

### DIFF
--- a/src/scene/text-html/HTMLTextPipe.ts
+++ b/src/scene/text-html/HTMLTextPipe.ts
@@ -32,12 +32,37 @@ export class HTMLTextPipe implements RenderPipe<HTMLText>
     {
         this._renderer = renderer;
         renderer.runners.resolutionChange.add(this);
+        renderer.runners.contextChange.add(this);
         this._managedTexts = new GCManagedHash({
             renderer,
             type: 'renderable',
             onUnload: this.onTextUnload.bind(this),
             name: 'htmlText'
         });
+    }
+
+    protected contextChange()
+    {
+        this._renderer.htmlText.clearActiveTextures();
+
+        for (const key in this._managedTexts.items)
+        {
+            const text = this._managedTexts.items[key];
+
+            if (!text) continue;
+
+            const gpuData = text._gpuData[this._renderer.uid];
+
+            if (gpuData)
+            {
+                gpuData.currentKey = '--';
+                gpuData.texture = Texture.EMPTY;
+                gpuData.texturePromise = null;
+                gpuData.generatingTexture = false;
+            }
+
+            text.onViewUpdate();
+        }
     }
 
     protected resolutionChange()
@@ -117,6 +142,8 @@ export class HTMLTextPipe implements RenderPipe<HTMLText>
 
         htmlText._resolution = htmlText._autoResolution ? this._renderer.resolution : htmlText.resolution;
 
+        const expectedKey = htmlText.styleKey;
+
         let texturePromise = this._renderer.htmlText.getTexturePromise(htmlText);
 
         if (oldTexturePromise)
@@ -132,7 +159,17 @@ export class HTMLTextPipe implements RenderPipe<HTMLText>
         batchableHTMLText.texturePromise = texturePromise;
         batchableHTMLText.currentKey = htmlText.styleKey;
 
-        batchableHTMLText.texture = await texturePromise;
+        const texture = await texturePromise;
+
+        // If a context loss reset this while we were awaiting, discard the stale texture
+        if (batchableHTMLText.currentKey === '--' && expectedKey !== '--')
+        {
+            batchableHTMLText.generatingTexture = false;
+
+            return;
+        }
+
+        batchableHTMLText.texture = texture;
 
         // need a rerender...
         const renderGroup = htmlText.renderGroup || htmlText.parentRenderGroup;

--- a/src/scene/text-html/HTMLTextSystem.ts
+++ b/src/scene/text-html/HTMLTextSystem.ts
@@ -224,6 +224,14 @@ export class HTMLTextSystem implements System
         return texture;
     }
 
+    public clearActiveTextures()
+    {
+        for (const key in this._activeTextures)
+        {
+            this._activeTextures[key] = null;
+        }
+    }
+
     public returnTexturePromise(texturePromise: Promise<Texture>)
     {
         texturePromise.then((texture) =>

--- a/src/scene/text/canvas/CanvasTextPipe.ts
+++ b/src/scene/text/canvas/CanvasTextPipe.ts
@@ -1,4 +1,5 @@
 import { ExtensionType } from '../../../extensions/Extensions';
+import { Texture } from '../../../rendering/renderers/shared/texture/Texture';
 import { GCManagedHash } from '../../../utils/data/GCManagedHash';
 import { updateTextBounds } from '../utils/updateTextBounds';
 import { BatchableText } from './BatchableText';
@@ -28,12 +29,35 @@ export class CanvasTextPipe implements RenderPipe<Text>
     {
         this._renderer = renderer;
         renderer.runners.resolutionChange.add(this);
+        renderer.runners.contextChange.add(this);
         this._managedTexts = new GCManagedHash({
             renderer,
             type: 'renderable',
             onUnload: this.onTextUnload.bind(this),
             name: 'canvasText'
         });
+    }
+
+    protected contextChange()
+    {
+        this._renderer.canvasText.clearActiveTextures();
+
+        for (const key in this._managedTexts.items)
+        {
+            const text = this._managedTexts.items[key];
+
+            if (!text) continue;
+
+            const gpuData = text._gpuData[this._renderer.uid];
+
+            if (gpuData)
+            {
+                gpuData.currentKey = '--';
+                gpuData.texture = Texture.EMPTY;
+            }
+
+            text.onViewUpdate();
+        }
     }
 
     protected resolutionChange()

--- a/src/scene/text/shared/AbstractTextSystem.ts
+++ b/src/scene/text/shared/AbstractTextSystem.ts
@@ -240,6 +240,14 @@ export abstract class AbstractTextSystem implements System
         }
     }
 
+    public clearActiveTextures()
+    {
+        for (const key in this._activeTextures)
+        {
+            this._activeTextures[key] = null;
+        }
+    }
+
     /**
      * Gets the current reference count for a texture associated with a text key.
      * @param textKey - The unique key identifying the text style configuration


### PR DESCRIPTION
Closes #11685

## Problem

When a WebGL context is lost and restored, all three text types (Canvas Text, HTML Text, Bitmap Text) can disappear permanently. The text rendering pipes hold references to GPU textures that become invalid after context restoration, but unlike `GraphicsPipe`, the text pipes don't listen for the `contextChange` event and never regenerate their textures.

## Fix

**CanvasTextPipe** and **HTMLTextPipe** now register to `renderer.runners.contextChange`. On context loss:

1. The system-level texture caches (`_activeTextures`) are cleared via a new `clearActiveTextures()` method on both `AbstractTextSystem` and `HTMLTextSystem`. This prevents stale cache hits when textures are regenerated.
2. Each managed text renderable's GPU data is reset (`currentKey = '--'`, `texture = Texture.EMPTY`), putting it back into the same state as after `initGpuText()`.
3. `text.onViewUpdate()` is called to set `_didTextUpdate = true`, which triggers texture regeneration on the next render frame.

**HTMLTextPipe** additionally includes an async race guard in `_updateGpuText()`: before awaiting the texture promise, the current `styleKey` is saved. After the await, if `contextChange` has reset `currentKey` to `'--'` in the meantime, the stale texture is discarded rather than assigned — preventing a texture generated against the old GL context from overwriting the reset state.

**BitmapText** delegates rendering to `GraphicsPipe`, which already handles `contextChange`. No changes needed there.

## Test steps

1. Create a scene with all three text types (`Text`, `HTMLText`, `BitmapText`)
2. Navigate to `chrome://gpucrash` in a separate tab (or use `WEBGL_lose_context` extension)
3. Return to the PixiJS tab
4. Verify all text reappears after context is restored