### PR TITLE
fix: skip _applyMipRange for single-mip textures (iOS 18.0–18.1)

### DIFF
--- a/src/rendering/renderers/gl/texture/GlTextureSystem.ts
+++ b/src/rendering/renderers/gl/texture/GlTextureSystem.ts
@@ -360,12 +360,7 @@ export class GlTextureSystem implements System, CanvasGenerator
 
         // Keep the texture's mip range in sync with the declared mipLevelCount.
         // This is required in WebGL2 for FBO attachments at mipLevel > 0 when using partial mip chains.
-        // Skip for single-mip textures: setting MAX_LEVEL=0 triggers an ANGLE Metal bug
-        // on iOS 18.0–18.1 (https://github.com/pixijs/pixijs/issues/11984).
-        if (source.mipLevelCount > 1)
-        {
-            this._applyMipRange(glTexture, source);
-        }
+        this._applyMipRange(glTexture, source);
 
         if (source.autoGenerateMipmaps && source.mipLevelCount > 1)
         {
@@ -527,6 +522,10 @@ export class GlTextureSystem implements System, CanvasGenerator
     private _applyMipRange(glTexture: GlTexture, source: TextureSource): void
     {
         if (this._renderer.context.webGLVersion !== 2) return;
+
+        // Skip for single-mip textures: setting MAX_LEVEL=0 triggers an ANGLE Metal bug
+        // on iOS 18.0–18.1 (https://github.com/pixijs/pixijs/issues/11984).
+        if (source.mipLevelCount <= 1) return;
 
         const gl = this._gl as WebGL2RenderingContext;
         const maxLevel = Math.max((source.mipLevelCount | 0) - 1, 0);

--- a/src/rendering/renderers/gl/texture/GlTextureSystem.ts
+++ b/src/rendering/renderers/gl/texture/GlTextureSystem.ts
@@ -360,7 +360,12 @@ export class GlTextureSystem implements System, CanvasGenerator
 
         // Keep the texture's mip range in sync with the declared mipLevelCount.
         // This is required in WebGL2 for FBO attachments at mipLevel > 0 when using partial mip chains.
-        this._applyMipRange(glTexture, source);
+        // Skip for single-mip textures: setting MAX_LEVEL=0 triggers an ANGLE Metal bug
+        // on iOS 18.0–18.1 (https://github.com/pixijs/pixijs/issues/11984).
+        if (source.mipLevelCount > 1)
+        {
+            this._applyMipRange(glTexture, source);
+        }
 
         if (source.autoGenerateMipmaps && source.mipLevelCount > 1)
         {


### PR DESCRIPTION
### Overview
- Guard `_applyMipRange()` with `source.mipLevelCount > 1` so `TEXTURE_MAX_LEVEL=0` is never set on single-mip textures, working around an ANGLE Metal bug on iOS 18.0–18.1 that causes texture corruption and freezing when switching FBOs.

Fixes: #11984

#### Fixes
- Skip `_applyMipRange` for single-mip textures to avoid setting `TEXTURE_MAX_LEVEL=0`, which triggers a Metal driver bug in iOS 18.0–18.1's ANGLE (`FramebufferMtl::syncState` creates texture views with `levelCount=1` hitting a buggy code path). Single-mip textures don't need explicit mip range clamping since the driver clamps to allocated levels by default.

##### Pre-Merge Checklist
- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change to WebGL2 texture parameter setup; it only adds an early return for `mipLevelCount <= 1` to avoid a known driver bug.
> 
> **Overview**
> Avoids setting `TEXTURE_MAX_LEVEL` for single-mip textures in WebGL2.
> 
> `GlTextureSystem._applyMipRange()` now returns early when `source.mipLevelCount <= 1`, working around an iOS 18.0–18.1 ANGLE Metal issue triggered by `MAX_LEVEL=0` while leaving multi-mip/partial-mip-chain behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d563a54b4f4fc13564b3272dfe0daf7c159f642. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->