### PR TITLE
feat: Add width option to MeshRope class

### DIFF
--- a/src/scene/mesh-simple/MeshRope.ts
+++ b/src/scene/mesh-simple/MeshRope.ts
@@ -53,6 +53,9 @@ export interface MeshRopeOptions extends Omit<MeshOptions, 'geometry'>
      * @default 0
      */
     textureScale?: number;
+
+    /** The width (i.e., thickness) of the rope. If not specified, defaults back to texture's height. */
+    width?: number;
 }
 
 /**
@@ -168,8 +171,8 @@ export class MeshRope extends Mesh
      */
     constructor(options: MeshRopeOptions)
     {
-        const { texture, points, textureScale, ...rest } = { ...MeshRope.defaultOptions, ...options };
-        const ropeGeometry = new RopeGeometry(definedProps({ width: texture.height, points, textureScale }));
+        const { width, texture, points, textureScale, ...rest } = { ...MeshRope.defaultOptions, ...options };
+        const ropeGeometry = new RopeGeometry(definedProps({ width: width ?? texture.height, points, textureScale }));
 
         if (textureScale > 0)
         {


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

Recently had to use MeshRope. Even though RopeGeometry does have the width option, MeshRope does not. Passing the width  to RopeGeometry works as expected. Texture scale is not applicable in this situation because it is tied to texture repeat logic.

I labeled it as feat but it's just passing props in.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
