### PR TITLE
feat: Replace earcut with tess2 for correct winding rules and self-intersection support

### DIFF
--- a/.configs/jest.config.js
+++ b/.configs/jest.config.js
@@ -16,7 +16,7 @@ module.exports = {
         '\\.wgsl$': 'jest-raw-loader',
         '\\.js$': ['babel-jest', { plugins: ['@babel/plugin-transform-modules-commonjs'] }]
     },
-    transformIgnorePatterns: ['/node_modules/(?!earcut|@types/earcut)'],
+    transformIgnorePatterns: ['/node_modules/(?!earcut|@types/earcut|tess2)'],
     moduleNameMapper: {
         '^worker:(.*)$': '$1',
         '^~/(.*)$': '<rootDir>/src/$1',

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "gifuct-js": "^2.1.2",
         "ismobilejs": "^1.1.1",
         "parse-svg-path": "^0.1.2",
+        "tess2": "^1.0.0",
         "tiny-lru": "^11.4.7"
       },
       "devDependencies": {
@@ -17378,6 +17379,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tess2": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tess2/-/tess2-1.0.0.tgz",
+      "integrity": "sha512-iSWBSOUoPn3cCT26L5Wi6mvVgL11RV4kReSnVIIPdMN7qNpkL5SLKen5BJcWj+ZTN7kK6JrHBdqTV7vvL8g+9w==",
+      "license": "SGI-B-2.0"
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -31479,6 +31486,11 @@
         "ansi-escapes": "^4.2.1",
         "supports-hyperlinks": "^2.0.0"
       }
+    },
+    "tess2": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tess2/-/tess2-1.0.0.tgz",
+      "integrity": "sha512-iSWBSOUoPn3cCT26L5Wi6mvVgL11RV4kReSnVIIPdMN7qNpkL5SLKen5BJcWj+ZTN7kK6JrHBdqTV7vvL8g+9w=="
     },
     "test-exclude": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "gifuct-js": "^2.1.2",
     "ismobilejs": "^1.1.1",
     "parse-svg-path": "^0.1.2",
+    "tess2": "^1.0.0",
     "tiny-lru": "^11.4.7"
   },
   "devDependencies": {

--- a/src/scene/graphics/shared/__tests__/SVGParser.test.ts
+++ b/src/scene/graphics/shared/__tests__/SVGParser.test.ts
@@ -83,7 +83,8 @@ describe('SVGParser Fill Rule', () =>
 
     it('should handle single subpath with evenodd using original behavior', () =>
     {
-        // Test 5: Single subpath with evenodd should use original behavior
+        // Test 5: Single subpath with evenodd should pass checkForHoles=true
+        // so the tessellator uses WINDING_ODD for evenodd fill rule
         const svgSingleEvenodd = `
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
                 <path d="M 100 20 L 120 80 L 180 80 L 135 120 L 155 180 L 100 145 L 45 180 L 65 120 L 20 80 L 80 80 Z"
@@ -100,7 +101,7 @@ describe('SVGParser Fill Rule', () =>
 
         const pathData = getFillInstructionData(context);
 
-        expect(pathData.path.checkForHoles).toBe(false);
+        expect(pathData.path.checkForHoles).toBe(true);
     });
 
     it('should handle single subpath with nonzero using original behavior', () =>

--- a/src/scene/graphics/shared/path/ShapePath.ts
+++ b/src/scene/graphics/shared/path/ShapePath.ts
@@ -270,51 +270,11 @@ export class ShapePath
             path.transform(transform);
         }
 
-        const shapePrimitives = this.shapePrimitives;
-        const start = shapePrimitives.length;
-
         for (let i = 0; i < path.instructions.length; i++)
         {
             const instruction = path.instructions[i];
 
             this[instruction.action](...(instruction.data as [never, never, never, never, never, never, never]));
-        }
-
-        // This section processes holes in polygons by checking if any polygon is contained within another.
-        // If a polygon is found to be inside another polygon (mainShape), it's treated as a hole.
-        // The hole polygon is removed from the main shapePrimitives array and added to the holes array
-        // of the containing polygon. This allows for proper rendering of shapes with holes.
-        if (path.checkForHoles && shapePrimitives.length - start > 1)
-        {
-            let mainShape = null;
-
-            // Process in place instead of creating a removal array
-            for (let i = start; i < shapePrimitives.length; i++)
-            {
-                const shapePrimitive = shapePrimitives[i];
-
-                if (shapePrimitive.shape.type === 'polygon')
-                {
-                    const polygon = shapePrimitive.shape as Polygon;
-                    const mainPolygon = mainShape?.shape as Polygon;
-
-                    if (mainPolygon && mainPolygon.containsPolygon(polygon))
-                    {
-                        // Initialize holes array only when needed
-                        mainShape.holes ||= [];
-                        mainShape.holes.push(shapePrimitive);
-
-                        // Remove the hole by moving elements left
-                        shapePrimitives.copyWithin(i, i + 1);
-                        shapePrimitives.length--;
-                        i--;
-                    }
-                    else
-                    {
-                        mainShape = shapePrimitive;
-                    }
-                }
-            }
         }
 
         return this;

--- a/src/scene/graphics/shared/svg/SVGParser.ts
+++ b/src/scene/graphics/shared/svg/SVGParser.ts
@@ -3,8 +3,6 @@ import { GraphicsPath } from '../path/GraphicsPath';
 import { parseSVGDefinitions } from './parseSVGDefinitions';
 import { parseSVGFloatAttribute } from './parseSVGFloatAttribute';
 import { parseSVGStyle } from './parseSVGStyle';
-import { checkForNestedPattern } from './utils/fillOperations';
-import { appendSVGPath, calculatePathArea, extractSubpaths } from './utils/pathOperations';
 
 import type { FillGradient } from '../fill/FillGradient';
 import type { FillStyle, StrokeStyle } from '../FillTypes';
@@ -144,84 +142,13 @@ function renderChildren(svg: SVGElement, session: Session, fillStyle: FillStyle,
 
             const fillRule = svg.getAttribute('fill-rule') as string;
 
-            const subpaths = extractSubpaths(d);
-            const hasExplicitEvenodd = fillRule === 'evenodd';
-            const hasMultipleSubpaths = subpaths.length > 1;
-
-            const shouldProcessHoles = hasExplicitEvenodd && hasMultipleSubpaths;
-
-            if (shouldProcessHoles)
-            {
-                const subpathsWithArea = subpaths.map((subpath) => ({
-                    path: subpath,
-                    area: calculatePathArea(subpath)
-                }));
-
-                subpathsWithArea.sort((a, b) => b.area - a.area);
-
-                // For complex cases, prefer multiple holes approach
-                const useMultipleHolesApproach = subpaths.length > 3 || !checkForNestedPattern(subpathsWithArea);
-
-                if (useMultipleHolesApproach)
-                {
-                    // Multiple holes approach: first (largest) is fill, rest are holes
-                    for (let i = 0; i < subpathsWithArea.length; i++)
-                    {
-                        const subpath = subpathsWithArea[i];
-                        const isMainShape = i === 0;
-
-                        session.context.beginPath();
-                        const newPath = new GraphicsPath(undefined, true); // Always use evenodd for hole processing
-
-                        appendSVGPath(subpath.path, newPath);
-                        session.context.path(newPath);
-
-                        if (isMainShape)
-                        {
-                            if (fillStyle) session.context.fill(fillStyle);
-                            if (strokeStyle) session.context.stroke(strokeStyle);
-                        }
-                        else
-                        {
-                            session.context.cut();
-                        }
-                    }
-                }
-                else
-                {
-                    // Nested holes approach: alternate between fill and cut
-                    for (let i = 0; i < subpathsWithArea.length; i++)
-                    {
-                        const subpath = subpathsWithArea[i];
-                        const isHole = i % 2 === 1; // Odd indices are holes
-
-                        session.context.beginPath();
-                        const newPath = new GraphicsPath(undefined, true); // Always use evenodd for hole processing
-
-                        appendSVGPath(subpath.path, newPath);
-                        session.context.path(newPath);
-
-                        if (isHole)
-                        {
-                            session.context.cut();
-                        }
-                        else
-                        {
-                            if (fillStyle) session.context.fill(fillStyle);
-                            if (strokeStyle) session.context.stroke(strokeStyle);
-                        }
-                    }
-                }
-            }
-            else
-            {
-                const useEvenoddForGraphicsPath = fillRule ? (fillRule === 'evenodd') : true;
-
-                graphicsPath = new GraphicsPath(d, useEvenoddForGraphicsPath);
-                session.context.path(graphicsPath);
-                if (fillStyle) session.context.fill(fillStyle);
-                if (strokeStyle) session.context.stroke(strokeStyle);
-            }
+            // Pass fill-rule to GraphicsPath so the tessellator can apply
+            // the correct winding rule (WINDING_ODD for evenodd, WINDING_NONZERO
+            // for nonzero). No heuristic hole detection needed — tess2 handles both.
+            graphicsPath = new GraphicsPath(d, fillRule === 'evenodd');
+            session.context.path(graphicsPath);
+            if (fillStyle) session.context.fill(fillStyle);
+            if (strokeStyle) session.context.stroke(strokeStyle);
             break;
         }
 

--- a/src/scene/graphics/shared/utils/buildContextBatches.ts
+++ b/src/scene/graphics/shared/utils/buildContextBatches.ts
@@ -13,7 +13,7 @@ import { buildPolygon } from '../buildCommands/buildPolygon';
 import { buildRectangle } from '../buildCommands/buildRectangle';
 import { buildTriangle } from '../buildCommands/buildTriangle';
 import { generateTextureMatrix as generateTextureFillMatrix } from './generateTextureFillMatrix';
-import { triangulateWithHoles } from './triangulateWithHoles';
+import { Tess2, triangulateWithHoles } from './triangulateWithHoles';
 
 import type { Polygon } from '../../../../maths/shapes/Polygon';
 import type { Topology } from '../../../../rendering/renderers/shared/geometry/const';
@@ -168,6 +168,83 @@ function addShapePathToGeometryData(
 )
 {
     const { vertices, uvs, indices } = geometryData;
+
+    // For fill paths with multiple contours and no explicit holes: batch all
+    // contours into a single tessellation call so the tessellator can compute
+    // winding across all contours, producing correct holes via winding cancellation.
+    // The winding rule (nonzero vs evenodd) determines how overlapping regions are filled.
+    if (!isStroke && shapePath.shapePrimitives.length > 1
+        && shapePath.shapePrimitives.every((p) => !p.holes))
+    {
+        const windingRule = shapePath.signed ? Tess2.WINDING_ODD : Tess2.WINDING_NONZERO;
+        const allContours: number[][] = [];
+
+        for (const { shape, transform: matrix } of shapePath.shapePrimitives)
+        {
+            const points: number[] = [];
+            const build = shapeBuilders[shape.type];
+
+            if (!build.build(shape, points)) continue;
+            if (matrix) transformVertices(points, matrix);
+            allContours.push(points);
+        }
+
+        if (allContours.length > 0)
+        {
+            const allPoints: number[] = [];
+            const holeIndices: number[] = [];
+
+            for (let ci = 0; ci < allContours.length; ci++)
+            {
+                if (ci > 0) holeIndices.push(allPoints.length / 2);
+
+                const contour = allContours[ci];
+
+                for (let j = 0; j < contour.length; j++)
+                {
+                    allPoints.push(contour[j]);
+                }
+            }
+
+            const indexOffset = indices.length;
+            const vertOffset = vertices.length / 2;
+
+            triangulateWithHoles(allPoints, holeIndices, vertices, 2, vertOffset, indices, indexOffset, windingRule);
+
+            const uvsOffset = uvs.length / 2;
+            const texture = (style as ConvertedFillStyle).texture;
+
+            if (texture !== Texture.WHITE)
+            {
+                const textureMatrix = generateTextureFillMatrix(
+                    tempTextureMatrix, style as ConvertedFillStyle,
+                    shapePath.shapePrimitives[0].shape, shapePath.shapePrimitives[0].transform
+                );
+
+                buildUvs(vertices, 2, vertOffset, uvs, uvsOffset, 2, (vertices.length / 2) - vertOffset, textureMatrix);
+            }
+            else
+            {
+                buildSimpleUvs(uvs, uvsOffset, 2, (vertices.length / 2) - vertOffset);
+            }
+
+            const graphicsBatch = BigPool.get(BatchableGraphics);
+
+            graphicsBatch.indexOffset = indexOffset;
+            graphicsBatch.indexSize = indices.length - indexOffset;
+            graphicsBatch.attributeOffset = vertOffset;
+            graphicsBatch.attributeSize = (vertices.length / 2) - vertOffset;
+            graphicsBatch.baseColor = (style as ConvertedFillStyle).color;
+            graphicsBatch.alpha = (style as ConvertedFillStyle).alpha;
+            graphicsBatch.texture = texture;
+            graphicsBatch.geometryData = geometryData;
+            graphicsBatch.topology = 'triangle-list';
+
+            batches.push(graphicsBatch);
+        }
+
+        return;
+    }
 
     shapePath.shapePrimitives.forEach(({ shape, transform: matrix, holes }) =>
     {

--- a/src/scene/graphics/shared/utils/tess2.d.ts
+++ b/src/scene/graphics/shared/utils/tess2.d.ts
@@ -1,0 +1,39 @@
+declare module 'tess2'
+{
+    interface TessResult
+    {
+        vertices: number[];
+        vertexIndices: number[];
+        vertexCount: number;
+        elements: number[];
+        elementCount: number;
+        mesh: unknown;
+    }
+
+    interface TessOptions
+    {
+        contours: number[][];
+        windingRule?: number;
+        elementType?: number;
+        polySize?: number;
+        vertexSize?: number;
+        normal?: number[];
+    }
+
+    interface Tess2Static
+    {
+        WINDING_ODD: number;
+        WINDING_NONZERO: number;
+        WINDING_POSITIVE: number;
+        WINDING_NEGATIVE: number;
+        WINDING_ABS_GEQ_TWO: number;
+        POLYGONS: number;
+        CONNECTED_POLYGONS: number;
+        BOUNDARY_CONTOURS: number;
+        tesselate(opts: TessOptions): TessResult;
+    }
+
+    const Tess2: Tess2Static;
+
+    export default Tess2;
+}

--- a/src/scene/graphics/shared/utils/triangulateWithHoles.ts
+++ b/src/scene/graphics/shared/utils/triangulateWithHoles.ts
@@ -1,13 +1,19 @@
-import { earcut } from '../../../../utils/utils';
+import Tess2 from 'tess2';
+
+export { Tess2 };
 
 /**
- * @param points
- * @param holes
- * @param vertices
- * @param verticesStride
- * @param verticesOffset
- * @param indices
- * @param indicesOffset
+ * Tessellates a polygon with holes using tess2 (GLU tessellator).
+ * Unlike earcut, tess2 correctly handles winding rules (nonzero, evenodd),
+ * self-intersecting polygons, and overlapping contours.
+ * @param points - Flat array of [x,y,x,y,...] for the outer polygon + all holes concatenated
+ * @param holes - Array of vertex indices where each hole contour starts
+ * @param vertices - Output vertex array
+ * @param verticesStride - Stride between vertices in the output
+ * @param verticesOffset - Starting vertex offset in output
+ * @param indices - Output triangle index array
+ * @param indicesOffset - Starting index offset in output
+ * @param windingRule - tess2 winding rule (default: WINDING_NONZERO)
  * @internal
  */
 export function triangulateWithHoles(
@@ -18,31 +24,61 @@ export function triangulateWithHoles(
     verticesOffset: number,
 
     indices: number[],
-    indicesOffset: number
+    indicesOffset: number,
+    windingRule: number = Tess2.WINDING_NONZERO,
 )
 {
-    const triangles = earcut(points, holes, 2);
+    // Split flat points array into separate contours for tess2,
+    // delimited by the hole index boundaries.
+    const contours: number[][] = [];
 
-    if (!triangles)
+    if (holes.length > 0)
+    {
+        const boundaries = [0, ...holes.map((h: number) => h * 2), points.length];
+
+        for (let i = 0; i < boundaries.length - 1; i++)
+        {
+            const start = boundaries[i];
+            const end = boundaries[i + 1];
+
+            if (end > start)
+            {
+                contours.push(points.slice(start, end));
+            }
+        }
+    }
+    else
+    {
+        contours.push(points.slice());
+    }
+
+    const result = Tess2.tesselate({
+        contours,
+        windingRule,
+        elementType: Tess2.POLYGONS,
+        polySize: 3,
+        vertexSize: 2,
+    });
+
+    if (!result || !result.elements || result.elements.length === 0)
     {
         return;
     }
 
-    for (let i = 0; i < triangles.length; i += 3)
+    for (let i = 0; i < result.elements.length; i += 3)
     {
-        indices[indicesOffset++] = (triangles[i] + verticesOffset);
-        indices[indicesOffset++] = (triangles[i + 1] + verticesOffset);
-        indices[indicesOffset++] = (triangles[i + 2] + verticesOffset);
+        indices[indicesOffset++] = (result.elements[i] + verticesOffset);
+        indices[indicesOffset++] = (result.elements[i + 1] + verticesOffset);
+        indices[indicesOffset++] = (result.elements[i + 2] + verticesOffset);
     }
 
     let index = verticesOffset * verticesStride;
 
-    for (let i = 0; i < points.length; i += 2)
+    for (let i = 0; i < result.vertices.length; i += 2)
     {
-        vertices[index] = points[i];
-        vertices[index + 1] = points[i + 1];
+        vertices[index] = result.vertices[i];
+        vertices[index + 1] = result.vertices[i + 1];
 
         index += verticesStride;
     }
 }
-

--- a/tests/visual/assets/svg-issue-10965-bezier.svg
+++ b/tests/visual/assets/svg-issue-10965-bezier.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 130 100">
+    <!-- Original reproduction from ShukantPal's JSFiddle fhoepg6m:
+         graphics.moveTo(10, 80); graphics.bezierCurveTo(40, 40, 80, 120, 120, 80);
+         The cubic bezier creates a self-intersecting loop when closed. -->
+    <path d="M 10 80 C 40 40 80 120 120 80 Z" fill="black"/>
+</svg>

--- a/tests/visual/assets/svg-issue-10965-twisted.svg
+++ b/tests/visual/assets/svg-issue-10965-twisted.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 130 130">
+    <!-- Simplified reproduction from bigtimebuddy's JSFiddle 9cw7zx5u:
+         graphics.moveTo(10, 80); graphics.lineTo(40, 40);
+         graphics.lineTo(80, 120); graphics.lineTo(120, 80); -->
+    <path d="M 10 80 L 40 40 L 80 120 L 120 80 Z" fill="black" fill-opacity="0.3"/>
+</svg>

--- a/tests/visual/assets/svg-issue-11752-bowtie.svg
+++ b/tests/visual/assets/svg-issue-11752-bowtie.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 250 250">
+    <!-- Exact reproduction from https://github.com/pixijs/pixijs/issues/11752
+         graphics.moveTo(50, 50); graphics.lineTo(200, 200);
+         graphics.lineTo(200, 50); graphics.lineTo(50, 200); graphics.closePath(); -->
+    <path d="M 50 50 L 200 200 L 200 50 L 50 200 Z" fill="#FF6B6B"/>
+</svg>

--- a/tests/visual/assets/svg-issue-7325-pentagram.svg
+++ b/tests/visual/assets/svg-issue-7325-pentagram.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <!-- Self-intersecting pentagram. Maintainer @ivanpopelyshev said
+         "Switch earcut to tess" as the solution for this class of shapes.
+         With nonzero fill, entire star including center should be solid. -->
+    <path d="M 100 10 L 155 180 L 20 70 L 180 70 L 45 180 Z" fill="#e040e0"/>
+</svg>

--- a/tests/visual/assets/svg-nonzero-overlapping-contours.svg
+++ b/tests/visual/assets/svg-nonzero-overlapping-contours.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <!-- Two concentric circle-like rectangles with opposite winding.
+         With nonzero fill rule, the inner rectangle should be a hole. -->
+    <path d="
+    M 10 10 L 190 10 L 190 190 L 10 190 Z
+    M 50 50 L 50 150 L 150 150 L 150 50 Z
+  " fill="black" />
+</svg>

--- a/tests/visual/assets/svg-self-intersecting-figure8.svg
+++ b/tests/visual/assets/svg-self-intersecting-figure8.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+    <!-- Figure-8: a single cubic bezier path that loops over itself.
+         Both lobes should be filled symmetrically. -->
+    <path d="M 100 100 C 100 10 190 10 190 100 C 190 190 100 190 100 100 C 100 10 10 10 10 100 C 10 190 100 190 100 100 Z" fill="#40a0ff"/>
+</svg>

--- a/tests/visual/scenes/graphics/svg/svg-issue-10965-bezier.scene.ts
+++ b/tests/visual/scenes/graphics/svg/svg-issue-10965-bezier.scene.ts
@@ -1,0 +1,23 @@
+import { Assets } from '~/assets';
+import { Graphics } from '~/scene';
+
+import type { TestScene } from '../../../types';
+import type { Container, GraphicsContext } from '~/scene';
+
+export const scene: TestScene = {
+    it: 'should fill a self-intersecting cubic bezier loop correctly',
+    create: async (scene: Container) =>
+    {
+        const context = await Assets.load<GraphicsContext>({
+            src: 'svg-issue-10965-bezier.svg',
+            data: { parseAsGraphicsContext: true }
+        });
+
+        const graphics = new Graphics(context);
+
+        graphics.width = 128;
+        graphics.height = 128;
+
+        scene.addChild(graphics);
+    },
+};

--- a/tests/visual/scenes/graphics/svg/svg-issue-10965-twisted.scene.ts
+++ b/tests/visual/scenes/graphics/svg/svg-issue-10965-twisted.scene.ts
@@ -1,0 +1,23 @@
+import { Assets } from '~/assets';
+import { Graphics } from '~/scene';
+
+import type { TestScene } from '../../../types';
+import type { Container, GraphicsContext } from '~/scene';
+
+export const scene: TestScene = {
+    it: 'should fill a twisted quadrilateral with crossing edges correctly',
+    create: async (scene: Container) =>
+    {
+        const context = await Assets.load<GraphicsContext>({
+            src: 'svg-issue-10965-twisted.svg',
+            data: { parseAsGraphicsContext: true }
+        });
+
+        const graphics = new Graphics(context);
+
+        graphics.width = 128;
+        graphics.height = 128;
+
+        scene.addChild(graphics);
+    },
+};

--- a/tests/visual/scenes/graphics/svg/svg-issue-11752-bowtie.scene.ts
+++ b/tests/visual/scenes/graphics/svg/svg-issue-11752-bowtie.scene.ts
@@ -1,0 +1,23 @@
+import { Assets } from '~/assets';
+import { Graphics } from '~/scene';
+
+import type { TestScene } from '../../../types';
+import type { Container, GraphicsContext } from '~/scene';
+
+export const scene: TestScene = {
+    it: 'should fill all regions of a self-intersecting bowtie polygon',
+    create: async (scene: Container) =>
+    {
+        const context = await Assets.load<GraphicsContext>({
+            src: 'svg-issue-11752-bowtie.svg',
+            data: { parseAsGraphicsContext: true }
+        });
+
+        const graphics = new Graphics(context);
+
+        graphics.width = 128;
+        graphics.height = 128;
+
+        scene.addChild(graphics);
+    },
+};

--- a/tests/visual/scenes/graphics/svg/svg-issue-7325-pentagram.scene.ts
+++ b/tests/visual/scenes/graphics/svg/svg-issue-7325-pentagram.scene.ts
@@ -1,0 +1,23 @@
+import { Assets } from '~/assets';
+import { Graphics } from '~/scene';
+
+import type { TestScene } from '../../../types';
+import type { Container, GraphicsContext } from '~/scene';
+
+export const scene: TestScene = {
+    it: 'should fill a self-intersecting pentagram with nonzero rule',
+    create: async (scene: Container) =>
+    {
+        const context = await Assets.load<GraphicsContext>({
+            src: 'svg-issue-7325-pentagram.svg',
+            data: { parseAsGraphicsContext: true }
+        });
+
+        const graphics = new Graphics(context);
+
+        graphics.width = 128;
+        graphics.height = 128;
+
+        scene.addChild(graphics);
+    },
+};

--- a/tests/visual/scenes/graphics/svg/svg-nonzero-overlapping-contours.scene.ts
+++ b/tests/visual/scenes/graphics/svg/svg-nonzero-overlapping-contours.scene.ts
@@ -1,0 +1,23 @@
+import { Assets } from '~/assets';
+import { Graphics } from '~/scene';
+
+import type { TestScene } from '../../../types';
+import type { Container, GraphicsContext } from '~/scene';
+
+export const scene: TestScene = {
+    it: 'should render nonzero SVG with opposite-wound inner contour as a hole',
+    create: async (scene: Container) =>
+    {
+        const context = await Assets.load<GraphicsContext>({
+            src: 'svg-nonzero-overlapping-contours.svg',
+            data: { parseAsGraphicsContext: true }
+        });
+
+        const graphics = new Graphics(context);
+
+        graphics.width = 128;
+        graphics.height = 128;
+
+        scene.addChild(graphics);
+    },
+};

--- a/tests/visual/scenes/graphics/svg/svg-self-intersecting-figure8.scene.ts
+++ b/tests/visual/scenes/graphics/svg/svg-self-intersecting-figure8.scene.ts
@@ -1,0 +1,23 @@
+import { Assets } from '~/assets';
+import { Graphics } from '~/scene';
+
+import type { TestScene } from '../../../types';
+import type { Container, GraphicsContext } from '~/scene';
+
+export const scene: TestScene = {
+    it: 'should fill both lobes of a self-intersecting figure-8 curve',
+    create: async (scene: Container) =>
+    {
+        const context = await Assets.load<GraphicsContext>({
+            src: 'svg-self-intersecting-figure8.svg',
+            data: { parseAsGraphicsContext: true }
+        });
+
+        const graphics = new Graphics(context);
+
+        graphics.width = 128;
+        graphics.height = 128;
+
+        scene.addChild(graphics);
+    },
+};


### PR DESCRIPTION
## Summary

Replaces earcut with [tess2](https://github.com/memononen/tess2.js) (GLU tessellator) for polygon triangulation. earcut does not support winding rules or self-intersecting contours — a [known limitation since 2016](https://github.com/pixijs/pixijs/issues/3282). tess2 handles both correctly.

This fixes font glyph rendering (e.g. `%` rendered with one circle filled solid instead of hollow — [reproduction](https://github.com/pixijs/pixijs/issues/11752#issuecomment-4147793344)), self-intersecting SVG paths, and multi-contour winding-based holes.

**What changed (net +230 lines, -143 lines):**

- `triangulateWithHoles.ts` — earcut → tess2, with optional `windingRule` parameter (defaults to `WINDING_NONZERO`)
- `buildContextBatches.ts` — batches all multi-contour fill paths into a single tess2 call, selecting `WINDING_ODD` vs `WINDING_NONZERO` based on `shapePath.signed`
- `SVGParser.ts` — removed ~70 lines of area-based heuristic hole detection (`extractSubpaths`, `calculatePathArea`, `checkForNestedPattern`, fill+cut simulation). tess2 handles both fill rules natively.
- `ShapePath.ts` — removed `containsPolygon` hole detection heuristic (same reason)
- `tess2.d.ts` — TypeScript declarations for the tess2 module
- `jest.config.js` — added tess2 to `transformIgnorePatterns`
- `SVGParser.test.ts` — updated `checkForHoles` expectation for evenodd paths

earcut remains as a public API re-export (`import { earcut } from 'pixi.js'`) for backwards compatibility but is no longer used internally.

**5 failing visual tests added (verified broken with earcut, passing with tess2):**

| Test | Shape | Issue |
|------|-------|-------|
| Bowtie polygon | Self-intersecting quad, edges cross | #11752 |
| Twisted quadrilateral | Crossing edges, Z-shape | #10965 |
| Cubic bezier loop | Self-intersecting curve | #10965 |
| Pentagram | 5 self-intersections | #7325 |
| Figure-8 curve | Two-lobe self-intersecting bezier | — |

Plus 1 regression test (opposite-wound nested rectangles — previously handled by `containsPolygon` heuristic, now handled natively by tess2).

**Trade-offs:**

- tess2 adds ~24KB gzipped to the bundle (vs earcut's ~6KB). This is the cost of correct winding rule support.
- tess2 is slower than earcut for simple convex polygons. For the shapes where earcut produces *wrong* output, this is acceptable.
- tess2 has [known precision issues](https://github.com/memononen/libtess2/issues/33) with very long degenerate contours — uncommon in typical SVG/Graphics usage. A future improvement could use [iTriangle](https://github.com/iShape-Rust/iTriangle) (Rust/WASM, integer math) for better robustness.
- Single-path evenodd (e.g. evenodd pentagram with hollow center) is not yet fixed — requires threading `windingRule` through the `ShapeBuildCommand` interface. Tracked separately.

## Test plan

- [x] Visual tests: 5 failing SVG tests added, all pass after fix
- [x] Regression test: opposite-wound contour hole detection preserved
- [x] Build passes (`npm run build`)
- [x] ESLint passes (lint-staged on every commit)
- [x] Existing `SVGParser.test.ts` updated and passing
- [ ] Full visual test suite (`npm run test:visual`) — needs snapshot regeneration

🤖 Generated with [Claude Code](https://claude.com/claude-code)