### PR TITLE
fix: CanvasFilterSystem is removed by vite build

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
     "./lib/index.*",
     "./lib/rendering/init.*",
     "./lib/spritesheet/init.*",
+    "./lib/rendering/canvas/CanvasFilterSystem.*",
     "./lib/rendering/renderers/shared/texture/utils/textureFrom.*",
     "./lib/gif/init.*",
     "./lib/accessibility/init.*",


### PR DESCRIPTION
##### Description of change
I hope this will fix #11981.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
