### PR TITLE
feat: adding a default anchor to texture generation

### DIFF
--- a/src/rendering/renderers/shared/extract/GenerateTextureSystem.ts
+++ b/src/rendering/renderers/shared/extract/GenerateTextureSystem.ts
@@ -132,6 +132,18 @@ export type GenerateTextureOptions = {
     antialias?: boolean;
 
     /**
+     * Default anchor point for the generated texture.
+     * @example
+     * ```ts
+     * const texture = renderer.generateTexture({
+     *     target: sprite,
+     *     defaultAnchor: { x: 0.5, y: 0.5 } // Center the anchor
+     * });
+     * ```
+     */
+    defaultAnchor?: { x: number; y: number };
+
+    /**
      * Advanced options for configuring the texture source.
      * Controls texture properties like scale mode and filtering.
      * @advanced
@@ -302,6 +314,10 @@ export class GenerateTextureSystem implements System
         const region = options.frame?.copyTo(tempRect)
             || getLocalBounds(container, tempBounds).rectangle;
 
+        const textureOptions = options.defaultAnchor && {
+            defaultAnchor: options.defaultAnchor
+        };
+
         region.width = Math.max(region.width, 1 / resolution) | 0;
         region.height = Math.max(region.height, 1 / resolution) | 0;
 
@@ -311,6 +327,7 @@ export class GenerateTextureSystem implements System
             height: region.height,
             resolution,
             antialias,
+            textureOptions
         });
 
         const transform = Matrix.shared.translate(-region.x, -region.y);

--- a/src/rendering/renderers/shared/texture/RenderTexture.ts
+++ b/src/rendering/renderers/shared/texture/RenderTexture.ts
@@ -1,7 +1,18 @@
 import { TextureSource } from './sources/TextureSource';
-import { Texture } from './Texture';
+import { Texture, type TextureOptions } from './Texture';
 
 import type { TextureSourceOptions } from './sources/TextureSource';
+
+/**
+ * The options that can be passed to a new RenderTexture
+ * @category rendering
+ * @advanced
+ */
+export interface RenderTextureOptions extends TextureSourceOptions
+{
+    /** texture options {@link TextureOptions} */
+    textureOptions?: Omit<TextureOptions, 'source' | 'dynamic'>
+}
 
 /**
  * A render texture, extends `Texture`.
@@ -13,18 +24,20 @@ export class RenderTexture extends Texture
 {
     /**
      * Creates a RenderTexture. Pass `dynamic: true` in options to allow resizing after creation.
-     * @param options - Options for the RenderTexture, including width, height, and dynamic.
+     * @param options - Options for the RenderTexture, including width, height, textureOptions, and dynamic.
      * @returns A new RenderTexture instance.
      * @example
-     * const rt = RenderTexture.create({ width: 100, height: 100, dynamic: true });
+     * const textureOptions = { defaultAnchor: { x: 0.5, y: 0.5 } };
+     * const rt = RenderTexture.create({ width: 100, height: 100, dynamic: true, textureOptions });
      * rt.resize(500, 500);
      */
-    public static create(options: TextureSourceOptions): RenderTexture
+    public static create(options: RenderTextureOptions): RenderTexture
     {
         // Pass dynamic to the RenderTexture constructor if present in options
-        const { dynamic, ...rest } = options;
+        const { dynamic, textureOptions, ...rest } = options;
 
         return new RenderTexture({
+            ...textureOptions,
             source: new TextureSource(rest),
             dynamic: dynamic ?? false,
         });

--- a/src/rendering/renderers/shared/texture/__tests__/GenerateTexture.test.ts
+++ b/src/rendering/renderers/shared/texture/__tests__/GenerateTexture.test.ts
@@ -25,4 +25,16 @@ describe('GenerateTexture', () =>
 
         expect(texture).toBeInstanceOf(Texture);
     });
+
+    it('should generate texture from options with default anchor', async () =>
+    {
+        const renderer = (await getWebGLRenderer()) as WebGLRenderer;
+        const container = new Container();
+        const texture = renderer.textureGenerator.generateTexture({
+            target: container,
+            defaultAnchor: { x: 0.5, y: 0.5 },
+        });
+
+        expect(texture.defaultAnchor).toEqual({ x: 0.5, y: 0.5 });
+    });
 });


### PR DESCRIPTION
##### Description of change
Added the ability to specify default anchor when generating a texture.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
