### PR TITLE
fix: move CanvasFilterSystem to filters module

### DIFF
--- a/src/filters/CanvasFilterSystem.ts
+++ b/src/filters/CanvasFilterSystem.ts
@@ -1,16 +1,16 @@
-import { extensions, ExtensionType } from '../../../extensions/Extensions';
-import { Bounds } from '../../../scene/container/bounds/Bounds';
-import { getGlobalRenderableBounds } from '../../../scene/container/bounds/getRenderableBounds';
-import { getPo2TextureFromSource } from '../../../scene/text/utils/getPo2TextureFromSource';
-import { CanvasPool } from '../shared/texture/CanvasPool';
-import { canvasUtils } from './utils/canvasUtils';
+import { ExtensionType } from '../extensions/Extensions';
+import { canvasUtils } from '../rendering/renderers/canvas/utils/canvasUtils';
+import { CanvasPool } from '../rendering/renderers/shared/texture/CanvasPool';
+import { Bounds } from '../scene/container/bounds/Bounds';
+import { getGlobalRenderableBounds } from '../scene/container/bounds/getRenderableBounds';
+import { getPo2TextureFromSource } from '../scene/text/utils/getPo2TextureFromSource';
 
-import type { ICanvasRenderingContext2D } from '../../../environment/canvas/ICanvasRenderingContext2D';
-import type { Filter } from '../../../filters/Filter';
-import type { FilterInstruction } from '../../../filters/FilterSystem';
-import type { Container } from '../../../scene/container/Container';
-import type { System } from '../shared/system/System';
-import type { Texture } from '../shared/texture/Texture';
+import type { ICanvasRenderingContext2D } from '../environment/canvas/ICanvasRenderingContext2D';
+import type { System } from '../rendering/renderers/shared/system/System';
+import type { Texture } from '../rendering/renderers/shared/texture/Texture';
+import type { Container } from '../scene/container/Container';
+import type { Filter } from './Filter';
+import type { FilterInstruction } from './FilterSystem';
 
 /**
  * Interface for filters that can supply a CSS filter string for Canvas2D.
@@ -418,5 +418,3 @@ export class CanvasFilterSystem implements System
         this._alphaMultiplier = 1;
     }
 }
-
-extensions.add(CanvasFilterSystem);

--- a/src/filters/index.ts
+++ b/src/filters/index.ts
@@ -2,6 +2,7 @@
 export * from './blend-modes/BlendModeFilter';
 export * from './blend-modes/hls/GLhls';
 export * from './blend-modes/hls/GPUhls';
+export * from './CanvasFilterSystem';
 export * from './defaults/alpha/AlphaFilter';
 export * from './defaults/blur/BlurFilter';
 export * from './defaults/blur/BlurFilterPass';

--- a/src/filters/init.ts
+++ b/src/filters/init.ts
@@ -1,6 +1,7 @@
 import { extensions } from '../extensions/Extensions';
+import { CanvasFilterSystem } from './CanvasFilterSystem';
 import { FilterPipe } from './FilterPipe';
 import { FilterSystem } from './FilterSystem';
 
-extensions.add(FilterSystem);
+extensions.add(FilterSystem, CanvasFilterSystem);
 extensions.add(FilterPipe);

--- a/src/rendering/index.ts
+++ b/src/rendering/index.ts
@@ -45,7 +45,6 @@ export * from './mask/utils/addMaskBounds';
 export * from './mask/utils/addMaskLocalBounds';
 export * from './renderers/autoDetectRenderer';
 export * from './renderers/canvas/CanvasContextSystem';
-export * from './renderers/canvas/CanvasFilterSystem';
 export * from './renderers/canvas/CanvasLimitsSystem';
 export * from './renderers/canvas/CanvasRenderer';
 export * from './renderers/canvas/renderTarget/CanvasRenderTargetAdaptor';


### PR DESCRIPTION
### Overview

Relocates `CanvasFilterSystem` from `src/rendering/renderers/canvas/` to `src/filters/` so it lives alongside the rest of the filter system code. Extension registration is now centralized in `filters/init.ts` instead of being a side-effect of importing the module, which ensures the canvas filter system is properly initialized through the filters module.

Replaces #12003 and fixes #11981.

#### Fixes
- `CanvasFilterSystem` is now correctly registered via the filters module's init, ensuring canvas filters work when importing from `pixi.js/filters`.

#### Chores
- Moved `CanvasFilterSystem` from `rendering/renderers/canvas` to `filters` module and updated its exports.

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
