### PR TITLE
chore: bump @xmldom/xmldom to 0.8.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@pixi/colord": "^2.9.6",
         "@types/earcut": "^3.0.0",
         "@webgpu/types": "^0.1.69",
-        "@xmldom/xmldom": "^0.8.11",
+        "@xmldom/xmldom": "^0.8.12",
         "earcut": "^3.0.2",
         "eventemitter3": "^5.0.1",
         "gifuct-js": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@pixi/colord": "^2.9.6",
     "@types/earcut": "^3.0.0",
     "@webgpu/types": "^0.1.69",
-    "@xmldom/xmldom": "^0.8.11",
+    "@xmldom/xmldom": "^0.8.12",
     "earcut": "^3.0.2",
     "eventemitter3": "^5.0.1",
     "gifuct-js": "^2.1.2",


### PR DESCRIPTION
### Overview

Bumps `@xmldom/xmldom` from `0.8.11` to `0.8.12` to address a security issue in the earlier version.

#### Chores
- Bump `@xmldom/xmldom` dependency from `^0.8.11` to `^0.8.12` (security fix)

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
